### PR TITLE
IMX-6 5x IMU support

### DIFF
--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -33,7 +33,8 @@ RESET = r"\u001b[0m"
 RAD2DEG = 180.0 / 3.14159
 DEG2RAD = 3.14159 / 180.0
 
-RTHR2RTS = 60 # sqrt(hr) to sqrt(sec)
+RTHR2RTS = 60       # sqrt(hr) to sqrt(sec)
+MPS2UG   = 1E6/9.81 # m/s^2 to micro g
 
 SHOW_GPS_W_INS = 1
 SHOW_HEADING_ARROW = 0
@@ -3128,7 +3129,7 @@ class logPlot:
                             rw_idx = (np.abs(t2 - 1.0)).argmin()
                             rw = ad[rw_idx] * np.sqrt(t2[rw_idx])
                             
-                            ax[i, n].loglog(t2, ad * RAD2DEG * 3600, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RAD2DEG * 3600/RTHR2RTS, bi * RAD2DEG * 3600))
+                            ax[i, n].loglog(t2, ad * RAD2DEG * 3600, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RAD2DEG * 1000, bi * RAD2DEG * 3600))
 
                             # (t2, ad, ade, adn) = allantools.ohdev(pqr[:,i], rate=1/(dtMean/self.d), data_type="freq", taus=t)
                             # # Compute random walk and bias instability
@@ -3140,7 +3141,7 @@ class logPlot:
 
                             # ax[i, n].loglog(t2, ad * RAD2DEG * 3600, '--', label='%s: %.2f, %.3g' % (self.log.serials[d], rw * RAD2DEG * 3600/RTHR2RTS, bi * RAD2DEG * 3600))
 
-                            sumARW[i][n].append(rw * RAD2DEG * 3600/RTHR2RTS)
+                            sumARW[i][n].append(rw * RAD2DEG * 1000)
                             sumBI[i][n].append(bi * RAD2DEG * 3600)
 
                             # Error bounds debug plots
@@ -3158,7 +3159,7 @@ class logPlot:
                         alable += '%d ' % n
                     else:
                         alable += ' '
-                    self.configureSubplot(ax[i, n], alable + axislable + r' ($deg/hr$), ARW: %.3g $deg/\sqrt{hr}$,  BI: %.3g $deg/hr$' % (np.mean(sumARW[i][n]) + np.std(sumARW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'deg/hr')
+                    self.configureSubplot(ax[i, n], alable + axislable + r' ($deg/hr$), ARW: %.3g $mdeg\sqrt{Hz}$,  BI: %.3g $deg/hr$' % (np.mean(sumARW[i][n]) + np.std(sumARW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'deg/hr')
 
         for i in range(len(initial_sensors)):
             for d in range(3):
@@ -3222,10 +3223,10 @@ class logPlot:
                             rw_idx = (np.abs(t2 - 0.1)).argmin()
                             rw = ad[rw_idx] * np.sqrt(t2[rw_idx])
 
-                            ax[i, n].loglog(t2, ad, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RTHR2RTS, bi))
+                            ax[i, n].loglog(t2, ad, label='%s: %.2g, %.2g' % (self.log.serials[d], rw, bi * MPS2UG))
 
-                            sumRW[i][n].append(rw * RTHR2RTS) 
-                            sumBI[i][n].append(bi)
+                            sumRW[i][n].append(rw) 
+                            sumBI[i][n].append(bi * MPS2UG)
 
         # Calculate the stats for ARW and bias instability over all units
         # The plots show the mean + 1 std deviation in accordance with IEEE spec (Analog Devices website)
@@ -3238,7 +3239,7 @@ class logPlot:
                         alable += '%d ' % n
                     else:
                         alable += ' '
-                    self.configureSubplot(ax[i, n], alable + axislable + r' ($m/s^2$), RW: %.3g $m/s/\sqrt{hr}$, BI: %.3g $m/s^2$' % (np.mean(sumRW[i][n]) + np.std(sumRW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'm/s^2')
+                    self.configureSubplot(ax[i, n], alable + axislable + r' ($uG$), RW: %.3g $m/s\sqrt{Hz}$, BI: %.3g $uG$' % (np.mean(sumRW[i][n]) + np.std(sumRW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'uG')
 
         for i in range(len(sensors)):
             for d in range(3):

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -3129,7 +3129,7 @@ class logPlot:
                             rw_idx = (np.abs(t2 - 1.0)).argmin()
                             rw = ad[rw_idx] * np.sqrt(t2[rw_idx])
                             
-                            ax[i, n].loglog(t2, ad * RAD2DEG * 3600, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RAD2DEG * 1000, bi * RAD2DEG * 3600))
+                            ax[i, n].loglog(t2, ad * RAD2DEG * 3600, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RAD2DEG * 3600/RTHR2RTS, bi * RAD2DEG * 3600))
 
                             # (t2, ad, ade, adn) = allantools.ohdev(pqr[:,i], rate=1/(dtMean/self.d), data_type="freq", taus=t)
                             # # Compute random walk and bias instability
@@ -3141,7 +3141,7 @@ class logPlot:
 
                             # ax[i, n].loglog(t2, ad * RAD2DEG * 3600, '--', label='%s: %.2f, %.3g' % (self.log.serials[d], rw * RAD2DEG * 3600/RTHR2RTS, bi * RAD2DEG * 3600))
 
-                            sumARW[i][n].append(rw * RAD2DEG * 1000)
+                            sumARW[i][n].append(rw * RAD2DEG * 3600/RTHR2RTS)
                             sumBI[i][n].append(bi * RAD2DEG * 3600)
 
                             # Error bounds debug plots
@@ -3149,7 +3149,6 @@ class logPlot:
                             # ax[i, n].loglog(t2, (ad - ade) * RAD2DEG*3600, '--')
 
         # Calculate the stats for ARW and bias instability over all units
-        # The plots show the mean + 1 std deviation in accordance with IEEE spec (Analog Devices website)
         for i in range(3):
             axislable = 'P' if (i == 0) else 'Q' if (i==1) else 'R'
             for n, pqr in enumerate(initial_sensors):
@@ -3159,7 +3158,7 @@ class logPlot:
                         alable += '%d ' % n
                     else:
                         alable += ' '
-                    self.configureSubplot(ax[i, n], alable + axislable + r' ($deg/hr$), ARW: %.3g $mdeg\sqrt{Hz}$,  BI: %.3g $deg/hr$' % (np.mean(sumARW[i][n]) + np.std(sumARW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'deg/hr')
+                    self.configureSubplot(ax[i, n], alable + axislable + r' ($deg/hr$), ARW: %.3g $deg/\sqrt{hr}$,  BI: %.3g $deg/hr$' % (np.mean(sumARW[i][n]) + np.std(sumARW[i][n]), np.mean(sumBI[i][n])), 'deg/hr')
 
         for i in range(len(initial_sensors)):
             for d in range(3):
@@ -3184,7 +3183,7 @@ class logPlot:
                 f.write('\n')
 
         return self.saveFigJoinAxes(ax, axs, fig, 'pqrIMU')
-
+    
     def allanVarianceAcc(self, fig=None, axs=None):
         if fig is None:
             fig = plt.figure()
@@ -3223,13 +3222,12 @@ class logPlot:
                             rw_idx = (np.abs(t2 - 0.1)).argmin()
                             rw = ad[rw_idx] * np.sqrt(t2[rw_idx])
 
-                            ax[i, n].loglog(t2, ad, label='%s: %.2g, %.2g' % (self.log.serials[d], rw, bi * MPS2UG))
+                            ax[i, n].loglog(t2, ad * MPS2UG, label='%s: %.2g, %.2g' % (self.log.serials[d], rw * RTHR2RTS, bi * MPS2UG))
 
-                            sumRW[i][n].append(rw) 
+                            sumRW[i][n].append(rw * RTHR2RTS) 
                             sumBI[i][n].append(bi * MPS2UG)
 
         # Calculate the stats for ARW and bias instability over all units
-        # The plots show the mean + 1 std deviation in accordance with IEEE spec (Analog Devices website)
         for i in range(3):
             axislable = 'X' if (i == 0) else 'Y' if (i==1) else 'Z'
             for n, pqr in enumerate(sensors):
@@ -3239,7 +3237,7 @@ class logPlot:
                         alable += '%d ' % n
                     else:
                         alable += ' '
-                    self.configureSubplot(ax[i, n], alable + axislable + r' ($uG$), RW: %.3g $m/s\sqrt{Hz}$, BI: %.3g $uG$' % (np.mean(sumRW[i][n]) + np.std(sumRW[i][n]), np.mean(sumBI[i][n]) + np.std(sumBI[i][n])), 'uG')
+                    self.configureSubplot(ax[i, n], alable + axislable + r' ($µG$), RW: %.3g $m/s/\sqrt{hr}$, BI: %.3g $µG$' % (np.mean(sumRW[i][n]) + np.std(sumRW[i][n]), np.mean(sumBI[i][n])), 'µG')
 
         for i in range(len(sensors)):
             for d in range(3):

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -4482,12 +4482,15 @@ class logPlot:
 
     def sensorCompGen(self, fig, name, useTemp=False):
         fig.suptitle('Sensor Comp ' + name + ' - ' + os.path.basename(os.path.normpath(self.log.directory)))
-        ax = fig.subplots(4, 3, sharex=True)
+        numSensors = 5
+        if name=='mag':
+            numSensors = 2
+        ax = fig.subplots(4, numSensors, sharex=True)
 
         useSampleNumber = 1
         noData = True
 
-        for i in range(3):
+        for i in range(numSensors):
             ax[0, i].set_title('X %s %d' % (name, i))
             ax[1, i].set_title('Y %s %d' % (name, i))
             ax[2, i].set_title('Z %s %d' % (name, i))
@@ -4495,37 +4498,37 @@ class logPlot:
                 ax[3, i].set_title('Temperature %s %d' % (name, i))
             else:
                 ax[3, i].set_title('Magnitude %s %d' % (name, i))            
-            for d in range(3):
+            for a in range(3):
                 if useTemp:
-                    ax[d,i].set_xlabel("Temperature (C)")
+                    ax[a,i].set_xlabel("Temperature (C)")
                 else:
                     if useSampleNumber:
-                        ax[d,i].set_xlabel("Sample")
+                        ax[a,i].set_xlabel("Sample")
                     else:
-                        ax[d,i].set_xlabel("Time (s)")
+                        ax[a,i].set_xlabel("Time (s)")
                 if name=='pqr':
-                    ax[d,i].set_ylabel("Gyro (deg/s)")
+                    ax[a,i].set_ylabel("Gyro (deg/s)")
                 elif name=='acc':
-                    ax[d,i].set_ylabel("Accel (m/s^2)")
+                    ax[a,i].set_ylabel("Accel (m/s^2)")
                 elif name=='mag':
-                    ax[d,i].set_ylabel("Mag")
+                    ax[a,i].set_ylabel("Mag")
 
-        for d in self.active_devs:
-            time = 0.001 * self.getData(d, DID_SCOMP, 'timeMs')
+        for a in self.active_devs:
+            time = 0.001 * self.getData(a, DID_SCOMP, 'timeMs')
             if np.any(time):
                 noData = False
-                imu = self.getData(d, DID_SCOMP, name)
-                status = self.getData(d, DID_SCOMP, 'status')
+                imu = self.getData(a, DID_SCOMP, name)
+                status = self.getData(a, DID_SCOMP, 'status')
 
                 if name=='mag':
-                    refVal = self.getData(d, DID_SCOMP, 'referenceMag')
+                    refVal = self.getData(a, DID_SCOMP, 'referenceMag')
                 else:
-                    refImu = self.getData(d, DID_SCOMP, 'referenceImu')
+                    refImu = self.getData(a, DID_SCOMP, 'referenceImu')
                     refImu = refImu
                     refVal = refImu[name]
 
-                print("Serial#: SN" + str(self.log.serials[d]) + " " + name + ": ")
-                for i in range(3):
+                print("Serial#: SN" + str(self.log.serials[a]) + " " + name + ": ")
+                for i in range(numSensors):
                     temp = imu[:,i]['lpfTemp']
                     sensor = imu[:,i]['lpfLsb']
 
@@ -4545,7 +4548,7 @@ class logPlot:
                             x = time
 
                     # ax[0,i].plot(x, sensor[:,0], label=self.log.serials[d] if i==0 else None)
-                    ax[0,i].plot(x, sensor[:,0]*scalar, label=self.log.serials[d])
+                    ax[0,i].plot(x, sensor[:,0]*scalar, label=self.log.serials[a])
                     ax[1,i].plot(x, sensor[:,1]*scalar)
                     ax[2,i].plot(x, sensor[:,2]*scalar)
                     if not useTemp:
@@ -4600,15 +4603,16 @@ class logPlot:
 
     def linearityAcc(self, fig=None, axs=None):
         fig.suptitle('Accelerometer Linearity - ' + os.path.basename(os.path.normpath(self.log.directory)))
-        ax = fig.subplots(3, 3)
+        numImus = 5
+        ax = fig.subplots(3, numImus)
 
-        for i in range(3):
-            ax[0, i].set_title('Accel%d X' % (i))
-            ax[1, i].set_title('Accel%d Y' % (i))
-            ax[2, i].set_title('Accel%d Z ' % (i))
+        for a in range(numImus):
+            ax[0, a].set_title('Acc%d X' % (a))
+            ax[1, a].set_title('Acc%d Y' % (a))
+            ax[2, a].set_title('Acc%d Z ' % (a))
             for d in range(3):
-                ax[d,i].set_xlabel("ref m/s^2")
-                ax[d,i].set_ylabel("residual m/s^2")
+                ax[d,a].set_xlabel("ref m/s^2")
+                ax[d,a].set_ylabel("residual m/s^2")
 
         for d in self.active_devs:
             sampleCount = self.getData(d, DID_SCOMP, 'sampleCount')
@@ -4616,35 +4620,15 @@ class logPlot:
             imu = self.getData(d, DID_SCOMP, 'acc')
             reference = self.getData(d, DID_SCOMP, 'referenceImu')
 
-            for i in range(3): # range through axes
-                data0 = imu[:,0]['lpfLsb'][:,i]
-                data1 = imu[:,1]['lpfLsb'][:,i]
-                data2 = imu[:,2]['lpfLsb'][:,i]
-
-                refdata = reference['acc'][:,i]
-
-                # refdata0 = reference['pqr'][sampleCount > 10000,i]
-                # refdata1 = reference['pqr'][sampleCount > 10000,i]
-                # refdata2 = reference['pqr'][sampleCount > 10000,i]
-
-                # ax[i,0].plot(refdata0, data0)
-                # ax[i,1].plot(refdata0, data1)
-                # ax[i,2].plot(refdata0, data2)
-
-                residual0 = [a - b for a, b in zip(refdata, data0)]
-                residual1 = [a - b for a, b in zip(refdata, data1)]
-                residual2 = [a - b for a, b in zip(refdata, data2)]
-
-                # ax[i,0].plot(range(0,np.size(residual0)), residual0)
-                # ax[i,1].plot(range(0,np.size(residual1)), residual1)
-                # ax[i,2].plot(range(0,np.size(residual2)), residual2)
-
-                if i == 0:
-                    ax[i,0].plot(refdata, residual0, label=self.log.serials[d])
-                else:
-                    ax[i,0].plot(refdata, residual0)
-                ax[i,1].plot(refdata, residual1)
-                ax[i,2].plot(refdata, residual2)
+            for i in range(numImus):
+                for a in range(3): # range through axes
+                    data = imu[:,i]['lpfLsb'][:,a]
+                    refdata = reference['acc'][:,a]
+                    residual = [a - b for a, b in zip(refdata, data)]
+                    if a == 0:
+                        ax[a,i].plot(refdata, residual, label=self.log.serials[d])
+                    else:
+                        ax[a,i].plot(refdata, residual)
 
 
         # Show serial numbers
@@ -4663,15 +4647,16 @@ class logPlot:
 
     def linearityGyr(self, fig=None, axs=None):
         fig.suptitle('Gyro Linearity - ' + os.path.basename(os.path.normpath(self.log.directory)))
-        ax = fig.subplots(3, 3)
+        numImus = 5
+        ax = fig.subplots(3, numImus)
 
-        for i in range(3):
-            ax[0, i].set_title('Gyro%d P' % (i))
-            ax[1, i].set_title('Gyro%d Q' % (i))
-            ax[2, i].set_title('Gyro%d R ' % (i))
+        for a in range(numImus):
+            ax[0, a].set_title('Gyr%d P' % (a))
+            ax[1, a].set_title('Gyr%d Q' % (a))
+            ax[2, a].set_title('Gyr%d R ' % (a))
             for d in range(3):
-                ax[d,i].set_xlabel("ref rad/s")
-                ax[d,i].set_ylabel("residual rad/s")
+                ax[d,a].set_xlabel("ref rad/s")
+                ax[d,a].set_ylabel("residual rad/s")
 
         for d in self.active_devs:
             sampleCount = self.getData(d, DID_SCOMP, 'sampleCount')
@@ -4679,35 +4664,15 @@ class logPlot:
             # imu = self.getData(d, DID_SCOMP, 'acc')
             reference = self.getData(d, DID_SCOMP, 'referenceImu')
 
-            for i in range(3): # range through axes
-                data0 = imu[:,0]['lpfLsb'][:,i]
-                data1 = imu[:,1]['lpfLsb'][:,i]
-                data2 = imu[:,2]['lpfLsb'][:,i]
-
-                refdata = reference['pqr'][:,i]
-
-                # refdata0 = reference['pqr'][sampleCount > 10000,i]
-                # refdata1 = reference['pqr'][sampleCount > 10000,i]
-                # refdata2 = reference['pqr'][sampleCount > 10000,i]
-
-                # ax[i,0].plot(refdata0, data0)
-                # ax[i,1].plot(refdata0, data1)
-                # ax[i,2].plot(refdata0, data2)
-
-                residual0 = [a - b for a, b in zip(refdata, data0)]
-                residual1 = [a - b for a, b in zip(refdata, data1)]
-                residual2 = [a - b for a, b in zip(refdata, data2)]
-
-                # ax[i,0].plot(range(0,np.size(residual0)), residual0)
-                # ax[i,1].plot(range(0,np.size(residual1)), residual1)
-                # ax[i,2].plot(range(0,np.size(residual2)), residual2)
-
-                if i == 0:
-                    ax[i,0].plot(refdata, residual0, label=self.log.serials[d])
-                else:
-                    ax[i,0].plot(refdata, residual0)
-                ax[i,1].plot(refdata, residual1)
-                ax[i,2].plot(refdata, residual2)
+            for i in range(numImus):
+                for a in range(3): # range through axes
+                    data = imu[:,0]['lpfLsb'][:,a]
+                    refdata = reference['pqr'][:,a]
+                    residual = [a - b for a, b in zip(refdata, data)]
+                    if a == 0:
+                        ax[a,i].plot(refdata, residual, label=self.log.serials[d])
+                    else:
+                        ax[a,i].plot(refdata, residual)
 
 
         # Show serial numbers

--- a/python/inertialsense/logs/include/log_reader.h
+++ b/python/inertialsense/logs/include/log_reader.h
@@ -17,6 +17,8 @@
 #pragma comment(lib, "SHELL32.LIB")
 #endif
 
+#define LOG_READER_DEBUG_ENABLED    0       // Set to 1 to enable debug print statements in LogReader, or 0 to disable them. These statements can be helpful for development and troubleshooting, but may produce a large amount of output for long logs.
+
 namespace py = pybind11;
 
 typedef struct {
@@ -155,11 +157,15 @@ class LogReader {
         T tmp{};
         memcpy(&tmp, msg, std::min(sizeof(T), (size_t)size));
         vec.push_back(tmp);
+#if LOG_READER_DEBUG_ENABLED
+        printf("Logged message with DID %d, size %d, vector now has %zu entries\n", did, size, vec.size());
+#endif
     }
 
    private:
     void organizeData(std::shared_ptr<cDeviceLog>);
     void forwardData(int device_id);
+    void logReaderDebugPrint(const std::string& message);
 
     cISLogger logger_;
     DeviceLog* dev_log_ = nullptr;

--- a/python/inertialsense/logs/src/log_reader.cpp
+++ b/python/inertialsense/logs/src/log_reader.cpp
@@ -2,12 +2,16 @@
 
 #include "convert_ins.h"
 
+#include <array>
+#include <cstdlib>
+
 #define STRINGIZE(x)                #x
 #define STRINGIZE_VALUE_OF(x)       STRINGIZE(x)
 #define MESSAGE_VALUE(x)            message(__FILE__ "(" STRINGIZE_VALUE_OF(__LINE__) "): " #x " = " STRINGIZE_VALUE_OF(x))
 #define CONCAT_MESSAGE(text, value) message(__FILE__ "(" STRINGIZE_VALUE_OF(__LINE__) "): " text " = " STRINGIZE_VALUE_OF(value))
 
 using namespace std;
+
 
 LogReader::LogReader()
     : python_parent_(py::object())
@@ -91,6 +95,7 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
     oss << " - SDK Protocol: " << PROTOCOL_VERSION_CHAR0 << "." << PROTOCOL_VERSION_CHAR1 << "." << PROTOCOL_VERSION_CHAR2 << "." << PROTOCOL_VERSION_CHAR3 << "\n";
 
     std::vector<std::string> stl_serials = serials.cast<std::vector<std::string>>();
+    logReaderDebugPrint("init() log_directory=" + log_directory + ", requested_serial_count=" + std::to_string(stl_serials.size()));
     oss << " - Loading from: " << log_directory << "\n";
 
     oss << " - Serials: ";
@@ -103,11 +108,14 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
     if (logger_.LoadFromDirectory(log_directory, cISLogger::LOGTYPE_DAT, stl_serials)) {
         oss << " - Found *.dat log with ";
         loaded = true;
+        logReaderDebugPrint("LoadFromDirectory DAT succeeded");
     } else if (logger_.LoadFromDirectory(log_directory, cISLogger::LOGTYPE_RAW, stl_serials)) {
         oss << " - Found *.raw log with ";
         loaded = true;
+        logReaderDebugPrint("LoadFromDirectory RAW succeeded");
     } else {
         oss << " - Unable to load files\n";
+        logReaderDebugPrint("LoadFromDirectory failed for DAT and RAW");
         std::cout << oss.str();
         return false;
     }
@@ -118,6 +126,7 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
     for (auto dev : logger_.DeviceLogs()) {
         oss << (serialNumbers.empty() ? " " : ", ") << dev->SerialNumber();
         serialNumbers.push_back(dev->SerialNumber());
+        logReaderDebugPrint("Discovered device serial=" + std::to_string(dev->SerialNumber()));
     }
     oss << "\n";
 
@@ -130,12 +139,25 @@ bool LogReader::init(py::object python_class, std::string log_directory, py::lis
 
 void LogReader::organizeData(shared_ptr<cDeviceLog> devLog) {
     p_data_buf_t* data = NULL;
+    std::array<uint32_t, DID_COUNT> didCounts{};
+    uint64_t totalMessages = 0;
+    uint64_t zeroSizeMessages = 0;
+    uint64_t unknownDidMessages = 0;
+
+    logReaderDebugPrint("organizeData() begin serial=" + std::to_string(devLog->SerialNumber()));
 
     while ((data = logger_.ReadData(devLog))) {
         // if (data->hdr.id == DID_DEV_INFO)
         //     volatile int debug = 0;
 
-        if (data->hdr.size == 0) continue;
+        totalMessages++;
+        if (data->hdr.id < DID_COUNT) {
+            didCounts[data->hdr.id]++;
+        }
+        if (data->hdr.size == 0) {
+            zeroSizeMessages++;
+            continue;
+        }
 
         switch (data->hdr.id) {
             case DID_IMUS_RAW:
@@ -245,10 +267,32 @@ void LogReader::organizeData(shared_ptr<cDeviceLog> devLog) {
             HANDLE_MSG(DID_GPX_BIT, dev_log_->gpxBit);
             HANDLE_MSG(DID_GPX_PORT_MONITOR, dev_log_->gpxPortMonitor);
             default:
+                unknownDidMessages++;
                 //            printf("Unhandled IS message DID: %d\n", message_type);
                 break;
         }
     }
+
+#if LOG_READER_DEBUG_ENABLED
+        std::ostringstream summary;
+        summary << "organizeData() end serial=" << devLog->SerialNumber()
+                << " total=" << totalMessages
+                << " zero_size=" << zeroSizeMessages
+                << " unknown_did=" << unknownDidMessages
+                << " DID_SCOMP=" << didCounts[DID_SCOMP]
+                << " DID_SENSORS_TCAL=" << didCounts[DID_SENSORS_TCAL]
+                << " DID_SENSORS_UCAL=" << didCounts[DID_SENSORS_UCAL]
+                << " DID_SENSORS_MCAL=" << didCounts[DID_SENSORS_MCAL];
+        logReaderDebugPrint(summary.str());
+
+        std::ostringstream vectorSummary;
+        vectorSummary << "organized vectors serial=" << devLog->SerialNumber()
+                      << " scomp=" << dev_log_->scomp.size()
+                      << " sensorsTcal=" << dev_log_->sensorsTcal.size()
+                      << " sensorsUcal=" << dev_log_->sensorsUcal.size()
+                      << " sensorsMcal=" << dev_log_->sensorsMcal.size();
+        logReaderDebugPrint(vectorSummary.str());
+#endif
 }
 
 void LogReader::forwardData(int device_id) {
@@ -347,13 +391,23 @@ bool LogReader::load() {
     // printf("LogReader::load() \n");
 
     std::vector<std::shared_ptr<cDeviceLog>> devices = logger_.DeviceLogs();
+    logReaderDebugPrint("load() device_count=" + std::to_string(devices.size()));
     for (int i = 0; i < (int)devices.size(); i++) {
         if (dev_log_ != nullptr) {
             delete dev_log_;
         }
         dev_log_ = new DeviceLog();
 
+        logReaderDebugPrint("load() processing device_index=" + std::to_string(i) + ", serial=" + std::to_string(devices[i]->SerialNumber()));
         organizeData(devices[i]);
+#if LOG_READER_DEBUG_ENABLED
+        std::ostringstream msg;
+        msg << "load() forwarding device_index=" << i
+            << " serial=" << devices[i]->SerialNumber()
+            << " scomp=" << dev_log_->scomp.size()
+            << " sensorsTcal=" << dev_log_->sensorsTcal.size();
+        logReaderDebugPrint(msg.str());
+#endif
         forwardData(i);
     }
 
@@ -396,6 +450,12 @@ void LogReader::cleanup() {
     // Clear the global python parent object to avoid GIL issues during shutdown
     // This prevents the pybind11 object from trying to call Python methods during finalization
     python_parent_ = py::object();
+}
+
+void LogReader::logReaderDebugPrint(const std::string& message) {
+#if LOG_READER_DEBUG_ENABLED
+    std::cout << "[log_reader_debug] " << message << "\n";
+#endif
 }
 
 // Look at the pybind documentation to understand what is going on here.

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -386,7 +386,6 @@ static inline void validPacketFound(is_comm_instance_t* c, int pktSize, int data
     validPacketReset(c, pktSize);
 }
 
-__attribute__((optimize("O0")))
 static protocol_type_t processIsbPkt(void* v)
 {
     is_comm_instance_t* c = (is_comm_instance_t*)v;
@@ -443,11 +442,6 @@ static protocol_type_t processIsbPkt(void* v)
 
     // Validate checksum
     packet_buf_t *isbPkt = (packet_buf_t*)(c->rxBuf.head);
-    if (isbPkt->hdr.id == DID_CAL_TEMP_COMP)
-    {
-        static int j = 0;
-        j++;
-    }
     if (isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB)
         return parseErrorResetState(c, EPARSE_INVALID_SIZE);
     if ((isbPkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET) &&

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -386,6 +386,7 @@ static inline void validPacketFound(is_comm_instance_t* c, int pktSize, int data
     validPacketReset(c, pktSize);
 }
 
+__attribute__((optimize("O0")))
 static protocol_type_t processIsbPkt(void* v)
 {
     is_comm_instance_t* c = (is_comm_instance_t*)v;
@@ -442,6 +443,11 @@ static protocol_type_t processIsbPkt(void* v)
 
     // Validate checksum
     packet_buf_t *isbPkt = (packet_buf_t*)(c->rxBuf.head);
+    if (isbPkt->hdr.id == DID_CAL_TEMP_COMP)
+    {
+        static int j = 0;
+        j++;
+    }
     if (isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB)
         return parseErrorResetState(c, EPARSE_INVALID_SIZE);
     if ((isbPkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET) &&
@@ -500,7 +506,10 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE)
+        if (pkt->data.size <= MAX_DATASET_SIZE || 
+            pkt->hdr.id == DID_CAL_SC || 
+            pkt->hdr.id == DID_CAL_TEMP_COMP ||
+            pkt->hdr.id == DID_CAL_MOTION)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -519,7 +528,10 @@ static protocol_type_t processIsbPkt(void* v)
         {
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
-            if (get->size <= MAX_DATASET_SIZE)
+            if (get->size <= MAX_DATASET_SIZE ||
+                get->id == DID_CAL_SC || 
+                get->id == DID_CAL_TEMP_COMP ||
+                get->id == DID_CAL_MOTION)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISUtilities.h"
 #include "ISConstants.h"
 #include "ISDevice.h"
+#include "IS_calibration.h"
 #include "data_sets.h"
 #include "util/util.h"
 
@@ -1594,6 +1595,153 @@ static void PopulateMapSensors(data_set_t data_set[DID_COUNT], uint32_t did)
     }
 }
 
+static void PopulateMapSensorTCalGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_tcal_group_t> mapper(data_set, did);
+
+    // Gyros
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddMember2("gyr" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_t, gyr[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("gyr" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, gyr[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("gyr" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, gyr[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
+    }
+
+    // Accels
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddMember2("acc" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_t, acc[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("acc" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, acc[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("acc" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, acc[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
+    }
+
+    // Magnetometers
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    {
+        mapper.AddMember2("mag" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_t, mag[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("mag" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, mag[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("mag" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_t, mag[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
+    }
+}
+
+static void PopulateMapSensorTCalSubsetGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_tcal_group_subset_t> mapper(data_set, did);
+
+    // Can be Gyros, Accel, or Magnetometer 
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
+    }
+}
+
+static void PopulateMapSensorMCalGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_group_t> mapper(data_set, did);
+
+    // Gyros
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("pqr" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("pqr" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
+    }
+
+    // Accels
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("acc" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("acc" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
+    }
+
+    // Magnetometers
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    {
+        mapper.AddArray2("mag" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("mag" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});
+    }
+}
+
+static void PopulateMapSensorCompensation(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_compensation_t> mapper(data_set, did);
+    int flags = DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4;
+    std::string str = 
+        std::to_string(SC_RUNTIME) + "=Runtime, Tcal[" +
+        std::to_string(SC_TCAL_INIT) + "=Init, " +
+        std::to_string(SC_TCAL_RUNNING) + "=Running, " +
+        std::to_string(SC_TCAL_STOP) + "=Stop, " +
+        std::to_string(SC_TCAL_DONE) + "=Done], MCAL[" +
+        std::to_string(SC_MCAL_SAMPLE_INIT) + "=Init, " +
+        std::to_string(SC_MCAL_SAMPLE_MEAN_UCAL) + "=UCAL, " +
+        std::to_string(SC_MCAL_SAMPLE_MEAN_TCAL) + "=TCAL, " +
+        std::to_string(SC_MCAL_SAMPLE_MEAN_MCAL) + "=MCAL, " +
+        std::to_string(SC_LPF_SAMPLE) + "=LPF 0.01Hz, " +
+        std::to_string(SC_LPF_SAMPLE_FAST) + "=LPF 1Hz ";
+
+    mapper.AddMember("timeMs", &sensor_compensation_t::timeMs, DATA_TYPE_UINT32, "ms", "Time since boot up", DATA_FLAGS_READ_ONLY);
+    mapper.AddMember("calState", &sensor_compensation_t::calState, DATA_TYPE_UINT32, "", str);
+    mapper.AddMember("status", &sensor_compensation_t::status, DATA_TYPE_UINT32, "", "", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("sampleCount", &sensor_compensation_t::sampleCount, DATA_TYPE_UINT32, "", "Used in averaging");
+    mapper.AddArray("alignAccel", &sensor_compensation_t::alignAccel, DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Alignment acceleration"}, flags);
+    // Gyros
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("pqr" + std::to_string(i) + ".lpfLsb",         i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].lpfLsb), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Low-pass filtered LSB"}, flags, C_RAD2DEG);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".lpfTemp",        i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].lpfTemp), DATA_TYPE_F32, SYM_DEG_C, "Low-pass filtered temperature", flags);
+        mapper.AddArray2("pqr" + std::to_string(i) + ".k",              i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].k), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Slope"}, flags, C_RAD2DEG);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".temp",           i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].temp), DATA_TYPE_F32, SYM_DEG_C, "Temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".tempRampRate",   i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].tempRampRate), DATA_TYPE_F32, SYM_DEG_C_PER_S, "Temperature ramp rate", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".tci",            i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].tci), DATA_TYPE_UINT32, "", "Temp comp index", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".numTcPts",       i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].numTcPts), DATA_TYPE_UINT32, "", "Number of temp comp points", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("pqr" + std::to_string(i) + ".dtTemp",         i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, pqr[0].dtTemp), DATA_TYPE_F32, SYM_DEG_C, "Delta from last tc point to current temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    }
+    // Accels
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("acc" + std::to_string(i) + ".lpfLsb",         i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].lpfLsb), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Low-pass filtered LSB"}, flags);
+        mapper.AddMember2("acc" + std::to_string(i) + ".lpfTemp",        i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].lpfTemp), DATA_TYPE_F32, SYM_DEG_C, "Low-pass filtered temperature", flags);
+        mapper.AddArray2("acc" + std::to_string(i) + ".k",              i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].k), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Slope"}, flags);
+        mapper.AddMember2("acc" + std::to_string(i) + ".temp",           i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].temp), DATA_TYPE_F32, SYM_DEG_C, "Temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddMember2("acc" + std::to_string(i) + ".tempRampRate",   i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].tempRampRate), DATA_TYPE_F32, SYM_M_PER_S_2, "Temperature ramp rate", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+        mapper.AddMember2("acc" + std::to_string(i) + ".tci",            i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].tci), DATA_TYPE_UINT32, "", "Temp comp index", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("acc" + std::to_string(i) + ".numTcPts",       i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].numTcPts), DATA_TYPE_UINT32, "", "Number of temp comp points", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("acc" + std::to_string(i) + ".dtTemp",         i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, acc[0].dtTemp), DATA_TYPE_F32, SYM_DEG_C, "Delta from last tc point to current temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    }
+
+    // Magnetometers
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    {
+        mapper.AddArray2("mag" + std::to_string(i) + ".lpfLsb",        i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].lpfLsb), DATA_TYPE_F32, 3, {""}, {"Low-pass filtered LSB"}, flags);
+        mapper.AddMember2("mag" + std::to_string(i) + ".lpfTemp",       i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].lpfTemp), DATA_TYPE_F32, SYM_DEG_C, "Low-pass filtered temperature", flags);
+        mapper.AddArray2("mag" + std::to_string(i) + ".k",             i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].k), DATA_TYPE_F32, 3, {""}, {"Slope"}, flags);
+        mapper.AddMember2("mag" + std::to_string(i) + ".temp",          i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].temp), DATA_TYPE_F32, SYM_DEG_C, "Temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
+        mapper.AddMember2("mag" + std::to_string(i) + ".tempRampRate",  i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].tempRampRate), DATA_TYPE_F32, "", "Temperature ramp rate", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+        mapper.AddMember2("mag" + std::to_string(i) + ".tci",           i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].tci), DATA_TYPE_UINT32, "", "Temp comp index", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("mag" + std::to_string(i) + ".numTcPts",      i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].numTcPts), DATA_TYPE_UINT32, "", "Number of temp comp points", DATA_FLAGS_READ_ONLY);
+        mapper.AddMember2("mag" + std::to_string(i) + ".dtTemp",        i*sizeof(sensor_comp_unit_t) + offsetof(sensor_compensation_t, mag[0].dtTemp), DATA_TYPE_F32, SYM_DEG_C, "Delta from last tc point to current temperature", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+    }
+
+    // Reference IMU
+    mapper.AddArray2("referenceImu.pqr", offsetof(sensor_compensation_t, referenceImu.pqr), DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Reference IMU angular rate"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3, C_RAD2DEG);
+    mapper.AddArray2("referenceImu.acc", offsetof(sensor_compensation_t, referenceImu.acc), DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Reference IMU linear acceleration"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
+    // Reference Mag
+    mapper.AddArray("referenceMag", &sensor_compensation_t::referenceMag, DATA_TYPE_F32, 3, {""}, {"Reference magnetometer"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
+}
+
 static void PopulateMapInl2MagObsInfo(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<inl2_mag_obs_info_t> mapper(data_set, did);
@@ -1921,6 +2069,10 @@ cISDataMappings::cISDataMappings()
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_TCAL);
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_MCAL);
     PopulateMapSensors(             m_data_set, DID_SENSORS_TC_BIAS);
+    // PopulateMapSensorTCalGroup(m_data_set, DID_CAL_TEMP_COMP);
+    PopulateMapSensorTCalSubsetGroup(m_data_set, DID_CAL_TEMP_COMP);
+    PopulateMapSensorMCalGroup(      m_data_set, DID_CAL_MOTION);
+    PopulateMapSensorCompensation(   m_data_set, DID_SCOMP);
 
     // This must come last
     for (uint32_t did = 0; did < DID_COUNT; did++)

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -19,6 +19,50 @@ extern "C" {
 #define SENSOR_CAL_VER1     3
 #define SENSOR_CAL_VER2     0
 
+
+enum eScompCalState
+{
+    SC_RUNTIME                      = 0,   // Calibration off
+    SC_TCAL_MONITOR_TEMP            = 1,
+    SC_TCAL_INIT                    = 2,
+    SC_TCAL_STARTUP_MEAN_LSB        = 3,
+    SC_TCAL_STARTUP_DELAY           = 4,
+    SC_TCAL_READY_TO_RUN            = 5,
+    SC_TCAL_RUNNING                 = 6,
+    SC_TCAL_STOP                    = 7,
+    SC_TCAL_DONE                    = 8,
+    SC_ACCEL_ALIGN_CHECK            = 9,
+    SC_MCAL_SAMPLE_INIT             = 10,
+    SC_MCAL_SAMPLE_MEAN_UCAL        = 11,    // Uncalibrated sensor
+    SC_MCAL_SAMPLE_MEAN_TCAL        = 12,    // Temperature compensated sensor 
+    SC_MCAL_SAMPLE_MEAN_MCAL        = 13,    // Motion calibrated + compensated sensor 
+    SC_MCAL_SAMPLE_STOP             = 14,
+    SC_LPF_SAMPLE                   = 15,
+    SC_LPF_SAMPLE_FAST              = 16,
+    SC_DONE                         = 17,
+    SC_LINEARITY_MEAN_TCAL          = 18,    // Like SC_MCAL_SAMPLE_MEAN_TCAL, but goes back to SC_RUNTIME after some samples
+};
+
+enum eScompStatus
+{
+    SC_STATUS_ALIGNMENT_MASK        = 0x0000000F,
+    SC_STATUS_ALIGNMENT_OFF         = 0x00000000,
+    SC_STATUS_ALIGNMENT_GOOD        = 0x00000001,
+    SC_STATUS_ALIGNMENT_BAD         = 0x00000002,
+    SC_STATUS_SAMPLE_VALID_MASK     = 0x00000F00,
+    SC_STATUS_SAMPLE_VALID_GYR      = 0x00000100,
+    SC_STATUS_SAMPLE_VALID_ACC      = 0x00000200,
+    SC_STATUS_SAMPLE_VALID_MAG      = 0x00000400,
+    SC_STATUS_REFERENCE_IMU_VALID   = 0x00010000,
+    SC_STATUS_REFERENCE_MAG_VALID   = 0x00020000,
+    SC_STATUS_USING_INFERRED_IMU    = 0x00040000,
+    SC_STATUS_USING_INFERRED_MAG    = 0x00080000,
+    SC_STATUS_TEMPERATURE_CAL_VALID = 0x00100000,
+    SC_STATUS_MOTION_CAL_VALID_MASK = 0x00600000,
+    SC_STATUS_MOTION_CAL_VALID_OFFSET = 21,
+    SC_STATUS_MOTION_CAL_VALID_IMU  = 0x00200000,
+    SC_STATUS_MOTION_CAL_VALID_MAG  = 0x00400000,
+};
 typedef struct PACKED
 {
     uint32_t                size;                               // Size of this struct
@@ -142,6 +186,8 @@ typedef struct PACKED
 } sensor_cal_v1p3_t;
 
 typedef sensor_cal_v1p3_t   sensor_cal_t;               // Current version
+
+
 
 #ifdef __cplusplus
 }

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -353,6 +353,8 @@ enum eHdwStatusFlags
     HDW_STATUS_SATURATION_BARO                  = (int)0x00000800,
 
     /** Sensor saturation mask */
+    HDW_STATUS_IMU_SATURATION_MASK              = (int)(HDW_STATUS_SATURATION_GYR | HDW_STATUS_SATURATION_ACC),
+    /** Sensor saturation mask */
     HDW_STATUS_SATURATION_MASK                  = (int)0x00000F00,
     /** Sensor saturation offset */
     HDW_STATUS_SATURATION_OFFSET                = 8,


### PR DESCRIPTION
This pull request updates plotting functions in `logPlotter.py` to generalize sensor handling for systems with more than three IMUs or sensors, and adds a new IMU saturation mask constant in `data_sets.h`. The changes improve flexibility for multi-IMU systems and provide clearer code structure for plotting and status flag handling.

**Generalization and flexibility for multi-IMU systems:**

* Updated `sensorCompGen`, `linearityAcc`, and `linearityGyr` methods in `logPlotter.py` to dynamically determine the number of sensors/IMUs, supporting up to five devices instead of being hardcoded for three. This includes changes to subplot creation, axis labeling, and data plotting loops. [[1]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4485-R4531) [[2]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4603-R4631) [[3]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4666-R4675)
* Changed variable names and loop indices throughout the plotting code to better reflect their purpose and to support the new generalized logic. [[1]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4485-R4531) [[2]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4603-R4631) [[3]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL4666-R4675)
* Ensured that device serial labeling and axis assignment are consistent with the increased number of sensors/IMUs.

**Status flag enhancements:**

* Added a new `HDW_STATUS_IMU_SATURATION_MASK` constant to the `eHdwStatusFlags` enum in `data_sets.h`, representing a bitmask for IMU (gyro and accelerometer) saturation flags.