### PR TITLE
SN-7158 - Fixes "Bus Error" on ARMv7 and older platforms when using ISDataMappings.

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -77,6 +77,18 @@ extern "C" {
     typedef int is_socket_t;
     #define CPU_IS_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
     #define CPU_IS_BIG_ENDIAN (__BYTE_ORDER == __BIG_ENDIAN)
+    // Detect if we're being compiled for ARM
+    #ifdef __ARM_ARCH
+        //#define STR_HELPER(x) #x
+        //#define STR(x) STR_HELPER(x)
+        //#pragma message "Compiling for ARMv" STR(__ARM_ARCH)
+        #define CPU_IS_ARM 1                    // NOTE that is is different than "PLATFORM_IS_ARM" since this still applied is LINUX operating systems running on ARM, like Raspberry Pi, etc
+        #if defined(__ARM_ARCH)                 // GCC compiler for ARM/version
+            #define CPU_ARM_VERSION (__ARM_ARCH)
+        #elif defined(__TARGET_ARCH_ARM)        // ARM compiler for ARM/version
+            #define CPU_ARM_VERSION (__TARGET_ARCH_ARM)
+        #endif
+    #endif
 #elif defined(__INERTIAL_SENSE_EVB_2__)
     #define PLATFORM_IS_EMBEDDED 1
     #define PLATFORM_IS_ARM 1

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1910,7 +1910,12 @@ bool cISDataMappings::VariableToString(eDataType dataType, eDataFlags dataFlags,
         break;
     case DATA_TYPE_F32:
         precision = (dataFlags&DATA_FLAGS_FIXED_DECIMAL_MASK);
-        valuef32 = (*(float*)dataBuffer) * conversion;
+#if (defined(CPU_IS_ARM) && (CPU_ARM_VERSION <= 7))
+            memcpy(&valuef32, dataBuffer, sizeof(float));
+            valuef32 *= conversion;
+#else
+            valuef32 = (*(float*)dataBuffer) * conversion;
+#endif
         if (precision)
         {
             precision -= 1;
@@ -1924,7 +1929,12 @@ bool cISDataMappings::VariableToString(eDataType dataType, eDataFlags dataFlags,
         break;
     case DATA_TYPE_F64:                             
         precision = (dataFlags&DATA_FLAGS_FIXED_DECIMAL_MASK);
-        valuef64 = (*(double*)dataBuffer) * conversion;
+#if (defined(CPU_IS_ARM) && (CPU_ARM_VERSION <= 7))
+            memcpy(&valuef64, dataBuffer, sizeof(double));
+            valuef64 *= conversion;
+#else
+            valuef64 = (*(double*)dataBuffer) * conversion;
+#endif
         if (precision)
         {   // Fixed precision
             SNPRINTF(stringBuffer, IS_DATA_MAPPING_MAX_STRING_LENGTH, "%.*f", precision, valuef64);


### PR DESCRIPTION
Adds checks to ISConstants.h to identify ARM CPU architecture and ARM version.
Adds guards in ISDataMappings.cpp::VariableToString() to do safe aligned float/double dereferencing.