### PR TITLE
Fix issue where cast of double to int rounds time down

### DIFF
--- a/EVB-2/IS_EVB-2/src/communications.cpp
+++ b/EVB-2/IS_EVB-2/src/communications.cpp
@@ -308,7 +308,7 @@ void handle_data_from_uINS(p_data_hdr_t &dataHdr, uint8_t *data)
 		if(dataHdr.size+dataHdr.offset > sizeof(ins_1_t)){ /* Invalid */ return; }
 		g_status.week = d.ins1.week;
 		g_statusToWlocal = false;
-		g_status.timeOfWeekMs = (uint32_t)(d.ins1.timeOfWeek*1000);
+		g_status.timeOfWeekMs = (uint32_t)round(d.ins1.timeOfWeek*1000);
 		break;
 	                    
 	case DID_INS_2:
@@ -316,21 +316,21 @@ void handle_data_from_uINS(p_data_hdr_t &dataHdr, uint8_t *data)
 		g_msg.ins2 = d.ins2;
 		g_status.week = g_msg.ins2.week;
 		g_statusToWlocal = false;
-		g_status.timeOfWeekMs = (uint32_t)(d.ins2.timeOfWeek*1000);
+		g_status.timeOfWeekMs = (uint32_t)round(d.ins2.timeOfWeek*1000);
 		break;
 
 	case DID_INS_3:
 		if(dataHdr.size+dataHdr.offset > sizeof(ins_3_t)){ /* Invalid */ return; }
 		g_status.week = d.ins1.week;
 		g_statusToWlocal = false;
-		g_status.timeOfWeekMs = (uint32_t)(d.ins3.timeOfWeek*1000);
+		g_status.timeOfWeekMs = (uint32_t)round(d.ins3.timeOfWeek*1000);
 		break;
 
 	case DID_INS_4:
 		if(dataHdr.size+dataHdr.offset > sizeof(ins_4_t)){ /* Invalid */ return; }
 		g_status.week = d.ins4.week;
 		g_statusToWlocal = false;
-		g_status.timeOfWeekMs = (uint32_t)(d.ins4.timeOfWeek*1000);
+		g_status.timeOfWeekMs = (uint32_t)round(d.ins4.timeOfWeek*1000);
 		break;
 	}
 	

--- a/EVB-2/IS_EVB-2/src/wheel_encoder.cpp
+++ b/EVB-2/IS_EVB-2/src/wheel_encoder.cpp
@@ -52,7 +52,7 @@ void step_wheel_encoder(is_comm_instance_t &comm)
 		
 		// Call read encoders
 		g_wheelEncoder.timeOfWeek = time_seclf();
-		g_wheelEncoderTimeMs = (uint32_t)(g_wheelEncoder.timeOfWeek*1000.0);
+		g_wheelEncoderTimeMs = (uint32_t)round(g_wheelEncoder.timeOfWeek*1000.0);
 		quadEncReadPositionAll(&chL, &dirL, &chR, &dirR);
 		quadEncReadPeriodAll(&periodL, &periodR);
 


### PR DESCRIPTION
This fixes an issue where time (i.e. 3.9) was rounded down to 3 when casting from double to int.