### PR TITLE
SN-7682 - Fix TCP Port Read Timeout & Related Networking Improvements

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -16,6 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <chrono>
 #include <ctime>
 #include "ISDataMappings.h"
+#include "ISmDnsPortFactory.h"
 
 using namespace std;
 
@@ -661,6 +662,20 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         else if (startsWith(a, "-use-mdns"))
         {
             g_commandLineOptions.useMdns = true;
+        }
+        else if (startsWith(a, "-mdns-resolve="))
+        {
+            std::string val = &a[14];
+            uint8_t flags = 0;
+            if (val.find("v4") != std::string::npos || val.find("ipv4") != std::string::npos)
+                flags |= MDNS_RESOLVE_IPV4;
+            if (val.find("v6") != std::string::npos || val.find("ipv6") != std::string::npos)
+                flags |= MDNS_RESOLVE_IPV6;
+            if (val.find("hostname") != std::string::npos || val.find("host") != std::string::npos)
+                flags |= MDNS_RESOLVE_HOSTNAME;
+            if (flags == 0)
+                flags = MDNS_RESOLVE_DEFAULT;
+            g_commandLineOptions.mdnsResolvePreference = flags;
         }
         else if (startsWith(a, "-lmf="))
         {

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -869,6 +869,14 @@ bool cltool_parseCommandLine(int argc, char* argv[])
                 case SYS_CMD_DISABLE_SERIAL_PORT_BRIDGE:        g_commandLineOptions.disableDeviceValidation = true;    break;
             }
         }
+        else if (matches(a, "-sn") && (i + 1) < argc)
+        {
+            g_commandLineOptions.targetDeviceId = ISDevice::parseDeviceIdString(argv[++i]);
+            if (g_commandLineOptions.targetDeviceId == 0) {
+                cout << "Invalid device identifier: " << argv[i] << ". Expected: 129495, SN129495, or IMX-5.0:SN129495" << endl;
+                return false;
+            }
+        }
         else if (startsWith(a, "-s"))
         {
             enable_display_mode(cInertialSenseDisplay::DMODE_SCROLL);
@@ -949,20 +957,22 @@ bool cltool_parseCommandLine(int argc, char* argv[])
     // Always apply the verboseLevel to the SDK log system
     IS_SET_LOG_LEVEL((eLogLevel)g_commandLineOptions.verboseLevel);
 
-    // We are either using a serial port or replaying data
-    if ((g_commandLineOptions.comPort.length() == 0) && !g_commandLineOptions.replayDataLog)
+    // We are either using a serial port, targeting a device by serial number, or replaying data
+    bool hasPort = (g_commandLineOptions.comPort.length() != 0);
+    bool hasTarget = (g_commandLineOptions.targetDeviceId != 0);
+    if (!hasPort && !hasTarget && !g_commandLineOptions.replayDataLog)
     {
         cltool_outputUsage();
         return false;
     }
-    else if (g_commandLineOptions.updateAppFirmwareFilename.length() != 0 && g_commandLineOptions.comPort.length() == 0)
+    else if (g_commandLineOptions.updateAppFirmwareFilename.length() != 0 && !hasPort && !hasTarget)
     {
-        cout << "Use DEVICE_PORT option \"-c \" with bootloader" << endl;
+        cout << "Use DEVICE_PORT option \"-c \" or \"-sn \" with bootloader" << endl;
         return false;
     }
-    else if (g_commandLineOptions.updateBootloaderFilename.length() != 0 && g_commandLineOptions.comPort.length() == 0)
+    else if (g_commandLineOptions.updateBootloaderFilename.length() != 0 && !hasPort && !hasTarget)
     {
-        cout << "Use DEVICE_PORT option \"-c \" with bootloader" << endl;
+        cout << "Use DEVICE_PORT option \"-c \" or \"-sn \" with bootloader" << endl;
         return false;
     }
 
@@ -1194,6 +1204,7 @@ void cltool_outputUsage()
 	cout << "OPTIONS (General)" << endl;
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select serial port(s). Options: single port (e.g., COM5 or /dev/ttyUSB0), multiple ports separated by ',' (e.g., COM2,COM4,COM5), \"*\" for all ports, or \"*4\" for first four ports." << endlbOn;
+	cout << "    -sn " << boldOff << "DEVICE_ID   Discover all devices and connect to the one matching the given identifier. Accepts: 129495, SN129495, or IMX-5.0:SN129495. Alternative to -c." << endlbOn;
 	cout << "    -dboc" << boldOff << "           Send stop-broadcast command `$STPB` on close." << endlbOn;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -182,6 +182,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     EVMContainer_t evMCont = {0};
     EVOContainer_t evOCont;
 
+    uint64_t targetDeviceId = 0;            // -sn: encoded device identifier (hdwId << 48 | serialNumber). Parsed from "IMX-5.0:SN129495" or just "129495"
     bool disableDeviceValidation = false;   // Keep port(s) open even if no devices response is received.
     bool listenMode = false;                // Disable device verification and don't send stop-broadcast command on start.
 } cmd_options_t;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -177,6 +177,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     uint32_t runDurationMs = 0;             // Run for this many millis before exiting (0 = indefinitely)
     bool list_devices = false;              // if true, dumps results of findDevices() including port name.
     bool useMdns = false;                   // if true, registers ISmDnsPortFactory for mDNS network device discovery
+    uint8_t mdnsResolvePreference = 0x07;  // bitmask of MdnsResolveFlags for address resolution preference (default: IPv4|IPv6|hostname)
     EVFContainer_t evFCont = {0};
     EVMContainer_t evMCont = {0};
     EVOContainer_t evOCont;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -972,6 +972,7 @@ static int cltool_dataStreaming()
     if (g_commandLineOptions.useMdns) {
         ISmDnsPortFactory& mdpf = ISmDnsPortFactory::getInstance();
         mdpf.portOptions.defaultBlocking = false;
+        mdpf.portOptions.resolvePreference = g_commandLineOptions.mdnsResolvePreference;
         portFactories.push_back(&mdpf);
     }
 

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1198,11 +1198,88 @@ static void sendNmea(port_handle_t port, string nmeaMsg)
     portWrite(port, (unsigned char*)buf, n);
 }
 
+/**
+ * Discovers all available devices and resolves the target device ID to a port name.
+ * On success, sets g_commandLineOptions.comPort to the resolved port and returns true.
+ */
+static bool cltool_resolveDeviceTarget()
+{
+    uint64_t targetId = g_commandLineOptions.targetDeviceId;
+    uint32_t serialNo = (uint32_t)(targetId & 0xFFFFFFFFFFFF);
+    is_hardware_t hdwId = (is_hardware_t)(targetId >> 48);
+
+    // Build port factories identically to cltool_dataStreaming()
+    SerialPortFactory& spf = SerialPortFactory::getInstance();
+    spf.portOptions.defaultBaudRate = g_commandLineOptions.baudRate;
+    spf.portOptions.defaultBlocking = false;
+    TcpPortFactory& tpf = TcpPortFactory::getInstance();
+    tpf.portOptions.defaultBlocking = false;
+
+    std::vector<PortFactory*> portFactories = {&spf, &tpf};
+    if (g_commandLineOptions.useMdns) {
+        ISmDnsPortFactory& mdpf = ISmDnsPortFactory::getInstance();
+        mdpf.portOptions.defaultBlocking = false;
+        mdpf.portOptions.resolvePreference = g_commandLineOptions.mdnsResolvePreference;
+        portFactories.push_back(&mdpf);
+    }
+
+    {
+        InertialSense is(portFactories, {&CltoolDeviceFactory::getInstance()});
+        is.EnableDeviceValidation(true);
+
+        // Pre-warm mDNS cache if needed
+        if (g_commandLineOptions.useMdns) {
+            printf("Discovering mDNS devices...\n");
+            uint32_t deadline = current_timeMs() + 3000;
+            while (current_timeMs() < deadline) {
+                ISmDnsPortFactory::tick();
+                SLEEP_MS(50);
+            }
+        }
+
+        // Discover all devices using wildcard
+        if (!is.Open("*", g_commandLineOptions.baudRate)) {
+            printf("Failed to discover any devices.\n");
+            return false;
+        }
+
+        // Search for matching device
+        DeviceManager& dm = DeviceManager::getInstance();
+        device_handle_t target = dm.getDevice(serialNo, hdwId);
+        if (target) {
+            g_commandLineOptions.comPort = target->getPortName();
+            g_commandLineOptions.useMdns = false;   // Resolved to a concrete port URL; mDNS no longer needed
+            printf("Resolved %s to %s\n", target->getIdAsString().c_str(), g_commandLineOptions.comPort.c_str());
+        } else {
+            printf("Device not found. Discovered devices:\n");
+            for (auto& dev : dm) {
+                printf("  %s --> %s\n", dev->getPortName().c_str(), dev->getIdAsString().c_str());
+            }
+            return false;
+        }
+    }   // InertialSense destructor closes all connections
+
+    // Clear singleton state so the subsequent Open() starts fresh
+    DeviceManager::getInstance().clear(true);
+    PortManager::getInstance().clear();
+    PortManager::getInstance().clearPortFactories();
+    DeviceManager::getInstance().clearDeviceFactories();
+
+    return true;
+}
+
 static int inertialSenseMain()
 {
     g_inertialSenseDisplay.SetDisplayMode((cInertialSenseDisplay::eDisplayMode)g_commandLineOptions.displayMode);
     g_inertialSenseDisplay.SetKeyboardNonBlocking();
     // g_inertialSenseDisplay.Clear();     // clear display
+
+    // Resolve -sn target to a port name before any other operations
+    if (g_commandLineOptions.targetDeviceId != 0) {
+        if (!cltool_resolveDeviceTarget()) {
+            return EXIT_CODE_NO_DEVICES_FOUND;
+        }
+    }
 
     // if replay data log specified on command line, do that now and return
     if (g_commandLineOptions.replayDataLog)

--- a/src/ISBFirmwareUpdater.cpp
+++ b/src/ISBFirmwareUpdater.cpp
@@ -719,17 +719,14 @@ bool ISBFirmwareUpdater::waitForAck(const std::string& ackStr, const std::string
         return false;
 
     int count = portRead(device->port, rxWorkBufPtr, ackStr.length());
-    if (count < 0) {
-        return false; // FIXME: handle read errors more appropriately
+    if (count > 0) {
+        rxWorkBufPtr += count;
     }
 
-    rxWorkBufPtr += count;
-
-    // we want to have a calculated progress which seems reasonable.
-    // Since erasing flash is a non-deterministic operation (from our standpoint)
-    // let's use a log algorithm that will elapse approx 75% of the progress in
-    // the average time that a device takes to complete this operation (about 10 seconds)
-    // the remaining 25% will slowly elapse as we get closer to the timeout period.
+    // Update progress and send periodic reports regardless of whether data was received.
+    // portRead() returns -1 (EAGAIN/EWOULDBLOCK) on non-blocking TCP sockets when no data
+    // is available — this is expected during long operations like flash erase, and should
+    // not prevent progress reporting.
     progress = (float)(1.0 - std::pow((double)(maxTimeout - elapsedTime) / (double)maxTimeout, 4));
     if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
         nextProgressReport = current_timeMs() + progress_interval;

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -188,7 +188,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define STRNCPY(dst, src, maxlen) strncpy_s(dst, maxlen, src, maxlen);
 #endif
 
-#define strncasecmp _strnicmp 
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #else
     #ifndef INLINE
         #define INLINE inline

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -221,7 +221,7 @@ bool ISDevice::handshakeISbl() {
 
         if ((i == 4) && portAvailable(port)) {
             log_warn(IS_LOG_ISDEVICE, "[%s] ISDevice::handshakeISbl() is unable to clear the port RX buffer. Handshaking is not possible.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
-            return false;   // unable to clear buffer, so we can't handshake
+            return true;   // unable to clear buffer, so we can't handshake, but return true anyway so we don't keep trying
         }
     }
     fn.mark("RX Buffer cleared. Starting handshake.");
@@ -252,7 +252,7 @@ bool ISDevice::queryDeviceInfoISbl(uint32_t timeout) {
         return false;
 
     FnProfiler fn("ISDevice::queryDeviceInfoISbl() [" + getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO) + "]", timeout / 2 * 1000);    // this shouldn't really ever take longer than 50ms to execute
-    log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::queryDeviceInfoISbl() called.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+    //log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::queryDeviceInfoISbl() called.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
     if (!hasHandshake) {
         hasHandshake = handshakeISbl();     // We have to handshake before we can do anything... if we've already handshaked, we won't go a response, so ignore this result
         fn.mark("Handshake == " + std::to_string(hasHandshake));
@@ -323,7 +323,7 @@ bool ISDevice::queryDeviceInfoISbl(uint32_t timeout) {
     // hdwId = IS_HARDWARE_TYPE_UNKNOWN;
     // devInfo = {};
     fn.mark("Timed-out waiting.");
-    log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::queryDeviceInfoISbl() no valid response received - Either not an ISDevice, or not in ISbootloader.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+    // log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::queryDeviceInfoISbl() no valid response received - Either not an ISDevice, or not in ISbootloader.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
     return false;
 }
 
@@ -493,6 +493,62 @@ std::string ISDevice::getIdAsString(const dev_info_t& devInfo) {
 
 std::string ISDevice::getIdAsString() const {
     return getIdAsString(devInfo);
+}
+
+uint64_t ISDevice::parseDeviceIdString(const std::string& str) {
+    uint32_t serialNo = 0;
+    is_hardware_t hdwId = IS_HARDWARE_ANY;
+
+    // Find separator — accept both "::" (canonical) and ":" (shorthand)
+    std::string snPart;
+    size_t sepPos = str.find("::");
+    size_t sepLen = 2;
+    if (sepPos == std::string::npos) {
+        sepPos = str.find(':');
+        sepLen = 1;
+    }
+
+    if (sepPos != std::string::npos) {
+        // Has hardware type prefix, e.g. "IMX-5.0::SN129495" or "IMX-5.0:129495"
+        std::string hdwStr = str.substr(0, sepPos);
+        snPart = str.substr(sepPos + sepLen);
+
+        // Parse hardware type: "IMX-5.0", "GPX-1.0", "uINS-3.2", etc.
+        size_t dashPos = hdwStr.find('-');
+        if (dashPos != std::string::npos) {
+            std::string typeName = hdwStr.substr(0, dashPos);
+            std::string verStr = hdwStr.substr(dashPos + 1);
+            uint8_t hdwType = 0;
+            if (strcasecmp(typeName.c_str(), "IMX") == 0)       hdwType = IS_HARDWARE_TYPE_IMX;
+            else if (strcasecmp(typeName.c_str(), "GPX") == 0)   hdwType = IS_HARDWARE_TYPE_GPX;
+            else if (strcasecmp(typeName.c_str(), "uINS") == 0)  hdwType = IS_HARDWARE_TYPE_UINS;
+            else if (strcasecmp(typeName.c_str(), "EVB") == 0)   hdwType = IS_HARDWARE_TYPE_EVB;
+            if (hdwType) {
+                uint8_t major = 0, minor = 0;
+                size_t dotPos = verStr.find('.');
+                if (dotPos != std::string::npos) {
+                    major = (uint8_t)strtoul(verStr.c_str(), nullptr, 10);
+                    minor = (uint8_t)strtoul(verStr.c_str() + dotPos + 1, nullptr, 10);
+                } else {
+                    major = (uint8_t)strtoul(verStr.c_str(), nullptr, 10);
+                }
+                hdwId = ENCODE_HDW_ID(hdwType, major, minor);
+            }
+        }
+    } else {
+        // No separator — could be "SN129495" or just "129495"
+        snPart = str;
+    }
+
+    // Strip optional "SN" prefix from serial number part
+    if (snPart.size() > 2 && strncasecmp(snPart.c_str(), "SN", 2) == 0)
+        snPart = snPart.substr(2);
+    serialNo = strtoul(snPart.c_str(), nullptr, 10);
+
+    if (serialNo == 0)
+        return 0;
+
+    return ((uint64_t)hdwId << 48) | serialNo;
 }
 
 /**

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -1010,6 +1010,9 @@ bool ISDevice::WaitForImxFlashCfgSynced(bool forceSync, uint32_t timeoutMs)
     if (!port)
         return false;   // No device, no flash-sync
 
+    if (devInfo.hdwRunState != HDW_STATE_APP)
+        return false;   // Device not running application firmware
+
     if (forceSync)
         sysParams.flashCfgChecksum = 0xFFFFFFFF;    // Invalidate to force re-sync
 
@@ -1042,6 +1045,9 @@ bool ISDevice::WaitForGpxFlashCfgSynced(bool forceSync, uint32_t timeout)
 
     if (!port)
         return false;   // No device, no flash-sync
+
+    if (devInfo.hdwRunState != HDW_STATE_APP)
+        return false;   // Device not running application firmware
 
     if (forceSync)
         gpxStatus.flashCfgChecksum = 0xFFFFFFFF;    // Invalidate to force re-sync

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -167,6 +167,14 @@ public:
     uint64_t getUniqueId() { return getUniqueId(this->devInfo); }
 
     /**
+     * Parses a device identifier string into a unique ID (hdwId << 48 | serialNumber).
+     * Accepted formats: "IMX-5.0::SN129495", "IMX-5.0:129495", "GPX-1.0:SN42", "SN129495", "129495"
+     * If no hardware type is specified, IS_HARDWARE_ANY is used.
+     * @return unique ID, or 0 on parse failure
+     */
+    static uint64_t parseDeviceIdString(const std::string& str);
+
+    /**
      * Binds the specified port to this device. Reconfigures the port handler to call back
      * into this device instance, and reinitializes the underlying ISComm instance and
      * buffers.

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -393,6 +393,7 @@ void ISFirmwareUpdater::fwUpdate_handleLocalDevice() {
 }
 
 void ISFirmwareUpdater::refreshUpdateState() {
+    auto lk = updateState.lock();
     auto activeCmd = getActiveCommand();
     if (&activeCmd != &nullCmd)
         updateState.lastMessage = activeCmd.resultMsg;
@@ -620,7 +621,10 @@ void ISFirmwareUpdater::handleCommandError(ISFwUpdaterCmd& cmd, int errCode, con
     va_end(args);
 
     cmd.status = ISFwUpdaterCmd::CMD_ERROR;
-    updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, buffer);
+    {
+        auto lk = updateState.lock();
+        updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, buffer);
+    }
 
     LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_ERROR, buffer);
 

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <deque>
 #include <map>
+#include <mutex>
 
 #include "ISConstants.h"
 
@@ -155,9 +156,47 @@ public:
         message(const std::string& _target, const ISFwUpdaterCmd& _cmd, eLogLevel _severity, const std::string& _msg) : target(_target), cmd(_cmd), severity(_severity), msg(_msg) { };
     };
 
-    explicit ISFwUpdateState() = default;
+    ISFwUpdateState() = default;
+
+    // Copy constructor — copies all data fields but creates a fresh mutex (mutexes are non-copyable).
+    // The source is NOT locked here; callers should use getSnapshot() for thread-safe copies.
+    ISFwUpdateState(const ISFwUpdateState& other)
+        : lastMessage(other.lastMessage), state(other.state), status(other.status),
+          target(other.target), slot(other.slot), progress(other.progress),
+          messages(other.messages), hasErrors(other.hasErrors) { }
+
+    ISFwUpdateState& operator=(const ISFwUpdateState& other) {
+        if (this != &other) {
+            lastMessage = other.lastMessage;
+            state = other.state;
+            status = other.status;
+            target = other.target;
+            slot = other.slot;
+            progress = other.progress;
+            messages = other.messages;
+            hasErrors = other.hasErrors;
+        }
+        return *this;
+    }
+
+    /**
+     * Acquire a lock on this state object. All reads and writes to this state should be done while holding this lock,
+     * to prevent cross-thread data races (e.g., GUI thread reading while IOManager thread writes).
+     */
+    std::unique_lock<std::recursive_mutex> lock() const { return std::unique_lock<std::recursive_mutex>(mtx); }
+
+    /**
+     * Returns a thread-safe snapshot (copy) of the current state. The caller can safely read from the copy
+     * without holding a lock. Prefer this over direct field access from non-owner threads.
+     */
+    ISFwUpdateState getSnapshot() const {
+        auto lk = lock();
+        ISFwUpdateState snapshot(*this);
+        return snapshot;
+    }
 
     void resetState() {
+        auto lk = lock();
         lastMessage.clear();
         messages.clear();
         target = fwUpdate::TARGET_HOST;
@@ -175,6 +214,9 @@ public:
     float                       progress = 0.f;                     //!< the current/last progress of the target upload
     std::vector<message>        messages;                           //!< the collection of all messages that have occurred during the update
     bool                        hasErrors = false;                  //!< an easy indicator to track errors while still in progress, generally true if msgs contains one more IS_LOG_LEVEL_ERROR messages
+
+private:
+    mutable std::recursive_mutex mtx;                               //!< protects all fields from concurrent read/write across threads
 };
 
 

--- a/src/ISmDnsPortFactory.cpp
+++ b/src/ISmDnsPortFactory.cpp
@@ -21,6 +21,13 @@
 #include "util/util.h"
 #include "PortManager.h"
 #include "ISmDnsPortFactory.h"
+#include "TcpPortFactory.h"
+
+#if PLATFORM_IS_WINDOWS
+#include <ws2tcpip.h>
+#elif !PLATFORM_IS_EMBEDDED
+#include <arpa/inet.h>
+#endif
 
 /**
  * Major function from glibc reimplemented as a normal C function instead of as a define
@@ -154,12 +161,40 @@ void ISmDnsPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, s
     for (std::pair<std::string, std::vector<port_t>> hostPorts : portsAndHosts) {
         std::string hostname = hostPorts.first;
         std::vector<port_t> ports = hostPorts.second;
+
+        // Resolve hostname to a tcp:// URL host using configured preference (IPv4 > IPv6 > hostname)
+        sockaddr_storage addr = mdns::resolveName(hostname);
+        uint8_t resolveFlags = portOptions.resolvePreference;
+        std::string tcpHost;
+
+        // Try IPv4 first (highest precedence)
+        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV4) && addr.ss_family == AF_INET) {
+            char ipBuf[INET_ADDRSTRLEN] = {};
+            inet_ntop(AF_INET, &reinterpret_cast<sockaddr_in*>(&addr)->sin_addr, ipBuf, sizeof(ipBuf));
+            tcpHost = ipBuf;
+        }
+        // Try IPv6 second
+        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV6) && addr.ss_family == AF_INET6) {
+            char ipBuf[INET6_ADDRSTRLEN] = {};
+            inet_ntop(AF_INET6, &reinterpret_cast<sockaddr_in6*>(&addr)->sin6_addr, ipBuf, sizeof(ipBuf));
+            tcpHost = std::string("[") + ipBuf + "]";
+        }
+        // Fall back to hostname (TcpPortFactory resolves via getaddrinfo)
+        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_HOSTNAME)) {
+            tcpHost = hostname;
+            if (!tcpHost.empty() && tcpHost.back() == '.') {
+                tcpHost.pop_back();
+            }
+        }
+        if (tcpHost.empty()) continue;
+
         for (port_t port : ports) {
             std::pair<std::string, port_t> portPair = {hostname, port};
             portPair = getCanonicalPortData(portPair);
-            std::string portURL = getPortURL(portPair);
-            if (std::regex_match(portURL, regexPattern)) {
-                portCallback(this, PORT_TYPE__TCP | pType, portURL);
+            std::string mdnsURL = getPortURL(portPair);
+            std::string tcpURL = "tcp://" + tcpHost + ":" + std::to_string(portPair.second.port);
+            if (std::regex_match(mdnsURL, regexPattern) || std::regex_match(tcpURL, regexPattern)) {
+                portCallback(&TcpPortFactory::getInstance(), PORT_TYPE__TCP | PORT_TYPE__COMM | pType, tcpURL);
             }
         }
     }
@@ -313,7 +348,7 @@ std::pair<std::string, ISmDnsPortFactory::port_t> ISmDnsPortFactory::getCanonica
         }
     } else if (partialPort.port != 0) {
         for (port_t fullPort: ports) {
-            if (partialPort.port == fullPort.devid) {
+            if (partialPort.port == fullPort.port) {
                 returnPort = fullPort;
                 break;
             }

--- a/src/ISmDnsPortFactory.cpp
+++ b/src/ISmDnsPortFactory.cpp
@@ -162,22 +162,33 @@ void ISmDnsPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, s
         std::string hostname = hostPorts.first;
         std::vector<port_t> ports = hostPorts.second;
 
-        // Resolve hostname to a tcp:// URL host using configured preference (IPv4 > IPv6 > hostname)
-        sockaddr_storage addr = mdns::resolveName(hostname);
+        // Resolve hostname to a tcp:// URL host using configured preference (IPv4 > IPv6 > hostname).
+        // resolveName() returns whichever record it finds first, which may not match the
+        // requested preference. Search the cache directly for the specific record type needed.
         uint8_t resolveFlags = portOptions.resolvePreference;
         std::string tcpHost;
 
         // Try IPv4 first (highest precedence)
-        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV4) && addr.ss_family == AF_INET) {
-            char ipBuf[INET_ADDRSTRLEN] = {};
-            inet_ntop(AF_INET, &reinterpret_cast<sockaddr_in*>(&addr)->sin_addr, ipBuf, sizeof(ipBuf));
-            tcpHost = ipBuf;
+        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV4)) {
+            auto records = mdns::getRecords([&hostname](const mdns::mdns_record_cpp_t& r) {
+                return r.type == MDNS_RECORDTYPE_A && r.name == hostname;
+            });
+            if (!records.empty()) {
+                char ipBuf[INET_ADDRSTRLEN] = {};
+                inet_ntop(AF_INET, &records[0].data.a.addr.sin_addr, ipBuf, sizeof(ipBuf));
+                tcpHost = ipBuf;
+            }
         }
         // Try IPv6 second
-        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV6) && addr.ss_family == AF_INET6) {
-            char ipBuf[INET6_ADDRSTRLEN] = {};
-            inet_ntop(AF_INET6, &reinterpret_cast<sockaddr_in6*>(&addr)->sin6_addr, ipBuf, sizeof(ipBuf));
-            tcpHost = std::string("[") + ipBuf + "]";
+        if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_IPV6)) {
+            auto records = mdns::getRecords([&hostname](const mdns::mdns_record_cpp_t& r) {
+                return r.type == MDNS_RECORDTYPE_AAAA && r.name == hostname;
+            });
+            if (!records.empty()) {
+                char ipBuf[INET6_ADDRSTRLEN] = {};
+                inet_ntop(AF_INET6, &records[0].data.aaaa.addr.sin6_addr, ipBuf, sizeof(ipBuf));
+                tcpHost = std::string("[") + ipBuf + "]";
+            }
         }
         // Fall back to hostname (TcpPortFactory resolves via getaddrinfo)
         if (tcpHost.empty() && (resolveFlags & MDNS_RESOLVE_HOSTNAME)) {

--- a/src/ISmDnsPortFactory.h
+++ b/src/ISmDnsPortFactory.h
@@ -15,6 +15,13 @@
 #include "core/tcpPort.h"
 #include "PortFactory.h"
 
+enum MdnsResolveFlags : uint8_t {
+    MDNS_RESOLVE_IPV4     = 0x01,   //!< Prefer resolved IPv4 address (e.g. tcp://192.168.1.5:port)
+    MDNS_RESOLVE_IPV6     = 0x02,   //!< Prefer resolved IPv6 address (e.g. tcp://[fdc2::1]:port)
+    MDNS_RESOLVE_HOSTNAME = 0x04,   //!< Use mDNS hostname (e.g. tcp://hostname.local:port)
+    MDNS_RESOLVE_DEFAULT  = MDNS_RESOLVE_IPV4 | MDNS_RESOLVE_IPV6 | MDNS_RESOLVE_HOSTNAME,
+};
+
 /**
  * Singleton class passed to PortManager to autodiscover and connect to remote serial ports over the network
  *
@@ -25,6 +32,7 @@ class ISmDnsPortFactory : public PortFactory {
 public:
     struct {
         bool defaultBlocking = false;
+        uint8_t resolvePreference = MDNS_RESOLVE_DEFAULT;   //!< Bitmask of MdnsResolveFlags; precedence: IPv4 > IPv6 > hostname
     } portOptions = {};
 
     static ISmDnsPortFactory& getInstance() {

--- a/src/TcpPortFactory.cpp
+++ b/src/TcpPortFactory.cpp
@@ -107,7 +107,7 @@ bool TcpPortFactory::releasePort(port_handle_t port) {
         return false;
     }
 
-    log_debug(IS_LOG_PORT, "Releasing TCP/network port '%s'\n", portName(port));
+    log_debug(IS_LOG_PORT, "Releasing TCP/network port '%s'", portName(port));
     tcpPortDelete(port);
     delete static_cast<tcp_port_t*>(port);
 

--- a/src/TcpServerPortFactory.cpp
+++ b/src/TcpServerPortFactory.cpp
@@ -85,7 +85,7 @@ bool TcpServerPortFactory::releasePort(port_handle_t port) {
         return false;
     }
 
-    log_debug(IS_LOG_PORT_FACTORY, "Releasing TCP/network port '%s'\n", portName(port));
+    log_debug(IS_LOG_PORT_FACTORY, "Releasing TCP/network port '%s'", portName(port));
 
     for (auto it = knownSockets.begin(); it != knownSockets.end(); it++) {
         if (it->port == port) {

--- a/src/core/msg_logger.c
+++ b/src/core/msg_logger.c
@@ -99,7 +99,7 @@ static inline void static_log_timestamp(FILE* log_file, const char* prefix) {
     #else
     localtime_r(&ts.tv_sec, &tm_buf);
     #endif
-    fprintf(log_file, "[%02d:%02d:%02d.%03ld] %s", tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec, (long)(ts.tv_nsec / 1000), (prefix ? prefix : ""));
+    fprintf(log_file, "[%02d:%02d:%02d.%06ld] %s", tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec, (long)(ts.tv_nsec / 1000), (prefix ? prefix : ""));
 }
 
 void static_log_msg(int facility_code, int msg_log_level, const char *facility_name, const char *format, ...) {
@@ -114,14 +114,13 @@ void static_log_msg(int facility_code, int msg_log_level, const char *facility_n
         }
     }
 
-    static_log_timestamp(log_file, ":: ");
+    static const char* log_level_names[] = { "NONE", "ERROR", "WARN", "INFO", "INFO+", "DEBUG", "DEBUG+", "CRAZY" };
+    static_log_timestamp(log_file, NULL);
 
-    if (facility_code) {
-        fprintf(log_file, "%s ", facility_name);
-    }
-
-    static const char* log_level_names[] = { "[NONE]", "[ERROR]", "[WARN]", "[INFO]", "[INFO+]", "[DEBUG]", "[DEBUG+]", "[CRAZY]" };
-    fprintf(log_file, "%s : ", log_level_names[msg_log_level]);
+    if (facility_code)
+        fprintf(log_file, "%-6s (%s) :: ", log_level_names[msg_log_level],  facility_name);
+    else
+        fprintf(log_file, "%-6s :: ", log_level_names[msg_log_level]);
 
     char logMsg[512];
     va_list args;

--- a/src/core/tcpPort.c
+++ b/src/core/tcpPort.c
@@ -73,8 +73,14 @@ int tcpPortOpen(port_handle_t port) {
         }
     }
 
-    // Connect socket to remote
-    int retval = connect(tcpPort->socket, &tcpPort->addr.generic, sizeof(tcpPort->addr.storage));
+    // Connect socket to remote (use family-specific address length)
+    socklen_t addrlen;
+    switch (tcpPort->addr.domain) {
+        case AF_INET:  addrlen = sizeof(struct sockaddr_in);  break;
+        case AF_INET6: addrlen = sizeof(struct sockaddr_in6); break;
+        default:       addrlen = sizeof(tcpPort->addr.storage); break;
+    }
+    int retval = connect(tcpPort->socket, &tcpPort->addr.generic, addrlen);
     if (retval != 0) {
         portFlagsClear(port, PORT_FLAG__OPENED);
         HANDLE_SOCKET_ERROR(tcpPort);   // this will override our socket... do we really want to do that?

--- a/src/core/tcpPort.c
+++ b/src/core/tcpPort.c
@@ -82,8 +82,10 @@ int tcpPortOpen(port_handle_t port) {
     }
     int retval = connect(tcpPort->socket, &tcpPort->addr.generic, addrlen);
     if (retval != 0) {
-        portFlagsClear(port, PORT_FLAG__OPENED);
-        HANDLE_SOCKET_ERROR(tcpPort);   // this will override our socket... do we really want to do that?
+        if (errno != EISCONN) {
+            portFlagsClear(port, PORT_FLAG__OPENED);
+            HANDLE_SOCKET_ERROR(tcpPort);   // this will override our socket... do we really want to do that?
+        }
     }
 
     // Set socket mode

--- a/src/core/tcpPort.c
+++ b/src/core/tcpPort.c
@@ -20,6 +20,7 @@
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#include <poll.h>
 #define SETSOCKOPT(sock, level, optname, optval, optlen) setsockopt(sock, level, optname, optval, optlen)
 #define HANDLE_SOCKET_ERROR(tcpPort) do { tcpPort->socket = -errno; tcpPort->base.perror = errno; return -errno; } while(0)
 #endif
@@ -285,32 +286,33 @@ int tcpPortReadTimeout(port_handle_t port, uint8_t* buf, unsigned int len, uint3
         return tcpPort->socket;
     }
 
+    // Use poll() to wait for data with timeout — works correctly regardless of
+    // blocking mode (SO_RCVTIMEO is ignored on non-blocking sockets on Linux).
+#ifdef PLATFORM_IS_WINDOWS
     tcpPortSetBlocking(port, false);
-    // Set a timeout on the socket
-#ifdef PLATFORM_IS_WINDOWS
     DWORD tv = timeout;
-#else
-    struct timeval tv;
-    tv.tv_sec = timeout/1000;
-    tv.tv_usec = (timeout % 1000) * 1000;
-#endif
     if (SETSOCKOPT(tcpPort->socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
         HANDLE_SOCKET_ERROR(tcpPort);
     }
-
-    // Receive data from the socket
     ssize_t retval = recv(tcpPort->socket, buf, len, 0);
-
-    // Reset socket timeout
-#ifdef PLATFORM_IS_WINDOWS
     tv = 0;
-#else
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-#endif
     if (SETSOCKOPT(tcpPort->socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) != 0) {
         HANDLE_SOCKET_ERROR(tcpPort);
     }
+#else
+    tcpPortSetBlocking(port, false);
+    struct pollfd pfd = { .fd = tcpPort->socket, .events = POLLIN };
+    int pollrc = poll(&pfd, 1, (int)timeout);
+    ssize_t retval;
+    if (pollrc > 0 && (pfd.revents & POLLIN)) {
+        retval = recv(tcpPort->socket, buf, len, 0);
+    } else if (pollrc == 0) {
+        return 0;  // Timeout — no data available
+    } else {
+        HANDLE_SOCKET_ERROR(tcpPort);
+        return -1;
+    }
+#endif
 
     // Return
     if (retval < 0) {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -25,6 +25,8 @@
 #define IS_LOG_FN_PROFILER         ((IS_LOG_CHRONO_STATS << 1))
 #define IS_LOG_FACILITY_MDNS       ((IS_LOG_FN_PROFILER << 1))
 #define IS_LOG_CORRECTIONS         ((IS_LOG_FACILITY_MDNS << 1))
+#define IS_LOG_APP_EVALTOOL        ((IS_LOG_CORRECTIONS << 1))
+#define IS_LOG_APP_CLTOOL          ((IS_LOG_APP_EVALTOOL << 1))
 #define IS_LOG_FACILITY_ALL        0xFFFF
 
 typedef enum {

--- a/src/protocol/mdns.cpp
+++ b/src/protocol/mdns.cpp
@@ -319,10 +319,11 @@ int mdns::queryCallback(int sock, const struct sockaddr* from, size_t addrlen, m
                         size_t size, size_t name_offset, size_t name_length, size_t record_offset,
                         size_t record_length, void* user_data) {
 
-    // Do not process ANSWER messages
-    if (entry != MDNS_ENTRYTYPE_ANSWER) {
-        log_more_debug(IS_LOG_FACILITY_MDNS, "Unable to process non ANSWER responses: Not Supported.");
-        return -ENOTSUP;
+    // Process ANSWER and ADDITIONAL records (additional carries A/AAAA/SRV/TXT
+    // alongside PTR responses per RFC 6762). Skip AUTHORITY and QUESTION entries.
+    if (entry != MDNS_ENTRYTYPE_ANSWER && entry != MDNS_ENTRYTYPE_ADDITIONAL) {
+        log_more_debug(IS_LOG_FACILITY_MDNS, "Ignoring AUTHORITY/QUESTION record entry type: %d", entry);
+        return 0;
     }
 
     // Create buffers for strings

--- a/src/protocol/mdns.hpp
+++ b/src/protocol/mdns.hpp
@@ -250,7 +250,11 @@ public:
         }
         mdns_record_cpp_t() = default;
         bool isEqual(const mdns_record_cpp_t &other) const {
-            if ((name != other.name) || (type != other.type) || (rclass != other.rclass) || (ttl != other.ttl)) return false;
+            // Record identity is (name, type, rclass) per DNS spec.
+            // TTL is metadata, not identity. rdata is included for PTR
+            // (multiple instances per service type) but excluded for TXT
+            // (updated data should replace, not accumulate).
+            if ((name != other.name) || (type != other.type) || (rclass != other.rclass)) return false;
             if (type == MDNS_RECORDTYPE_PTR) {
                 return data.ptr.isEqual(other.data.ptr);
             } else if (type == MDNS_RECORDTYPE_SRV) {
@@ -260,7 +264,10 @@ public:
             } else if (type == MDNS_RECORDTYPE_AAAA) {
                 return data.aaaa.isEqual(other.data.aaaa);
             } else if (type == MDNS_RECORDTYPE_TXT) {
-                return data.txt.isEqual(other.data.txt);
+                // TXT identity is (name, type, rclass, key) — value is metadata.
+                // When a service re-registers with new port data, the new TXT
+                // record should replace the old one, not accumulate both.
+                return data.txt.key == other.data.txt.key;
             } else {
                 return true; // ANY and IGNORE record types don't have data to compare
             }
@@ -337,16 +344,18 @@ public:
         return seed;
     }
 
-    // We need to write our own hash function to store mdns records in a hashmap
+    // Hash function for mDNS record cache. Must be consistent with isEqual().
+    // TTL is excluded (it's metadata, not identity). TXT value is excluded
+    // so that updated TXT data replaces old entries instead of accumulating.
     struct mdns_record_cpp_tHash {
         std::size_t operator()(const mdns::mdns_record_cpp_t& r) const noexcept {
-            std::size_t hash1 = std::hash<std::string>{}(std::to_string(r.ttl));
-            std::size_t hash2 = std::hash<std::string>{}(std::to_string(r.rclass));
-            hash1 = hash1 ^ (hash2 << 1); // Combine hashes
-            hash2 = std::hash<std::string>{}(std::to_string(r.type));
+            // Base identity: (name, type, rclass)
+            std::size_t hash1 = std::hash<std::string>{}(std::to_string(r.rclass));
+            std::size_t hash2 = std::hash<std::string>{}(std::to_string(r.type));
             hash1 = hash1 ^ (hash2 << 1);
             hash2 = std::hash<std::string>{}(r.name);
             hash1 = hash1 ^ (hash2 << 1);
+            // Include rdata for types where multiple records per name are valid
             if (r.type == MDNS_RECORDTYPE_PTR) {
                 hash2 = std::hash<std::string>{}(r.data.ptr.name);
                 hash1 = hash1 ^ (hash2 << 1);
@@ -380,8 +389,8 @@ public:
                     hash1 = hash1 ^ (hash2 << 1);
                 }
             } else if (r.type == MDNS_RECORDTYPE_TXT) {
-                hash2 = hashVector(r.data.txt.value);
-                hash1 = hash1 ^ (hash2 << 1);
+                // Only hash TXT key, not value — updated port data should
+                // replace old entries, not accumulate alongside them
                 hash2 = std::hash<std::string>{}(r.data.txt.key);
                 hash1 = hash1 ^ (hash2 << 1);
             }


### PR DESCRIPTION
## Summary

This branch fixes the `tcpPortReadTimeout` function on Linux and bundles several related networking, mDNS, firmware update, and cltool improvements that were developed together during TCP/mDNS device connectivity work.

### Core Fix: TCP Read Timeout on Linux (596f05ef)
- `tcpPortReadTimeout()` used `SO_RCVTIMEO` to implement read timeouts, but this socket option is **ignored for non-blocking sockets on Linux**, causing timeouts to silently not work.
- Refactored Linux implementation to use `poll()`, which correctly handles timeouts regardless of blocking mode. The Windows path (which works with `SO_RCVTIMEO`) is unchanged.

### mDNS Fixes & Configurable Resolution (f1f9ccc8, 6f345811, 49b597ef)
- **Cache ADDITIONAL records** alongside ANSWER records in mDNS query callback. PTR responses include A/AAAA/SRV/TXT as additional records per RFC 6762 — previously these were silently dropped, so IPv4 (A) records from PTR responses were never cached.
- **Family-aware port resolution**: When `-mdns-resolve=v4` is set, the code now searches the mDNS cache for A records directly, instead of relying on `resolveName()` which returns whichever A/AAAA it finds first.
- **Fix mDNS record identity**: TTL is now excluded from record identity (it's metadata per DNS spec). For TXT records, only the key determines identity — updated port data replaces old entries instead of accumulating duplicates. Hash function updated to match.
- **New `-mdns-resolve=` option** for cltool: configurable preference for resolving mDNS hostnames to IPv4, IPv6, or raw hostname via a bitmask (`MdnsResolveFlags`).
- mDNS port factory now resolves `.local` hostnames to concrete IP addresses and hands off to `TcpPortFactory` instead of passing mDNS URLs directly.

### Device Discovery by ID — New `-sn` Option (0a59af11)
- New cltool option `-sn DEVICE_ID` discovers all devices (serial, TCP, mDNS) and connects to the one matching the identifier.
- Accepts flexible formats: `129495`, `SN129495`, `IMX-5.0:SN129495`, `GPX-1.0::SN42`.
- Implemented via `ISDevice::parseDeviceIdString()` (static parser) and `cltool_resolveDeviceTarget()` (discovery + resolution flow).

### Firmware Update Thread Safety (1efee621)
- Added `std::recursive_mutex` to `ISFwUpdateState` with `lock()` and `getSnapshot()` methods to prevent data races between GUI and I/O threads.
- Copy constructor and assignment operator implemented to handle non-copyable mutex.
- `refreshUpdateState()` and `handleCommandError()` now acquire the lock before modifying state.

### Additional Fixes
- **ISBFirmwareUpdater**: `portRead()` returning -1 (`EAGAIN`/`EWOULDBLOCK`) on non-blocking TCP sockets no longer halts progress reporting during long operations like flash erase.
- **tcpPort.c**: Use family-specific `socklen_t` in `connect()` call (fixes IPv6 connections). Handle `EISCONN` from `connect()` on already-connected sockets.
- **ISDevice**: `handshakeISbl()` returns `true` when unable to clear RX buffer to avoid repeated failing attempts. Flash config sync skipped when device is not in app firmware state (`HDW_STATE_APP`).
- **Logging**: Timestamps upgraded to microsecond precision (`%06ld`). Log format improved with aligned level names and facility codes.
- **Log facilities**: Added `IS_LOG_APP_EVALTOOL` and `IS_LOG_APP_CLTOOL` facility codes.
- **Minor**: Fixed port vs devid comparison bug in `getCanonicalPortData()`. Removed stray `\n` in log format strings for `TcpPortFactory` and `TcpServerPortFactory`.

## Files Changed (17 files, +361 / -67)

| File | Changes |
|------|---------|
| `cltool/src/cltool.cpp` | `-sn` and `-mdns-resolve=` CLI options, usage text |
| `cltool/src/cltool.h` | New fields: `targetDeviceId`, `mdnsResolvePreference` |
| `cltool/src/cltool_main.cpp` | `cltool_resolveDeviceTarget()`, mDNS resolve preference passthrough |
| `src/ISBFirmwareUpdater.cpp` | Handle EAGAIN from non-blocking portRead during flash erase |
| `src/ISDevice.cpp` | `parseDeviceIdString()`, bootloader handshake fix, flash sync guards |
| `src/ISDevice.h` | `parseDeviceIdString()` declaration |
| `src/ISFirmwareUpdater.cpp` | Thread-safe state updates |
| `src/ISFirmwareUpdater.h` | `recursive_mutex`, `lock()`, `getSnapshot()`, copy ctor/assignment |
| `src/ISmDnsPortFactory.cpp` | IPv4/IPv6/hostname resolution, TcpPortFactory handoff, port comparison fix |
| `src/ISmDnsPortFactory.h` | `MdnsResolveFlags` enum, `resolvePreference` option |
| `src/TcpPortFactory.cpp` | Remove stray `\n` from log format |
| `src/TcpServerPortFactory.cpp` | Remove stray `\n` from log format |
| `src/core/msg_logger.c` | Microsecond timestamps, improved log format |
| `src/core/tcpPort.c` | `poll()` for timeouts on Linux, family-specific addrlen, EISCONN handling |
| `src/core/types.h` | New log facility codes |
| `src/protocol/mdns.cpp` | Accept ADDITIONAL records in queryCallback |
| `src/protocol/mdns.hpp` | Record identity excludes TTL/TXT value, updated hash function |

## Test Plan
- [x] Verify TCP read timeouts work correctly on Linux with non-blocking sockets
- [x] Test mDNS device discovery with `-mdns-resolve=v4`, `-mdns-resolve=v6`, and `-mdns-resolve=hostname`
- [x] Test `-sn` option with serial number, SN-prefixed, and full hardware type formats
- [x] Confirm firmware update progress reporting continues during flash erase over TCP
- [ ] Verify no regressions on Windows TCP path
- [ ] Test mDNS discovery finds devices that were previously missed due to dropped ADDITIONAL records
