### PR TITLE
SN-7264 - Support for loading calibration for REST API/Calibration DB.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,8 @@ if (WIN32)
 	add_dependencies(${PROJECT_NAME} gen_files)
 
     # We need to ensure windows static libs are found
-    target_link_libraries(${PROJECT_NAME} Ws2_32.lib Iphlpapi.lib)
+    # PUBLIC so consumers of InertialSenseSDK automatically link Winsock
+    target_link_libraries(${PROJECT_NAME} PUBLIC Ws2_32.lib Iphlpapi.lib)
 elseif(APPLE)
     # macOS specific include dir
     target_include_directories(${PROJECT_NAME} PUBLIC
@@ -209,5 +210,5 @@ elseif(LINUX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 	# Link in Linux specific packages
-    target_link_libraries(${PROJECT_NAME} ${UDEV_LIBRARIES} m)
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${UDEV_LIBRARIES} m)
 endif ()

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,6 +69,8 @@ ext_modules = [
         "inertialsense.logs.log_reader",
         sorted(glob.glob("inertialsense/logs/src/*.cpp")),  # Sort source files for reproducibility
         include_dirs = include_dirs,
+        libraries = libraries,
+        library_dirs = library_dirs,
         extra_objects = extra_objects
     ),
 ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,7 +46,7 @@ else:
 
 static_libraries = ['InertialSenseSDK']
 static_lib_dir = '..'
-libraries = []
+libraries = ['Ws2_32', 'Iphlpapi'] if sys.platform == 'win32' else []
 library_dirs = []
 
 if sys.platform == 'win32':

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -10,6 +10,7 @@
 #include "ISDevice.h"
 #include "ISFirmwareUpdater.h"
 #include "ISDeviceCal.h"
+#include "ISHttpRequest.h"
 #include "util/util.h"
 #include "imx_defaults.h"
 #include "ISLogger.h"
@@ -1290,7 +1291,7 @@ bool ISDevice::UploadImxCalibrationFromFile(std::string path)
 {
     // Load Calibration data
     sensor_cal_t scal = {};
-    if( !ISDeviceCal::loadCalibrationFromJsonObj( path, NULL, &(scal.info), &(scal.data.dinfo), &(scal.data.tcal), &(scal.data.mcal) ) )
+    if( !ISDeviceCal::loadCalibrationFromJsonFile( path, NULL, &(scal.info), &(scal.data.dinfo), &(scal.data.tcal), &(scal.data.mcal) ) )
         return false;
 
     if (!port)
@@ -1315,7 +1316,198 @@ bool ISDevice::UploadImxCalibrationFromFile(std::string path)
     {
         log_error(IS_LOG_ISDEVICE, "[%s] Calibration upload failed!", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
         return false;
-    }       
+    }
+}
+
+bool ISDevice::UploadImxCalibrationFromJson(const nlohmann::json& calJson)
+{
+    // Load calibration data from JSON object
+    sensor_cal_t scal = {};
+    if (!ISDeviceCal::loadCalibrationFromJsonObj(calJson, NULL, &(scal.info), &(scal.data.dinfo), &(scal.data.tcal), &(scal.data.mcal)))
+        return false;
+
+    if (!port)
+        return false;
+
+    int calUploadState = 0;
+    int result = 0;
+    do {
+        result = ISDeviceCal::uploadSensorCalStep(port, calUploadState, scal);
+        SLEEP_MS(ISDeviceCal::CAL_UPLOAD_SLEEP_MS);
+    } while (result == 0);
+
+    if (result == 1)
+    {
+        log_info(IS_LOG_ISDEVICE, "[%s] Calibration upload from JSON complete.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        return true;
+    }
+    else
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Calibration upload from JSON failed!", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        return false;
+    }
+}
+
+int ISDevice::UploadIMXCalibrationFromURL(const std::string& restBaseUrl)
+{
+    using json = nlohmann::json;
+
+    // Build hardware type string (e.g., "IMX-5.0")
+    const char *typeName = "???";
+    switch (devInfo.hardwareType) {
+        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
+        case IS_HARDWARE_TYPE_IMX:  typeName = "IMX"; break;
+        case IS_HARDWARE_TYPE_GPX:  typeName = "GPX"; break;
+        default: break;
+    }
+    std::string hwType = std::string(typeName) + "-" + std::to_string(devInfo.hardwareVer[0]) + "." + std::to_string(devInfo.hardwareVer[1]);
+
+    log_info(IS_LOG_ISDEVICE, "[%s] Fetching calibration from DB for %s SN%ld",
+        getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), hwType.c_str(), devInfo.serialNumber);
+
+    // Step 1: Fetch device calibration list
+    std::string deviceUrl = restBaseUrl + "/api/calibration/device/" + hwType + "/" + std::to_string(devInfo.serialNumber);
+    ISHttpRequest::Response listResp = ISHttpRequest::get(deviceUrl);
+
+    if (listResp.statusCode == -1)
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Failed to connect to calibration DB at %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), deviceUrl.c_str());
+        return -1;
+    }
+
+    if (listResp.statusCode == 404)
+    {
+        log_warn(IS_LOG_ISDEVICE, "[%s] Device not found in calibration DB (HTTP 404)",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        return 404;
+    }
+
+    if (listResp.statusCode != 200)
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Calibration DB returned HTTP %d: %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), listResp.statusCode, listResp.statusMessage.c_str());
+        return listResp.statusCode;
+    }
+
+    // Step 2: Parse response to find most recent calibration UUID
+    json listJson;
+    try {
+        listJson = json::parse(listResp.body);
+    } catch (const json::parse_error& e) {
+        log_error(IS_LOG_ISDEVICE, "[%s] Failed to parse calibration list JSON: %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), e.what());
+        return -1;
+    }
+
+    // Find most recent calibration by calDateTime
+    std::string bestUuid;
+    std::string bestDateTime;
+
+    // API returns { "<deviceUuid>": [ {calUuid, calDateTime, ...}, ... ] }
+    // Iterate all values in the top-level object to find calibration entries
+    if (listJson.is_object())
+    {
+        for (auto& [devUuid, calArray] : listJson.items())
+        {
+            if (!calArray.is_array())
+                continue;
+
+            for (const auto& cal : calArray)
+            {
+                std::string calUuid;
+                if (cal.contains("calUuid"))
+                    calUuid = cal["calUuid"].get<std::string>();
+                else if (cal.contains("uuid"))
+                    calUuid = cal["uuid"].get<std::string>();
+                else
+                    continue;
+
+                std::string dateTime;
+                if (cal.contains("calDateTime"))
+                    dateTime = cal["calDateTime"].get<std::string>();
+
+                if (bestUuid.empty() || dateTime > bestDateTime)
+                {
+                    bestUuid = calUuid;
+                    bestDateTime = dateTime;
+                }
+            }
+        }
+    }
+    else if (listJson.is_array())
+    {
+        // Fallback: top-level array of calibration entries
+        for (const auto& cal : listJson)
+        {
+            std::string calUuid;
+            if (cal.contains("calUuid"))
+                calUuid = cal["calUuid"].get<std::string>();
+            else if (cal.contains("uuid"))
+                calUuid = cal["uuid"].get<std::string>();
+            else
+                continue;
+
+            std::string dateTime;
+            if (cal.contains("calDateTime"))
+                dateTime = cal["calDateTime"].get<std::string>();
+
+            if (bestUuid.empty() || dateTime > bestDateTime)
+            {
+                bestUuid = calUuid;
+                bestDateTime = dateTime;
+            }
+        }
+    }
+
+    if (bestUuid.empty())
+    {
+        log_warn(IS_LOG_ISDEVICE, "[%s] No calibrations found for device in DB",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        return 404;
+    }
+
+    log_info(IS_LOG_ISDEVICE, "[%s] Found calibration UUID: %s (date: %s)",
+        getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), bestUuid.c_str(), bestDateTime.c_str());
+
+    // Step 3: Fetch full calibration JSON
+    std::string calUrl = restBaseUrl + "/api/calibration/" + bestUuid;
+    ISHttpRequest::Response calResp = ISHttpRequest::get(calUrl);
+
+    if (calResp.statusCode == -1)
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Failed to fetch calibration data from %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), calUrl.c_str());
+        return -1;
+    }
+
+    if (calResp.statusCode != 200)
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Calibration DB returned HTTP %d for UUID %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), calResp.statusCode, bestUuid.c_str());
+        return calResp.statusCode;
+    }
+
+    // Step 4: Parse and upload calibration
+    json calJson;
+    try {
+        calJson = json::parse(calResp.body);
+    } catch (const json::parse_error& e) {
+        log_error(IS_LOG_ISDEVICE, "[%s] Failed to parse calibration JSON: %s",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), e.what());
+        return -1;
+    }
+
+    if (!UploadImxCalibrationFromJson(calJson))
+    {
+        log_error(IS_LOG_ISDEVICE, "[%s] Failed to upload calibration from DB",
+            getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        return -1;
+    }
+
+    log_info(IS_LOG_ISDEVICE, "[%s] Successfully uploaded calibration from DB (UUID: %s)",
+        getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), bestUuid.c_str());
+    return 200;
 }
 
 bool ISDevice::softwareReset() {

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <memory>
 
+#include "json.hpp"
 #include "core/msg_logger.h"
 #include "DeviceLog.h"
 #include "protocol/FirmwareUpdate.h"
@@ -570,6 +571,20 @@ public:
      * @return true for success, false for failure.
      */
     bool UploadImxCalibrationFromFile(std::string path);
+
+    /**
+     * @brief Upload calibration from a pre-parsed JSON object
+     * @param calJson - Parsed JSON object containing calibration data
+     * @return true for success, false for failure.
+     */
+    bool UploadImxCalibrationFromJson(const nlohmann::json& calJson);
+
+    /**
+     * @brief Fetch calibration from REST API and upload to device
+     * @param restBaseUrl - Base URL of the calibration database (e.g., "http://caldb.local:8080")
+     * @return HTTP status code (200 = success), -1 for connection/parse errors
+     */
+    int UploadIMXCalibrationFromURL(const std::string& restBaseUrl);
 
     void SaveFlashConfigFile(std::string path);
 

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -313,7 +313,7 @@ static void JsonObjv1p2ToSensor(const json& jTC, int device, sensor_tcal_group_t
     }
 }
 
-bool ISDeviceCal::loadCalibrationFromJsonObj(const std::string& filePath, sOrthoCal *ocal, sensor_cal_info_t *info, sensor_data_info_t *dinfo, sensor_tcal_group_t *tcal, sensor_mcal_group_t* mcal, int* pose)
+bool ISDeviceCal::loadCalibrationFromJsonFile(const std::string& filePath, sOrthoCal *ocal, sensor_cal_info_t *info, sensor_data_info_t *dinfo, sensor_tcal_group_t *tcal, sensor_mcal_group_t* mcal, int* pose)
 {
     // Read file
     std::ifstream jsonFile(filePath);
@@ -323,7 +323,6 @@ bool ISDeviceCal::loadCalibrationFromJsonObj(const std::string& filePath, sOrtho
         return false;
     }
 
-    // cout << "Loading calibration: " << filePath << endl;
     printf("Loading calibration: %s\n", filePath.c_str());
 
     // Parse JSON
@@ -340,6 +339,30 @@ bool ISDeviceCal::loadCalibrationFromJsonObj(const std::string& filePath, sOrtho
     {   // Error in file.  Likely invalid data (i.e. Infinity or NAN).
         return false;
     }
+
+    return loadCalibrationFromJsonObj(jObj, ocal, info, dinfo, tcal, mcal, pose, filePath);
+}
+
+bool ISDeviceCal::loadCalibrationFromJsonString(const std::string& jsonString, sOrthoCal *ocal, sensor_cal_info_t *info, sensor_data_info_t *dinfo, sensor_tcal_group_t *tcal, sensor_mcal_group_t* mcal, int* pose)
+{
+    json jObj;
+    try {
+        jObj = json::parse(jsonString);
+    } catch (const json::parse_error& e) {
+        cout << "JSON parse error: " << e.what() << endl;
+        return false;
+    }
+
+    if (jObj.empty())
+        return false;
+
+    return loadCalibrationFromJsonObj(jObj, ocal, info, dinfo, tcal, mcal, pose);
+}
+
+bool ISDeviceCal::loadCalibrationFromJsonObj(const json& jObj, sOrthoCal *ocal, sensor_cal_info_t *info, sensor_data_info_t *dinfo, sensor_tcal_group_t *tcal, sensor_mcal_group_t* mcal, int* pose, const std::string& filePath)
+{
+    if (jObj.empty())
+        return false;
 
     //////////////////////////////////////////////////////////////////////////
     //  Calibration Info
@@ -405,7 +428,7 @@ bool ISDeviceCal::loadCalibrationFromJsonObj(const std::string& filePath, sOrtho
                 info->devSerialNum = jInf["devSerialNum"].get<int>();
             }
         }
-        else
+        else if (!filePath.empty())
         {   // Get date and time from filename
             memset(info, 0, sizeof(sensor_cal_info_t));
 
@@ -483,7 +506,7 @@ bool ISDeviceCal::loadCalibrationFromJsonObj(const std::string& filePath, sOrtho
                 JsonObjv1p2ToSensor(jObj["tempComp2"], 1, *tcal);
         }
     }
-    
+
     if (info)
     {   // Update info size and checksum
         info->size = sizeof(sensor_cal_info_t);

--- a/src/ISDeviceCal.h
+++ b/src/ISDeviceCal.h
@@ -163,21 +163,64 @@ class ISDeviceCal
 public:
     /**
      * @brief Load calibration data from a JSON file
-     * 
+     *
      * @param filePath Path to the JSON file to load
      * @param ocal Pointer to orthonormalization calibration data (can be NULL)
      * @param info Pointer to sensor calibration info (can be NULL)
+     * @param dinfo Pointer to sensor data info (can be NULL)
      * @param tcal Pointer to temperature compensation calibration (can be NULL)
      * @param mcal Pointer to motion calibration (can be NULL)
      * @param pose Pointer to current pose value (can be NULL)
      * @return true if calibration was successfully loaded, false otherwise
      */
-    static bool loadCalibrationFromJsonObj(const std::string& filePath, 
-                                       sOrthoCal *ocal, 
-                                       sensor_cal_info_t *info = NULL, 
+    static bool loadCalibrationFromJsonFile(const std::string& filePath,
+                                       sOrthoCal *ocal,
+                                       sensor_cal_info_t *info = NULL,
                                        sensor_data_info_t *dinfo = NULL,
-                                       sensor_tcal_group_t *tcal = NULL, 
-                                       sensor_mcal_group_t* mcal = NULL, 
+                                       sensor_tcal_group_t *tcal = NULL,
+                                       sensor_mcal_group_t* mcal = NULL,
+                                       int* pose = NULL);
+
+    /**
+     * @brief Load calibration data from a pre-parsed JSON object
+     *
+     * @param jObj The parsed JSON object containing calibration data
+     * @param ocal Pointer to orthonormalization calibration data (can be NULL)
+     * @param info Pointer to sensor calibration info (can be NULL)
+     * @param dinfo Pointer to sensor data info (can be NULL)
+     * @param tcal Pointer to temperature compensation calibration (can be NULL)
+     * @param mcal Pointer to motion calibration (can be NULL)
+     * @param pose Pointer to current pose value (can be NULL)
+     * @param filePath Optional file path used for fallback serial/date extraction (empty if not from file)
+     * @return true if calibration was successfully loaded, false otherwise
+     */
+    static bool loadCalibrationFromJsonObj(const json& jObj,
+                                       sOrthoCal *ocal,
+                                       sensor_cal_info_t *info = NULL,
+                                       sensor_data_info_t *dinfo = NULL,
+                                       sensor_tcal_group_t *tcal = NULL,
+                                       sensor_mcal_group_t* mcal = NULL,
+                                       int* pose = NULL,
+                                       const std::string& filePath = "");
+
+    /**
+     * @brief Load calibration data from a JSON string
+     *
+     * @param jsonString The JSON string to parse
+     * @param ocal Pointer to orthonormalization calibration data (can be NULL)
+     * @param info Pointer to sensor calibration info (can be NULL)
+     * @param dinfo Pointer to sensor data info (can be NULL)
+     * @param tcal Pointer to temperature compensation calibration (can be NULL)
+     * @param mcal Pointer to motion calibration (can be NULL)
+     * @param pose Pointer to current pose value (can be NULL)
+     * @return true if calibration was successfully loaded, false otherwise
+     */
+    static bool loadCalibrationFromJsonString(const std::string& jsonString,
+                                       sOrthoCal *ocal,
+                                       sensor_cal_info_t *info = NULL,
+                                       sensor_data_info_t *dinfo = NULL,
+                                       sensor_tcal_group_t *tcal = NULL,
+                                       sensor_mcal_group_t* mcal = NULL,
                                        int* pose = NULL);
 
     /**

--- a/src/ISHttpRequest.cpp
+++ b/src/ISHttpRequest.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file ISHttpRequest.cpp
+ * @brief Lightweight HTTP client using tcpPort infrastructure
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISHttpRequest.h"
+#include "ISUtilities.h"
+#include "uri.hpp"
+#include "TcpPortFactory.h"
+#include "core/msg_logger.h"
+
+#include <sstream>
+#include <algorithm>
+#include <cstring>
+
+std::string ISHttpRequest::buildGetRequest(const std::string& host, const std::string& path)
+{
+    std::string req = "GET " + path + " HTTP/1.1\r\n";
+    req += "Host: " + host + "\r\n";
+    req += "Accept: */*\r\n";
+    req += "Connection: close\r\n";
+    req += "\r\n";
+    return req;
+}
+
+ISHttpRequest::Response ISHttpRequest::parseResponse(port_handle_t port, int timeoutMs)
+{
+    Response resp;
+    unsigned char lineBuf[4096];
+
+    // Read status line
+    int bytesRead = portReadLineTimeout(port, lineBuf, sizeof(lineBuf), timeoutMs);
+    if (bytesRead <= 0)
+    {
+        log_error(IS_LOG_ISDEVICE, "ISHttpRequest: Timeout reading HTTP status line");
+        return resp;
+    }
+
+    std::string statusLine(reinterpret_cast<char*>(lineBuf), bytesRead);
+    // Parse "HTTP/1.x <code> <message>"
+    size_t firstSpace = statusLine.find(' ');
+    if (firstSpace == std::string::npos)
+    {
+        log_error(IS_LOG_ISDEVICE, "ISHttpRequest: Malformed HTTP status line");
+        return resp;
+    }
+    size_t secondSpace = statusLine.find(' ', firstSpace + 1);
+    std::string codeStr = statusLine.substr(firstSpace + 1, secondSpace - firstSpace - 1);
+    resp.statusCode = std::stoi(codeStr);
+    if (secondSpace != std::string::npos)
+    {
+        resp.statusMessage = statusLine.substr(secondSpace + 1);
+        // Trim trailing whitespace/CR/LF
+        while (!resp.statusMessage.empty() && (resp.statusMessage.back() == '\r' || resp.statusMessage.back() == '\n' || resp.statusMessage.back() == ' '))
+            resp.statusMessage.pop_back();
+    }
+
+    // Read headers
+    int contentLength = -1;
+    bool chunked = false;
+    while (true)
+    {
+        bytesRead = portReadLineTimeout(port, lineBuf, sizeof(lineBuf), timeoutMs);
+        if (bytesRead <= 0)
+            break;
+
+        std::string line(reinterpret_cast<char*>(lineBuf), bytesRead);
+        // Trim trailing CR/LF
+        while (!line.empty() && (line.back() == '\r' || line.back() == '\n'))
+            line.pop_back();
+
+        if (line.empty())
+            break;  // End of headers
+
+        size_t colonPos = line.find(':');
+        if (colonPos != std::string::npos)
+        {
+            std::string key = line.substr(0, colonPos);
+            std::string value = line.substr(colonPos + 1);
+            // Trim leading whitespace from value
+            size_t start = value.find_first_not_of(' ');
+            if (start != std::string::npos)
+                value = value.substr(start);
+
+            resp.headers[key] = value;
+
+            // Case-insensitive header checks
+            std::string keyLower = key;
+            std::transform(keyLower.begin(), keyLower.end(), keyLower.begin(), ::tolower);
+
+            if (keyLower == "content-length")
+                contentLength = std::stoi(value);
+            else if (keyLower == "transfer-encoding")
+            {
+                std::string valueLower = value;
+                std::transform(valueLower.begin(), valueLower.end(), valueLower.begin(), ::tolower);
+                chunked = (valueLower.find("chunked") != std::string::npos);
+            }
+        }
+    }
+
+    // Read body
+    if (chunked)
+    {
+        // Chunked transfer encoding
+        while (true)
+        {
+            bytesRead = portReadLineTimeout(port, lineBuf, sizeof(lineBuf), timeoutMs);
+            if (bytesRead <= 0)
+                break;
+
+            std::string chunkSizeLine(reinterpret_cast<char*>(lineBuf), bytesRead);
+            while (!chunkSizeLine.empty() && (chunkSizeLine.back() == '\r' || chunkSizeLine.back() == '\n'))
+                chunkSizeLine.pop_back();
+
+            int chunkSize = (int)std::strtol(chunkSizeLine.c_str(), nullptr, 16);
+            if (chunkSize == 0)
+                break;
+
+            // Read chunk data
+            int remaining = chunkSize;
+            while (remaining > 0)
+            {
+                int toRead = std::min(remaining, (int)sizeof(lineBuf));
+                int totalRead = 0;
+                uint32_t startMs = current_timeMs();
+                while (totalRead < toRead && (current_timeMs() - startMs) < (uint32_t)timeoutMs)
+                {
+                    int n = portRead(port, lineBuf + totalRead, toRead - totalRead);
+                    if (n > 0)
+                        totalRead += n;
+                    else
+                        SLEEP_MS(1);
+                }
+                resp.body.append(reinterpret_cast<char*>(lineBuf), totalRead);
+                remaining -= totalRead;
+                if (totalRead == 0)
+                    break;
+            }
+            // Read trailing CRLF after chunk data
+            portReadLineTimeout(port, lineBuf, sizeof(lineBuf), timeoutMs);
+        }
+    }
+    else if (contentLength > 0)
+    {
+        // Read exactly contentLength bytes
+        int remaining = contentLength;
+        while (remaining > 0)
+        {
+            int toRead = std::min(remaining, (int)sizeof(lineBuf));
+            int totalRead = 0;
+            uint32_t startMs = current_timeMs();
+            while (totalRead < toRead && (current_timeMs() - startMs) < (uint32_t)timeoutMs)
+            {
+                int n = portRead(port, lineBuf + totalRead, toRead - totalRead);
+                if (n > 0)
+                    totalRead += n;
+                else
+                    SLEEP_MS(1);
+            }
+            resp.body.append(reinterpret_cast<char*>(lineBuf), totalRead);
+            remaining -= totalRead;
+            if (totalRead == 0)
+                break;
+        }
+    }
+    else
+    {
+        // Read until connection closes (Connection: close)
+        uint32_t startMs = current_timeMs();
+        while ((current_timeMs() - startMs) < (uint32_t)timeoutMs)
+        {
+            int n = portRead(port, lineBuf, sizeof(lineBuf));
+            if (n > 0)
+            {
+                resp.body.append(reinterpret_cast<char*>(lineBuf), n);
+                startMs = current_timeMs();  // Reset timeout on data received
+            }
+            else if (n < 0)
+            {
+                break;  // Connection closed or error
+            }
+            else
+            {
+                SLEEP_MS(1);
+            }
+        }
+    }
+
+    return resp;
+}
+
+ISHttpRequest::Response ISHttpRequest::get(const std::string& url, int timeoutMs)
+{
+    Response resp;
+
+    // Parse URL
+    FIX8::basic_uri uri(url);
+    uri.parse();
+
+    std::string host(uri.get_host());
+    std::string portStr(uri.get_port());
+    std::string path(uri.get_path());
+
+    if (host.empty())
+    {
+        log_error(IS_LOG_ISDEVICE, "ISHttpRequest: Failed to parse host from URL: %s", url.c_str());
+        return resp;
+    }
+
+    int port = portStr.empty() ? 80 : std::strtol(portStr.c_str(), nullptr, 10);
+    if (path.empty())
+        path = "/";
+
+    log_info(IS_LOG_ISDEVICE, "ISHttpRequest: GET %s (host=%s, port=%d, path=%s)", url.c_str(), host.c_str(), port, path.c_str());
+
+    // Create TCP connection
+    std::string serverUrl = "tcp://" + host + ":" + std::to_string(port);
+    port_handle_t tcpPort = TcpPortFactory::getInstance().bindPort(serverUrl, PORT_TYPE__TCP | PORT_TYPE__COMM);
+
+    if (!tcpPort || (portOpen(tcpPort) != PORT_ERROR__NONE))
+    {
+        log_error(IS_LOG_ISDEVICE, "ISHttpRequest: Failed to connect to %s:%d", host.c_str(), port);
+        if (tcpPort)
+            TcpPortFactory::getInstance().releasePort(tcpPort);
+        return resp;
+    }
+
+    // Send GET request
+    std::string request = buildGetRequest(host, path);
+    int bytesSent = portWrite(tcpPort, (uint8_t*)request.data(), (int)request.length());
+    if ((size_t)bytesSent != request.length())
+    {
+        log_error(IS_LOG_ISDEVICE, "ISHttpRequest: Failed to send request to %s", url.c_str());
+        portClose(tcpPort);
+        TcpPortFactory::getInstance().releasePort(tcpPort);
+        return resp;
+    }
+
+    // Parse response
+    resp = parseResponse(tcpPort, timeoutMs);
+
+    // Cleanup
+    portClose(tcpPort);
+    TcpPortFactory::getInstance().releasePort(tcpPort);
+
+    log_info(IS_LOG_ISDEVICE, "ISHttpRequest: Response %d %s (%d bytes)", resp.statusCode, resp.statusMessage.c_str(), (int)resp.body.size());
+
+    return resp;
+}

--- a/src/ISHttpRequest.h
+++ b/src/ISHttpRequest.h
@@ -1,0 +1,42 @@
+/**
+ * @file ISHttpRequest.h
+ * @brief Lightweight HTTP client using tcpPort infrastructure
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
+#ifndef IS_SDK_ISHTTPREQUEST_H
+#define IS_SDK_ISHTTPREQUEST_H
+
+#include <string>
+#include <map>
+
+extern "C"
+{
+    #include "core/base_port.h"
+}
+
+class ISHttpRequest {
+public:
+    struct Response {
+        int statusCode = -1;
+        std::string statusMessage;
+        std::string body;
+        std::map<std::string, std::string> headers;
+    };
+
+    /**
+     * Perform an HTTP GET request to the given URL.
+     * @param url Full HTTP URL (e.g., "http://host:port/path")
+     * @param timeoutMs Timeout in milliseconds for the entire request
+     * @return Response with status code, headers, and body. statusCode == -1 on error.
+     */
+    static Response get(const std::string& url, int timeoutMs = 10000);
+
+private:
+    static std::string buildGetRequest(const std::string& host, const std::string& path);
+    static Response parseResponse(port_handle_t port, int timeoutMs);
+};
+
+#endif // IS_SDK_ISHTTPREQUEST_H

--- a/tests/test_ISDeviceCal.cpp
+++ b/tests/test_ISDeviceCal.cpp
@@ -1,0 +1,301 @@
+/**
+ * @file test_ISDeviceCal.cpp
+ * @brief Unit tests for ISDeviceCal calibration load/save refactoring
+ *
+ * Tests the three loading methods:
+ *   - loadCalibrationFromJsonFile() (file path)
+ *   - loadCalibrationFromJsonObj() (pre-parsed json object)
+ *   - loadCalibrationFromJsonString() (JSON string)
+ *
+ * Also verifies round-trip: save → load → compare
+ *
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include <fstream>
+#include <cstring>
+#include <cstdio>
+
+#include <gtest/gtest.h>
+#include "gtest_helpers.h"
+
+#include "ISDeviceCal.h"
+#include "ISLogFile.h"
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+// Helper: build a minimal but valid calibration JSON object
+static json makeTestCalJson(uint32_t serialNum = 12345)
+{
+    json jObj;
+
+    // Info section
+    json jInfo;
+    jInfo["version"] = "1.2.3 0";
+    jInfo["calDate"] = "2025-06-15 0";
+    jInfo["calTime"] = "14:30:00 0";
+    jInfo["devSerialNum"] = (int)serialNum;
+    jObj["info"] = jInfo;
+
+    // Minimal tempComp section with 2 points for gyr1
+    json jTC;
+    json jGyr1 = json::array();
+    for (int i = 0; i < 2; i++)
+    {
+        json pt;
+        pt["index"] = i;
+        pt["tmp"] = 25.0f + i * 10.0f;
+        pt["SS"] = json::array({0.1f * (i + 1), 0.2f * (i + 1), 0.3f * (i + 1)});
+        jGyr1.push_back(pt);
+    }
+    jTC["gyr1"] = jGyr1;
+    jObj["tempComp"] = jTC;
+
+    return jObj;
+}
+
+// Helper: write JSON to a temp file, return path
+static std::string writeTempCalFile(const json& jObj, const std::string& filename = "test_cal.json")
+{
+    std::string path = "/tmp/" + filename;
+    std::ofstream f(path);
+    f << jObj.dump(2);
+    f.close();
+    return path;
+}
+
+class test_ISDeviceCal : public ::testing::Test {
+protected:
+    void SetUp() override {
+        memset(&info, 0, sizeof(info));
+        memset(&dinfo, 0, sizeof(dinfo));
+        memset(&tcal, 0, sizeof(tcal));
+        memset(&mcal, 0, sizeof(mcal));
+    }
+
+    sensor_cal_info_t info = {};
+    sensor_data_info_t dinfo = {};
+    sensor_tcal_group_t tcal = {};
+    sensor_mcal_group_t mcal = {};
+};
+
+// ---- loadCalibrationFromJsonFile tests ----
+
+TEST_F(test_ISDeviceCal, loadFromFile_validJson)
+{
+    json jObj = makeTestCalJson(99001);
+    std::string path = writeTempCalFile(jObj, "test_cal_file.json");
+
+    bool result = ISDeviceCal::loadCalibrationFromJsonFile(path, NULL, &info, &dinfo, &tcal, &mcal);
+    ASSERT_TRUE(result);
+
+    // Verify info was populated
+    EXPECT_EQ(info.version[0], 1);
+    EXPECT_EQ(info.version[1], 2);
+    EXPECT_EQ(info.version[2], 3);
+    EXPECT_EQ(info.devSerialNum, 99001u);
+
+    // Verify date
+    EXPECT_EQ(info.calDate[0], 25);  // 2025 - 2000
+    EXPECT_EQ(info.calDate[1], 6);
+    EXPECT_EQ(info.calDate[2], 15);
+
+    // Verify tcal was populated
+    EXPECT_EQ(tcal.gyr[0].numPts, 2u);
+    EXPECT_NEAR(tcal.gyr[0].pt[0].temp, 25.0f, 0.001f);
+    EXPECT_NEAR(tcal.gyr[0].pt[1].temp, 35.0f, 0.001f);
+
+    std::remove(path.c_str());
+}
+
+TEST_F(test_ISDeviceCal, loadFromFile_missingFile)
+{
+    bool result = ISDeviceCal::loadCalibrationFromJsonFile("/tmp/nonexistent_cal_file.json", NULL, &info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(test_ISDeviceCal, loadFromFile_invalidJson)
+{
+    std::string path = "/tmp/test_cal_invalid.json";
+    std::ofstream f(path);
+    f << "{ this is not valid json }}}";
+    f.close();
+
+    bool result = ISDeviceCal::loadCalibrationFromJsonFile(path, NULL, &info);
+    EXPECT_FALSE(result);
+
+    std::remove(path.c_str());
+}
+
+TEST_F(test_ISDeviceCal, loadFromFile_fallbackFilename)
+{
+    // JSON without "info" section — should extract serial/date from filename
+    json jObj;
+    jObj["tempComp"] = json::object();  // minimal non-empty
+    std::string path = writeTempCalFile(jObj, "tc_SN12345_20250615_1430.json");
+
+    bool result = ISDeviceCal::loadCalibrationFromJsonFile(path, NULL, &info);
+    ASSERT_TRUE(result);
+
+    EXPECT_EQ(info.devSerialNum, 12345u);
+    EXPECT_EQ(info.calDate[0], 25);  // 2025 - 2000
+    EXPECT_EQ(info.calDate[1], 6);
+    EXPECT_EQ(info.calDate[2], 15);
+    EXPECT_EQ(info.calTime[0], 14);
+    EXPECT_EQ(info.calTime[1], 30);
+
+    std::remove(path.c_str());
+}
+
+// ---- loadCalibrationFromJsonObj tests ----
+
+TEST_F(test_ISDeviceCal, loadFromJsonObj_validJson)
+{
+    json jObj = makeTestCalJson(88001);
+
+    bool result = ISDeviceCal::loadCalibrationFromJsonObj(jObj, NULL, &info, &dinfo, &tcal, &mcal);
+    ASSERT_TRUE(result);
+
+    EXPECT_EQ(info.devSerialNum, 88001u);
+    EXPECT_EQ(info.version[0], 1);
+    EXPECT_EQ(tcal.gyr[0].numPts, 2u);
+}
+
+TEST_F(test_ISDeviceCal, loadFromJsonObj_emptyJson)
+{
+    json jObj = json::object();
+    // Empty object with no sections — should return false
+    bool result = ISDeviceCal::loadCalibrationFromJsonObj(jObj, NULL, &info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(test_ISDeviceCal, loadFromJsonObj_noInfoNoFilePath)
+{
+    // JSON without "info" section and no filePath — info should remain zeroed (no filename fallback)
+    json jObj;
+    jObj["tempComp"] = json::object();
+
+    memset(&info, 0xFF, sizeof(info));  // fill with garbage to verify it gets cleared/set
+    bool result = ISDeviceCal::loadCalibrationFromJsonObj(jObj, NULL, &info, &dinfo, &tcal, &mcal);
+    ASSERT_TRUE(result);
+
+    // Without filePath and no "info" in JSON, info fields should not be populated from filename
+    // The info size and checksum should still be computed
+    EXPECT_EQ(info.size, sizeof(sensor_cal_info_t));
+}
+
+// ---- loadCalibrationFromJsonString tests ----
+
+TEST_F(test_ISDeviceCal, loadFromJsonString_validJson)
+{
+    json jObj = makeTestCalJson(77001);
+    std::string jsonStr = jObj.dump();
+
+    bool result = ISDeviceCal::loadCalibrationFromJsonString(jsonStr, NULL, &info, &dinfo, &tcal, &mcal);
+    ASSERT_TRUE(result);
+
+    EXPECT_EQ(info.devSerialNum, 77001u);
+    EXPECT_EQ(tcal.gyr[0].numPts, 2u);
+}
+
+TEST_F(test_ISDeviceCal, loadFromJsonString_invalidJson)
+{
+    std::string badJson = "not json at all {{{";
+    bool result = ISDeviceCal::loadCalibrationFromJsonString(badJson, NULL, &info);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(test_ISDeviceCal, loadFromJsonString_emptyString)
+{
+    // Empty string should fail to parse
+    bool result = ISDeviceCal::loadCalibrationFromJsonString("", NULL, &info);
+    EXPECT_FALSE(result);
+}
+
+// ---- Consistency: all three methods produce the same result ----
+
+TEST_F(test_ISDeviceCal, allMethods_produceConsistentResults)
+{
+    json jObj = makeTestCalJson(55001);
+    std::string path = writeTempCalFile(jObj, "test_cal_consistency.json");
+    std::string jsonStr = jObj.dump();
+
+    // Load via file
+    sensor_cal_info_t infoFile = {};
+    sensor_tcal_group_t tcalFile = {};
+    ASSERT_TRUE(ISDeviceCal::loadCalibrationFromJsonFile(path, NULL, &infoFile, NULL, &tcalFile));
+
+    // Load via json object
+    sensor_cal_info_t infoObj = {};
+    sensor_tcal_group_t tcalObj = {};
+    ASSERT_TRUE(ISDeviceCal::loadCalibrationFromJsonObj(jObj, NULL, &infoObj, NULL, &tcalObj));
+
+    // Load via string
+    sensor_cal_info_t infoStr = {};
+    sensor_tcal_group_t tcalStr = {};
+    ASSERT_TRUE(ISDeviceCal::loadCalibrationFromJsonString(jsonStr, NULL, &infoStr, NULL, &tcalStr));
+
+    // All should produce the same info
+    EXPECT_EQ(infoFile.devSerialNum, infoObj.devSerialNum);
+    EXPECT_EQ(infoObj.devSerialNum, infoStr.devSerialNum);
+    EXPECT_EQ(infoFile.version[0], infoObj.version[0]);
+    EXPECT_EQ(infoObj.version[0], infoStr.version[0]);
+
+    // All should produce the same tcal
+    EXPECT_EQ(tcalFile.gyr[0].numPts, tcalObj.gyr[0].numPts);
+    EXPECT_EQ(tcalObj.gyr[0].numPts, tcalStr.gyr[0].numPts);
+    EXPECT_NEAR(tcalFile.gyr[0].pt[0].temp, tcalObj.gyr[0].pt[0].temp, 0.001f);
+    EXPECT_NEAR(tcalObj.gyr[0].pt[0].temp, tcalStr.gyr[0].pt[0].temp, 0.001f);
+
+    std::remove(path.c_str());
+}
+
+// ---- Round-trip: save → load → compare ----
+
+TEST_F(test_ISDeviceCal, roundTrip_saveAndLoad)
+{
+    // Set up calibration data
+    sensor_cal_info_t origInfo = {};
+    origInfo.version[0] = 2;
+    origInfo.version[1] = 1;
+    origInfo.version[2] = 0;
+    origInfo.version[3] = 0;
+    origInfo.devSerialNum = 66001;
+    origInfo.calDate[0] = 25;  // 2025
+    origInfo.calDate[1] = 3;
+    origInfo.calDate[2] = 13;
+    origInfo.calTime[0] = 10;
+    origInfo.calTime[1] = 30;
+    origInfo.calTime[2] = 0;
+    origInfo.size = sizeof(sensor_cal_info_t);
+
+    sensor_mcal_group_t origMcal = {};
+    // Set identity matrices for gyro
+    for (int d = 0; d < MAX_IMU_DEVICES; d++)
+    {
+        origMcal.pqr[d].orth[0] = 1.01f; origMcal.pqr[d].orth[4] = 1.0f; origMcal.pqr[d].orth[8] = 1.0f;
+        origMcal.pqr[d].bias[0] = 0.001f; origMcal.pqr[d].bias[1] = 0.002f; origMcal.pqr[d].bias[2] = 0.003f;
+        origMcal.acc[d].orth[0] = 1.0f; origMcal.acc[d].orth[4] = 1.02f; origMcal.acc[d].orth[8] = 1.0f;
+        origMcal.acc[d].bias[0] = 0.01f;
+    }
+
+    std::string path = "/tmp/test_cal_roundtrip.json";
+    ASSERT_TRUE(ISDeviceCal::saveCalibrationToJsonObj(path, NULL, &origInfo, NULL, &origMcal));
+
+    // Load it back
+    sensor_cal_info_t loadInfo = {};
+    sensor_mcal_group_t loadMcal = {};
+    ASSERT_TRUE(ISDeviceCal::loadCalibrationFromJsonFile(path, NULL, &loadInfo, NULL, NULL, &loadMcal));
+
+    EXPECT_EQ(loadInfo.devSerialNum, origInfo.devSerialNum);
+    EXPECT_EQ(loadInfo.version[0], origInfo.version[0]);
+    EXPECT_EQ(loadInfo.version[1], origInfo.version[1]);
+
+    // Verify motion cal data survived round-trip
+    EXPECT_NEAR(loadMcal.pqr[0].orth[0], origMcal.pqr[0].orth[0], 0.001f);
+    EXPECT_NEAR(loadMcal.pqr[0].bias[0], origMcal.pqr[0].bias[0], 0.001f);
+    EXPECT_NEAR(loadMcal.acc[0].orth[4], origMcal.acc[0].orth[4], 0.001f);
+
+    std::remove(path.c_str());
+}

--- a/tests/test_ISHttpRequest.cpp
+++ b/tests/test_ISHttpRequest.cpp
@@ -2,7 +2,8 @@
  * @file test_ISHttpRequest.cpp
  * @brief Unit tests for ISHttpRequest HTTP client
  *
- * Uses a simple POSIX socket server to simulate HTTP responses.
+ * Uses a simple socket server to simulate HTTP responses.
+ * Cross-platform: POSIX sockets on Linux/macOS, Winsock on Windows.
  *
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
  */
@@ -12,10 +13,22 @@
 #include <atomic>
 #include <cstring>
 
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <unistd.h>
-#include <arpa/inet.h>
+#ifdef _WIN32
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #pragma comment(lib, "Ws2_32.lib")
+    typedef SOCKET socket_t;
+    #define CLOSE_SOCKET closesocket
+    #define SOCKET_INVALID INVALID_SOCKET
+#else
+    #include <sys/socket.h>
+    #include <netinet/in.h>
+    #include <unistd.h>
+    #include <arpa/inet.h>
+    typedef int socket_t;
+    #define CLOSE_SOCKET close
+    #define SOCKET_INVALID (-1)
+#endif
 
 #include <gtest/gtest.h>
 #include "gtest_helpers.h"
@@ -26,36 +39,45 @@
 
 using json = nlohmann::json;
 
-// Simple POSIX socket HTTP mock server
+#ifdef _WIN32
+// RAII helper to initialize/cleanup Winsock
+struct WinsockInit {
+    WinsockInit() { WSADATA wsa; WSAStartup(MAKEWORD(2, 2), &wsa); }
+    ~WinsockInit() { WSACleanup(); }
+};
+static WinsockInit s_winsockInit;
+#endif
+
+// Simple cross-platform socket HTTP mock server
 class MockHttpServer {
 public:
     MockHttpServer(int port, const std::string& response)
-        : m_port(port), m_response(response), m_listenFd(-1), m_running(false) {}
+        : m_port(port), m_response(response), m_listenFd(SOCKET_INVALID), m_running(false) {}
 
     bool start()
     {
         m_listenFd = socket(AF_INET, SOCK_STREAM, 0);
-        if (m_listenFd < 0) return false;
+        if (m_listenFd == SOCKET_INVALID) return false;
 
         int opt = 1;
-        setsockopt(m_listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        setsockopt(m_listenFd, SOL_SOCKET, SO_REUSEADDR, (const char*)&opt, sizeof(opt));
 
         struct sockaddr_in addr = {};
         addr.sin_family = AF_INET;
         addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         addr.sin_port = htons(m_port);
 
-        if (bind(m_listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+        if (bind(m_listenFd, (struct sockaddr*)&addr, sizeof(addr)) != 0)
         {
-            close(m_listenFd);
-            m_listenFd = -1;
+            CLOSE_SOCKET(m_listenFd);
+            m_listenFd = SOCKET_INVALID;
             return false;
         }
 
-        if (listen(m_listenFd, 1) < 0)
+        if (listen(m_listenFd, 1) != 0)
         {
-            close(m_listenFd);
-            m_listenFd = -1;
+            CLOSE_SOCKET(m_listenFd);
+            m_listenFd = SOCKET_INVALID;
             return false;
         }
 
@@ -63,8 +85,8 @@ public:
         m_thread = std::thread([this]() {
             struct sockaddr_in clientAddr = {};
             socklen_t clientLen = sizeof(clientAddr);
-            int clientFd = accept(m_listenFd, (struct sockaddr*)&clientAddr, &clientLen);
-            if (clientFd < 0) return;
+            socket_t clientFd = accept(m_listenFd, (struct sockaddr*)&clientAddr, &clientLen);
+            if (clientFd == SOCKET_INVALID) return;
 
             // Read request (drain until we see end of headers)
             char buf[4096];
@@ -88,8 +110,8 @@ public:
             }
 
             // Small delay then close
-            usleep(50000);
-            close(clientFd);
+            SLEEP_MS(50);
+            CLOSE_SOCKET(clientFd);
         });
 
         return true;
@@ -98,10 +120,10 @@ public:
     void stop()
     {
         m_running = false;
-        if (m_listenFd >= 0)
+        if (m_listenFd != SOCKET_INVALID)
         {
-            close(m_listenFd);
-            m_listenFd = -1;
+            CLOSE_SOCKET(m_listenFd);
+            m_listenFd = SOCKET_INVALID;
         }
         if (m_thread.joinable())
             m_thread.join();
@@ -112,7 +134,7 @@ public:
 private:
     int m_port;
     std::string m_response;
-    int m_listenFd;
+    socket_t m_listenFd;
     std::atomic<bool> m_running;
     std::thread m_thread;
 };

--- a/tests/test_ISHttpRequest.cpp
+++ b/tests/test_ISHttpRequest.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file test_ISHttpRequest.cpp
+ * @brief Unit tests for ISHttpRequest HTTP client
+ *
+ * Uses a simple POSIX socket server to simulate HTTP responses.
+ *
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include <string>
+#include <thread>
+#include <atomic>
+#include <cstring>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+
+#include <gtest/gtest.h>
+#include "gtest_helpers.h"
+
+#include "ISHttpRequest.h"
+#include "ISUtilities.h"
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+// Simple POSIX socket HTTP mock server
+class MockHttpServer {
+public:
+    MockHttpServer(int port, const std::string& response)
+        : m_port(port), m_response(response), m_listenFd(-1), m_running(false) {}
+
+    bool start()
+    {
+        m_listenFd = socket(AF_INET, SOCK_STREAM, 0);
+        if (m_listenFd < 0) return false;
+
+        int opt = 1;
+        setsockopt(m_listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        struct sockaddr_in addr = {};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = htons(m_port);
+
+        if (bind(m_listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
+        {
+            close(m_listenFd);
+            m_listenFd = -1;
+            return false;
+        }
+
+        if (listen(m_listenFd, 1) < 0)
+        {
+            close(m_listenFd);
+            m_listenFd = -1;
+            return false;
+        }
+
+        m_running = true;
+        m_thread = std::thread([this]() {
+            struct sockaddr_in clientAddr = {};
+            socklen_t clientLen = sizeof(clientAddr);
+            int clientFd = accept(m_listenFd, (struct sockaddr*)&clientAddr, &clientLen);
+            if (clientFd < 0) return;
+
+            // Read request (drain until we see end of headers)
+            char buf[4096];
+            std::string received;
+            while (received.find("\r\n\r\n") == std::string::npos)
+            {
+                int n = recv(clientFd, buf, sizeof(buf), 0);
+                if (n <= 0) break;
+                received.append(buf, n);
+            }
+
+            // Send canned response
+            const char* data = m_response.data();
+            int remaining = (int)m_response.size();
+            while (remaining > 0)
+            {
+                int sent = send(clientFd, data, remaining, 0);
+                if (sent <= 0) break;
+                data += sent;
+                remaining -= sent;
+            }
+
+            // Small delay then close
+            usleep(50000);
+            close(clientFd);
+        });
+
+        return true;
+    }
+
+    void stop()
+    {
+        m_running = false;
+        if (m_listenFd >= 0)
+        {
+            close(m_listenFd);
+            m_listenFd = -1;
+        }
+        if (m_thread.joinable())
+            m_thread.join();
+    }
+
+    ~MockHttpServer() { stop(); }
+
+private:
+    int m_port;
+    std::string m_response;
+    int m_listenFd;
+    std::atomic<bool> m_running;
+    std::thread m_thread;
+};
+
+static std::string makeHttpResponse(int statusCode, const std::string& statusMsg, const std::string& body)
+{
+    std::string resp = "HTTP/1.1 " + std::to_string(statusCode) + " " + statusMsg + "\r\n";
+    resp += "Content-Type: application/json\r\n";
+    resp += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+    resp += "Connection: close\r\n";
+    resp += "\r\n";
+    resp += body;
+    return resp;
+}
+
+// ---- Tests ----
+
+TEST(test_ISHttpRequest, connectionFailure_refusedPort)
+{
+    // Connect to localhost on a port nothing is listening on — should fail fast (connection refused)
+    auto resp = ISHttpRequest::get("http://127.0.0.1:19999/nonexistent", 5000);
+    EXPECT_EQ(resp.statusCode, -1);
+}
+
+TEST(test_ISHttpRequest, successfulGet_200)
+{
+    int port = 18301;
+    json body;
+    body["message"] = "hello";
+    body["count"] = 42;
+    std::string httpResp = makeHttpResponse(200, "OK", body.dump());
+
+    MockHttpServer server(port, httpResp);
+    ASSERT_TRUE(server.start());
+    SLEEP_MS(100);  // Give server time to start listening
+
+    auto resp = ISHttpRequest::get("http://127.0.0.1:" + std::to_string(port) + "/api/test", 10000);
+
+    EXPECT_EQ(resp.statusCode, 200);
+    EXPECT_EQ(resp.statusMessage, "OK");
+    EXPECT_FALSE(resp.body.empty());
+
+    // Parse the body as JSON and verify
+    json parsed = json::parse(resp.body);
+    EXPECT_EQ(parsed["message"].get<std::string>(), "hello");
+    EXPECT_EQ(parsed["count"].get<int>(), 42);
+
+    server.stop();
+}
+
+TEST(test_ISHttpRequest, notFound_404)
+{
+    int port = 18302;
+    std::string httpResp = makeHttpResponse(404, "Not Found", "{\"error\": \"not found\"}");
+
+    MockHttpServer server(port, httpResp);
+    ASSERT_TRUE(server.start());
+    SLEEP_MS(100);
+
+    auto resp = ISHttpRequest::get("http://127.0.0.1:" + std::to_string(port) + "/api/missing", 10000);
+
+    EXPECT_EQ(resp.statusCode, 404);
+    EXPECT_EQ(resp.statusMessage, "Not Found");
+
+    server.stop();
+}
+
+TEST(test_ISHttpRequest, serverError_500)
+{
+    int port = 18303;
+    std::string httpResp = makeHttpResponse(500, "Internal Server Error", "{\"error\": \"server error\"}");
+
+    MockHttpServer server(port, httpResp);
+    ASSERT_TRUE(server.start());
+    SLEEP_MS(100);
+
+    auto resp = ISHttpRequest::get("http://127.0.0.1:" + std::to_string(port) + "/api/broken", 10000);
+
+    EXPECT_EQ(resp.statusCode, 500);
+
+    server.stop();
+}
+
+TEST(test_ISHttpRequest, largeBody)
+{
+    int port = 18304;
+
+    // Generate a larger body (~10KB)
+    json body;
+    json items = json::array();
+    for (int i = 0; i < 100; i++)
+    {
+        json item;
+        item["index"] = i;
+        item["value"] = "test_value_" + std::to_string(i);
+        item["data"] = std::string(80, 'A' + (i % 26));
+        items.push_back(item);
+    }
+    body["items"] = items;
+    std::string bodyStr = body.dump();
+    std::string httpResp = makeHttpResponse(200, "OK", bodyStr);
+
+    MockHttpServer server(port, httpResp);
+    ASSERT_TRUE(server.start());
+    SLEEP_MS(100);
+
+    auto resp = ISHttpRequest::get("http://127.0.0.1:" + std::to_string(port) + "/api/large", 10000);
+
+    EXPECT_EQ(resp.statusCode, 200);
+    EXPECT_EQ(resp.body.size(), bodyStr.size());
+
+    // Verify JSON round-trips correctly
+    json parsed = json::parse(resp.body);
+    EXPECT_EQ(parsed["items"].size(), 100u);
+    EXPECT_EQ(parsed["items"][0]["index"].get<int>(), 0);
+    EXPECT_EQ(parsed["items"][99]["index"].get<int>(), 99);
+
+    server.stop();
+}
+
+TEST(test_ISHttpRequest, headersAreParsed)
+{
+    int port = 18305;
+
+    std::string httpResp = "HTTP/1.1 200 OK\r\n";
+    httpResp += "Content-Type: application/json\r\n";
+    httpResp += "X-Custom-Header: test-value\r\n";
+    httpResp += "Content-Length: 2\r\n";
+    httpResp += "Connection: close\r\n";
+    httpResp += "\r\n";
+    httpResp += "{}";
+
+    MockHttpServer server(port, httpResp);
+    ASSERT_TRUE(server.start());
+    SLEEP_MS(100);
+
+    auto resp = ISHttpRequest::get("http://127.0.0.1:" + std::to_string(port) + "/api/headers", 10000);
+
+    EXPECT_EQ(resp.statusCode, 200);
+    EXPECT_TRUE(resp.headers.count("Content-Type") > 0);
+    EXPECT_EQ(resp.headers["Content-Type"], "application/json");
+    EXPECT_TRUE(resp.headers.count("X-Custom-Header") > 0);
+    EXPECT_EQ(resp.headers["X-Custom-Header"], "test-value");
+
+    server.stop();
+}


### PR DESCRIPTION
This refactoring enables new functionality to load calibrations from sources other than files. New methods have been added to `ISDevice`:
- `UploadImxCalibrationFromJson`: Uploads a calibration from a `nlohmann::json` object.
- `UploadIMXCalibrationFromURL`: Fetches the latest calibration for a device from a REST API, parses it, and uploads it.

This commit refactors the calibration loading mechanism to separate JSON parsing from file reading.

The existing `loadCalibrationFromJsonObj` function has been renamed to `loadCalibrationFromJsonFile`. A new `loadCalibrationFromJsonObj` has been introduced that accepts a pre-parsed `nlohmann::json` object, and a new `loadCalibrationFromJsonString` is added for convenience.

