### PR TITLE
SN-7622 - Refactor: Encapsulate firmware update state in ISFwUpdateState

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1136,7 +1136,7 @@ static int cltool_dataStreaming()
     //If Firmware Update is specified return an error code based on the Status of the Firmware Update
     if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && g_commandLineOptions.updateAppFirmwareFilename.empty()) {
         for (auto device : inertialSenseInterface.getDevices()) {
-            if (device->fwHasError) {
+            if (device->fwUpdateState.hasErrors) {
                 exitCode = EXIT_CODE_FIRMWARE_UPDATE_FAILED;
                 break;
             }

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -132,15 +132,10 @@ is_operation_result ISDevice::updateFirmware(fwUpdate::target_t targetDevice, st
     if (!lock.owns_lock())
         return IS_OP_ERROR;
 
-    fwHasError = false;
-    fwErrors.clear();
-    fwLastMessage.clear();
-    fwLastTarget = fwUpdate::TARGET_HOST;
-    fwLastStatus = fwUpdate::NOT_STARTED;
-    fwLastSlot = 0;
+    fwUpdateState.resetState();
 
     if (!fwUpdater) {
-        fwUpdater = new ISFirmwareUpdater(shared_from_this());
+        fwUpdater = new ISFirmwareUpdater(shared_from_this(), fwUpdateState);
     }
 
     fwUpdater->setInfoProgressCb(infoProgress);
@@ -160,6 +155,20 @@ bool ISDevice::fwUpdateInProgress() { return (fwUpdater && !fwUpdater->fwUpdate_
  */
 float ISDevice::fwUpdatePercentCompleted() {
     return (fwUpdater && !fwUpdater->fwUpdate_isDone()) ? fwUpdater->getProgress() : 0.0f;
+}
+
+/**
+ * Returns a set of messages generated during a firmware update
+ * @param level the IS_LOG_LEVEL_* of messages to return from the update (defaults to IS_LOG_LEVEL_ERROR)
+ * @return
+ */
+std::vector<ISFwUpdateState::message> ISDevice::fwUpdateMessages(eLogLevel level) {
+    std::vector<ISFwUpdateState::message> out;
+    for (auto msg : fwUpdateState.messages) {
+        if (msg.severity < level)
+            out.push_back(msg);
+    }
+    return out;
 }
 
 /**
@@ -186,68 +195,11 @@ bool ISDevice::fwUpdate(p_data_t* msg) {
 
         fwUpdater->step();
 
-        auto activeCmd = fwUpdater->getActiveCommand();
-        if (&activeCmd != &nullCmd)
-            fwLastMessage = activeCmd.resultMsg;
-
-        if (activeCmd.cmd == "upload") {
-            if (fwUpdater->getActiveTarget() != fwLastTarget) {
-                fwHasError = false;
-                fwLastStatus = fwUpdate::NOT_STARTED;
-                fwLastMessage.clear();
-                fwLastTarget = fwUpdater->getActiveTarget();
-            }
-            fwLastSlot = fwUpdater->getActiveSlot();
-            auto curStatus = fwUpdater->getUploadStatus();
-
-            if ((fwUpdater->getUploadStatus() == fwUpdate::NOT_STARTED) && (activeCmd.status == ISFwUpdaterCmd::CMD_QUEUED)) {
-                // We're just starting (no error yet, but no response either)
-                fwLastStatus = fwUpdate::INITIALIZING;
-                fwLastMessage = fwUpdater->getUploadStatusName();
-            } else if ((curStatus != fwUpdate::NOT_STARTED) && (curStatus != fwLastStatus)) {
-                // We're got a valid status update (error or otherwise)
-                fwLastStatus = curStatus;
-                fwLastMessage = fwUpdater->getUploadStatusName();
-
-                // check for error
-                if (!fwHasError && fwUpdater && ((curStatus < fwUpdate::NOT_STARTED) || fwUpdater->hasErrors())) {
-                    fwHasError = true;
-                }
-            }
-        } else if (activeCmd.cmd == "waitfor") {
-            fwLastMessage = "Waiting for response from device.";
-        } else if (activeCmd.cmd == "reset") {
-            fwLastMessage = "Resetting device.";
-        } else if (activeCmd.cmd == "delay") {
-            fwLastMessage = "Waiting...";
-        }
-
-        if (!fwUpdater->hasPendingCommands()) {
-            if (fwUpdater->hasErrors()) {
-                fwHasError = fwUpdater->hasErrors();
-                fwLastMessage = "Error: ";
-                fwLastMessage += "One or more step errors occurred.";
-            } else if (fwHasError) {
-                fwLastMessage = "Error: ";
-                fwLastMessage += fwUpdater->getUploadStatusName();
-            } else {
-                fwLastMessage = "Completed successfully.";
-            }
-        }
-
         // cleanup if we're done.
-        bool is_done = fwUpdater->fwUpdate_isDone();
-        if (is_done) {
+        if (fwUpdater->fwUpdate_isDone()) {
             // collect errors before we close out the updater
-            fwErrors = fwUpdater->getStepErrors();
-            fwHasError |= !fwErrors.empty();
-            fwLastMessage = "";
-            fwLastProgress = 1.0f;
-
             delete fwUpdater;
             fwUpdater = nullptr;
-        } else {
-            fwLastProgress = fwUpdatePercentCompleted();
         }
     }
 

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -569,7 +569,7 @@ public:
     * Gets current update status for selected device index
     * @param deviceIndex
     */
-    fwUpdate::update_status_e getUpdateStatus() { return fwLastStatus; };
+    fwUpdate::update_status_e getUpdateStatus() { return fwUpdateState.status; };
 
     std::recursive_mutex        portMutex;                           //!< used to guard against concurrent use of the port in multi-threaded environments - only one read/write at a time
     port_handle_t               port = 0;                            //!< the current port (if any) through which we communicate with the physical device
@@ -603,14 +603,8 @@ public:
 
     // TODO: make these private or protected
     std::mutex                  fwUpdateMutex;                       //!< used to guard against re-entrant calls into fwUpdate functions
-    ISFirmwareUpdater*          fwUpdater = NULLPTR;
-    bool                        fwHasError = false;
-    std::vector<ISFirmwareUpdater::update_msgs> fwErrors;
-    uint16_t                    fwLastSlot = 0;
-    fwUpdate::target_t          fwLastTarget = fwUpdate::TARGET_UNKNOWN;
-    fwUpdate::update_status_e   fwLastStatus = fwUpdate::NOT_STARTED;
-    std::string                 fwLastMessage;
-    float                       fwLastProgress = 0.f;
+    ISFirmwareUpdater*          fwUpdater = NULLPTR;                 //!< a pointer to the active updater
+    ISFwUpdateState             fwUpdateState;                       //!< stores the state of the fwUpdater (current or previous)
 
     uint32_t                    lastResetRequest = 0;                //!< system time when the last reset requests was sent
     uint32_t                    resetRequestThreshold = 5000;        //!< Don't allow to send reset requests more frequently than this...
@@ -619,6 +613,7 @@ public:
     is_operation_result updateFirmware(fwUpdate::target_t targetDevice, std::vector<std::string> cmds, fwUpdate::pfnStatusCb infoProgress, void (*waitAction)());
     bool fwUpdateInProgress();
     float fwUpdatePercentCompleted();
+    std::vector<ISFwUpdateState::message> fwUpdateMessages(eLogLevel level = IS_LOG_LEVEL_ERROR);
     bool fwUpdate(p_data_t* msg = nullptr);
 
     bool operator==(const ISDevice& a) const { return (a.devInfo.serialNumber == devInfo.serialNumber) && (a.devInfo.hardwareType == devInfo.hardwareType); };

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -13,10 +13,11 @@
 } while (0); }                                                                                              \
 
 
-ISFirmwareUpdater::ISFirmwareUpdater(device_handle_t device) : FirmwareUpdateHost(), device(device) {
+ISFirmwareUpdater::ISFirmwareUpdater(device_handle_t device, ISFwUpdateState& state) : FirmwareUpdateHost(), device(device), updateState(state) {
     if (device) {
         port = device->port;
         devInfo = &device->devInfo;
+        uint16_t targetHdwId = ENCODE_DEV_INFO_TO_HDW_ID(device->devInfo);
 
         // At some point during the upgrade, we'll likely reset the device and we need to watch for the device to come back. But the EvalTool normally doesn't discovery
         // new devices (only new ports). So, let's use the PortManagers::port_listener mechanism to detect when new ports are discover, only during the Firmware Update
@@ -29,7 +30,7 @@ ISFirmwareUpdater::ISFirmwareUpdater(device_handle_t device) : FirmwareUpdateHos
         portListenerHdl = PortManager::getInstance().addPortListener(
                 [&](PortManager::port_event_e event, uint16_t portType, std::string portName, port_handle_t port, PortFactory& portFactory) {
                     if (event == PortManager::PORT_ADDED) {
-                        if ( DeviceManager::getInstance().discoverDevice(port, IS_HARDWARE_ANY, 500, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE | DeviceManager::DISCOVERY__FORCE_REVALIDATION) ) {
+                        if ( DeviceManager::getInstance().discoverDevice(port, targetHdwId, 500, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE | DeviceManager::DISCOVERY__FORCE_REVALIDATION) ) {
                             log_info(IS_LOG_FWUPDATE, "Discovered device [%s] while performing Firmware Updates.", DeviceManager::getInstance().getDevice(port)->getDescription().c_str())
                         } else {
                             log_info(IS_LOG_FWUPDATE, "Discovered new port [%s] while performing Firmware Updates, but couldn't associate an ISDevice.", portName.c_str())
@@ -89,7 +90,7 @@ bool ISFirmwareUpdater::setCommands(std::vector<std::string> cmds) {
 
         commands.emplace_back("", cmdName, cmdArgs);
     }
-    updateState = UPDATER_CMDS_QUEUED;
+    updateState.state = ISFwUpdateState::UPDATER_CMDS_QUEUED;
     return true;
 }
 
@@ -183,17 +184,42 @@ fwUpdate::update_status_e ISFirmwareUpdater::initializeUpload(fwUpdate::target_t
  *   update will immediately stop all operations, which could leave devices in an inoperable or unrecoverable state.
  * @return the current operating status of the update
  */
-
 fwUpdate::update_status_e ISFirmwareUpdater::cancel(bool immediately) {
     if (fwUpdate_getSessionStatus()) {
-        updateState = UPDATER_WAITING_TO_CANCEL;
+        updateState.state = ISFwUpdateState::UPDATER_WAITING_TO_CANCEL;
+    }
+
+    // Since updates can be critical in nature, making hardware inoperable if managed incorrectly, we need to make sure
+    // its safe to cancel.  All steps which have NOT already been executed are deemed safe to cancel (though, we may
+    // need to revisit this in the future.
+
+    // For now, first, we'll cancel all pending commands
+    if (hasPendingCommands()) {
+        for (auto& cmd : commands) {
+            if (cmd.status == ISFwUpdaterCmd::CMD_QUEUED)
+                cmd.status = ISFwUpdaterCmd::CMD_CANCELLED;
+        }
+    }
+
+    // Second, if the current command is cancelable, then mark it as canceled, otherwise, keep its state and let it finish
+    if (activeCmd && (activeCmd->flags & ISFwUpdaterCmd::CMD_FLAGS__CANCELABLE))
+        activeCmd->status = ISFwUpdaterCmd::CMD_CANCELLED;
+
+    // finally, if the user has requested an IMMEDIATE cancel, then we take the nuclear option
+    // WARNING - THIS interrupts all tasks IMMEDIATELY in whatever state they were in. There is no
+    // attempt to allow actions/commands to "save face" and the device maybe left in an inoperable
+    // (and possibly IRRECOVERABLE) state!
+    if (immediately) {
+        commands.clear();
+        activeCmd = &nullCmd;
+        target = fwUpdate::TARGET_HOST;
     }
 
     return fwUpdate_getSessionStatus();
 }
 
 bool ISFirmwareUpdater::isCancelable() {
-    return true;
+    return (activeCmd && (activeCmd->flags & ISFwUpdaterCmd::CMD_FLAGS__CANCELABLE));
 }
 
 bool ISFirmwareUpdater::fwUpdate_handleVersionResponse(const fwUpdate::payload_t& msg) {
@@ -366,6 +392,71 @@ void ISFirmwareUpdater::fwUpdate_handleLocalDevice() {
     delete [] toHostBuf;
 }
 
+void ISFirmwareUpdater::refreshUpdateState() {
+    auto activeCmd = getActiveCommand();
+    if (&activeCmd != &nullCmd)
+        updateState.lastMessage = activeCmd.resultMsg;
+
+    // let's always recheck our error state for any commands (past, present, or future) which have failed
+    updateState.hasErrors = false;
+    for (auto& c :commands) {
+        if (c.status == ISFwUpdaterCmd::CMD_ERROR)
+            updateState.hasErrors = true;
+    }
+
+    if (activeCmd.cmd == "upload") {
+        updateState.status = fwUpdate_getSessionStatus();
+        updateState.slot = fwUpdate_getSessionImageSlot();
+        // TODO?? updateState.state should keep the state of the entire update, not just the last upload... right??
+
+        if (fwUpdate_getSessionTarget() != updateState.target) {
+            updateState.target = fwUpdate_getSessionTarget();
+            updateState.status = fwUpdate::NOT_STARTED;
+            updateState.messages.clear();
+        }
+
+        if ((getUploadStatus() == fwUpdate::NOT_STARTED) && (activeCmd.status == ISFwUpdaterCmd::CMD_QUEUED)) {
+            updateState.status = fwUpdate::INITIALIZING;    // We're just starting (no error yet, but no response either)
+        }
+        updateState.lastMessage = fwUpdate_getNiceStatusName(updateState.status);
+    } else if (activeCmd.cmd == "waitfor") {
+        updateState.lastMessage = "Waiting for response from device.";
+    } else if (activeCmd.cmd == "reset") {
+        updateState.lastMessage = "Resetting device.";
+    } else if (activeCmd.cmd == "delay") {
+        updateState.lastMessage = "Waiting...";
+    }
+    switch (updateState.state) {
+        case ISFwUpdateState::UPDATER_CANCELED:
+            updateState.lastMessage = "Cancelled by User.";
+            break;
+        case ISFwUpdateState::UPDATER_DONE_WITH_ERRORS:
+            updateState.lastMessage = "Error: One or more step errors occurred.";
+            break;
+        case ISFwUpdateState::UPDATER_WAITING_TO_CANCEL:
+            updateState.lastMessage = "Cancelling (waiting for non-cancelable step to complete).";
+            break;
+        case ISFwUpdateState::UPDATER_IDLE:
+            break;
+        case ISFwUpdateState::UPDATER_CMDS_QUEUED:
+            updateState.lastMessage = "Starting update...";
+            break;
+        case ISFwUpdateState::UPDATER_IN_PROGRESS:
+            updateState.lastMessage = "Updating...";
+            if (updateState.hasErrors) {
+                updateState.lastMessage = "Error: ";
+                updateState.lastMessage += getUploadStatusName();
+            }
+            break;
+        case ISFwUpdateState::UPDATER_SUCCESSFUL:
+        case ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS:
+            updateState.lastMessage = "Completed successfully.";
+            break;
+    }
+
+    updateState.progress = (!fwUpdate_isDone() ? getProgress() : 0.0f);
+}
+
 bool ISFirmwareUpdater::step() {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     FnProfiler fnStep("ISFirmwareUpdater::step() [" + ( device ? device->getIdAsString() : "") + "]", 30000);   // this can typically take around 25ms in Windows
@@ -417,7 +508,7 @@ bool ISFirmwareUpdater::step() {
     fnStep.mark("Finished fwUpdate_step().");
 
     if (fwUpdate_isDone()) {
-        updateState = hasErrors() ? UPDATER_DONE_WITH_ERRORS : UPDATER_SUCCESSFUL;
+        updateState.state = hasErrors() ? ISFwUpdateState::UPDATER_DONE_WITH_ERRORS : ISFwUpdateState::UPDATER_SUCCESSFUL;
 
         // be sure to release/cleanup the source file after we are finished with it.
         if (srcFile) {
@@ -426,6 +517,7 @@ bool ISFirmwareUpdater::step() {
         }
     }
 
+    refreshUpdateState();
     return result;
 }
 
@@ -528,7 +620,7 @@ void ISFirmwareUpdater::handleCommandError(ISFwUpdaterCmd& cmd, int errCode, con
     va_end(args);
 
     cmd.status = ISFwUpdaterCmd::CMD_ERROR;
-    stepErrors.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, buffer);
+    updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, buffer);
 
     LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_ERROR, buffer);
 
@@ -560,7 +652,7 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
             LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_MORE_DEBUG, "Executing manifest command '%s\\%s'", cmd.step.c_str(), cmd.cmd.c_str());
         }
     } else
-        updateState = UPDATER_IN_PROGRESS;
+        updateState.state = ISFwUpdateState::UPDATER_IN_PROGRESS;
 
     if (cmd.step != activeStep) {
         // new step section/target - we should reset certain states here if needed
@@ -979,7 +1071,7 @@ void ISFirmwareUpdater::initialize() {
     remoteDevInfo = {};
     logLevel = IS_LOG_LEVEL_INFO;                           //!< default log level to show
 
-    stepErrors.clear();
+    updateState.resetState();
 }
 
 /**

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -46,23 +46,30 @@ extern "C"
 class ISFwUpdaterCmd {
 public:
     enum cmd_status_e : int8_t {
+        CMD_CANCELLED = -3,                                 //!< command was canceled (by the user) before it could complete
         CMD_NOT_EXECUTED = -2,                              //!< command was queued, but ultimately never executed (was skipped due to jumps, etc)
         CMD_ERROR = -1,                                     //!< command failed to execute successfully
         CMD_QUEUED = 0,                                     //!< command is queued, and waiting to be executed
         CMD_IN_PROCESS = 1,                                 //!< command has start execution, but has not completed
         CMD_SUCCESS = 2,                                    //!< command had successfully completed
+        CMD_SUSPENDED = 3,                                  //!< command has been suspended (by the user) - must be moved back into IN_PROCESS to resume
+    };
+    enum cmd_flags_e : int16_t {
+        CMD_FLAGS__PAUSABLE = 1 << 0,                       //!< command can be paused/suspended
+        CMD_FLAGS__CANCELABLE = 1 << 1,                     //!< command can be canceled (by the user)
     };
 
-    std::string step;                                   //!< the step label that this command is executed under
-    std::string cmd;                                    //!< the name of the command
-    cmd_status_e status = CMD_QUEUED;                   //!< a code indicating the state of the command: PENDING, IN_PROCESS, SUCCESS, ERROR, etc.
-    std::map<std::string, std::string> args;            //!< a set of parameters (key-value pairs) to be used by the command
+    std::string step;                                           //!< the step label that this command is executed under
+    std::string cmd;                                        //!< the name of the command
+    cmd_status_e status = CMD_QUEUED;                       //!< a code indicating the state of the command: PENDING, IN_PROCESS, SUCCESS, ERROR, etc.
+    std::map<std::string, std::string> args;                //!< a set of parameters (key-value pairs) to be used by the command
+    cmd_flags_e flags;                                      //!< a bitmask of flags that apply to this command (which are common to all commands)
 
-    std::string resultMsg;                              //!< an optional message to be reported/displayed reflecting the active/last-known state of the command (ie, can still be used when the cmd is in progress).
-    std::vector<std::tuple<uint8_t, std::string>> msgs; //!< a list of messages that occurred doing the execution of this cmd
-    std::chrono::system_clock::time_point timeQueued;   //!< wall-clock time when this command was queued
-    std::chrono::system_clock::time_point timeStarted;  //!< wall-clock time when this command started execution
-    std::chrono::system_clock::time_point timeFinished; //!< wall-clock time when this command finished execution (error or success)
+    std::string resultMsg;                                  //!< an optional message to be reported/displayed reflecting the active/last-known state of the command (ie, can still be used when the cmd is in progress).
+    std::vector<std::tuple<uint8_t, std::string>> msgs;     //!< a list of messages that occurred doing the execution of this cmd
+    std::chrono::system_clock::time_point timeQueued;       //!< wall-clock time when this command was queued
+    std::chrono::system_clock::time_point timeStarted;      //!< wall-clock time when this command started execution
+    std::chrono::system_clock::time_point timeFinished;     //!< wall-clock time when this command finished execution (error or success)
 
     explicit ISFwUpdaterCmd() { }
 
@@ -124,22 +131,59 @@ public:
     inline std::string getArg(const std::string& k, const std::string& def = "") {
         return (hasArg(k) ? args[k] : def);
     }
-
 };
 
+class ISFwUpdateState {
+public:
+    enum updater_state_e : int8_t {
+        UPDATER_CANCELED = -3,                              //!< no longer running, user cancelled, and not all steps were completed.
+        UPDATER_DONE_WITH_ERRORS = -2,                      //!< no longer running, errors occurred during the update
+        UPDATER_WAITING_TO_CANCEL = -1,                     //!< user requested a cancel, but operations are still pending
+        UPDATER_IDLE = 0,                                   //!< the Updater is idle. Nothing started, nothing to do, etc.
+        UPDATER_CMDS_QUEUED = 1,                            //!< commands are queued, but no commands are in process
+        UPDATER_IN_PROGRESS = 2,                            //!< commands are queued, and one or more are actively being ran
+        UPDATER_SUCCESSFUL = 3,                             //!< no more queued commands, and no errors reported
+        SUCCESS_WITH_NOTIFICATIONS = 4,                     //!< no more queued commands, but there were notifications/messages reported (but not errors)
+    };
+
+    struct message {
+        std::string target;                                 //!< the target (if any) which was active, if any
+        ISFwUpdaterCmd cmd;                                 //!< the command that generated this message
+        eLogLevel severity;                                 //!< the severity level of the message - use one of IS_LOG_LEVEL_*
+        std::string msg;                                    //!< the fully-formatted message
+
+        message(const std::string& _target, const ISFwUpdaterCmd& _cmd, eLogLevel _severity, const std::string& _msg) : target(_target), cmd(_cmd), severity(_severity), msg(_msg) { };
+    };
+
+    explicit ISFwUpdateState() = default;
+
+    void resetState() {
+        lastMessage.clear();
+        messages.clear();
+        target = fwUpdate::TARGET_HOST;
+        status = fwUpdate::NOT_STARTED;
+        slot = 0;
+        progress = 0.f;
+        hasErrors = false;
+    }
+
+    std::string                 lastMessage;                        //!< the current/last/most recent message which should be shown to the user
+    updater_state_e             state = UPDATER_IDLE;               //!< the current/last state of the updater (overall, across all commands)
+    fwUpdate::update_status_e   status = fwUpdate::NOT_STARTED;     //!< the current/last status of the updater (typically more for the current upload/command);
+    fwUpdate::target_t          target = fwUpdate::TARGET_UNKNOWN;  //!< the current/last target device that is/was being updated
+    uint16_t                    slot = 0;                           //!< the current/last target slot that is/was being uploaded to
+    float                       progress = 0.f;                     //!< the current/last progress of the target upload
+    std::vector<message>        messages;                           //!< the collection of all messages that have occurred during the update
+    bool                        hasErrors = false;                  //!< an easy indicator to track errors while still in progress, generally true if msgs contains one more IS_LOG_LEVEL_ERROR messages
+};
+
+
+
 static ISFwUpdaterCmd nullCmd = ISFwUpdaterCmd();
+static ISFwUpdateState nullState = ISFwUpdateState();
 
 class ISFirmwareUpdater : private fwUpdate::FirmwareUpdateHost {
 public:
-
-    struct update_msgs {
-        std::string target;                                 //!< the target (if any) which was active, if any
-        ISFwUpdaterCmd cmd;                                 //!< the command that generated this message
-        int severity;                                       //!< the severity level of the message - use one of IS_LOG_LEVEL_*
-        std::string msg;                                    //!< the fully-formatted message
-
-        update_msgs(const std::string& _target, const ISFwUpdaterCmd& _cmd, int _severity, const std::string& _msg) : target(_target), cmd(_cmd), severity(_severity), msg(_msg) { };
-    };
 
     port_handle_t port = nullptr;                           //!< a handle to the comm port which we use to talk to the device - if possible, we should be using the device->port
     device_handle_t device;                                 //!< a handle to the device which is being updated; maybe null in some cases
@@ -151,9 +195,9 @@ public:
      * @param portHandle handle to the port (typically serial) to which the device is connected
      * @param portName a named reference to the connected port handle (ie, COM1 or /dev/ttyACM0)
      */
-    ISFirmwareUpdater(port_handle_t port, const dev_info_t *devInfo) : FirmwareUpdateHost(), port(port), devInfo(devInfo), activeCmd(&nullCmd) { }
+    ISFirmwareUpdater(port_handle_t port, const dev_info_t *devInfo, ISFwUpdateState& state) : FirmwareUpdateHost(), port(port), devInfo(devInfo), updateState(state), activeCmd(&nullCmd) { }
 
-    explicit ISFirmwareUpdater(device_handle_t device);
+    explicit ISFirmwareUpdater(device_handle_t device, ISFwUpdateState& state);
 
     void setInfoProgressCb(fwUpdate::pfnStatusCb cb) { pfnStatus_cb = cb; }
 
@@ -172,26 +216,23 @@ public:
         devInfo = nullptr;
     };
 
+    void refreshUpdateState();
+
     void setTarget(fwUpdate::target_t _target);
 
     bool setCommands(std::vector<std::string> cmds);
 
-    // bool addCommands(std::vector<std::string> cmds);
-
     bool step();
-
-    // bool isWaitingResponse() { return requestPending; }
 
     bool hasPendingCommands() { for (auto& c :commands) { if ((c.status == ISFwUpdaterCmd::CMD_QUEUED) || (c.status == ISFwUpdaterCmd::CMD_IN_PROCESS)) return true; } return false; }
 
-    // bool hasErrors() { return !stepErrors.empty(); }
     bool hasErrors() { for (auto& c :commands) { if (c.status == ISFwUpdaterCmd::CMD_ERROR) return true; } return false; }
 
     void setLogLevel(eLogLevel level) { logLevel = level; }
 
     eLogLevel getLogLevel() { return logLevel; }
 
-    std::vector<update_msgs> getStepErrors() { return stepErrors; }
+    std::vector<ISFwUpdateState::message> getMessages() { return updateState.messages; }
 
     ISFwUpdaterCmd& getActiveCommand() { return *activeCmd; };
 
@@ -270,17 +311,7 @@ private:
 
     /** These are member variables that are indicate the state of this updater (not a specific upload, etc) **/
 
-    enum updater_state_e : int8_t {
-        UPDATER_DONE_WITH_ERRORS = -2,                      //!< no longer running, errors occurred during the update
-        UPDATER_WAITING_TO_CANCEL = -1,                     //!< user requested a cancel, but operations are still pending
-        UPDATER_IDLE = 0,                                   //!< the Updater is idle. Nothing started, nothing to do, etc.
-        UPDATER_CMDS_QUEUED = 1,                            //!< commands are queued, but no commands are in process
-        UPDATER_IN_PROGRESS,                                //!< commands are queued, and one or more are actively being ran
-        UPDATER_SUCCESSFUL,                                 //!< no more queued commands, and no errors reported
-        SUCCESS_WITH_NOTIFICATIONS,                         //!< no more queued commands, but there were notifications/messages reported (but not errors)
-    };
-
-    updater_state_e updateState = UPDATER_IDLE;             //!< true if this update has been cancelled (but may still be waiting for a step to complete)
+    ISFwUpdateState& updateState;                           //!< a reference to an ISFwUpdateState object which will hold the state of this updater
     std::vector<ISFwUpdaterCmd> commands;                   //!< the stack of commands to execute for this update
     std::string activeStep;                                 //!< the name of the currently executing step name, from the manifest when available
     std::string failLabel;                                  //!< a label to jump to, when an error occurs
@@ -288,7 +319,7 @@ private:
     std::string statusMsg;                                  //!< a string the reflects the current state of the updater - this should be "Human Readable" (it generally gets reported directly to the user in the UI, etc).
 
     eLogLevel logLevel = IS_LOG_LEVEL_INFO;                 //!< default log level to show
-    std::vector<update_msgs> stepErrors;                    //!< a list of error messages messages that occurred during the update
+    //std::vector<ISFwUpdateState::message> stepErrors;       //!< a list of error messages messages that occurred during the update
     //bool requestPending = false;                            //!< true if a fwUpdate request has been made, and we're still waiting for a response.
 
 


### PR DESCRIPTION
This commit introduces the `ISFwUpdateState` class to encapsulate all state related to a firmware update, including progress, status, messages, and errors.

Key changes:
- The `ISDevice` and `ISFirmwareUpdater` classes now use an `ISFwUpdateState` object to manage and share the firmware update state, removing multiple individual state-tracking member variables.
- A new `refreshUpdateState()` method in `ISFirmwareUpdater` centralizes the logic for updating the shared state based on the current command and overall progress.
- The `ISDevice::fwUpdate()` method is simplified, with state management logic moved into `ISFirmwareUpdater`.
- Added the ability to gracefully cancel firmware updates by introducing `CMD_CANCELLED` and `CMD_FLAGS__CANCELABLE` to `ISFwUpdaterCmd`.
- `ISDevice` now provides `fwUpdateMessages()` to retrieve log messages from the update process.