### PR TITLE
SN-7678 - Concurrent, Asynchronous Device Discovery

### DIFF
--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -18,6 +18,8 @@ include_directories(
 # Link the InertialSenseSDK static library 
 link_directories(${IS_SDK_DIR})
 
+add_definitions(-DIS_LOG_LEVEL=IS_LOG_LEVEL_MORE_INFO)
+
 if(WIN32)
     # yamlcpp needs to know it's a static lib
     add_definitions(-DYAML_CPP_STATIC_DEFINE)

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -658,6 +658,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.list_devices = true;
             g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
         }
+        else if (startsWith(a, "-use-mdns"))
+        {
+            g_commandLineOptions.useMdns = true;
+        }
         else if (startsWith(a, "-lmf="))
         {
             g_commandLineOptions.maxLogFileSize = (uint32_t)strtoul(&a[5], NULL, 10);
@@ -927,6 +931,9 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         }
     }
 
+    // Always apply the verboseLevel to the SDK log system
+    IS_SET_LOG_LEVEL((eLogLevel)g_commandLineOptions.verboseLevel);
+
     // We are either using a serial port or replaying data
     if ((g_commandLineOptions.comPort.length() == 0) && !g_commandLineOptions.replayDataLog)
     {
@@ -1175,6 +1182,7 @@ void cltool_outputUsage()
 	cout << "    -dboc" << boldOff << "           Send stop-broadcast command `$STPB` on close." << endlbOn;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;
+    cout << "    -use-mdns" << boldOff << "       Enable mDNS network discovery of remote devices (e.g., socat TCP-forwarded serial ports)." << endlbOn;
     cout << "    -lm" << boldOff << "             Listen mode for ISB. Disables device verification (-vd) and does not send stop-broadcast command on start." << endlbOn;
     cout << "    -magRecal[n]" << boldOff << "    Recalibrate magnetometers: 0=multi-axis, 1=single-axis" << endlbOn;
     cout << "    -nmea=[s]" << boldOff << "       Send NMEA message s with added checksum footer. Display rx messages. (`-nmea=ASCE,0,GxGGA,1`)" << endlbOn;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -176,6 +176,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     uint32_t updateFirmwareSlot = 0;
     uint32_t runDurationMs = 0;             // Run for this many millis before exiting (0 = indefinitely)
     bool list_devices = false;              // if true, dumps results of findDevices() including port name.
+    bool useMdns = false;                   // if true, registers ISmDnsPortFactory for mDNS network device discovery
     EVFContainer_t evFCont = {0};
     EVMContainer_t evMCont = {0};
     EVOContainer_t evOCont;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -41,6 +41,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "CorrectionService.h"
 #include "NtripCorrectionService.h"
 #include "TcpPortFactory.h"
+#include "ISmDnsPortFactory.h"
 #include "util/natsort.h"
 #include "util/uri.hpp"
 
@@ -956,12 +957,38 @@ void getMemoryEvent(InertialSense& inertialSenseInterface, uint32_t addrs, const
 
 static int cltool_dataStreaming()
 {
+    IS_LOG_OUTPUT(stdout);
+
     // [C++ COMM INSTRUCTION] STEP 1: Instantiate InertialSense Class
     // Create InertialSense object, passing in data callback function pointer.
-    InertialSense inertialSenseInterface({}, {&CltoolDeviceFactory::getInstance()});
+    // Build explicit port factory list — only include ISmDnsPortFactory when -use-mdns is specified
+    SerialPortFactory& spf = SerialPortFactory::getInstance();
+    spf.portOptions.defaultBaudRate = g_commandLineOptions.baudRate;
+    spf.portOptions.defaultBlocking = false;
+    TcpPortFactory& tpf = TcpPortFactory::getInstance();
+    tpf.portOptions.defaultBlocking = false;
+
+    std::vector<PortFactory*> portFactories = {&spf, &tpf};
+    if (g_commandLineOptions.useMdns) {
+        ISmDnsPortFactory& mdpf = ISmDnsPortFactory::getInstance();
+        mdpf.portOptions.defaultBlocking = false;
+        portFactories.push_back(&mdpf);
+    }
+
+    InertialSense inertialSenseInterface(portFactories, {&CltoolDeviceFactory::getInstance()});
     g_inertialSenseInterface = &inertialSenseInterface;
     inertialSenseInterface.setErrorHandler(cltool_errorCallback);
     inertialSenseInterface.EnableDeviceValidation(!g_commandLineOptions.disableDeviceValidation);
+
+    // Pre-warm mDNS cache so network devices are discoverable when Open() calls discoverPorts()
+    if (g_commandLineOptions.useMdns) {
+        printf("Discovering mDNS devices...\n");
+        uint32_t deadline = current_timeMs() + 3000;
+        while (current_timeMs() < deadline) {
+            ISmDnsPortFactory::tick();
+            SLEEP_MS(50);
+        }
+    }
 
     // [C++ COMM INSTRUCTION] STEP 2: Open serial port
     if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))

--- a/src/DeviceFactory.cpp
+++ b/src/DeviceFactory.cpp
@@ -1,5 +1,5 @@
 /**
- * @file DeviceFactory.cpp 
+ * @file DeviceFactory.cpp
  * @brief ${BRIEF_DESC}
  *
  * @author Kyle Mallory on 3/10/25.
@@ -24,63 +24,120 @@ void DeviceFactory::locateDevices(std::function<bool(DeviceFactory*, const dev_i
 }
 
 /**
- * Attempts to identify a specific type of device on the specified port, within the timeout period.
- * @param deviceCallback a function to be called if this Factory identified a possible/viable Inertial Sense device on the specified port
- * @param port the port to check for an Inertial Sense device. In most uses, the port specified should already be opened, however if the
- *   port is not opened, this function will attempt to open it in order for ensure discovery.
- * @param hdwId a hardware Id qualifier that can be used to narrow the type of device.  There is no direct indication that a hardware type
- *   failed to match.
- * @param timeout the maximum time to attempt to identify a device before giving up. There is no direct indication that a timeout occurred.
- * @return true if a device was detected, otherwise false. Note that a false can result for any number of reasons, including invalid port,
- *   hdwId mismatch, or a timeout.
+ * Blocking single-port discovery. Implemented as a wrapper around the three-phase validation protocol.
  */
 bool DeviceFactory::locateDevice(std::function<bool(DeviceFactory*, const dev_info_t&, port_handle_t)>& deviceCallback, port_handle_t port, uint16_t hdwId, uint16_t timeoutMs) {
-    if (!portIsValid(port))
-        return false;     // TODO: Should we do anything special if the port is invalid?  Really, we should never get here with an invalid port...
+    // Check for existing device on this port
+    device_handle_t dev = DeviceManager::getInstance().getDevice(port);
+    if (dev) {
+        if (dev->matchesHdwId(hdwId)) {
+            if (!dev->port)
+                dev->assignPort(port);
+            return dev->validate(timeoutMs);
+        }
+        return false;
+    }
 
-    // can we open the port?
-    if (!portIsOpened(port)) {
-        log_debug(IS_LOG_DEVICE_FACTORY, "Opening serial port '%s'", portName(port));
+    // Phase 1: begin validation
+    auto ctx = beginValidation(port, hdwId, timeoutMs);
+    if (!ctx)
+        return false;
+
+    // Phase 2: blocking loop
+    while (!ctx->complete) {
+        stepValidation(*ctx);
+        if (!ctx->complete)
+            SLEEP_MS(2);
+    }
+
+    // Phase 3: complete validation
+    dev_info_t devInfo;
+    if (completeValidation(*ctx, devInfo)) {
+        return deviceCallback(this, devInfo, port);
+    }
+    return false;
+}
+
+/**
+ * Phase 1: Opens the port, validates it, creates a base ISDevice for probing, and calls the
+ * onBeginValidation() hook to allow the factory to decline or do custom setup.
+ */
+std::unique_ptr<DeviceFactory::ValidationContext> DeviceFactory::beginValidation(port_handle_t port, uint16_t hdwId, uint32_t timeoutMs, std::shared_ptr<ISDevice> sharedDevice) {
+    if (!portIsValid(port)) {
+        log_more_debug(IS_LOG_DEVICE_FACTORY, "beginValidation: port '%s' is invalid, skipping.", portName(port));
+        return nullptr;
+    }
+
+    // Open port if needed (only when no shared device provided, i.e. standalone/blocking path)
+    if (!sharedDevice && !portIsOpened(port)) {
         if (!portValidate(port) || (portOpen(port) != PORT_ERROR__NONE)) {
-            log_debug(IS_LOG_DEVICE_FACTORY, "Error opening serial port '%s'.  Ignoring.  Error was: %s", portName(port), SERIAL_PORT(port)->error);
-            portClose(port);              // failed to open
+            portClose(port);
             portInvalidate(port);
-            return false;
-            // m_ignoredPorts.push_back(curPortName);     // record this port name as bad, so we don't try and reopen it again
+            return nullptr;
         }
     }
 
-    // We can only validate devices connected on COMM ports, since ISComm is needed to parse/communicate with the device
-    if (!(portType(port) & PORT_TYPE__COMM))
-        return false;
+    // Only COMM ports can be validated via ISComm protocol
+    if (!(portType(port) & PORT_TYPE__COMM)) {
+        log_more_debug(IS_LOG_DEVICE_FACTORY, "beginValidation: port '%s' is not a COMM port (type=0x%04X), skipping.", portName(port), portType(port));
+        return nullptr;
+    }
 
     if (timeoutMs <= 0)
         timeoutMs = deviceTimeout;
 
-    // at this point, the port should be opened...
-    device_handle_t dev = DeviceManager::getInstance().getDevice(port);
-    if (!dev) {
-        // no previous device exists, so identify the device and then register it with the manager
-        int validationResult = 0;
-        ISDevice localDev(hdwId, port);
-        do {
-            is_comm_port_parse_messages(port); // Read data directly into comm buffer and call callback functions
-            validationResult = localDev.validateAsync(timeoutMs);
-            SLEEP_MS(2);
-        } while (!validationResult);
-
-        if (localDev.hasDeviceInfo() && localDev.matchesHdwId(hdwId)) {
-            // note that the deviceHandler callback can still reject the device for reasons
-            return deviceCallback(this, localDev.devInfo, port);
-        }
-    } else if (dev->matchesHdwId(hdwId)) {
-        if (!dev->port)
-            dev->assignPort(port);
-        else if (dev->port != port) {
-            // FIXME: this isn't good - it shouldn't happen, but it might... we should deal with it.
-        }
-        // a device exists associated with this port already, there isn't anything to do.
-        return dev->validate(timeoutMs);
+    // Let the factory decline this port
+    if (!onBeginValidation(port, hdwId)) {
+        log_more_debug(IS_LOG_DEVICE_FACTORY, "beginValidation: factory declined port '%s'.", portName(port));
+        return nullptr;
     }
-    return false;
+
+    log_more_debug(IS_LOG_DEVICE_FACTORY, "beginValidation: created validation context for port '%s' (hdwId=0x%04X, timeout=%dms)", portName(port), hdwId, timeoutMs);
+    auto ctx = std::make_unique<ValidationContext>();
+    ctx->port = port;
+    ctx->device = sharedDevice ? sharedDevice : std::make_shared<ISDevice>(hdwId, port);
+    ctx->hdwId = hdwId;
+    ctx->timeoutMs = timeoutMs;
+    return ctx;
+}
+
+/**
+ * Phase 2: Reads pending data from the port, then calls the onStepValidation() hook to
+ * advance validation state.
+ */
+int DeviceFactory::stepValidation(ValidationContext& ctx) {
+    if (ctx.complete)
+        return ctx.result;
+
+    is_comm_port_parse_messages(ctx.port);
+    ctx.result = onStepValidation(*ctx.device, ctx.timeoutMs);
+    ctx.complete = (ctx.result != 0);
+    if (ctx.result == 1) {
+        log_debug(IS_LOG_DEVICE_FACTORY, "stepValidation: port '%s' validated successfully.", portName(ctx.port));
+    } else if (ctx.result == -1) {
+        log_debug(IS_LOG_DEVICE_FACTORY, "stepValidation: port '%s' timed out.", portName(ctx.port));
+    }
+    return ctx.result;
+}
+
+/**
+ * Phase 3: Checks that validation succeeded and the device has info, then calls the
+ * onCompleteValidation() hook to let the factory accept or reject.
+ */
+bool DeviceFactory::completeValidation(ValidationContext& ctx, dev_info_t& devInfoOut) {
+    if (ctx.result <= 0)
+        return false;
+    if (!ctx.device || !ctx.device->hasDeviceInfo()) {
+        log_debug(IS_LOG_DEVICE_FACTORY, "completeValidation: port '%s' validated but has no device info.", portName(ctx.port));
+        return false;
+    }
+    if (!onCompleteValidation(ctx.device->devInfo, ctx.hdwId)) {
+        log_debug(IS_LOG_DEVICE_FACTORY, "completeValidation: factory rejected device on port '%s' (hdwId=0x%04X).", portName(ctx.port), ctx.hdwId);
+        return false;
+    }
+
+    devInfoOut = ctx.device->devInfo;
+    log_debug(IS_LOG_DEVICE_FACTORY, "completeValidation: factory accepted device %s on port '%s'.",
+        ISDevice::getIdAsString(devInfoOut).c_str(), portName(ctx.port));
+    return true;
 }

--- a/src/DeviceFactory.h
+++ b/src/DeviceFactory.h
@@ -22,10 +22,29 @@
 
 /**
  * An interface, to be implemented as a singleton, that is responsible for identifying various types of ISDevice and allocating and releasing them.
+ *
+ * Supports both blocking single-port discovery (locateDevice) and concurrent multi-port discovery
+ * via a three-phase protocol (beginValidation / stepValidation / completeValidation) driven by
+ * DeviceManager::discoverDevices(). Subclasses customize behavior by overriding the virtual hooks
+ * (onBeginValidation, onStepValidation, onCompleteValidation) without managing ValidationContext.
  */
 class DeviceFactory {
 public:
     virtual ~DeviceFactory() = default;
+
+    /**
+     * Per-port, per-factory state during concurrent validation. Managed by the base class
+     * beginValidation/stepValidation/completeValidation methods. Subclasses should not need
+     * to interact with this directly — override the onXxx hooks instead.
+     */
+    struct ValidationContext {
+        port_handle_t port = nullptr;
+        std::shared_ptr<ISDevice> device;
+        uint16_t hdwId = IS_HARDWARE_ANY;
+        uint32_t timeoutMs = 3000;
+        bool complete = false;
+        int result = 0;  // -1 = failed/timeout, 0 = in-progress, 1 = success
+    };
 
     /**
      * A function to be implemented in the factory responsible for allocating the underlying device type and returning a pointer to it
@@ -66,6 +85,7 @@ public:
 
     /**
      * Attempts to identify a specific type of device on the specified port, within the timeout period.
+     * Implemented as a blocking wrapper around beginValidation/stepValidation/completeValidation.
      * @param deviceCallback a function to be called if this Factory identified a possible/viable Inertial Sense device on the specified port
      * @param port the port to check for an Inertial Sense device. In most uses, the port specified should already be opened, however if the
      *   port is not opened, this function will attempt to open it in order for ensure discovery.
@@ -78,13 +98,70 @@ public:
     virtual bool locateDevice(std::function<bool(DeviceFactory*, const dev_info_t&, port_handle_t)>& deviceCallback, port_handle_t port, uint16_t hdwId, uint16_t timeout);
 
     /**
+     * Phase 1: Prepare a ValidationContext for concurrent validation on this port.
+     * If a shared ISDevice probe is provided, it will be used (concurrent discovery shares one
+     * ISDevice per port across all factories). Otherwise, opens the port and creates a new probe.
+     * Calls onBeginValidation() to allow the factory to decline or do custom setup.
+     * @return a ValidationContext, or nullptr if this port cannot be validated
+     */
+    std::unique_ptr<ValidationContext> beginValidation(port_handle_t port, uint16_t hdwId, uint32_t timeoutMs, std::shared_ptr<ISDevice> sharedDevice = nullptr);
+
+    /**
+     * Phase 2: Non-blocking validation step. Reads pending data from the port, then calls
+     * onStepValidation() to advance validation state. Called repeatedly during the concurrent
+     * loop, only when this factory is the active round-robin slot for this port.
+     * @return -1 = failed/timeout, 0 = still in progress, 1 = validated successfully
+     */
+    int stepValidation(ValidationContext& ctx);
+
+    /**
+     * Phase 3: After stepValidation returns 1, checks that the device has valid info and calls
+     * onCompleteValidation() to let the factory accept or reject the device.
+     * @param ctx the completed validation context
+     * @param devInfoOut populated with the validated device info on success
+     * @return true if this factory claims the device, false otherwise
+     */
+    bool completeValidation(ValidationContext& ctx, dev_info_t& devInfoOut);
+
+    /**
      * Assigns a Factory-specific timeout period for each port
      * @param timeout
      */
     void setPerDeviceTimeout(uint32_t timeout) { deviceTimeout = timeout; };
 
+    uint32_t getPerDeviceTimeout() const { return deviceTimeout; };
+
+protected:
+    /**
+     * Virtual hook called during Phase 1. Override to decline certain ports or perform
+     * custom port setup before validation begins.
+     * @param port the port about to be validated
+     * @param hdwId the hardware Id filter
+     * @return true to proceed with validation, false to skip this port
+     */
+    virtual bool onBeginValidation(port_handle_t port, uint16_t hdwId) { (void)port; (void)hdwId; return true; }
+
+    /**
+     * Virtual hook called during Phase 2. Override to inject custom validation logic
+     * (e.g., factory-specific queries or handshakes). The base class has already called
+     * is_comm_port_parse_messages() before invoking this hook.
+     * @param device the ISDevice probe to validate against
+     * @param timeoutMs the timeout for this validation attempt
+     * @return -1 = failed/timeout, 0 = still in progress, 1 = validated successfully
+     */
+    virtual int onStepValidation(ISDevice& device, uint32_t timeoutMs) { return device.validateAsync(timeoutMs); }
+
+    /**
+     * Virtual hook called during Phase 3. Override to accept or reject a validated device
+     * based on factory-specific criteria (e.g., hardware type, firmware version).
+     * @param devInfo the validated device info
+     * @param hdwId the hardware Id filter from the discovery request
+     * @return true to claim this device, false to pass to the next factory
+     */
+    virtual bool onCompleteValidation(const dev_info_t& devInfo, uint16_t hdwId) { (void)devInfo; (void)hdwId; return true; }
+
 private:
-    uint32_t deviceTimeout = 3000;
+    uint32_t deviceTimeout = 3000;  // should match DeviceManager::DISCOVERY__DEFAULT_TIMEOUT
 };
 
 class ImxDeviceFactory : public DeviceFactory {

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -9,6 +9,209 @@
 #include "DeviceManager.h"
 
 /**
+ * Concurrently validates all ports against all registered factories. Each port is probed by
+ * each factory in round-robin, so every factory gets fair time to validate. The first factory
+ * to successfully validate on a port wins that port and allocates the device.
+ *
+ * Total discovery time is bounded by max(factory timeout) rather than (num_ports * num_factories * timeout).
+ */
+bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t options) {
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+    bool result = false;
+    options = (options != OPTIONS_USE_DEFAULTS) ? options : managementOptions;
+    options = (options == OPTIONS_USE_DEFAULTS) ? DISCOVERY__DEFAULTS : options;
+
+    // Per-factory validation slot for a single port
+    struct FactorySlot {
+        DeviceFactory* factory;
+        std::unique_ptr<DeviceFactory::ValidationContext> ctx;
+        bool eliminated = false;  // true if this factory timed out or declined this port
+    };
+
+    // Per-port state tracking all factory slots and round-robin position
+    struct PendingPort {
+        port_handle_t port;
+        std::vector<FactorySlot> slots;
+        int activeSlot = 0;
+        bool resolved = false;
+        DeviceFactory* winner = nullptr;
+        dev_info_t devInfo = {};
+    };
+
+    std::vector<PendingPort> pending;
+
+    // Phase 1: For each port, ask each factory to beginValidation
+    for (auto port : portManager.locked_range()) {
+        if (!portIsValid(port))
+            continue;
+
+        // Check if port is already associated with a known device
+        bool alreadyHandled = false;
+        for (auto d : *this) {
+            if (d && d->hasDeviceInfo() && (d->port == port)) {
+                if (options & DISCOVERY__FORCE_REVALIDATION) {
+                    d->devInfo.hdwRunState = HDW_STATE_UNKNOWN;
+                    memset(d->devInfo.firmwareVer, 0, sizeof(d->devInfo.firmwareVer));
+                } else {
+                    if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)
+                        portClose(port);
+                    result = true;
+                    alreadyHandled = true;
+                    break;
+                }
+            }
+        }
+        if (alreadyHandled)
+            continue;
+
+        // Open port if needed
+        if ((!portIsOpened(port) && (options & DISCOVERY__IGNORE_CLOSED_PORTS)) ||
+            (portOpen(port) != PORT_ERROR__NONE))
+            continue;
+
+        // Only COMM ports can be validated via ISComm protocol
+        if (!(portType(port) & PORT_TYPE__COMM))
+            continue;
+
+        // Check if DeviceManager already has a device for this port
+        device_handle_t existingDev = getDevice(port);
+        if (existingDev) {
+            if (existingDev->matchesHdwId(hdwId)) {
+                if (!existingDev->port)
+                    existingDev->assignPort(port);
+                result |= existingDev->validate(timeoutMs);
+            }
+            if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)
+                portClose(port);
+            continue;
+        }
+
+        // Open port if needed (once, before any factory sees it)
+        if (!portIsOpened(port)) {
+            if (portOpen(port) != PORT_ERROR__NONE)
+                continue;
+        }
+
+        // Only COMM ports can be validated via ISComm protocol
+        if (!(portType(port) & PORT_TYPE__COMM))
+            continue;
+
+        // Create ONE shared ISDevice probe per port — all factories share this instance
+        uint32_t effectiveTimeout = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
+        auto sharedDevice = std::make_shared<ISDevice>(hdwId, port);
+
+        PendingPort pp;
+        pp.port = port;
+        for (auto f : factories) {
+            auto ctx = f->beginValidation(port, hdwId, effectiveTimeout, sharedDevice);
+            if (ctx) {
+                pp.slots.push_back({f, std::move(ctx), false});
+            }
+        }
+        if (!pp.slots.empty()) {
+            pending.push_back(std::move(pp));
+        }
+    }
+
+    // Phase 2+3: Concurrent validation loop with round-robin across factories per port
+    if (!pending.empty()) {
+        log_debug(IS_LOG_DEVICE_MANAGER, "Concurrently validating %zu port(s) across %zu factory(ies)",
+            pending.size(), factories.size());
+
+        bool allResolved = false;
+        while (!allResolved) {
+            allResolved = true;
+            for (auto& pp : pending) {
+                if (pp.resolved)
+                    continue;
+
+                // Find the active non-eliminated slot
+                int startSlot = pp.activeSlot;
+                bool foundActive = false;
+                do {
+                    if (!pp.slots[pp.activeSlot].eliminated) {
+                        foundActive = true;
+                        break;
+                    }
+                    pp.activeSlot = (pp.activeSlot + 1) % (int)pp.slots.size();
+                } while (pp.activeSlot != startSlot);
+
+                if (!foundActive) {
+                    // All factories eliminated — port failed
+                    log_more_debug(IS_LOG_DEVICE_MANAGER, "All factories eliminated for port '%s'.", portName(pp.port));
+                    pp.resolved = true;
+                    if (options & DISCOVERY__CLOSE_PORT_ON_FAILURE)
+                        portClose(pp.port);
+                    continue;
+                }
+
+                auto& slot = pp.slots[pp.activeSlot];
+                int stepResult = slot.factory->stepValidation(*slot.ctx);
+
+                if (stepResult == 1) {
+                    // Phase 3 inline: this factory validated — check if it claims the device
+                    dev_info_t devInfo;
+                    if (slot.factory->completeValidation(*slot.ctx, devInfo)) {
+                        pp.resolved = true;
+                        pp.winner = slot.factory;
+                        pp.devInfo = devInfo;
+
+                        // Register via deviceHandler
+                        std::function<bool(DeviceFactory*, const dev_info_t&, port_handle_t)> cb =
+                            std::bind(&DeviceManager::deviceHandler, this,
+                                std::placeholders::_1, std::placeholders::_2,
+                                std::placeholders::_3, options);
+                        if (cb(pp.winner, pp.devInfo, pp.port)) {
+                            log_debug(IS_LOG_DEVICE_MANAGER, "deviceHandler accepted %s on port '%s'. DeviceCount=%zu",
+                                ISDevice::getIdAsString(pp.devInfo).c_str(), portName(pp.port), size());
+                            result = true;
+                        } else {
+                            // The winning factory's deviceHandler rejected — try remaining factories
+                            bool handled = false;
+                            for (auto f : factories) {
+                                if (f == pp.winner)
+                                    continue;
+                                if (cb(f, pp.devInfo, pp.port)) {
+                                    log_debug(IS_LOG_DEVICE_MANAGER, "deviceHandler accepted %s via fallback factory on port '%s'. DeviceCount=%zu",
+                                        ISDevice::getIdAsString(pp.devInfo).c_str(), portName(pp.port), size());
+                                    result = true;
+                                    handled = true;
+                                    break;
+                                }
+                            }
+                            if (!handled) {
+                                log_debug(IS_LOG_DEVICE_MANAGER, "deviceHandler REJECTED %s on port '%s' by all factories. DeviceCount=%zu",
+                                    ISDevice::getIdAsString(pp.devInfo).c_str(), portName(pp.port), size());
+                                if (options & DISCOVERY__CLOSE_PORT_ON_FAILURE)
+                                    portClose(pp.port);
+                            }
+                        }
+                    } else {
+                        // Factory validated but rejected the device — eliminate and try others
+                        slot.eliminated = true;
+                    }
+                } else if (stepResult == -1) {
+                    // This factory timed out on this port — eliminate it
+                    slot.eliminated = true;
+                } else {
+                    allResolved = false;
+                }
+
+                // Advance round-robin to next factory for this port's next cycle
+                pp.activeSlot = (pp.activeSlot + 1) % (int)pp.slots.size();
+
+                if (!pp.resolved)
+                    allResolved = false;
+            }
+            if (!allResolved)
+                SLEEP_MS(2);
+        }
+    }
+
+    return result;
+}
+
+/**
  * Registers a previously created ISDevice instance - use this when a device which is manually allocated (statically, etc) needs to be managed
  * @param device
  * @return

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -59,6 +59,8 @@ public:
 
     static const uint16_t DISCOVERY__DEFAULTS                     = DISCOVERY__CLOSE_PORT_ON_FAILURE; // (DISCOVERY__IGNORE_CLOSED_PORTS | DISCOVERY__CLOSE_PORT_ON_FAILURE);
 
+    static const uint32_t DISCOVERY__DEFAULT_TIMEOUT               = 3000;         //!< default timeout (ms) for device discovery; matches DeviceFactory::deviceTimeout
+
     DeviceManager(DeviceManager const &) = delete;
     DeviceManager& operator=(DeviceManager const&) = delete;
 
@@ -78,18 +80,7 @@ public:
      * @param options a bitmask of misc options that will can affect the discovery behavior.
      * @return true if one more more devices were discovered, otherwise false
      */
-    bool discoverDevices(uint16_t hdwId = IS_HARDWARE_ANY, uint32_t timeoutMs = 0, uint32_t options = OPTIONS_USE_DEFAULTS) {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
-        bool result = false;
-        // options = (options != OPTIONS_USE_DEFAULTS) ? options : managementOptions;
-        for (auto port : portManager.locked_range()) {
-            // FIXME: sometimes this segfaults - I think the portManager's set gets updated while iterating here.
-            //  we may need to put a mutex on the PortManager so we can't add/remove ports while iterating on the base set.
-            //  probably s smart thing to do for the DeviceManager too
-            result |= discoverDevice(port, hdwId, timeoutMs, options);
-        }
-        return result;
-    }
+    bool discoverDevices(uint16_t hdwId = IS_HARDWARE_ANY, uint32_t timeoutMs = 0, uint32_t options = OPTIONS_USE_DEFAULTS);
 
     /**
      * Iterates through all registered factories attempting to identify a discoverable device on the specified port.

--- a/src/ISBFirmwareUpdater.cpp
+++ b/src/ISBFirmwareUpdater.cpp
@@ -207,21 +207,83 @@ bool ISBFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proc
                     // do some verify step??
                 } else {
                     updateState = REBOOT_TO_APP;
-                    session_status = fwUpdate::FINALIZING;
                 }
                 break;
             case REBOOT_TO_APP:
                 if (device->devInfo.hdwRunState == HDW_STATE_BOOTLOADER)
-                    rebootToAPP(false);  // we should be able to keep the port open
+                    rebootToAPP(false);
+                session_status = fwUpdate::FINALIZING;
+                last_reboot = current_timeMs();
+                nextStepMs = last_reboot + 2000;  // give device 2s to start rebooting
                 updateState = UPDATE_DONE;
                 break;
-            case UPDATE_DONE:
-                // at this point, we should have rebooted, and we're waiting for the device to reboot back up, so we can confirm the update succeeded.
+            case UPDATE_DONE: {
+                // Async wait: device is rebooting from bootloader to APP mode.
+                // Keep session_status == FINALIZING until device is rediscovered in APP mode.
+
+                // Periodically trigger port rediscovery
+                if (current_timeMs() > nextPortCheck) {
+                    portManager.discoverPorts();
+                    nextPortCheck = current_timeMs() + 1000;
+                }
+
+                // Re-fetch device (port may have changed after USB re-enumeration)
+                device = deviceManager.getDevice(ENCODE_DEV_INFO_TO_UNIQUE_ID(target_devInfo));
+                if (!device) {
+                    // Device not yet rediscovered — report progress and return
+                    if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
+                        nextProgressReport = current_timeMs() + progress_interval;
+                        fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
+                            "Waiting for device [%s] to reboot into APP mode.",
+                            ISDevice::getIdAsString(target_devInfo).c_str());
+                    }
+                    // Timeout check
+                    if ((current_timeMs() - last_reboot) > 20000) {
+                        fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_WARN,
+                            "Timed out waiting for device [%s] to reboot into APP mode. Upload was successful.",
+                            ISDevice::getIdAsString(target_devInfo).c_str());
+                        // Fall through to finish — the upload itself succeeded
+                    } else {
+                        break;  // keep waiting
+                    }
+                } else {
+                    // Device found — try to connect and validate
+                    if (portIsValid(device->port) && !device->isConnected()) {
+                        if (!device->connect(false))
+                            break;  // retry next cycle
+                    }
+
+                    if (device->isConnected()) {
+                        if (!device->hasDeviceInfo() && (device->validateAsync() != 1))
+                            break;  // keep waiting for validation
+
+                        if (device->devInfo.hdwRunState != HDW_STATE_APP) {
+                            // Still in bootloader or unknown — keep waiting
+                            if ((current_timeMs() - last_reboot) > 20000) {
+                                fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_WARN,
+                                    "Device [%s] rebooted but not in APP mode (state=%d). Upload was successful.",
+                                    device->getIdAsString().c_str(), device->devInfo.hdwRunState);
+                                // Fall through to finish
+                            } else {
+                                break;
+                            }
+                        } else {
+                            fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
+                                "Device [%s] confirmed running in APP mode.",
+                                device->getIdAsString().c_str());
+                        }
+                    } else {
+                        break;  // not yet connected
+                    }
+                }
+
+                // Finalize — either confirmed APP mode or timed out (upload was successful either way)
                 if (imgStream) { delete imgStream; imgStream = nullptr; }
                 if (imgBuffer) { delete imgBuffer; imgBuffer = nullptr; }
                 session_status = fwUpdate::FINISHED;
                 fn.mark("Finished UPDATE_DONE step.");
                 break;
+            }
         }
         fn.mark("Finished non-initializing steps.");
     }

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -79,7 +79,7 @@ public:
         char* clientBuffer = nullptr;
         int clientBufferSize = 0;
         int* clientBytesToSend = 0;
-        int16_t discoveryTimeout = 5000;
+        int16_t discoveryTimeout = DeviceManager::DISCOVERY__DEFAULT_TIMEOUT;
     };
 
     typedef struct

--- a/src/core/msg_logger.h
+++ b/src/core/msg_logger.h
@@ -25,7 +25,7 @@ extern "C" {
 // --- Compile-time configuration ---
 // Define the default log level to show messages at or above this level.
 #ifndef IS_LOG_LEVEL
-#define IS_LOG_LEVEL  IS_LOG_LEVEL_WARN // Default to WARNING
+#define IS_LOG_LEVEL  IS_LOG_LEVEL_INFO // Default to INFO
 #endif
 
 // Define the highest (most verbose) level that will be compiled into the binary

--- a/src/message_stats.h
+++ b/src/message_stats.h
@@ -26,10 +26,10 @@ public:
     struct stats_t
     {
         int count;
-        int timeMs;
-        int prevTimeMs;
-        int bytes;
-        unsigned int startTimeMs;
+        uint64_t timeMs;
+        uint64_t prevTimeMs;
+        uint64_t bytes;
+        uint64_t startTimeMs;
         int bytesPerSec;
         std::string description;
     };


### PR DESCRIPTION
## Summary

This commit refactors the device discovery mechanism to support concurrent, non-blocking validation of multiple ports across multiple device factories. This greatly improves the responsiveness of the applications, particularly when there are large numbers of devices, such as during manufacturing.

The key changes include:

-   **`DeviceManager`:** `discoverDevices` is completely rewritten to perform concurrent validation. It uses a round-robin scheduler to give each factory fair time on each port, significantly speeding up discovery when multiple ports or factories (like serial, TCP, mDNS) are present. The total discovery time is now bounded by the longest single-factory timeout, rather than the sum of all timeouts.

-   **`DeviceFactory`:** A new three-phase validation protocol (`beginValidation`, `stepValidation`, `completeValidation`) is introduced. This allows `DeviceManager` to drive the discovery process in a non-blocking manner. The existing `locateDevice` method is reimplemented as a blocking wrapper around this new protocol for single-port discovery.

-   **`cltool`:**
    -   Added a `-use-mdns` command-line option to enable network device discovery via mDNS.

-   **Firmware Updater:** The post-update process is improved to more robustly wait for the device to reboot into application mode, with better progress reporting and timeout handling.

-   **Other:** Data types for message statistics in `message_stats.h` have been changed from `int` to `uint64_t` to prevent potential overflow.

## Details

- **Concurrent multi-factory device discovery**: Refactored `DeviceManager::discoverDevices()` from sequential per-port validation to a concurrent round-robin system. All ports are validated simultaneously across all registered factories, reducing total discovery time from `O(num_ports * num_factories * timeout)` to `O(max(factory_timeout))`.
- **Three-phase DeviceFactory validation protocol**: Split `DeviceFactory::locateDevice()` into `beginValidation()` / `stepValidation()` / `completeValidation()` phases with virtual hooks (`onBeginValidation`, `onStepValidation`, `onCompleteValidation`) for subclass customization. The blocking `locateDevice()` is preserved as a wrapper.
- **ISBFirmwareUpdater async APP mode confirmation**: After firmware upload and reboot, the updater now waits asynchronously for the device to be rediscovered in APP mode (up to 20s) before setting `session_status = FINISHED`. Previously it set FINISHED immediately, causing premature exit with `EXIT_CODE_DEVICE_DISCONNECTED`.
- **Port lifecycle fix**: Fixed `discoverDevices()` not honoring `DISCOVERY__CLOSE_PORT_ON_COMPLETION` on the existing-device early-exit path, which caused port contention (EBUSY) when external processes needed the port after discovery.
- **cltool `-use-mdns` option**: Added CLI flag and explicit port factory construction for optional mDNS network device discovery (socat TCP-forwarded serial ports).
- **Log level defaults**: SDK runtime default changed from `IS_LOG_LEVEL_WARN` to `IS_LOG_LEVEL_INFO`. cltool always applies its own `verboseLevel` (WARN) via `IS_SET_LOG_LEVEL` after argument parsing, ensuring clean output without `-verbose`.

## Changed Files

| File | Change |
|------|--------|
| `src/DeviceFactory.cpp` | Three-phase validation protocol (beginValidation/stepValidation/completeValidation) |
| `src/DeviceFactory.h` | ValidationContext struct, virtual hooks, phase methods |
| `src/DeviceManager.cpp` | New concurrent `discoverDevices()`, port lifecycle fix for CLOSE_PORT_ON_COMPLETION |
| `src/DeviceManager.h` | Moved `discoverDevices()` out-of-line, added `DISCOVERY__DEFAULT_TIMEOUT` |
| `src/ISBFirmwareUpdater.cpp` | Async wait for APP mode after reboot in UPDATE_DONE state |
| `src/InertialSense.h` | Use `DISCOVERY__DEFAULT_TIMEOUT` constant |
| `src/core/msg_logger.h` | Default log level → `IS_LOG_LEVEL_INFO` |
| `cltool/CMakeLists.txt` | Added `IS_LOG_LEVEL=IS_LOG_LEVEL_MORE_INFO` compile definition |
| `cltool/src/cltool.cpp` | `-use-mdns` parsing, `IS_SET_LOG_LEVEL` always applied after parsing |
| `cltool/src/cltool.h` | `useMdns` field in `cmd_options_t` |
| `cltool/src/cltool_main.cpp` | Explicit port factory construction, mDNS pre-warm, `IS_LOG_OUTPUT(stdout)` |

## Test Plan

- [x] `cltool_tests.firmware_update` — firmware upload completes, device confirmed in APP mode, exit 0
- [x] `cltool_tests.did_option_single` — clean DID output, no log noise
- [x] `cltool_tests.did_option_stream` — streaming DID data works
- [x] `cltool_tests.edit_option_single` — edit format output works
- [x] `cltool_tests.flash_config_option_read_set_read` — flash config read/modify/verify cycle
- [x] `cltool_tests.GetSetOptions` — YAML get/set round-trip
- [x] `cltool -did 1=0` — clean output with no INFO log messages (WARN default applied)
- [x] `cltool -verbose++ -did 1=0` — DEBUG/INFO messages appear when verbose enabled
- [x] EvalTool launches without segfault, discovers devices correctly
- [x] ci_hdw full suite: 37/42 pass (5 failures are pre-existing: 3 bit_tests need calibration, 2 GNSS need antenna/sky)