### PR TITLE
SN-7724 - Device Connection Event Handling

### DIFF
--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -449,8 +449,10 @@ bool DeviceManager::deviceHandler(DeviceFactory *factory, const dev_info_t &devI
     if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)
         portClose(port);
 
-    if (portIsOpened(deviceEntry.device->port))
-        notifyListeners(deviceEntry.device, DEVICE_CONNECTED);  // notify that we've connected (if we are)
+    if (portIsOpened(deviceEntry.device->port)) {
+        if (deviceEntry.device->connect())  // even though the port is opened, we want the device to manage connection initialization
+            notifyListeners(deviceEntry.device, DEVICE_CONNECTED);  // connect() above wont notify, because the port is already opened.
+    }
 
     return true;    // successfully handled
 }

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -51,6 +51,8 @@ public:
         DEVICE_REMOVED,                 //!< a previously known device was removed from the manager
     };
 
+    inline static const char* device_event_names[] = { "DEVICE_ADDED", "DEVICE_PORT_BOUND", "DEVICE_CONNECTED", "DEVICE_INFO_CHANGED", "DEVICE_DISCONNECTED", "DEVICE_PORT_LOST", "DEVICE_REMOVED" };
+
     static const uint16_t OPTIONS_USE_DEFAULTS                    = 0xFFFF;       //!< used to indicate that higher-order options, if set should be used
     static const uint16_t DISCOVERY__IGNORE_CLOSED_PORTS          = 0x0001;       //!< when set, this will cause closed ports to be skipped/ignored, otherwise open the port before attempting discovery
     static const uint16_t DISCOVERY__CLOSE_PORT_ON_FAILURE        = 0x0002;       //!< when set, this will cause the port to be closed when discovery fails, otherwise the port will be left open

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -13,6 +13,7 @@
 #include "util/util.h"
 #include "imx_defaults.h"
 #include "ISLogger.h"
+#include "../../ROS/catkin_ws/src/inertial-sense-sdk/src/DeviceManager.h"
 
 const ISDevice ISDevice::invalidRef;
 
@@ -103,6 +104,11 @@ bool ISDevice::step() {
 
     if (portFlagsIsSet(port, PORT_FLAG__NO_ISDEVICE))
         return false;
+
+    if (was_connected != portIsOpened(port)) {
+        was_connected = isConnected();
+        DeviceManager::getInstance().notifyListeners(shared_from_this(), isConnected() ? DeviceManager::DEVICE_CONNECTED : DeviceManager::DEVICE_DISCONNECTED);
+    }
 
     bool didStuff = false;
     if (isConnected() && (portType(port) & PORT_TYPE__COMM) && !(COMM_PORT(port)->flags & COMM_PORT_FLAG__EXPLICIT_READ)) {
@@ -1635,7 +1641,8 @@ bool ISDevice::connect(bool revalidate) {
     if (revalidate)
         devInfo.hdwRunState = HDW_STATE_UNKNOWN; // this will further reinforce a validation
 
-    if (!portIsOpened(port)) {
+    bool alreadyOpened = portIsOpened(port);
+    if (!alreadyOpened) {
         if (nextConnectMs > current_timeMs()) {
             SLEEP_MS(15);
             log_debug(IS_LOG_ISDEVICE, "Connection throttled. You can retry this device again in %dms.", nextConnectMs - current_timeMs());
@@ -1656,7 +1663,13 @@ bool ISDevice::connect(bool revalidate) {
         SLEEP_MS(15);
         success = validate();          // if validating, only return true if we successfully validated
     }
-    log_debug(IS_LOG_ISDEVICE, "Connected to ISDevice::%s%s", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), (success ? " (revalidated)" : ""));
+
+    // ONLY notify of DEVICE_CONNECTED, if the port was closed at the start of this function
+    if (!alreadyOpened) {
+        DeviceManager::getInstance().notifyListeners(shared_from_this(), DeviceManager::DEVICE_CONNECTED);  // notify that we've connected (if we are)
+        log_debug(IS_LOG_ISDEVICE, "Connected to ISDevice::%s%s", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), (success ? " (revalidated)" : ""));
+    }
+    was_connected = success;
     return success;
 }
 

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -7,13 +7,13 @@
  */
 
 #include "core/msg_logger.h"
+#include "DeviceManager.h"
 #include "ISDevice.h"
 #include "ISFirmwareUpdater.h"
 #include "ISHttpRequest.h"
+#include "ISLogger.h"
 #include "util/util.h"
 #include "imx_defaults.h"
-#include "ISLogger.h"
-#include "../../ROS/catkin_ws/src/inertial-sense-sdk/src/DeviceManager.h"
 
 const ISDevice ISDevice::invalidRef;
 

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -205,7 +205,7 @@ public:
         bool valid = portIsValid(port);
         bool comPort = portType(port) & PORT_TYPE__COMM;    // Not sure that this is entirely required; but it doesn't really hurt currently
         bool open = portIsOpened(port);
-        return valid && comPort && open;
+        return (valid && comPort && open);
     }
 
     /**
@@ -690,6 +690,8 @@ public:
     };
 
 private:
+    bool                        was_connected = false;               //!< true, if this device's port was opened during the previous call to step()
+
     uint32_t                    validationStartMs = 0;               //!< If non-zero, the time in Epoch Ms at which validation was started; if zero, validation has finished (use hasDeviceInfo() to determine device status)
     uint32_t                    nextValidationMs = 0;                //!< if current_timeMs() > than this time, we'll perform the next validation query, otherwise we wait to see if the previous responds.
     queryType                   nextValidationType = QUERYTYPE_NMEA; //!< we cycle through different types of device queries looking for the first response (0 = NMEA, 1 = ISbinary, 2 = ISbootloader, 3 = MCUboot/SMP)

--- a/src/PortManager.h
+++ b/src/PortManager.h
@@ -34,6 +34,8 @@ public:
         PORT_REMOVED,
     };
 
+    inline static const char* port_event_names[] = { "PORT_ADDED", "PORT_REMOVED" };
+
     typedef std::function<void(port_event_e, uint16_t, std::string, port_handle_t, PortFactory& factory)> port_listener;
     typedef std::shared_ptr<port_listener> port_listener_handle_t;
 


### PR DESCRIPTION
This PR refactor device connection event handling for improved monitoring/management of when devices are connected, disconnected, etc.

This commit refactors the device connection and disconnection event logic to be more robust and prevent duplicate or missed notifications.

A `was_connected` flag is added to `ISDevice` to track the connection state between calls to `step()`, allowing `DEVICE_CONNECTED` and `DEVICE_DISCONNECTED` events to be emitted when the port's status changes.

The `ISDevice::connect()` method is updated to prevent sending a `DEVICE_CONNECTED` notification if the port was already open. `DeviceManager` is adjusted to correctly call `ISDevice::connect()` after discovery and then trigger the notification.

Additionally, string name arrays for port and device events have been added for easier debugging.