### PR TITLE
Refactor: Consolidate serial port initialization into `serialPortInit`

### DIFF
--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -259,7 +259,7 @@ void cISBootloaderThread::update_thread_serial(void* context)
     SLEEP_MS(100);
 
     port_handle_t port = (port_handle_t)&(thread_info->serialPort);
-    serialPortPlatformInit(port);
+    serialPortInit(port, BASE_PORT(port)->pnum, BASE_PORT(port)->ptype, BASE_PORT(port)->pflags);
     m_serial_thread_mutex.lock();
     const char* serial_name = portName(port);
     thread_info->reuse_port = false;

--- a/src/ISBootloaderThread.h
+++ b/src/ISBootloaderThread.h
@@ -54,9 +54,8 @@ public:
         thread_serial_t(const std::string& port_name, bool force_isb_update = false) {
             // FIXME: This is pretty jank... and ridiculous.  I can do better!
             port_handle_t port = (port_handle_t)&(serialPort);
-            serialPortInit(port, (int)m_serial_threads.size(), PORT_TYPE__UART | PORT_TYPE__COMM, 0);
-            serialPortPlatformInit(port);
             serialPortSetName(port, port_name.c_str());
+            serialPortInit(port, (int)m_serial_threads.size(), PORT_TYPE__UART | PORT_TYPE__COMM, 0);
 
             ctx = NULL;
             done = false;

--- a/src/ISSerialPort.cpp
+++ b/src/ISSerialPort.cpp
@@ -32,7 +32,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using namespace std;
 
 
-cISSerialPort::cISSerialPort(port_handle_t port_) : cISStream()
+cISSerialPort::cISSerialPort(port_handle_t port_) : m_timeout(0), m_blocking(false)
 {
     if (port_ != NULLPTR)
     {
@@ -40,7 +40,8 @@ cISSerialPort::cISSerialPort(port_handle_t port_) : cISStream()
     }
     else
     {
-        serialPortPlatformInit(port);
+        memset(port, 0, sizeof(serial_port_t));
+        serialPortInit(port, PortManager::getInstance().getPortCount()+1, PORT_TYPE__UART | PORT_TYPE__COMM, 0);
     }
     Close();
 }

--- a/src/ISSerialPort.h
+++ b/src/ISSerialPort.h
@@ -21,12 +21,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "serialPortPlatform.h"
 
 
-class cISSerialPort : public cISStream
+class cISSerialPort : serial_port_t, public cISStream
 {
 private:
-    cISSerialPort(const cISSerialPort& copy); // disable copy constructor
+    cISSerialPort(const cISSerialPort& copy) = delete; // disable copy constructor
 
-    port_handle_t port;
+    port_handle_t port= this;
     int m_timeout;
     bool m_blocking;
 

--- a/src/PortFactory.cpp
+++ b/src/PortFactory.cpp
@@ -35,11 +35,8 @@ port_handle_t SerialPortFactory::bindPort(const std::string& pName, uint16_t pTy
     port_handle_t port = (port_handle_t)serialPort;
 
     *serialPort = {};
-    serialPort->base.pnum = (uint16_t)PortManager::getInstance().getPortCount();
-    serialPort->base.ptype = (pType | PORT_TYPE__UART | PORT_TYPE__COMM);
+    serialPortInit(port, (uint16_t)PortManager::getInstance().getPortCount(), (pType | PORT_TYPE__UART | PORT_TYPE__COMM), 0);
     strncpy(serialPort->portName, pName.c_str(), pName.length());
-
-    serialPortPlatformInit(port);
 
     // serialPort->base.portOpen = SerialPortFactory::open_port;
     serialPort->base.portValidate = SerialPortFactory::validate_port;

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -329,7 +329,7 @@ static int configure_serial_port(int fd, int baudRate)
  * @brief configures flow control on the specified file descriptor
  * @param fd
  * @param control
- * @return
+ * @return 0 one success or errno on failure
  */
 int set_flowcontrol(int fd, int control)
 {
@@ -337,8 +337,8 @@ int set_flowcontrol(int fd, int control)
     memset(&tty, 0, sizeof tty);
     if (tcgetattr(fd, &tty) != 0)
     {
-        perror("error from tggetattr");
-        return -1;
+        log_more_debug(IS_LOG_PORT, "set_flowcontrol():: error calling tcgetattr : %s (%d)", strerror(errno), errno);
+        return errno;
     }
 
     if(control) tty.c_cflag |= CRTSCTS;
@@ -346,8 +346,8 @@ int set_flowcontrol(int fd, int control)
 
     if (tcsetattr(fd, TCSANOW, &tty) != 0)
     {
-        perror("error setting term attributes");
-        return -1;
+        log_more_debug(IS_LOG_PORT, "set_flowcontrol():: error calling tcsetattr : %s (%d)", strerror(errno), errno);
+        return errno;
     }
     return 0;
 }
@@ -359,7 +359,7 @@ int set_flowcontrol(int fd, int control)
  * It also uses `flock` to get an exclusive, non-blocking lock on the file descriptor.
  *
  * @param fd The file descriptor.
- * @return int 0 on success, -1 on failure.
+ * @return int 0 on success, errno on failure.
  */
 int set_nonblocking(int fd) 
 {
@@ -367,14 +367,14 @@ int set_nonblocking(int fd)
     if (flags == -1) 
     {
         log_error(IS_LOG_PORT, "set_nonblocking():: error fcntl F_GETFL : %s (%d)", strerror(errno), errno);
-        return -1;
+        return errno;
     }
 
     flags |= O_NONBLOCK;
     if (fcntl(fd, F_SETFL, flags) == -1) 
     {
         log_error(IS_LOG_PORT, "set_nonblocking():: error setting O_NONBLOCK : %s (%d)", strerror(errno), errno);
-        return -1;
+        return errno;
     }
 
     // Alternate method - this maybe redundant, but better to be safe, eh?
@@ -661,12 +661,15 @@ static int serialPortClosePlatform(port_handle_t port)
 #else
 
     // we need to do some extended checking here... It seems linux/posix close(fd) can block if data is in the TX buffer, but can't be sent
-    set_flowcontrol(handle->fd, 0);
-    if (tcflush(handle->fd, TCIOFLUSH) < 0) {
-        // something bad happened...
-        serialPort->errorCode = errno;
-        serialPort->error = strerror(serialPort->errorCode);
-        log_error(IS_LOG_PORT, "[%s] serialPortClosePlatform():: Error flushing: %s (%d)", portName(port), serialPort->error, serialPort->errorCode);
+    if (set_flowcontrol(handle->fd, 0) == 0) {
+        // no point is doing this if the previous call had an error -- this will probably fail too.
+        if (tcflush(handle->fd, TCIOFLUSH) < 0) {
+            // something bad happened...
+            serialPort->errorCode = errno;
+            serialPort->error = strerror(serialPort->errorCode);
+            // FIXME: This should *probably* be a silent error - if we're closing a port that was previously closed or lost (USB disconnected, device reset, etc), then do we need to report an error?
+            log_error(IS_LOG_PORT, "[%s] serialPortClosePlatform():: Error flushing: %s (%d)", portName(port), serialPort->error, serialPort->errorCode);
+        }
     }
 
     close(handle->fd);


### PR DESCRIPTION
This commit refactors the serial port initialization by removing the `serialPortPlatformInit` function and consolidating its logic into `serialPortInit`. This simplifies the initialization process and removes redundant code.

The `cISSerialPort` class now inherits from `serial_port_t` to streamline its integration with the port management system. Additionally, its copy constructor is now explicitly deleted using C++11 syntax for better type safety.