### PR TITLE
Support for IMX-6 motion calibration

### DIFF
--- a/python/inertialsense/plotWindow/plotWindow.py
+++ b/python/inertialsense/plotWindow/plotWindow.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from PyQt5.QtWidgets import QMainWindow, QApplication, QPushButton, QWidget, QAction, QTabWidget,QVBoxLayout
 from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import pyqtSlot
+from PyQt5.QtCore import pyqtSlot, QTimer
 import sys, os
 
 class plotWindow():
@@ -23,7 +23,34 @@ class plotWindow():
         self.MainWindow.setCentralWidget(self.tabs)
         # self.MainWindow.resize(1920, 1080)
         self.MainWindow.resize(1200, 980)
+
+        self._close_marker_path = os.environ.get('IMX_CLOSE_PLOTS_MARKER', '')
+        self._close_marker_mtime = 0.0
+        if self._close_marker_path:
+            try:
+                self._close_marker_mtime = os.path.getmtime(self._close_marker_path)
+            except OSError:
+                self._close_marker_mtime = 0.0
+
+            self._close_timer = QTimer(self.MainWindow)
+            self._close_timer.timeout.connect(self._poll_close_request)
+            self._close_timer.start(250)
+
         self.MainWindow.show()
+
+    def _poll_close_request(self):
+        if not self._close_marker_path:
+            return
+        try:
+            marker_mtime = os.path.getmtime(self._close_marker_path)
+        except OSError:
+            return
+
+        if marker_mtime > self._close_marker_mtime:
+            self._close_marker_mtime = marker_mtime
+            plt.close('all')
+            self.MainWindow.close()
+            self.app.quit()
 
     def addPlot(self, title, figure, threeD=False):
         new_tab = QWidget()

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -973,6 +973,10 @@ enum eImusStatus
     IMUS_STATUS_IMU_OK_BITSIZE                  = 6,
     /** IMU valid mask */
     IMUS_STATUS_IMU_OK_MASK                     = (int)0x0000003F,
+    /** Gyro valid mask */
+    IMUS_STATUS_GYR_OK_MASK                     = (int)0x00000007,
+    /** Accelerometer valid mask */
+    IMUS_STATUS_ACC_OK_MASK                     = (int)0x00000038,
     
     /** Sensor saturation */
     IMUS_STATUS_SATURATION_GYR                  = (int)0x40000000,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -972,11 +972,11 @@ enum eImusStatus
     /** Number of IMU OK bits */
     IMUS_STATUS_IMU_OK_BITSIZE                  = 6,
     /** IMU valid mask */
-    IMUS_STATUS_IMU_OK_MASK                     = (int)0x0000003F,
+    IMUS_STATUS_IMU_OK_MASK                     = IMUS_STATUS_GYR_X_OK | IMUS_STATUS_GYR_Y_OK | IMUS_STATUS_GYR_Z_OK | IMUS_STATUS_ACC_X_OK | IMUS_STATUS_ACC_Y_OK | IMUS_STATUS_ACC_Z_OK,
     /** Gyro valid mask */
-    IMUS_STATUS_GYR_OK_MASK                     = (int)0x00000007,
+    IMUS_STATUS_GYR_OK_MASK                     = IMUS_STATUS_GYR_X_OK | IMUS_STATUS_GYR_Y_OK | IMUS_STATUS_GYR_Z_OK,
     /** Accelerometer valid mask */
-    IMUS_STATUS_ACC_OK_MASK                     = (int)0x00000038,
+    IMUS_STATUS_ACC_OK_MASK                     = IMUS_STATUS_ACC_X_OK | IMUS_STATUS_ACC_Y_OK | IMUS_STATUS_ACC_Z_OK,
     
     /** Sensor saturation */
     IMUS_STATUS_SATURATION_GYR                  = (int)0x40000000,
@@ -1002,7 +1002,11 @@ enum eImuStatus
     /** Number of IMU OK bits */
     IMU_STATUS_IMU_OK_BITSIZE                   = 6,
     /** IMU valid mask */
-    IMU_STATUS_IMU_OK_MASK                      = (int)0x0000003F,
+    IMU_STATUS_IMU_OK_MASK                      = IMU_STATUS_GYR_X_OK | IMU_STATUS_GYR_Y_OK | IMU_STATUS_GYR_Z_OK | IMU_STATUS_ACC_X_OK | IMU_STATUS_ACC_Y_OK | IMU_STATUS_ACC_Z_OK,
+    /** Gyro valid mask */
+    IMU_STATUS_GYR_OK_MASK                      = IMU_STATUS_GYR_X_OK | IMU_STATUS_GYR_Y_OK | IMU_STATUS_GYR_Z_OK,
+    /** Accelerometer valid mask */
+    IMU_STATUS_ACC_OK_MASK                      = IMU_STATUS_ACC_X_OK | IMU_STATUS_ACC_Y_OK | IMU_STATUS_ACC_Z_OK,
 
     /** Sensor shock detected */
     IMU_STATUS_SHOCK_PRESENT                    = (int)0x00000040,


### PR DESCRIPTION
This pull request adds new status mask definitions to the `eImusStatus` enum to provide more granular checks for the validity of individual IMU sensor components.

Sensor status mask additions:

* Added `IMUS_STATUS_GYR_OK_MASK` for checking the validity of the gyroscope status bits.
* Added `IMUS_STATUS_ACC_OK_MASK` for checking the validity of the accelerometer status bits.