### PR TITLE
SN-7737: SDK support for firmware update policy UI

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1039,24 +1039,24 @@ static int cltool_dataStreaming()
 
         try
         {
-            // Inject policy override commands before the firmware update commands
-            if (!g_commandLineOptions.fwPolicyOverrides.empty()) {
-                std::vector<std::string> combined;
-                for (auto& po : g_commandLineOptions.fwPolicyOverrides) {
-                    auto colonPos = po.find(':');
-                    if (colonPos != std::string::npos) {
-                        // pattern-specific: "skip:GNSS" → "policy=skip,target=GNSS"
-                        combined.push_back("policy=" + po.substr(0, colonPos) + ",target=" + po.substr(colonPos + 1));
-                    } else {
-                        // default: "force" → "policy=force"
-                        combined.push_back("policy=" + po);
-                    }
-                }
-                combined.insert(combined.end(), g_commandLineOptions.fwUpdateCmds.begin(), g_commandLineOptions.fwUpdateCmds.end());
-                g_commandLineOptions.fwUpdateCmds = combined;
-            }
-
             if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && !g_commandLineOptions.fwUpdateCmds.empty()) {
+                // Inject policy override commands before the firmware update commands
+                if (!g_commandLineOptions.fwPolicyOverrides.empty()) {
+                    std::vector<std::string> combined;
+                    for (auto& po : g_commandLineOptions.fwPolicyOverrides) {
+                        auto colonPos = po.find(':');
+                        if (colonPos != std::string::npos) {
+                            // pattern-specific: "skip:GNSS" → "policy=skip,target=GNSS"
+                            combined.push_back("policy=" + po.substr(0, colonPos) + ",target=" + po.substr(colonPos + 1));
+                        } else {
+                            // default: "force" → "policy=force"
+                            combined.push_back("policy=" + po);
+                        }
+                    }
+                    combined.insert(combined.end(), g_commandLineOptions.fwUpdateCmds.begin(), g_commandLineOptions.fwUpdateCmds.end());
+                    g_commandLineOptions.fwUpdateCmds = combined;
+                }
+
                 if (inertialSenseInterface.updateFirmware(
                         g_commandLineOptions.updateFirmwareTarget,
                         g_commandLineOptions.fwUpdateCmds,

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -176,8 +176,9 @@ float ISDevice::fwUpdatePercentCompleted() {
  * @return
  */
 std::vector<ISFwUpdateState::message> ISDevice::fwUpdateMessages(eLogLevel level) {
+    auto lk = fwUpdateState.lock();
     std::vector<ISFwUpdateState::message> out;
-    for (auto msg : fwUpdateState.messages) {
+    for (const auto& msg : fwUpdateState.messages) {
         if (msg.severity < level)
             out.push_back(msg);
     }

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -7,6 +7,9 @@
 
 #include "ISBFirmwareUpdater.h"
 
+#include <algorithm>
+#include <map>
+
 // Forward declarations for static helpers used throughout this file
 static bool icontains(const std::string& haystack, const std::string& needle);
 static update_policy_e parsePolicyString(const std::string& str);
@@ -507,7 +510,7 @@ bool ISFirmwareUpdater::step() {
             activeCmd = &getNextQueuedCmd(activeCmd);
         activeCmd = &runCommand(*activeCmd);
     } else {
-        activeCmd = nullptr;
+        activeCmd = &nullCmd;
     }
 
     bool result = fwUpdate_step();
@@ -660,6 +663,8 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
         if (!cmd.cmd.empty()) {
             LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_MORE_DEBUG, "Executing manifest command '%s\\%s'", cmd.step.c_str(), cmd.cmd.c_str());
         }
+        if (updateState.state == ISFwUpdateState::UDPATER_SUSPENDED)
+            return cmd; // this should prevent the next QUEUED command from executing (until updateState is changed)
     } else
         updateState.state = ISFwUpdateState::UPDATER_IN_PROGRESS;
 
@@ -716,7 +721,11 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
     }
 
-    if (cmd.cmd == "package") cmd_ExtractPackage(cmd);
+    if (cmd.cmd == "package") {
+        cmd_ExtractPackage(cmd);
+        // cmd reference is now dangling (commands vector was repopulated) — return nullCmd
+        return nullCmd;
+    }
     else if (cmd.cmd == "target") cmd_SetTarget(cmd);
     else if (cmd.cmd == "waitfor") cmd_WaitFor(cmd);
     else if (cmd.cmd == "delay") cmd_Delay(cmd);
@@ -759,15 +768,15 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
         } else if (!patternArg.empty()) {
             // Explicit target pattern provided: apply as a pattern match
             setPolicyPattern(patternArg, p);
-            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set update policy '%s' for targets matching '%s'", policyArg.c_str(), patternArg.c_str());
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_DEBUG, "Set update policy '%s' for targets matching '%s'", policyArg.c_str(), patternArg.c_str());
         } else if (!activeStep.empty()) {
             // No target specified, but we're inside a step scope: apply to the current step
             setStepPolicy(activeStep, p);
-            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set update policy '%s' for step '%s'", policyArg.c_str(), activeStep.c_str());
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_DEBUG, "Set update policy '%s' for step '%s'", policyArg.c_str(), activeStep.c_str());
         } else {
             // No target, no active step: set the global default
             setDefaultPolicy(p);
-            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Set default update policy: %s", policyArg.c_str());
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_DEBUG, "Set default update policy: %s", policyArg.c_str());
         }
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
     } else if ((cmd.cmd == "chunk") && (cmd.args.size() == 1)) {
@@ -791,6 +800,18 @@ ISFwUpdaterCmd& ISFirmwareUpdater::runCommand(ISFwUpdaterCmd& cmd) {
     return *activeCmd;
 }
 
+/**
+ * @brief locates a provided manifest (either directly, or within a ZIP package), extracts the manifest and expands the
+ * manifest into a new set of commands, loading them into the command queue. Optionally, this can suspend the updater
+ * after extracting those commands..
+ * @param args a set of positional arguments
+ * This command has the following arguments:
+ *     path [requires] :: the path to the package - if the path ends with ".yaml" it is treated as a path directly to
+ *       the manifest file, otherwise its assumed the path is a .zip file which contains a manifest.yaml.
+ *     suspend [optional] :: if true (default is false) the updater will be suspeneded (requiring explicit resumption)
+ *       immediately after extracting the manifest and populating the command queue - this allows additional "post-processing"
+ *       on the resulting command queue before performing any additional commands.
+ */
 void ISFirmwareUpdater::cmd_ExtractPackage(ISFwUpdaterCmd cmd) {
     // NOTE: Unlike other actions, use a copy of the ISFwUpdaterCmd, because processPackageManifest() by design
     // modifies the list of commands to process, which could possibly invalidate the underlying reference to this
@@ -798,8 +819,15 @@ void ISFirmwareUpdater::cmd_ExtractPackage(ISFwUpdaterCmd cmd) {
 
     // std::lock_guard<std::recursive_mutex> lock(mutex);
     std::string arg0 = cmd[0];  // REMEMBER cmd[0] is getting the first argument (std::string) from cmd
+    bool suspendAfterExtraction = ((cmd.args.size() == 2) && (cmd[1] == "true"));
     bool isManifest = (arg0.length() >= 5) && (0 == arg0.compare (arg0.length() - 5, 5, ".yaml"));
     pkg_error_e err_result = isManifest ? processPackageManifest(arg0) : openFirmwarePackage(arg0);
+
+    // processPackageManifest/openFirmwarePackage modifies the commands vector, which
+    // invalidates any pointers into it (including the caller's reference and activeCmd).
+    // Reset activeCmd so step() doesn't dereference a dangling pointer.
+    activeCmd = &nullCmd;
+
     if (err_result != PKG_SUCCESS) {
         const char *err_msg = nullptr;
         switch (err_result) {
@@ -843,7 +871,11 @@ void ISFirmwareUpdater::cmd_ExtractPackage(ISFwUpdaterCmd cmd) {
                 break;
         }
         handleCommandError(cmd, err_result, "Error processing firmware package [%s] (Error code: %d) :: %s", arg0.c_str(), err_result, err_msg);
+    } else if (suspendAfterExtraction) {
+        // we aren't ready to process any new commands from the package...
+        updateState.state = ISFwUpdateState::UDPATER_SUSPENDED;
     }
+
 }
 
 /**
@@ -1079,8 +1111,8 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                 int64_t cmp = utils::compareFirmwareVersions(imageDevInfo, *target_devInfo, parsed);
                 if (cmp <= 0) {
                     LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO,
-                        "Target is already up to date (%s); skipping upload of '%s' (image version: %s)",
-                        targetVerStr.c_str(), filename.c_str(), imageVerStr.c_str());
+                        "Ignoring Update. New firmware %s is older than device %s.",
+                        imageVerStr.c_str(), targetVerStr.c_str());
                     cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
                     cmd.resultMsg = "Target is already up to date.";
                     return;
@@ -1242,6 +1274,32 @@ void ISFirmwareUpdater::initialize() {
     updateState.resetState();
 }
 
+
+std::vector<ISFirmwareUpdater::StepInfo> ISFirmwareUpdater::getStepSummary() const {
+    std::lock_guard<std::recursive_mutex> lock(mutex);
+    std::vector<StepInfo> result;
+    std::map<std::string, size_t> targetIndex;  // targetName -> index in result
+
+    for (const auto& cmd : commands) {
+        if (cmd.step.empty() || cmd.cmd != "target" || !cmd.args.count("target"))
+            continue;
+
+        std::string targetName = cmd.args.at("target");
+        auto it = targetIndex.find(targetName);
+        if (it == targetIndex.end()) {
+            // First time seeing this target — create a new entry
+            targetIndex[targetName] = result.size();
+            result.push_back({targetName, {cmd.step}, getEffectivePolicy(cmd.step)});
+        } else {
+            // Additional step for the same target — just add the step label
+            auto& existing = result[it->second];
+            if (std::find(existing.stepLabels.begin(), existing.stepLabels.end(), cmd.step) == existing.stepLabels.end()) {
+                existing.stepLabels.push_back(cmd.step);
+            }
+        }
+    }
+    return result;
+}
 
 void ISFirmwareUpdater::setStepPolicy(const std::string& stepLabel, update_policy_e policy) {
     stepPolicies[stepLabel].policy = policy;

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -1051,29 +1051,32 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
         if (((target & fwUpdate::TARGET_IMX5) == fwUpdate::TARGET_IMX5) && (target & fwUpdate::TARGET_ISB_FLAG) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX))
             target = fwUpdate::TARGET_ISB_IMX5;
 
-        // Resolve target_devInfo when not already populated (e.g., no waitfor command, or explicit -uf-cmd mode)
+        // Resolve target_devInfo when not already populated (e.g., no waitfor command, or explicit -uf-cmd mode).
+        // This must happen for ALL policies — not just IF_NEWER — because the resolved version
+        // determines the IMG_FLAG_useAlternateMD5 flag needed for correct checksum computation.
         if (!target_devInfo) {
             if (((target & fwUpdate::TARGET_IMX5) && (devInfo->hardwareType == IS_HARDWARE_TYPE_IMX)) ||
                 ((target & fwUpdate::TARGET_GPX1) && (devInfo->hardwareType == IS_HARDWARE_TYPE_GPX))) {
                 // Target is the same device as the host — use its dev info directly
                 remoteDevInfo = *devInfo;
                 target_devInfo = &remoteDevInfo;
-            } else if (effectivePolicy == UPDATE_POLICY_IF_NEWER) {
-                // Target info not available — request via firmware update protocol and retry async
+            } else {
+                // Target is a different device (e.g., GPX proxied through IMX) — request version
+                // info from the target via the firmware update protocol
                 if (!pingTimeoutExpires) {
                     pingTimeoutExpires = current_timeMs() + 3000;
-                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Requesting target version info for version comparison (up to 3s)...");
+                    LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, "Requesting target version info (up to 3s)...");
                 }
                 fwUpdate_requestVersionInfo(target);
                 if (current_timeMs() < pingTimeoutExpires) {
                     return;  // stay CMD_QUEUED, re-enter on next cycle
                 }
-                // Timeout — proceed without target version (will fall through to upload)
+                // Timeout — proceed without target version
                 LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_WARN, "Timed out waiting for target version info; proceeding with upload");
                 pingTimeoutExpires = 0;
             }
 
-            // Set useAlternateMD5 for legacy firmware compatibility
+            // Set useAlternateMD5 for legacy firmware compatibility (only needed for GPX 2.0.0)
             if (target_devInfo && remoteDevInfo.firmwareVer[0] == 2 && remoteDevInfo.firmwareVer[1] == 0 && remoteDevInfo.firmwareVer[2] == 0)
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
             else if (!target_devInfo)

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -162,9 +162,10 @@ public:
         UPDATER_WAITING_TO_CANCEL = -1,                     //!< user requested a cancel, but operations are still pending
         UPDATER_IDLE = 0,                                   //!< the Updater is idle. Nothing started, nothing to do, etc.
         UPDATER_CMDS_QUEUED = 1,                            //!< commands are queued, but no commands are in process
-        UPDATER_IN_PROGRESS = 2,                            //!< commands are queued, and one or more are actively being ran
-        UPDATER_SUCCESSFUL = 3,                             //!< no more queued commands, and no errors reported
-        SUCCESS_WITH_NOTIFICATIONS = 4,                     //!< no more queued commands, but there were notifications/messages reported (but not errors)
+        UDPATER_SUSPENDED = 2,                              //!< commands are queued, IN_PROCESS commands can continue to execute, but no QUEUED commands will be allowed to enter IN_PROCESS
+        UPDATER_IN_PROGRESS = 3,                            //!< commands are queued, and one or more are actively being ran
+        UPDATER_SUCCESSFUL = 4,                             //!< no more queued commands, and no errors reported
+        SUCCESS_WITH_NOTIFICATIONS = 5,                     //!< no more queued commands, but there were notifications/messages reported (but not errors)
     };
 
     struct message {
@@ -319,6 +320,22 @@ public:
     void clearAllCommands() { commands.clear(); }
 
     /**
+     * Summary info for a unique target device, aggregated across all manifest steps.
+     */
+    struct StepInfo {
+        std::string targetName;                  //!< unique target device name (e.g., "IMX5")
+        std::vector<std::string> stepLabels;     //!< all step labels that reference this target
+        update_policy_e policy;                  //!< effective policy for the first step (shared across all)
+    };
+
+    /**
+     * Returns a summary of unique firmware update targets from the queued commands.
+     * Deduplicates by target name — each target appears once with all associated step labels.
+     * Thread-safe: locks the internal mutex.
+     */
+    std::vector<StepInfo> getStepSummary() const;
+
+    /**
      * Sets an explicit update policy for a specific step (by exact label name).
      */
     void setStepPolicy(const std::string& stepLabel, update_policy_e policy);
@@ -354,7 +371,7 @@ public:
     void handleCommandError(ISFwUpdaterCmd& cmd, int errCode, const char *errMmsg, ...);
 
     /**
-     * Signals the updater that is should complete any pending commands, and stop processing any further commands. Optionally (if immediately == true), it will
+     * Signals the updater that it should complete any pending commands, and stop processing any further commands. Optionally (if immediately == true), it will
      * no wait for pending commands to complete; this should be avoided do to possibly leaving some devices in an non-bootable state.
      * @param immediately if true (default is false), will not wait for existing actions to complete
      * @return the final update state; this should be fwUpdate::ERR_INTERRUPTED, but maybe any valid state.
@@ -363,6 +380,30 @@ public:
 
     bool isCancelable();
 
+    /**
+     * Signals to the updater that it should complete any pending command, and stop processing any further commands, until later resumed.
+     * This is different from cancel() in that this does not invalidate/skip/cancel any pending/queued commands; it simply falls into
+     * a state where any pending/queued commands are not allowed to start until the updateState exits to the UPDATER_SUSPENDED state,
+     * at which point all remaining commands will proceed. Note that if the current/active command is IN_PROGRESS, it will be allowed
+     * to finish. This does not prevent execution of the state machine or command executor, it only prevents queued commands from being
+     * started.
+     */
+    void suspend() { updateState.state = ISFwUpdateState::UDPATER_SUSPENDED; }
+
+    /**
+     * @return true if the updater is in a suspended state. Note that commands IN_PROGRESS will continue to execute.
+     */
+    bool isSuspended() { return updateState.state == ISFwUpdateState::UDPATER_SUSPENDED; }
+
+    /**
+     * Instructs the updater to exit the SUSPENDED state, and resume processing queued commands.
+     */
+    void resume() { updateState.state = ISFwUpdateState::UPDATER_IN_PROGRESS; }
+
+    /**
+     * @return true if the updater has no pending/queued commands, and the updater has been previously started.
+     *   This means that a call to fwUpdate_isDone() may return false, if the updater was never started.
+     */
     bool fwUpdate_isDone();
 
     /**
@@ -393,7 +434,7 @@ private:
         PKG_ERR_NO_MANIFEST = -12,                          //!< the package does not contain a manifest, or the manifest was invalid.
     };
 
-    std::recursive_mutex mutex;                             //!< make things thread-safe??
+    mutable std::recursive_mutex mutex;                     //!< make things thread-safe??
     fwUpdate::pfnStatusCb pfnStatus_cb = nullptr;           //!< callback for status updates
     PortManager::port_listener_handle_t portListenerHdl {}; //!< handle to a port listener so we can watch for devices that reboot
 


### PR DESCRIPTION
## Summary
- Add `StepInfo` struct and `getStepSummary()` API to `ISFirmwareUpdater` for enumerating unique targets from queued manifest commands
- Fix dangling pointer crashes in `cmd_ExtractPackage` / `runCommand` / `step()` when manifest repopulates the commands vector
- Add `UDPATER_SUSPENDED` check in `runCommand` to block queued commands while suspended (enables suspend/resume flow)
- Add suspend flag support to `cmd_ExtractPackage` for pre-start policy review
- Add "Ignoring Update" user-facing message when if-newer policy skips an upload
- Downgrade policy-setting log messages from INFO to DEBUG

## Test plan
- [x] Verify FwPkg extraction suspends correctly and `getStepSummary()` returns correct targets
- [x] Verify if-newer policy correctly skips upload when device version matches image version
- [x] Verify force/always policy proceeds with upload regardless of version
- [x] Verify no crashes during package extraction or device type switching
