### PR TITLE
SN-7616 - Implement  extended renderers for GPX & GNSS status fields

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -61,6 +61,9 @@ const unsigned char g_asciiToLowerMap[256] =
     224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255
 };
 
+#define STR_ENDS_WITH(str, suffix)  ((str.length() >= suffix.length()) && (str.compare(str.length() - suffix.length(), std::string_view::npos, suffix)) == 0)
+
+
 
 /**
  * @brief a basic renderer to convert data types to basic/simple strings
@@ -430,6 +433,300 @@ std::string renderRTKCfgBits(const data_info_t& info, std::any value, int arrayI
     }
 }
 
+/**
+ * @brief a custom data renderer for GNSS Status Bits
+ * @param info
+ * @param value
+ * @return
+ */
+std::string renderGnssStatusBits(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "status"))
+        return "";
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+    try {
+        std::stringstream buff;
+        uint32_t gpsStatusBits = std::any_cast<uint32_t>(value);
+
+        // satCount is to be deprecated - but we'll show it for backwards compatibility
+        uint8_t satCount = (gpsStatusBits & GPS_STATUS_NUM_SATS_USED_MASK);
+        buff << utils::string_format("0x000000%02X - %d satellites used in solution (deprecated)", satCount, satCount) << std::endl;
+
+        switch (gpsStatusBits & GPS_STATUS_FIX_MASK) {
+            case GPS_STATUS_FIX_NONE                : buff << "0x00000000 - No GNSS" << std::endl; break;
+            case GPS_STATUS_FIX_DEAD_RECKONING_ONLY : buff << "0x00000100 - GNSS Dead Reckoning Only" << std::endl; break;
+            case GPS_STATUS_FIX_2D                  : buff << "0x00000200 - 2D Fix" << std::endl; break;
+            case GPS_STATUS_FIX_3D                  : buff << "0x00000300 - 3D Fix" << std::endl; break;
+            case GPS_STATUS_FIX_GPS_PLUS_DEAD_RECK  : buff << "0x00000400 - 3D Fix + Dead Reckoning" << std::endl; break;
+            case GPS_STATUS_FIX_TIME_ONLY           : buff << "0x00000500 - Time-Only Fix" << std::endl; break;
+            case GPS_STATUS_FIX_REF_LLA             : buff << "0x00000600 - Usign Reference LLA" << std::endl; break;
+            case GPS_STATUS_FIX_UNUSED2             : buff << "0x00000700 - << UNUSED >>" << std::endl; break;
+            case GPS_STATUS_FIX_DGPS                : buff << "0x00000800 - Using DGPS" << std::endl; break;
+            case GPS_STATUS_FIX_SBAS                : buff << "0x00000900 - Using SBAS" << std::endl; break;
+            case GPS_STATUS_FIX_RTK_SINGLE          : buff << "0x00000A00 - RTK Single" << std::endl; break;
+            case GPS_STATUS_FIX_RTK_FLOAT           : buff << "0x00000B00 - RTK Float" << std::endl; break;
+            case GPS_STATUS_FIX_RTK_FIX             : buff << "0x00000C00 - RTK Fix" << std::endl; break;
+        }
+
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_FIX_OK                          , "0x00010000 - within limits (e.g. DOP & accuracy)");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_DGPS_USED                       , "0x00020000 - Differential GPS (DGPS) used.");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_RTK_FIX_AND_HOLD                , "0x00040000 - RTK feedback on the integer solutions to drive the float biases towards the resolved integers");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_UNUSED_1                        , "0x00080000 - << UNUSED >>");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS1_RTK_POSITION_ENABLED       , "0x00100000 - GPS1 RTK precision positioning mode enabled");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_STATIC_MODE                     , "0x00200000 - Static mode");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_ENABLED        , "0x00400000 - GPS2 RTK moving base mode enabled");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS1_RTK_RAW_GPS_DATA_ERROR     , "0x00800000 - GPS1 RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)");
+
+        uint32_t rtkError = (gpsStatusBits & GPS_STATUS_FLAGS_ERROR_MASK);
+        switch (rtkError) {
+            case GPS_STATUS_FLAGS_GPS1_RTK_BASE_DATA_MISSING        : buff << "0x01000000 - GPS1 RTK error: Either base observations or antenna position have not been received." << std::endl; break;
+            case GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_MOVING     : buff << "0x02000000 - GPS1 RTK error: base position moved when it should be stationary" << std::endl; break;
+            case GPS_STATUS_FLAGS_GPS1_RTK_BASE_POSITION_INVALID    : buff << "0x03000000 - GPS1 RTK error: base position is invalid or not surveyed well" << std::endl; break;
+        }
+
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS1_RTK_POSITION_VALID         , "0x04000000 - GPS1 RTK precision position and carrier phase range solution with fixed ambiguities.");
+        if (gpsStatusBits & GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_MASK) {
+            BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_VALID          , "0x08000000 - GPS2 RTK moving base heading valid and available in DID_GPS2_RTK_CMP_REL.");
+            BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_BAD   , "0x00002000 - GPS2 RTK Compassing Baseline distance is invalid");
+            BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS2_RTK_COMPASS_BASELINE_UNSET , "0x00004000 - GPS2 RTK Compassing Baseline distance is unset (must be > 0)");
+        }
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS_NMEA_DATA                   , "0x00008000 - Data from NMEA message. GPS velocity is NED (not ECEF).");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_GPS_PPS_TIMESYNC                , "0x10000000 - Time is synchronized by GPS PPS.");
+
+
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_UNUSED_2                        , "0x20000000 - <<UNUSED>>");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_UNUSED_3                        , "0x40000000 - <<UNUSED>>");
+        BIT_MSG(gpsStatusBits, GPS_STATUS_FLAGS_UNUSED_4                        , "0x80000000 - <<UNUSED>>");
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+
+std::string renderGpxStatus_status(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "status"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint32_t status = std::any_cast<uint32_t>(value);
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    /** Communications parse error count */
+        BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_MASK      , "0x0000000F - Communications parse error count");
+        // BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET    , ""           = 0,
+
+#define GPX_STATUS_COM_PARSE_ERROR_COUNT(gpxStatus) ((gpxStatus&GPX_STATUS_COM_PARSE_ERR_COUNT_MASK)>>GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET)
+
+    /** Rx communications not dectected in last 30 seconds */
+        BIT_MSG(status, GPX_STATUS_COM0_RX_TRAFFIC_NOT_DECTECTED , "0x00000010 - COM0 RX traffic not dectected in last 30 seconds.");
+        BIT_MSG(status, GPX_STATUS_COM1_RX_TRAFFIC_NOT_DECTECTED , "0x00000020 - COM1 RX traffic not dectected in last 30 seconds.");
+        BIT_MSG(status, GPX_STATUS_COM2_RX_TRAFFIC_NOT_DECTECTED , "0x00000040 - COM2 RX traffic not dectected in last 30 seconds.");
+        BIT_MSG(status, GPX_STATUS_USB_RX_TRAFFIC_NOT_DECTECTED  , "0x00000080 - USB RX traffic not dectected in last 30 seconds.");
+
+    /** General Fault mask */
+        // BIT_MSG(status, GPX_STATUS_GENERAL_FAULT_MASK            , "0xFFFF0000 -
+
+    /** RTK buffer filled causing data loss */
+        BIT_MSG(status, GPX_STATUS_FAULT_RTK_QUEUE_LIMITED       , "0x00010000 - RTK buffer overflow.");
+
+    /** GNSS receiver time fault **/
+        BIT_MSG(status, GPX_STATUS_FAULT_GNSS_RCVR_TIME          , "0x00100000 - GNSS receiver time fault");
+    /** DMA Fault detected **/
+        BIT_MSG(status, GPX_STATUS_FAULT_DMA                     , "0x00800000 - DMA fault");
+
+    /** Fatal faults - critical failure resulting in CPU reset */
+        //BIT_MSG(status, GPX_STATUS_FATAL_MASK                    , 0x1F000000,
+        //BIT_MSG(status, GPX_STATUS_FATAL_OFFSET                  ,           = 24,
+
+        uint32_t fatalStatus = ((status & GPX_STATUS_FATAL_MASK) >> GPX_STATUS_FATAL_OFFSET);
+        switch (fatalStatus) {
+            case GPX_STATUS_FATAL_RESET_LOW_POW:                buff << "0x01000000 - Reset from low power" << std::endl; break;
+            case GPX_STATUS_FATAL_RESET_BROWN:                  buff << "0x02000000 - Reset from brown out" << std::endl; break;
+            case GPX_STATUS_FATAL_RESET_WATCHDOG:               buff << "0x03000000 - Reset from watchdog" << std::endl; break;
+            case GPX_STATUS_FATAL_CPU_EXCEPTION:                buff << "0x04000000 - CPU exception" << std::endl; break;
+            case GPX_STATUS_FATAL_UNHANDLED_INTERRUPT:          buff << "0x05000000 - Unhandled interrupt" << std::endl; break;
+            case GPX_STATUS_FATAL_STACK_OVERFLOW:               buff << "0x06000000 - Stack overflow" << std::endl; break;
+            case GPX_STATUS_FATAL_KERNEL_OOPS:                  buff << "0x07000000 - Kernel oops" << std::endl; break;
+            case GPX_STATUS_FATAL_KERNEL_PANIC:                 buff << "0x08000000 - Kernel panic" << std::endl; break;
+            case GPX_STATUS_FATAL_UNALIGNED_ACCESS:             buff << "0x09000000 - Unaligned access" << std::endl; break;
+            case GPX_STATUS_FATAL_MEMORY_ERROR:                 buff << "0x0A000000 - Memory error" << std::endl; break;
+            case GPX_STATUS_FATAL_BUS_ERROR:                    buff << "0x0B000000 - Bus error" << std::endl; break;
+            case GPX_STATUS_FATAL_USAGE_ERROR:                  buff << "0x0C000000 - Usage error" << std::endl; break;
+            case GPX_STATUS_FATAL_DIV_ZERO:                     buff << "0x0D000000 - Division by zero" << std::endl; break;
+            case GPX_STATUS_FATAL_SER0_REINIT:                  buff << "0x0E000000 - SER0 reinit" << std::endl; break;
+            case GPX_STATUS_FATAL_UNKNOWN:                      buff << "0x1F000000 - Unknown" << std::endl; break;
+        }
+
+    /** Internal use */
+        BIT_MSG(status, GPX_STATUS_FAULT_RP                     , "0x20000000 - RP fault");
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+std::string renderGpxStatus_hdwStatus(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "hdwStatus"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint32_t hdwStatus = std::any_cast<uint32_t>(value);
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_SATELLITE_RX            , "0x00000001 - GNSS1 satellite signals are being received (antenna and cable are good)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_SATELLITE_RX            , "0x00000002 - GNSS2 satellite signals are being received (antenna and cable are good)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_TIME_OF_WEEK_VALID      , "0x00000004 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_TIME_OF_WEEK_VALID      , "0x00000008 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
+
+    /** GNSS 1 reset required count */
+    // GPX_HDW_STATUS_GNSS1_RESET_COUNT_MASK               = (int)0x00000070,
+    // GPX_HDW_STATUS_GNSS1_RESET_COUNT_OFFSET             = 4,
+#define GPX_HDW_STATUS_GNSS1_RESET_COUNT(hdwStatus)     ((hdwStatus&GPX_HDW_STATUS_GNSS1_RESET_COUNT_MASK)>>GPX_HDW_STATUS_GNSS1_RESET_COUNT_OFFSET)
+
+    /** Failed to communicate or setup GNSS receiver 1 */
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS1_INIT              , "0x00000080 - Failed to communicate or setup GNSS receiver 1");
+        // BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_FAULT_FLAG_OFFSET              = 7,
+
+    /** GNSS 2 reset required count */
+    // GPX_HDW_STATUS_GNSS2_RESET_COUNT_MASK               = (int)0x00000700,
+    // GPX_HDW_STATUS_GNSS2_RESET_COUNT_OFFSET             = 8,
+#define GPX_HDW_STATUS_GNSS2_RESET_COUNT(hdwStatus)     ((hdwStatus&GPX_HDW_STATUS_GNSS2_RESET_COUNT_MASK)>>GPX_HDW_STATUS_GNSS2_RESET_COUNT_OFFSET)
+
+    /** Failed to communicate or setup GNSS receiver 2 */
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS2_INIT              , "0x00000800 - Failed to communicate or setup GNSS receiver 2");
+        // BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_FAULT_FLAG_OFFSET              = 11,
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS_FW_UPDATE_REQUIRED       , "0x00001000 - GNSS is faulting firmware update REQUIRED");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_LED_ENABLED                   , "0x00002000 - Enables LED in Manufacturing TBed");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_SYSTEM_RESET_REQUIRED         , "0x00004000 - System Reset is Required for proper function");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FLASH_WRITE_PENDING           , "0x00008000 - System flash write staging or occuring now.");
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_TX_LIMITED            , "0x00010000 - Communications Tx buffer limited");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_RX_OVERRUN            , "0x00020000 - Communications Rx buffer overrun");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GPS1_PPS               , "0x00040000 - GPS1 PPS timepulse signal has not been received or is in error");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GPS2_PPS               , "0x00080000 - GPS2 PPS timepulse signal has not been received or is in error");
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GPS1              , "0x00100000 - GPS1 signal strength low (<20)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GPS2              , "0x00200000 - GPS2 signal strength low (<20)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GPS1_IR               , "0x00400000 - GPS1 signal irregular. High Cno standard deviation over 5 second period detected.");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GPS2_IR               , "0x00800000 - GPS2 signal irregular. High Cno standard deviation over 5 second period detected.");
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_RUNNING                   , "0x01000000 - (BIT) Built-in self-test running");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_PASSED                    , "0x02000000 - (BIT) Built-in self-test passed");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_FAULT                     , "0x03000000 - (BIT) Built-in self-test failure");
+        // GPX_HDW_STATUS_BIT_MASK                              = 0x03000000
+        // GPX_HDW_STATUS_BIT_OFFSET                            = 24,
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_TEMPERATURE               , "0x04000000 - Temperature outside spec'd operating range");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GPS_PPS_TIMESYNC              , "0x08000000 - Time synchronized by GPS PPS");
+
+    /** Cause of system reset */
+        // GPX_HDW_STATUS_RESET_CAUSE_MASK                     = (int)0x70000000,
+
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_BACKUP_MODE       , "0x10000000 - Reset from Backup mode (low-power state w/ CPU off)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_SOFT              , "0x20000000 - Reset from Software");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_HDW               , "0x40000000 - Reset from Hardware (NRST pin low)");
+        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_SYS_CRITICAL            , "0x80000000 - Critical System Fault, CPU error.");
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+std::string renderGpxStatus_gnssLastResetCause(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    static const char* rstReasons[] = {
+        "Power On", "Watchdog", "ErrOpCode", "ErrorOpCode_FwUp",
+        "ErrorOpCode_init", "UserRequested", "FWUpdate", "SysCmd",
+        "InitTimeout", "Status5", "StatusNot0", "flashUpdate",
+        "RTKEphMissing"
+    };
+
+    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("lastRstCause"))) {
+        try {
+            std::stringstream buff;
+            uint8_t msgIdx = std::any_cast<uint8_t>(value);
+            if (msgIdx < cxdRst_Max) {
+                return std::string(rstReasons[msgIdx]);
+            }
+        } catch (std::bad_any_cast& e) {
+        }
+    }
+    return "";
+}
+
+std::string renderGpxStatus_gnssInitState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    static const char* initStates[] = {
+        "Bootup", "UartSetting", "UartWait", "UartDone",
+        "VersionCheck", "StopPos", "SetL5", "SetSats",
+        "SetSatLimits", "SetOutput", "SetAlgo", "SetPeriod",
+        "SetRtcmMsgs", "SetRtcmTimeMode", "SetPinningMode", "SetVelocitySmoothing",
+        "SetAltituedSmoothing", "SetEphmOutputPeriod", "StartPos", "Done"
+        };
+
+    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("initState"))) {
+        try {
+            std::stringstream buff;
+            uint8_t msgIdx = std::any_cast<uint8_t>(value);
+            if (msgIdx <= 19) {
+                return std::string(initStates[msgIdx]);
+            }
+        } catch (std::bad_any_cast& e) {
+        }
+    }
+    return "";
+}
+
+std::string renderGpxStatus_gnssRunState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    static const char* runStates[] = {
+        "Reset", "Initializing", "Running", "Passthrough",
+        "FwUpdate Init", "FwUpdate", "Error", "Shutdown",
+        "ReInit", "Hard Reset"
+    };
+
+    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("runState"))) {
+        try {
+            std::stringstream buff;
+            uint8_t msgIdx = std::any_cast<uint8_t>(value);
+            if (msgIdx <= kHardReset) {
+                return std::string(runStates[msgIdx]);
+            }
+        } catch (std::bad_any_cast& e) {
+        }
+    }
+    return "";
+}
+
+
+std::string renderGpxStatus_gnssFwUpdateState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    static const char* fwStates[] = {
+        "LockoutWait", "ResetSet", "ResetWait", "StartSet", "StartWait",
+        "BootModeSet", "BootModeWait", "BaudSet", "BaudWait", "BaudFinish",
+        "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
+        "WriteNvmWait", "WriteNvmFinish", "Done",
+    };
+
+    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("fwUpdateState"))) {
+        try {
+            std::stringstream buff;
+            uint8_t msgIdx = std::any_cast<uint8_t>(value);
+            if (msgIdx < cxdRst_Max) {
+                return std::string(fwStates[msgIdx]);
+            }
+        } catch (std::bad_any_cast& e) {
+        }
+    }
+    return "";
+}
+
+
 static void PopulateMapTimestampField(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     static const string timestampFields[] = { "time", "timeOfWeek", "timeOfWeekMs", "seconds" };
@@ -730,7 +1027,7 @@ static void PopulateMapGpsPos(data_set_t data_set[DID_COUNT], uint32_t did)
     DataMapper<gps_pos_t> mapper(data_set, did);
     mapper.AddMember("week", &gps_pos_t::week, DATA_TYPE_UINT32, "week", "Weeks since Jan 6, 1980", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("timeOfWeekMs", &gps_pos_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddMember("status", &gps_pos_t::status, DATA_TYPE_UINT32, "", "GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GPS_STATUS);
+    mapper.AddMember("status", &gps_pos_t::status, DATA_TYPE_UINT32, "", "GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GPS_STATUS).renderExtended = renderGnssStatusBits;
     mapper.AddArray("ecef", &gps_pos_t::ecef, DATA_TYPE_F64, 3, {"m"}, {"Position in ECEF {x,y,z}"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddLlaDegM("lla", offsetof(gps_pos_t, lla), "", "ellipsoid altitude", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("hMSL", &gps_pos_t::hMSL, DATA_TYPE_F32, "m", "Meters above sea level", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
@@ -751,7 +1048,7 @@ static void PopulateMapGpsVel(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("timeOfWeekMs", &gps_vel_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4);
     mapper.AddArray("vel", &gps_vel_t::vel, DATA_TYPE_F32, 3, {"m/s"}, {"Velocity in ECEF {vx,vy,vz} or NED {vN, vE, 0} if status GPS_STATUS_FLAGS_GPS_NMEA_DATA = 0 or 1"}, DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
     mapper.AddMember("sAcc", &gps_vel_t::sAcc, DATA_TYPE_F32, "m/s", "Speed accuracy", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_2);
-    mapper.AddMember("status", &gps_vel_t::status, DATA_TYPE_UINT32, "", "GPS status: NMEA input if status flag GPS_STATUS_FLAGS_GPS_NMEA_DATA", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("status", &gps_vel_t::status, DATA_TYPE_UINT32, "", "GPS status: NMEA input if status flag GPS_STATUS_FLAGS_GPS_NMEA_DATA", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX).renderExtended = renderGnssStatusBits;;
 }
 
 static void PopulateMapGpsSat(data_set_t data_set[DID_COUNT], uint32_t did)
@@ -1070,8 +1367,8 @@ static void PopulateMapGpxStatus(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<gpx_status_t> mapper(data_set, did);
     mapper.AddMember("timeOfWeekMs", &gpx_status_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning", DATA_FLAGS_READ_ONLY);
-    mapper.AddMember("status",       &gpx_status_t::status,       DATA_TYPE_UINT32, "", "General status flags (see eGpxStatus)", DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddMember("hdwStatus",    &gpx_status_t::hdwStatus,    DATA_TYPE_UINT32, "", "Hardware status flags (see eGPXHdwStatusFlags)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("status",       &gpx_status_t::status,       DATA_TYPE_UINT32, "", "General status flags (see eGpxStatus)", DATA_FLAGS_DISPLAY_HEX).renderExtended = renderGpxStatus_status;;
+    mapper.AddMember("hdwStatus",    &gpx_status_t::hdwStatus,    DATA_TYPE_UINT32, "", "Hardware status flags (see eGPXHdwStatusFlags)", DATA_FLAGS_DISPLAY_HEX).renderExtended = renderGpxStatus_hdwStatus;
     mapper.AddMember("grmcBitsSer0", &gpx_status_t::grmcBitsSer0, DATA_TYPE_UINT64, "", "GPX RMC bit Serial 0", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("grmcBitsSer1", &gpx_status_t::grmcBitsSer1, DATA_TYPE_UINT64, "", "GPX RMC bit Serial 1", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember("grmcBitsSer2", &gpx_status_t::grmcBitsSer2, DATA_TYPE_UINT64, "", "GPX RMC bit Serial 2", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
@@ -1093,10 +1390,10 @@ static void PopulateMapGpxStatus(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("rtkMode", &gpx_status_t::rtkMode, DATA_TYPE_UINT32, "", str, DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
     for (int i=0; i<GNSS_RECEIVER_COUNT; i++)
     {
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".lastRstCause", i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].lastRstCause), DATA_TYPE_UINT8, "", "GNSS last reset cause (see eGnssResetCause)");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".fwUpdateState",  i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].fwUpdateState),  DATA_TYPE_UINT8, "", "GNSS FW update status (see FirmwareUpdateState)");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".initState",      i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].initState),      DATA_TYPE_UINT8, "", "GNSS init status (see InitSteps)");
-        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".runState",       i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].runState),       DATA_TYPE_UINT8, "", "GNSS run status (see eGPXGnssRunState)");
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".initState",      i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].initState),      DATA_TYPE_UINT8, "", "GNSS init status (see InitSteps)").renderExtended = renderGpxStatus_gnssInitState;
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".runState",       i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].runState),       DATA_TYPE_UINT8, "", "GNSS run status (see eGPXGnssRunState)").renderExtended = renderGpxStatus_gnssRunState;
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".fwUpdateState",  i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].fwUpdateState),  DATA_TYPE_UINT8, "", "GNSS FW update status (see FirmwareUpdateState)").renderExtended = renderGpxStatus_gnssFwUpdateState;
+        mapper.AddMember2("gnssStatus" + std::to_string(i) + ".lastRstCause", i*sizeof(gpx_gnss_status_t) + offsetof(gpx_status_t, gnssStatus[0].lastRstCause), DATA_TYPE_UINT8, "", "GNSS last reset cause (see eGnssResetCause)").renderExtended = renderGpxStatus_gnssLastResetCause;
     }
     mapper.AddMember("gpxSourcePort", &gpx_status_t::gpxSourcePort, DATA_TYPE_UINT8, "", "Port", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("upTime", &gpx_status_t::upTime, DATA_TYPE_F64, "s", "Local time since startup.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);
@@ -1362,7 +1659,7 @@ static void PopulateMapGpsRtkRel(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("baseToRoverDistance", &gps_rtk_rel_t::baseToRoverDistance, DATA_TYPE_F32, "", "baseToRoverDistance (m)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("baseToRoverHeading", &gps_rtk_rel_t::baseToRoverHeading, DATA_TYPE_F32, SYM_DEG, "Angle from north to baseToRoverVector in local tangent plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
     mapper.AddMember("baseToRoverHeadingAcc", &gps_rtk_rel_t::baseToRoverHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of baseToRoverHeading.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
-    mapper.AddMember("status", &gps_rtk_rel_t::status, DATA_TYPE_UINT32, "", "GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GPS_STATUS);
+    mapper.AddMember("status", &gps_rtk_rel_t::status, DATA_TYPE_UINT32, "", "GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GPS_STATUS).renderExtended = renderGnssStatusBits;
 }
 
 static void PopulateMapGpsRtkMisc(data_set_t data_set[DID_COUNT], uint32_t did)


### PR DESCRIPTION
This commit introduces custom "extended renderers" for various status fields to provide detailed, human-readable decoding of bitmasks and enumerated values.

<img width="1782" height="675" alt="image" src="https://github.com/user-attachments/assets/0d8ed935-0756-4c72-8bf3-5ab212740842" />

The following fields now have extended renderers:
- `DID_GPS1_POS.status`
- `DID_GPS2_POS.status`
- `DID_GPS1_VEL.status`
- `DID_GPS2_VEL.status`
- `DID_GPS_RTK_REL.status`
- `DID_GPX_STATUS.status`
- `DID_GPX_STATUS.hdwStatus`
- `DID_GPX_STATUS.gnssStatus[i].initState`
- `DID_GPX_STATUS.gnssStatus[i].runState`
- `DID_GPX_STATUS.gnssStatus[i].fwUpdateState`
- `DID_GPX_STATUS.gnssStatus[i].lastRstCause`

These renderers translate the raw integer values into descriptive strings, explaining what each bit or value represents, which significantly improves the usability and readability of the data for end-users. A `STR_ENDS_WITH` macro was also added to support matching field names for the new generic renderers.