### PR TITLE
SN-7728: Per-target firmware update policies (SKIP, IF_NEWER, FORCE)

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -911,6 +911,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
                 g_commandLineOptions.updateAppFirmwareFilename = argv[++i];         // use next argument
             }
         }
+        else if (startsWith(a, "-fw-set-policy") && (i + 1) < argc)
+        {
+            g_commandLineOptions.fwPolicyOverrides.push_back(argv[++i]);
+        }
         else if (startsWith(a, "-uv"))
         {
             g_commandLineOptions.updateFirmwareTarget = fwUpdate::TARGET_HOST;      // use legacy firmware update mechanism
@@ -1257,6 +1261,11 @@ void cltool_outputUsage()
     cout << "    -ub " << boldOff << "FILEPATH    Update bootloader using .bin file FILEPATH if version is old. Must be used with option -uf." << endlbOn;
     cout << "    -fb " << boldOff << "            Force bootloader update regardless of the version." << endlbOn;
     cout << "    -uv " << boldOff << "            Run verification after application firmware update." << endlbOn;
+    cout << "    -fw-set-policy " << boldOff << "POLICY[:PATTERN]  Set update policy (skip, if-newer, force)." << endlbOn;
+    cout << "         " << boldOff << "                              Without :PATTERN, sets default for all targets." << endlbOn;
+    cout << "         " << boldOff << "                              With :PATTERN, overrides policy for matching" << endlbOn;
+    cout << "         " << boldOff << "                              step labels or target names (case-insensitive" << endlbOn;
+    cout << "         " << boldOff << "                              substring match). Can be specified multiple times." << endlbOn;
 
 	cout << endlbOn;
 	cout << "OPTIONS (Messages)" << endl;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -127,6 +127,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     std::string updateAppFirmwareFilename;     // -uf file_name
     std::string updateBootloaderFilename;     // -ub file_name
     std::vector<std::string> fwUpdateCmds;  // commands for firmware updates
+    std::vector<std::string> fwPolicyOverrides; // -fw-set-policy args
     bool forceBootloaderUpdate;                // -fb
     bool bootloaderVerify;                     // -bv
     bool replayDataLog;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1039,6 +1039,23 @@ static int cltool_dataStreaming()
 
         try
         {
+            // Inject policy override commands before the firmware update commands
+            if (!g_commandLineOptions.fwPolicyOverrides.empty()) {
+                std::vector<std::string> combined;
+                for (auto& po : g_commandLineOptions.fwPolicyOverrides) {
+                    auto colonPos = po.find(':');
+                    if (colonPos != std::string::npos) {
+                        // pattern-specific: "skip:GNSS" → "policy=skip,target=GNSS"
+                        combined.push_back("policy=" + po.substr(0, colonPos) + ",target=" + po.substr(colonPos + 1));
+                    } else {
+                        // default: "force" → "policy=force"
+                        combined.push_back("policy=" + po);
+                    }
+                }
+                combined.insert(combined.end(), g_commandLineOptions.fwUpdateCmds.begin(), g_commandLineOptions.fwUpdateCmds.end());
+                g_commandLineOptions.fwUpdateCmds = combined;
+            }
+
             if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && !g_commandLineOptions.fwUpdateCmds.empty()) {
                 if (inertialSenseInterface.updateFirmware(
                         g_commandLineOptions.updateFirmwareTarget,

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -37,6 +37,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Contains command line parsing and utility functions.  Include this in your project to use these utility functions.
 #include "cltool.h"
 
+#include "core/msg_logger.h"
+
 #include "protocol_nmea.h"
 #include "CorrectionService.h"
 #include "NtripCorrectionService.h"
@@ -957,8 +959,6 @@ void getMemoryEvent(InertialSense& inertialSenseInterface, uint32_t addrs, const
 
 static int cltool_dataStreaming()
 {
-    IS_LOG_OUTPUT(stdout);
-
     // [C++ COMM INSTRUCTION] STEP 1: Instantiate InertialSense Class
     // Create InertialSense object, passing in data callback function pointer.
     // Build explicit port factory list — only include ISmDnsPortFactory when -use-mdns is specified
@@ -1364,6 +1364,10 @@ static int inertialSenseMain()
 
 int main(int argc, char* argv[])
 {
+
+    // IS_LOG_OUTPUT(stdout);
+    // IS_SET_LOG_LEVEL(IS_LOG_LEVEL_MORE_DEBUG);
+
     // Parse command line options
     if (!cltool_parseCommandLine(argc, argv))
     {   // parsing failed

--- a/include_is_sdk_find_library.cmake
+++ b/include_is_sdk_find_library.cmake
@@ -8,6 +8,7 @@ else()
     set(IS_SDK_BUILD_DIR "${IS_SDK_DIR}/build")
 endif()
 
+unset(SDK_LIBRARY_PATH CACHE)
 find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_BUILD_DIR})
 
 if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -648,7 +648,8 @@ std::vector<std::pair<device_handle_t, std::string>> DeviceManager::getUpgradabl
     ISFileManager::GetAllFilesInDirectory(firmwarePath, true, "", fwImageFiles);
 
     // build a map of devInfo to files; we want to use a custom sorted map, where the map is ordered by version info
-    std::map<uint16_t, std::map<dev_info_t, std::string, decltype(&utils::compareFirmwareVersions)>> fwImages;
+    using cmpFn_t = int64_t(*)(const dev_info_t&, const dev_info_t&);
+    std::map<uint16_t, std::map<dev_info_t, std::string, cmpFn_t>> fwImages;
 
     for (auto imgPath : fwImageFiles) {
         std::string imgDir, imgFile, imgExt;
@@ -658,7 +659,7 @@ std::vector<std::pair<device_handle_t, std::string>> DeviceManager::getUpgradabl
         if (utils::devInfoFromString(imgFile, tmpDevInfo)) {
             auto hdwId = ENCODE_DEV_INFO_TO_HDW_ID(tmpDevInfo);
             if (fwImages.find(hdwId) != fwImages.end())
-                fwImages[hdwId] = std::map<dev_info_t, std::string, decltype(&utils::compareFirmwareVersions)>(&utils::compareFirmwareVersions);
+                fwImages[hdwId] = std::map<dev_info_t, std::string, cmpFn_t>(static_cast<cmpFn_t>(&utils::compareFirmwareVersions));
             fwImages[hdwId][tmpDevInfo] = imgPath;
         }
     }

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -593,6 +593,10 @@ std::string ISDevice::getName(const dev_info_t &devInfo, int flags) {
         case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
         case IS_HARDWARE_TYPE_IMX: typeName = "IMX"; break;
         case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
+        case IS_HDW_GNSS_SONY: typeName = "CXD"; break;
+        case IS_HDW_GNSS_UBLOX: typeName = "UBX"; break;
+        case IS_HDW_GNSS_SEPTENTRIO: typeName = "SEP"; break;
+        case IS_HDW_GNSS_STM_TESSIO: typeName = "STM"; break;
         default: typeName = "\?\?\?"; break;
     }
     out += utils::string_format("%s-%u.%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1]);

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -1454,6 +1454,13 @@ int ISDevice::onIsbDataHandler(p_data_t* data, port_handle_t port)
             if (devInfo.hdwRunState == HDW_STATE_UNKNOWN)   // this value should be passed from the device, but if not...
                 devInfo.hdwRunState = HDW_STATE_APP;        // since this is ISB, its pretty safe to assume that we are in APP mode.
             break;
+        case DID_GPX_DEV_INFO:
+            gpxDevInfo = *(dev_info_t*)data->ptr;
+            log_more_debug(IS_LOG_ISDEVICE, "[%s] Received DID_GPX_DEV_INFO: hwType=%d, fw=%d.%d.%d.%d",
+                getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(),
+                gpxDevInfo.hardwareType, gpxDevInfo.firmwareVer[0], gpxDevInfo.firmwareVer[1],
+                gpxDevInfo.firmwareVer[2], gpxDevInfo.firmwareVer[3]);
+            break;
         case DID_SYS_CMD:
             sysCmd = *(system_command_t*)data->ptr;
             break;

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -239,6 +239,8 @@ bool ISFirmwareUpdater::fwUpdate_handleVersionResponse(const fwUpdate::payload_t
     remoteDevInfo.hdwRunState = msg.data.version_resp.hdwRunState;
     memcpy(remoteDevInfo.hardwareVer, msg.data.version_resp.hardwareVer, 4);
     memcpy(remoteDevInfo.firmwareVer, msg.data.version_resp.firmwareVer, 4);
+    remoteDevInfo.buildType = msg.data.version_resp.buildType;
+    remoteDevInfo.buildNumber = msg.data.version_resp.buildNumber;
     remoteDevInfo.buildYear = msg.data.version_resp.buildYear;
     remoteDevInfo.buildMonth = msg.data.version_resp.buildMonth;
     remoteDevInfo.buildDay = msg.data.version_resp.buildDay;
@@ -246,7 +248,6 @@ bool ISFirmwareUpdater::fwUpdate_handleVersionResponse(const fwUpdate::payload_t
     remoteDevInfo.buildMinute = msg.data.version_resp.buildMinute;
     remoteDevInfo.buildSecond = msg.data.version_resp.buildSecond;
     remoteDevInfo.buildMillisecond = msg.data.version_resp.buildMillis;
-    remoteDevInfo.buildType = msg.data.version_resp.buildType;
 
     target_devInfo = &remoteDevInfo;
     LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Received device version: %s, %s", ISDevice::getName(remoteDevInfo).c_str(), ISDevice::getFirmwareInfo(remoteDevInfo).c_str());
@@ -1018,36 +1019,33 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
         if (((target & fwUpdate::TARGET_IMX5) == fwUpdate::TARGET_IMX5) && (target & fwUpdate::TARGET_ISB_FLAG) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX))
             target = fwUpdate::TARGET_ISB_IMX5;
 
-        // Resolve target_devInfo from host device info when target hasn't responded to version request
+        // Resolve target_devInfo when not already populated (e.g., no waitfor command, or explicit -uf-cmd mode)
         if (!target_devInfo) {
             if (((target & fwUpdate::TARGET_IMX5) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX)) ||
                 ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_GPX))) {
                 // Target is the same device as the host — use its dev info directly
                 remoteDevInfo = *devInfo;
                 target_devInfo = &remoteDevInfo;
-            } else if ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX) && device) {
-                if (device->gpxDevInfo.hardwareType == IS_HARDWARE_TYPE_GPX) {
-                    // GPX dev info already populated via DID_GPX_DEV_INFO
-                    remoteDevInfo = device->gpxDevInfo;
-                    target_devInfo = &remoteDevInfo;
-                } else if (effectivePolicy == UPDATE_POLICY_IF_NEWER) {
-                    // GPX dev info not yet available — request it async and retry
-                    if (!pingTimeoutExpires) {
-                        pingTimeoutExpires = current_timeMs() + 3000;
-                        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Requesting GPX device info for version comparison (up to 3s)...");
-                    }
-                    device->GetData(DID_GPX_DEV_INFO);
-                    if (current_timeMs() < pingTimeoutExpires) {
-                        return;  // stay CMD_QUEUED, re-enter on next cycle
-                    }
-                    // Timeout — proceed without target version (will fall through to upload)
-                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_WARN, "Timed out waiting for GPX device info; proceeding with upload");
-                    pingTimeoutExpires = 0;
+            } else if (effectivePolicy == UPDATE_POLICY_IF_NEWER) {
+                // Target info not available — request via firmware update protocol and retry async
+                if (!pingTimeoutExpires) {
+                    pingTimeoutExpires = current_timeMs() + 3000;
+                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Requesting target version info for version comparison (up to 3s)...");
                 }
-                if (target_devInfo && remoteDevInfo.firmwareVer[0] == 2 && remoteDevInfo.firmwareVer[1] == 0 && remoteDevInfo.firmwareVer[2] == 0)
-                    flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
-            } else
+                fwUpdate_requestVersionInfo(target);
+                if (current_timeMs() < pingTimeoutExpires) {
+                    return;  // stay CMD_QUEUED, re-enter on next cycle
+                }
+                // Timeout — proceed without target version (will fall through to upload)
+                LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_WARN, "Timed out waiting for target version info; proceeding with upload");
+                pingTimeoutExpires = 0;
+            }
+
+            // Set useAlternateMD5 for legacy firmware compatibility
+            if (target_devInfo && remoteDevInfo.firmwareVer[0] == 2 && remoteDevInfo.firmwareVer[1] == 0 && remoteDevInfo.firmwareVer[2] == 0)
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
+            else if (!target_devInfo)
+                flags |= fwUpdate::IMG_FLAG_useAlternateMD5;  // unknown version, use alternate MD5 for safety
         }
 
         // IF_NEWER: compare image version against target's current firmware version

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -7,6 +7,10 @@
 
 #include "ISBFirmwareUpdater.h"
 
+// Forward declarations for static helpers used throughout this file
+static bool icontains(const std::string& haystack, const std::string& needle);
+static update_policy_e parsePolicyString(const std::string& str);
+
 #define LOG_FWUPDATE_STATUS(log_level, ...)   { do {                                                        \
     /* log_msg(IS_LOG_FWUPDATE, log_level, __VA_ARGS__); */                                                 \
     if (pfnStatus_cb) { pfnStatus_cb(std::make_any<ISFirmwareUpdater*>(this), log_level, __VA_ARGS__); }    \
@@ -664,6 +668,50 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
         session_target = target = fwUpdate::TARGET_HOST;
         session_image_slot = slotNum = 0;
         failLabel.clear();
+
+        // Late pattern resolution: if this step has no resolved policy yet, try matching
+        // policyPatterns against the target name within this step's commands.
+        if (!activeStep.empty() &&
+            (stepPolicies.find(activeStep) == stepPolicies.end() ||
+             stepPolicies[activeStep].policy == UPDATE_POLICY_DEFAULT)) {
+            for (auto& c : commands) {
+                if (c.step == activeStep && c.cmd == "target" && c.hasArg("target")) {
+                    std::string targetName = c.getArg("target");
+                    for (auto& [pattern, policy] : policyPatterns) {
+                        if (icontains(targetName, pattern)) {
+                            stepPolicies[activeStep].policy = policy;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Check if this step should be skipped entirely.
+        // Policies only apply to steps that have a "target" command — because policies are
+        // inherently about firmware targets. Steps without a target are control-flow (FINALIZE,
+        // ERROR, etc.) and should always run. Without a target, there's no version to compare
+        // for IF_NEWER, and no device to skip or force.
+        bool stepHasTarget = false;
+        for (auto& c : commands) {
+            if (c.step == activeStep && c.cmd == "target") { stepHasTarget = true; break; }
+        }
+
+        if (!activeStep.empty() && stepHasTarget) {
+            update_policy_e policy = getEffectivePolicy(activeStep);
+            if (policy == UPDATE_POLICY_SKIP) {
+                LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Skipping step '%s' (policy: SKIP)", activeStep.c_str());
+                for (auto& c : commands) {
+                    if (c.step == activeStep && c.status == ISFwUpdaterCmd::CMD_QUEUED)
+                        c.status = ISFwUpdaterCmd::CMD_NOT_EXECUTED;
+                }
+                cmd.status = ISFwUpdaterCmd::CMD_NOT_EXECUTED;
+                activeCmd = &getNextQueuedCmd(&cmd);
+                return *activeCmd;
+            }
+        }
+
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
     }
 
@@ -699,6 +747,27 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
     } else if (cmd.cmd == "force") {
         forceUpdate = (cmd[0] == "true" ? true : false);
+        defaultPolicy = forceUpdate ? UPDATE_POLICY_FORCE : UPDATE_POLICY_DEFAULT;
+        cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+    } else if (cmd.cmd == "policy") {
+        std::string policyArg = cmd.getArg("policy", cmd[0]);
+        std::string patternArg = cmd.getArg("target", "");
+        update_policy_e p = parsePolicyString(policyArg);
+        if (p == UPDATE_POLICY_DEFAULT) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_ERROR, "Unknown update policy: '%s' (valid: skip, if-newer, force, always)", policyArg.c_str());
+        } else if (!patternArg.empty()) {
+            // Explicit target pattern provided: apply as a pattern match
+            setPolicyPattern(patternArg, p);
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set update policy '%s' for targets matching '%s'", policyArg.c_str(), patternArg.c_str());
+        } else if (!activeStep.empty()) {
+            // No target specified, but we're inside a step scope: apply to the current step
+            setStepPolicy(activeStep, p);
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set update policy '%s' for step '%s'", policyArg.c_str(), activeStep.c_str());
+        } else {
+            // No target, no active step: set the global default
+            setDefaultPolicy(p);
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set default update policy: %s", policyArg.c_str());
+        }
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
     } else if ((cmd.cmd == "chunk") && (cmd.args.size() == 1)) {
         chunkSize = strtol(cmd[0].c_str(), nullptr, 10);
@@ -722,7 +791,7 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
 }
 
 void ISFirmwareUpdater::cmd_ExtractPackage(ISFwUpdaterCmd cmd) {
-    // NOTE: Unlike other actions, use of copy of the ISFwUpdaterCmd, because processPackageManifest() by design
+    // NOTE: Unlike other actions, use a copy of the ISFwUpdaterCmd, because processPackageManifest() by design
     // modifies the list of commands to process, which could possibly invalidate the underlying reference to this
     // command.
 
@@ -915,6 +984,30 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
         if (cmd.hasArg("chunkSize")) progressRate = std::strtol(cmd.getArg("chunkSize", "512").c_str(), nullptr, 10);
         if (cmd.hasArg("force")) forceUpdate = (cmd.getArg("force", "false") == "true");
 
+        // Resolve effective update policy for this upload
+        update_policy_e effectivePolicy;
+        if (cmd.hasArg("force") && cmd.getArg("force") == "true") {
+            effectivePolicy = UPDATE_POLICY_FORCE;
+        } else if (cmd.hasArg("update-policy")) {
+            effectivePolicy = parsePolicyString(cmd.getArg("update-policy"));
+            if (effectivePolicy == UPDATE_POLICY_DEFAULT)
+                effectivePolicy = getEffectivePolicy(cmd.step);
+        } else {
+            effectivePolicy = getEffectivePolicy(cmd.step);
+        }
+
+        // SKIP: skip this upload entirely
+        if (effectivePolicy == UPDATE_POLICY_SKIP) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Skipping upload of '%s' (policy: SKIP)", filename.c_str());
+            cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+            cmd.resultMsg = "Upload skipped (policy: SKIP).";
+            return;
+        }
+
+        // FORCE: ensure forceUpdate is set for protocol-level behavior
+        if (effectivePolicy == UPDATE_POLICY_FORCE)
+            forceUpdate = true;
+
         fwUpdate_resetEngine();
 
         uint8_t flags = 0;
@@ -925,31 +1018,77 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
         if (((target & fwUpdate::TARGET_IMX5) == fwUpdate::TARGET_IMX5) && (target & fwUpdate::TARGET_ISB_FLAG) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX))
             target = fwUpdate::TARGET_ISB_IMX5;
 
-        // any target which doesn't report version info will also expect the old MD5 digest
+        // Resolve target_devInfo from host device info when target hasn't responded to version request
         if (!target_devInfo) {
-            // TODO: We should be able to remove most of this after 2.1.0 has been released
             if (((target & fwUpdate::TARGET_IMX5) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX)) ||
                 ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_GPX))) {
-                // just copy in the current "main" device's dev info, since they are the same device as the target
+                // Target is the same device as the host — use its dev info directly
                 remoteDevInfo = *devInfo;
                 target_devInfo = &remoteDevInfo;
-            } else if ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX)) {
-                // let's see if we can get the GPX version from the IMX dev info (it should be in addInfo)
-                const char *gpxVInfo = strstr(devInfo->addInfo, "G2.");
-                if (gpxVInfo) {
-                    int v1 = 0, v2 = 0, v3 = 0, v4 = 0, bn = 0;
-                    if ((sscanf(gpxVInfo, "G%d.%d.%d.%d-%d", &v1, &v2, &v3, &v4, &bn) == 5) ||
-                        (sscanf(gpxVInfo, "G%d.%d.%d-%d", &v1, &v2, &v3, &bn) == 4)) {
-                        remoteDevInfo.hardwareType = IS_HARDWARE_TYPE_GPX;
-                        remoteDevInfo.hardwareVer[0] = 1, remoteDevInfo.hardwareVer[1] = 0, remoteDevInfo.hardwareVer[2] = 3, remoteDevInfo.hardwareVer[3] = 0;
-                        remoteDevInfo.firmwareVer[0] = v1, remoteDevInfo.firmwareVer[1] = v2, remoteDevInfo.firmwareVer[2] = v3, remoteDevInfo.firmwareVer[3] = v4;
-                        target_devInfo = &remoteDevInfo;
-                        if ((v1 == 2) && (v2 == 0) && (v3 == 0))
-                            flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
+            } else if ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX) && device) {
+                if (device->gpxDevInfo.hardwareType == IS_HARDWARE_TYPE_GPX) {
+                    // GPX dev info already populated via DID_GPX_DEV_INFO
+                    remoteDevInfo = device->gpxDevInfo;
+                    target_devInfo = &remoteDevInfo;
+                } else if (effectivePolicy == UPDATE_POLICY_IF_NEWER) {
+                    // GPX dev info not yet available — request it async and retry
+                    if (!pingTimeoutExpires) {
+                        pingTimeoutExpires = current_timeMs() + 3000;
+                        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Requesting GPX device info for version comparison (up to 3s)...");
                     }
+                    device->GetData(DID_GPX_DEV_INFO);
+                    if (current_timeMs() < pingTimeoutExpires) {
+                        return;  // stay CMD_QUEUED, re-enter on next cycle
+                    }
+                    // Timeout — proceed without target version (will fall through to upload)
+                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_WARN, "Timed out waiting for GPX device info; proceeding with upload");
+                    pingTimeoutExpires = 0;
                 }
+                if (target_devInfo && remoteDevInfo.firmwareVer[0] == 2 && remoteDevInfo.firmwareVer[1] == 0 && remoteDevInfo.firmwareVer[2] == 0)
+                    flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
             } else
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
+        }
+
+        // IF_NEWER: compare image version against target's current firmware version
+        if (effectivePolicy == UPDATE_POLICY_IF_NEWER && target_devInfo) {
+            dev_info_t imageDevInfo = {};
+            uint16_t parsed = 0;
+            bool hasImageVer = false;
+
+            if (cmd.hasArg("image-version")) {
+                std::string verStr = cmd.getArg("image-version");
+                // devInfoFromString expects a 'v' or 'fw' prefix for version parsing
+                if (!verStr.empty() && verStr[0] != 'v' && verStr.substr(0, 2) != "fw")
+                    verStr.insert(0, "v");
+                parsed = utils::devInfoFromString(verStr, imageDevInfo);
+                if (parsed & utils::DV_BIT_FIRMWARE_VER)
+                    hasImageVer = true;
+            }
+
+            // Fallback: try to parse version from the filename itself
+            if (!hasImageVer && !filename.empty()) {
+                parsed = utils::devInfoFromString(filename, imageDevInfo);
+                if (parsed & utils::DV_BIT_FIRMWARE_VER)
+                    hasImageVer = true;
+            }
+
+            if (hasImageVer) {
+                std::string imageVerStr = utils::devInfoToString(imageDevInfo, utils::DV_BIT_FIRMWARE_VER);
+                std::string targetVerStr = utils::devInfoToString(*target_devInfo, utils::DV_BIT_FIRMWARE_VER);
+
+                // Only compare fields that were actually parsed from the image version string
+                int64_t cmp = utils::compareFirmwareVersions(imageDevInfo, *target_devInfo, parsed);
+                if (cmp <= 0) {
+                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO,
+                        "Target is already up to date (%s); skipping upload of '%s' (image version: %s)",
+                        targetVerStr.c_str(), filename.c_str(), imageVerStr.c_str());
+                    cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+                    cmd.resultMsg = "Target is already up to date.";
+                    return;
+                }
+            }
+            // If no image version available, fall through to upload (can't compare)
         }
 
         fwUpdate::update_status_e status = initializeUpload(target, filename, slotNum, flags, forceUpdate, chunkSize, progressRate);
@@ -993,6 +1132,7 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
         if (session_status == fwUpdate::FINISHED) {
             cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
             cmd.resultMsg = "Upload successful.";
+            targetUploadPerformed[target] = true;
         } else if (session_status < fwUpdate::NOT_STARTED) {
             cmd.status = ISFwUpdaterCmd::CMD_ERROR;
             cmd.resultMsg = utils::string_format("Error: %s", fwUpdate_getNiceStatusName(fwUpdate_getSessionStatus()));
@@ -1005,6 +1145,27 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
 
 void ISFirmwareUpdater::cmd_resetDevice(ISFwUpdaterCmd& cmd) {
     // std::lock_guard<std::recursive_mutex> lock(mutex);
+
+    bool force = (cmd.getArg("force", "false") == "true");
+
+    if (!force) {
+        // Skip reset if target's policy is SKIP
+        update_policy_e policy = getEffectivePolicy(cmd.step);
+        if (policy == UPDATE_POLICY_SKIP) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Skipping reset (policy: SKIP)");
+            cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+            cmd.resultMsg = "Reset skipped (policy: SKIP).";
+            return;
+        }
+
+        // Skip reset if no upload was actually performed for this target (e.g. IF_NEWER with same version)
+        if (targetUploadPerformed.find(target) == targetUploadPerformed.end()) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Skipping reset — no upload was performed for this target");
+            cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+            cmd.resultMsg = "Reset skipped (no upload performed).";
+            return;
+        }
+    }
 
     bool hard = (cmd.getArg("type", "soft") == "hard");
     if (cmd.hasArg("type") && (cmd["type"] == "tobl")) {
@@ -1073,10 +1234,63 @@ void ISFirmwareUpdater::initialize() {
     //mz_zip_archive *zip_archive = nullptr; //!< is NOT null IF we are updating from a firmware package (zip archive).
     //fwUpdate::FirmwareUpdateDevice *deviceUpdater = nullptr;
     remoteDevInfo = {};
+    targetUploadPerformed.clear();
     logLevel = IS_LOG_LEVEL_INFO;                           //!< default log level to show
+
+    // NOTE: stepPolicies, policyPatterns, and defaultPolicy are intentionally
+    // NOT reset here. They are set by policy commands which run BEFORE the
+    // package command calls initialize() via processPackageManifest().
 
     updateState.resetState();
 }
+
+
+void ISFirmwareUpdater::setStepPolicy(const std::string& stepLabel, update_policy_e policy) {
+    stepPolicies[stepLabel].policy = policy;
+}
+
+void ISFirmwareUpdater::setPolicyPattern(const std::string& pattern, update_policy_e policy) {
+    policyPatterns.emplace_back(pattern, policy);
+}
+
+void ISFirmwareUpdater::setDefaultPolicy(update_policy_e policy) {
+    defaultPolicy = policy;
+}
+
+update_policy_e ISFirmwareUpdater::getEffectivePolicy(const std::string& stepLabel) const {
+    auto it = stepPolicies.find(stepLabel);
+    if (it != stepPolicies.end() && it->second.policy != UPDATE_POLICY_DEFAULT)
+        return it->second.policy;
+
+    if (defaultPolicy != UPDATE_POLICY_DEFAULT)
+        return defaultPolicy;
+
+    if (forceUpdate)
+        return UPDATE_POLICY_FORCE;
+
+    return UPDATE_POLICY_IF_NEWER;
+}
+
+/**
+ * Case-insensitive substring match. Returns true if haystack contains needle (ignoring case).
+ */
+static bool icontains(const std::string& haystack, const std::string& needle) {
+    if (needle.size() > haystack.size()) return false;
+    auto it = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(),
+        [](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+    return it != haystack.end();
+}
+
+/**
+ * Parses a policy string ("skip", "if-newer", "force", "always") into an update_policy_e value.
+ */
+static update_policy_e parsePolicyString(const std::string& str) {
+    if (str == "skip") return UPDATE_POLICY_SKIP;
+    if (str == "if-newer") return UPDATE_POLICY_IF_NEWER;
+    if (str == "force" || str == "always") return UPDATE_POLICY_FORCE;
+    return UPDATE_POLICY_DEFAULT;
+}
+
 
 /**
  * Locates the next queued, command in the command stack and returns it
@@ -1206,7 +1420,36 @@ ISFirmwareUpdater::pkg_error_e ISFirmwareUpdater::processPackageManifest(YAML::N
                         if (image["slot"].IsDefined() && image["slot"].IsScalar())
                             args += ",slot="+image["slot"].as<std::string>();
 
-                        //commands.emplace_back("slot",);
+                        // Extract image version from manifest (for IF_NEWER comparison)
+                        if (image["version"].IsDefined() && image["version"].IsScalar()) {
+                            std::string verStr = image["version"].as<std::string>();
+                            args += ",image-version=" + verStr;
+                        }
+
+                        // Resolve update policy for this step:
+                        //   1. Exact stepPolicies entry (from CLI setStepPolicy) — highest priority
+                        //   2. Pattern match from policyPatterns (from CLI setPolicyPattern)
+                        //   3. Manifest's update: field (only if no CLI default was set)
+                        if (stepPolicies.find(labelName) == stepPolicies.end() ||
+                            stepPolicies[labelName].policy == UPDATE_POLICY_DEFAULT) {
+                            // Try deferred pattern match against step label
+                            for (auto& [pattern, policy] : policyPatterns) {
+                                if (icontains(labelName, pattern)) {
+                                    stepPolicies[labelName].policy = policy;
+                                    break;
+                                }
+                            }
+                        }
+                        // Only apply manifest's update: field if no CLI-level policy
+                        // (neither per-step, pattern, nor defaultPolicy) would override it.
+                        if (defaultPolicy == UPDATE_POLICY_DEFAULT &&
+                            (stepPolicies.find(labelName) == stepPolicies.end() ||
+                             stepPolicies[labelName].policy == UPDATE_POLICY_DEFAULT)) {
+                            if (image["update"].IsDefined() && image["update"].IsScalar()) {
+                                stepPolicies[labelName].policy = parsePolicyString(image["update"].as<std::string>());
+                            }
+                        }
+
                         commands.emplace_back(labelName, "upload", args);
                     } else {
                         // anything that isn't "image" is treated like a normal command

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -43,6 +43,25 @@ extern "C"
 #endif
 
 
+/**
+ * Defines the update policy for a firmware update step/target.
+ */
+enum update_policy_e : int8_t {
+    UPDATE_POLICY_DEFAULT   = 0,   //!< inherit from updater-level default (backward compat)
+    UPDATE_POLICY_SKIP      = 1,   //!< skip this target's step entirely
+    UPDATE_POLICY_IF_NEWER  = 2,   //!< upload only if image version > target's current version
+    UPDATE_POLICY_FORCE     = 3,   //!< always upload (current behavior)
+};
+
+/**
+ * Stores the update policy and image version metadata for a single step/target.
+ */
+struct step_policy_t {
+    update_policy_e policy = UPDATE_POLICY_DEFAULT;
+    uint8_t imageVersion[4] = {};  //!< parsed from manifest "version: x.y.z.w"
+    bool hasImageVersion = false;  //!< true if imageVersion was explicitly set
+};
+
 
 class ISFwUpdaterCmd {
 public:
@@ -85,6 +104,7 @@ public:
                 {"waitfor", {"timeout", "interval", "force", "on-timeout"}},
                 {"upload", {"filename", "slot", "force", "interval"}},
                 {"reset", {"type"}},
+                {"policy", {"policy", "target"}},
         };
 
         auto tmpArgs = utils::split_string(_args, ",");
@@ -299,6 +319,32 @@ public:
     void clearAllCommands() { commands.clear(); }
 
     /**
+     * Sets an explicit update policy for a specific step (by exact label name).
+     */
+    void setStepPolicy(const std::string& stepLabel, update_policy_e policy);
+
+    /**
+     * Stores a deferred pattern-based policy override. The pattern is matched (case-insensitive
+     * substring) against step labels during manifest parsing, and against target names at step
+     * transition time. First matching pattern wins.
+     */
+    void setPolicyPattern(const std::string& pattern, update_policy_e policy);
+
+    /**
+     * Sets the updater-wide default policy, used when no step-specific or pattern-matched policy applies.
+     */
+    void setDefaultPolicy(update_policy_e policy);
+
+    /**
+     * Resolves the effective update policy for a given step label, using the following priority:
+     *   1. Exact stepPolicies entry
+     *   2. defaultPolicy (if not DEFAULT)
+     *   3. forceUpdate bool (legacy)
+     *   4. IF_NEWER fallback
+     */
+    update_policy_e getEffectivePolicy(const std::string& stepLabel) const;
+
+    /**
      * Called when an error occurs while processing a command, to perform corrective actions (if possible).
      * Primarily, this checks if there is a failLabel defined and looks for the corresponding command label.
      * Otherwise it logs the message/errorcode, and clears the command stack.
@@ -361,8 +407,12 @@ private:
     std::string statusMsg;                                  //!< a string the reflects the current state of the updater - this should be "Human Readable" (it generally gets reported directly to the user in the UI, etc).
 
     eLogLevel logLevel = IS_LOG_LEVEL_INFO;                 //!< default log level to show
-    //std::vector<ISFwUpdateState::message> stepErrors;       //!< a list of error messages messages that occurred during the update
-    //bool requestPending = false;                            //!< true if a fwUpdate request has been made, and we're still waiting for a response.
+
+    /** ---- Per-target update policy state ---- **/
+    std::map<std::string, step_policy_t> stepPolicies;      //!< resolved per-step policies, keyed by exact step label
+    std::vector<std::pair<std::string, update_policy_e>> policyPatterns; //!< deferred patterns to match against step labels / target names
+    update_policy_e defaultPolicy = UPDATE_POLICY_DEFAULT;  //!< updater-wide default policy
+    std::map<fwUpdate::target_t, bool> targetUploadPerformed; //!< tracks whether any upload actually occurred for each target
 
 
     /** =========================================================== **/

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -222,6 +222,10 @@ std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) 
         case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
         case IS_HARDWARE_TYPE_IMX: typeName = "IMX"; break;
         case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
+        case IS_HDW_GNSS_SONY: typeName = "CXD"; break;
+        case IS_HDW_GNSS_UBLOX: typeName = "UBX"; break;
+        case IS_HDW_GNSS_SEPTENTRIO: typeName = "SEP"; break;
+        case IS_HDW_GNSS_STM_TESSIO: typeName = "STM"; break;
         default: typeName = "\?\?\?"; break;
     }
     std::string out = utils::string_format("%s-%u.%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1]);
@@ -613,7 +617,8 @@ int64_t utils::compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b,
         if (a.firmwareVer[3] != b.firmwareVer[3])
             result |= ((int64_t)(a.firmwareVer[3] > b.firmwareVer[3]) & 0xFF) << 24;
 
-        result |= ((int64_t)(a.buildType - b.buildType) & 0xFF);
+        if (a.buildType && b.buildType && a.buildType != b.buildType)
+            result |= ((int64_t)(a.buildType - b.buildType) & 0xFF);
     }
 
     if (fields & (DV_BIT_BUILD_DATE | DV_BIT_BUILD_TIME)) {

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -597,25 +597,36 @@ bool utils::devInfoVersionMatch(const dev_info_t &info1, const dev_info_t &info2
  *   determine the specific differences between versions.
  */
 int64_t utils::compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b) {
+    return compareFirmwareVersions(a, b, 0xFFFF);
+}
+
+int64_t utils::compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b, uint16_t fields) {
     int64_t result = 0;
-    if (a.firmwareVer[0] != b.firmwareVer[0])
-        result |= ((int64_t)(a.firmwareVer[0] - b.firmwareVer[0]) & 0xFF) << 56;
-    if (a.firmwareVer[1] != b.firmwareVer[1])
-        result |= ((int64_t)(a.firmwareVer[1] - b.firmwareVer[1]) & 0xFF) << 48;
-    if (a.firmwareVer[2] != b.firmwareVer[2])
-        result |= ((int64_t)(a.firmwareVer[2] - b.firmwareVer[2]) & 0xFF) << 32;
-    if (a.firmwareVer[3] != b.firmwareVer[3])
-        result |= ((int64_t)(a.firmwareVer[3] > b.firmwareVer[3]) & 0xFF) << 24;
 
-    uint64_t aDateTime = intDateTimeFromDevInfo(a);
-    uint64_t bDateTime = intDateTimeFromDevInfo(b);
-    if (aDateTime != bDateTime)
-        result |= ((int64_t)(aDateTime - bDateTime) & 0xFF) << 16;
+    if (fields & DV_BIT_FIRMWARE_VER) {
+        if (a.firmwareVer[0] != b.firmwareVer[0])
+            result |= ((int64_t)(a.firmwareVer[0] - b.firmwareVer[0]) & 0xFF) << 56;
+        if (a.firmwareVer[1] != b.firmwareVer[1])
+            result |= ((int64_t)(a.firmwareVer[1] - b.firmwareVer[1]) & 0xFF) << 48;
+        if (a.firmwareVer[2] != b.firmwareVer[2])
+            result |= ((int64_t)(a.firmwareVer[2] - b.firmwareVer[2]) & 0xFF) << 32;
+        if (a.firmwareVer[3] != b.firmwareVer[3])
+            result |= ((int64_t)(a.firmwareVer[3] > b.firmwareVer[3]) & 0xFF) << 24;
 
-    if (a.buildNumber != b.buildNumber)
-        result |= ((int64_t)(a.buildNumber - b.buildNumber) & 0xFF) << 8;
+        result |= ((int64_t)(a.buildType - b.buildType) & 0xFF);
+    }
 
-    result |= ((int64_t)(a.buildType - b.buildType) & 0xFF);
+    if (fields & (DV_BIT_BUILD_DATE | DV_BIT_BUILD_TIME)) {
+        uint64_t aDateTime = intDateTimeFromDevInfo(a);
+        uint64_t bDateTime = intDateTimeFromDevInfo(b);
+        if (aDateTime != bDateTime)
+            result |= ((int64_t)(aDateTime - bDateTime) & 0xFF) << 16;
+    }
+
+    if (fields & DV_BIT_BUILD_KEY) {
+        if (a.buildNumber != b.buildNumber)
+            result |= ((int64_t)(a.buildNumber - b.buildNumber) & 0xFF) << 8;
+    }
 
     return result;
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -241,6 +241,7 @@ namespace utils {
     bool devInfoVersionMatch(const dev_info_t &info1, const dev_info_t &info2, int flags = DV_BIT_FIRMWARE_VER | DV_BIT_BUILD_COMMIT | DV_BIT_BUILD_DATE | DV_BIT_BUILD_TIME);
     bool isDevInfoCompatible(const dev_info_t& a, const dev_info_t& b);
     int64_t compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b);
+    int64_t compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b, uint16_t fields);
 
     // int parseStringVersion(const std::string& vIn, uint8_t vOut[4]);
     // bool devInfoFromFirmwareImage(std::string imgFilename, dev_info_t& devInfo);


### PR DESCRIPTION
This PR adds support to the SDK to optionally/conditionally perform updates to individual components, based on policy flags assigned globally, or per step/target.  For example "skip:IMX5, force:GPX1, if-newer:GNSS".

## Summary

- Add per-target update policy system to ISFirmwareUpdater with three policies: **SKIP** (bypass target entirely), **IF_NEWER** (upload only if image version is newer), and **FORCE** (always upload)
- Policies can be set via CLI (`-fw-set-policy skip:GNSS -fw-set-policy force:IMX`), explicit commands (`policy=skip,target=GNSS`), or manifest `update:` field — with pattern-based case-insensitive substring matching against step labels and target names
- Reset commands are automatically skipped when the target's policy is SKIP, or when no upload was actually performed (IF_NEWER with same version) — handles CXD multi-image case where reset triggers if any image was uploaded
- Added async `DID_GPX_DEV_INFO` request with retry for GPX version comparison when updating through an IMX host; added missing binary data handler in ISDevice
- Added `compareFirmwareVersions()` overload with field bitmask to only compare parsed version fields (avoids false positives when date/time unavailable from manifest)
- Fixed stale SDK library cache in cmake `find_library`

## Files Changed

| File | Changes |
|------|---------|
| `src/ISFirmwareUpdater.h` | `update_policy_e` enum, `step_policy_t` struct, policy maps, public API |
| `src/ISFirmwareUpdater.cpp` | Policy resolution, step SKIP, IF_NEWER comparison, reset skip, async GPX dev info, `policy` command handler |
| `src/ISDevice.cpp` | `DID_GPX_DEV_INFO` binary data handler |
| `src/util/util.h` / `util.cpp` | 3-arg `compareFirmwareVersions()` with field bitmask |
| `src/DeviceManager.cpp` | Fix `decltype` ambiguity from overload |
| `cltool/src/cltool.h` / `cltool.cpp` / `cltool_main.cpp` | `-fw-set-policy` CLI option |
| `include_is_sdk_find_library.cmake` | Unset cached SDK library path |

## Test plan

- [x] Skip all targets: `-fw-set-policy skip` — all steps skipped, FINALIZE still runs
- [x] IF_NEWER same version: upload and reset both skipped with "already up to date"
- [x] FORCE by pattern: `-fw-set-policy force:IMX` — IMX forced, others use default
- [x] IF_NEWER with newer firmware: upload proceeds correctly
- [x] Explicit commands: `-uf-cmd "target=GPX1,upload=...,reset"` — version parsed from filename
- [x] GPX via IMX host: async `DID_GPX_DEV_INFO` request resolves version for comparison
- [x] Backward compatible: `-ufpkg` without policy args works as before
- [ ] EvalTool UI integration (Phase 2, separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)