### PR TITLE
SN-7586: Enhanced PPD log summary file

### DIFF
--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -82,7 +82,7 @@ void cDeviceLog::InitDeviceForReading()
 bool cDeviceLog::CloseAllFiles()
 {
     if (m_writeMode) {
-        string str = m_directory + "/stats_SN" + to_string(m_devSerialNo) + ".txt";
+        string str = m_directory + "/summary_SN" + to_string(m_devSerialNo) + ".txt";
         m_logStats.WriteToFile(str);
     }
     return true;
@@ -127,6 +127,12 @@ bool cDeviceLog::SaveData(p_data_hdr_t *dataHdr, const uint8_t* dataBuf, protoco
     {
         double timestamp = (ptype == _PTYPE_INERTIAL_SENSE_DATA ? cISDataMappings::TimestampOrCurrentTime(dataHdr, dataBuf) : current_timeSecD());
         m_logStats.LogData(ptype, dataHdr->id, dataHdr->size, timestamp);
+
+        // Cache diagnostic DIDs for summary generation
+        if (ptype == _PTYPE_INERTIAL_SENSE_DATA)
+        {
+            m_logStats.CacheDiagnosticData(dataHdr->id, dataBuf, dataHdr->size, timestamp);
+        }
 
         addIndexRecord();
         m_lastIndexOffset += dataHdr->size;

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -155,6 +155,12 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
             // Update log statistics
             m_logStats.LogData(ptype, m_comm.rxPkt.id, m_comm.rxPkt.size, timestamp);
             globalLogStats.LogData(ptype, m_comm.rxPkt.id, m_comm.rxPkt.size, timestamp);
+
+            // Cache diagnostic DIDs for summary generation
+            if (ptype == _PTYPE_INERTIAL_SENSE_DATA || ptype == _PTYPE_INERTIAL_SENSE_CMD)
+            {
+                m_logStats.CacheDiagnosticData(m_comm.rxPkt.dataHdr.id, m_comm.rxPkt.data.ptr, m_comm.rxPkt.dataHdr.size, timestamp, m_comm.rxPkt.dataHdr.offset);
+            }
         }
     }
 

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -726,6 +726,140 @@ std::string renderGpxStatus_gnssFwUpdateState(const data_info_t& info, std::any 
 }
 
 
+std::string renderImxHdwBitStatus(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "hdwBitStatus"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint32_t hdwBitStatus = std::any_cast<uint32_t>(value);
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+        BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_ALL                      ,"0x00000001 - Passed all tests");
+        BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_NO_GPS                   ,"0x00000002 - Passed without valid GPS signal");
+        if (HDW_BIT_MODE(hdwBitStatus)) {
+            buff << "0x000000" << std::hex << (hdwBitStatus & HDW_BIT_MODE_MASK) << std::dec
+                 << " - BIT mode: " << HDW_BIT_MODE(hdwBitStatus) << std::endl;
+        }
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_PQR                 ,"0x00000100 - FAULT: Gyro noise");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_ACC                 ,"0x00000200 - FAULT: Accelerometer noise");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_MAGNETOMETER              ,"0x00000400 - FAULT: Magnetometer");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_BAROMETER                 ,"0x00000800 - FAULT: Barometer");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GPS_NO_COM                ,"0x00001000 - FAULT: No GPS serial communications");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GPS_POOR_CNO              ,"0x00002000 - FAULT: Poor GPS signal strength");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GPS_POOR_ACCURACY         ,"0x00004000 - FAULT: GPS poor accuracy");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GPS_NOISE                 ,"0x00008000 - FAULT: GPS noise");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_IMU_FAULT_REJECTION       ,"0x00010000 - FAULT: IMU fault rejection failure");
+        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_INCORRECT_HARDWARE_TYPE   ,"0x01000000 - FAULT: Hardware type does not match firmware");
+
+#undef BIT_MSG
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+std::string renderImxCalBitStatus(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "calBitStatus"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint32_t calBitStatus = std::any_cast<uint32_t>(value);
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+        BIT_MSG(calBitStatus, CAL_BIT_PASSED_ALL                      ,"0x00000001 - Passed all calibration tests");
+        if (CAL_BIT_MODE(calBitStatus)) {
+            buff << "0x000000" << std::hex << (calBitStatus & CAL_BIT_MODE_MASK) << std::dec
+                 << " - CAL BIT mode: " << CAL_BIT_MODE(calBitStatus) << std::endl;
+        }
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_EMPTY                ,"0x00000100 - FAULT: Temperature calibration not present");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_TSPAN                ,"0x00000200 - FAULT: Temperature calibration range inadequate");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_INCONSISTENT         ,"0x00000400 - FAULT: Temperature calibration inconsistent");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_CORRUPT              ,"0x00000800 - FAULT: Temperature calibration corrupt");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_BIAS             ,"0x00001000 - FAULT: Gyro bias temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_SLOPE            ,"0x00002000 - FAULT: Gyro slope temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_LIN              ,"0x00004000 - FAULT: Gyro linearity temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_BIAS             ,"0x00008000 - FAULT: Accel bias temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_SLOPE            ,"0x00010000 - FAULT: Accel slope temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_LIN              ,"0x00020000 - FAULT: Accel linearity temp cal");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_CAL_SERIAL_NUM            ,"0x00040000 - FAULT: Calibration serial number mismatch");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_MAG_INVALID          ,"0x00080000 - FAULT: Magnetometer cross-axis alignment invalid");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_EMPTY                ,"0x00100000 - FAULT: Motion calibration not present");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_IMU_INVALID          ,"0x00200000 - FAULT: IMU cross-axis alignment invalid");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_PQR                ,"0x00400000 - FAULT: Motion detected on gyros");
+        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_ACC                ,"0x00800000 - FAULT: Motion detected on accelerometers");
+        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_PQR_BIAS            ,"0x01000000 - NOTICE: IMU 1 gyro bias offset detected");
+        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_PQR_BIAS            ,"0x02000000 - NOTICE: IMU 2 gyro bias offset detected");
+        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_ACC_BIAS            ,"0x10000000 - NOTICE: IMU 1 accel bias offset detected");
+        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_ACC_BIAS            ,"0x20000000 - NOTICE: IMU 2 accel bias offset detected");
+
+#undef BIT_MSG
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+std::string renderGpxBitResults(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "results"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint32_t results = std::any_cast<uint32_t>(value);
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+        BIT_MSG(results, GPXBit_resultsBit_PPS1      ,"0x01 - PPS1 test passed");
+        BIT_MSG(results, GPXBit_resultsBit_PPS2      ,"0x02 - PPS2 test passed");
+        BIT_MSG(results, GPXBit_resultsBit_UART      ,"0x04 - UART test passed");
+        BIT_MSG(results, GPXBit_resultsBit_IO        ,"0x08 - IO test passed");
+        BIT_MSG(results, GPXBit_resultsBit_GPS       ,"0x10 - GPS test passed");
+        BIT_MSG(results, GPXBit_resultsBit_FINISHED  ,"0x20 - Test finished");
+        BIT_MSG(results, GPXBit_resultsBit_CANCELED  ,"0x40 - Test canceled");
+        BIT_MSG(results, GPXBit_resultsBit_ERROR     ,"0x80 - Test error");
+
+#undef BIT_MSG
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+std::string renderGpxBitState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || (info.name != "state"))
+        return "";
+
+    try {
+        std::stringstream buff;
+        uint8_t state = std::any_cast<uint8_t>(value);
+
+        // eGPXBit_state values (from GPXBit.h)
+        switch (state) {
+            case 0: buff << "NOT_RUNNING" << std::endl; break;
+            case 1: buff << "MANUF_INIT" << std::endl; break;
+            case 2: buff << "MANUF_BLINK" << std::endl; break;
+            case 3: buff << "MANUF_UART" << std::endl; break;
+            case 4: buff << "MANUF_IO" << std::endl; break;
+            case 5: buff << "MANUF_PPS" << std::endl; break;
+            case 6: buff << "MANUF_GPS" << std::endl; break;
+            case 7: buff << "MANUF_REPORT" << std::endl; break;
+            default: buff << "UNKNOWN(" << (int)state << ")" << std::endl; break;
+        }
+
+        return buff.str();
+    } catch (std::bad_any_cast& e) {
+        return "";
+    }
+}
+
+
 static void PopulateMapTimestampField(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     static const string timestampFields[] = { "time", "timeOfWeek", "timeOfWeekMs", "seconds" };
@@ -791,8 +925,8 @@ static void PopulateMapBit(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("lastCommand", &bit_t::lastCommand, DATA_TYPE_UINT8, "", "Last input command", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("state", &bit_t::state, DATA_TYPE_UINT8, "", "[state: " + std::to_string(BIT_STATE_RUNNING) + "=running " + std::to_string(BIT_STATE_DONE) + "=done]", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("reserved", &bit_t::reserved, DATA_TYPE_UINT8);
-    mapper.AddMember("hdwBitStatus", &bit_t::hdwBitStatus, DATA_TYPE_UINT32, "", "Hardware built-in test status. See eHdwBitStatusFlags for info.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddMember("calBitStatus", &bit_t::calBitStatus, DATA_TYPE_UINT32, "", "Calibration built-in test status. See eCalBitStatusFlags for info.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("hdwBitStatus", &bit_t::hdwBitStatus, DATA_TYPE_UINT32, "", "Hardware built-in test status. See eHdwBitStatusFlags for info.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX).renderExtended = renderImxHdwBitStatus;
+    mapper.AddMember("calBitStatus", &bit_t::calBitStatus, DATA_TYPE_UINT32, "", "Calibration built-in test status. See eCalBitStatusFlags for info.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX).renderExtended = renderImxCalBitStatus;
     mapper.AddMember("tcPqrBias", &bit_t::tcPqrBias, DATA_TYPE_F32, SYM_DEG_PER_S, "Gyro temp cal bias", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
     mapper.AddMember("tcAccBias", &bit_t::tcAccBias, DATA_TYPE_F32, SYM_DEG_PER_S "/C", "Gyro temp cal slope", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
     mapper.AddMember("tcPqrSlope", &bit_t::tcPqrSlope, DATA_TYPE_F32, SYM_DEG_PER_S "/C", "Gyro temp cal linearity", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
@@ -811,11 +945,11 @@ static void PopulateMapBit(data_set_t data_set[DID_COUNT], uint32_t did)
 static void PopulateMapGpxBit(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<gpx_bit_t> mapper(data_set, did);
-    mapper.AddMember("results", &gpx_bit_t::results, DATA_TYPE_UINT32, "", "GPX BIT test status (see eGPXBit_results)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("results", &gpx_bit_t::results, DATA_TYPE_UINT32, "", "GPX BIT test status (see eGPXBit_results)", DATA_FLAGS_DISPLAY_HEX).renderExtended = renderGpxBitResults;
     mapper.AddMember("command", &gpx_bit_t::command, DATA_TYPE_UINT8, "", "Command (see eGPXBit_CMD)");
     mapper.AddMember("port", &gpx_bit_t::port, DATA_TYPE_UINT8, "", "Port used with the test");
     mapper.AddMember("testMode", &gpx_bit_t::testMode, DATA_TYPE_UINT8, "", "Self-test mode: 102=TxOverflow, 103=RxOverflow (see eGPXBit_test_mode)");
-    mapper.AddMember("state", &gpx_bit_t::state, DATA_TYPE_UINT8, "", "Built-in self-test state (see eGPXBit_state)");
+    mapper.AddMember("state", &gpx_bit_t::state, DATA_TYPE_UINT8, "", "Built-in self-test state (see eGPXBit_state)").renderExtended = renderGpxBitState;
     mapper.AddMember("detectedHardwareId", &gpx_bit_t::detectedHardwareId, DATA_TYPE_UINT16, "", "Hardware ID detected (see eIsHardwareType) used to validate correct firmware use.", DATA_FLAGS_DISPLAY_HEX);
     mapper.AddArray("reserved", &gpx_bit_t::reserved, DATA_TYPE_UINT8, 2);
 }

--- a/src/ISLogStats.cpp
+++ b/src/ISLogStats.cpp
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cstring>
 
 #include "ISDataMappings.h"
 #include "ISLogFile.h"
@@ -21,6 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISLogStats.h"
 #include "ISUtilities.h"
 #include "protocol_nmea.h"
+#include "util/util.h"
 
 using namespace std;
 
@@ -261,11 +263,259 @@ string cLogStats::Stats()
 void cLogStats::WriteToFile(const string& file_name)
 {
     unsigned int count = Count();
-    // unsigned int errors = Errors();
     if (count != 0)
-    {   // Write log stats to disk
+    {   // Write log summary + stats to disk
         statsFile = CreateISLogFile(file_name, "wb");
+        string diagSummary = DiagnosticSummary();
+        if (!diagSummary.empty())
+        {
+            statsFile->lprintf("%s\n", diagSummary.c_str());
+        }
         statsFile->lprintf("%s", Stats().c_str());
         CloseISLogFile(statsFile);
     }
+}
+
+
+// ============================================================================
+// Diagnostic DID caching and summary generation
+// ============================================================================
+
+const std::set<uint32_t> cLogStats::s_diagnosticDIDs = {
+    DID_DEV_INFO,           // 1
+    DID_SYS_PARAMS,         // 10
+    DID_FLASH_CONFIG,       // 12
+    DID_BIT,                // 64
+    DID_GPX_DEV_INFO,       // 120
+    DID_GPX_FLASH_CFG,      // 121
+    DID_GPX_STATUS,         // 123
+    DID_GPX_BIT,            // 125
+};
+
+void cLogStats::CacheDiagnosticData(uint32_t did, const uint8_t* data, uint32_t size, double timestamp, uint32_t offset)
+{
+    if (s_diagnosticDIDs.find(did) == s_diagnosticDIDs.end())
+        return;
+
+    DiagnosticDIDCache& cache = m_diagCache[did];
+
+    // Get the full struct size from data mappings
+    uint32_t fullSize = cISDataMappings::DataSize(did);
+    if (fullSize == 0)
+        fullSize = offset + size;
+
+    // Initialize buffer to zero on first use or if it's too small
+    if (cache.data.size() < fullSize)
+        cache.data.resize(fullSize, 0);
+
+    // Merge partial update at the correct offset
+    uint32_t copySize = _MIN(size, fullSize - offset);
+    memcpy(cache.data.data() + offset, data, copySize);
+
+    cache.timestamp = timestamp;
+    cache.observed = true;
+}
+
+string cLogStats::FormatTimestamp(double timestamp)
+{
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(3) << timestamp << "s";
+    return ss.str();
+}
+
+string cLogStats::FormatDevInfoSection(uint32_t did, const char* label)
+{
+    auto it = m_diagCache.find(did);
+    if (it == m_diagCache.end() || !it->second.observed)
+        return "";
+
+    const DiagnosticDIDCache& cache = it->second;
+    if (cache.data.size() < sizeof(dev_info_t))
+        return "";
+
+    const dev_info_t* devInfo = reinterpret_cast<const dev_info_t*>(cache.data.data());
+
+    std::stringstream ss;
+    ss << "=== Device Info (" << label << ") ===" << endl;
+    ss << utils::devInfoToString(*devInfo) << endl;
+    ss << "(last received: " << FormatTimestamp(cache.timestamp) << ")" << endl;
+    ss << endl;
+    return ss.str();
+}
+
+static void flashCfgDefaultsIMX(nvm_flash_cfg_t* fc)
+{
+    memset(fc, 0, sizeof(nvm_flash_cfg_t));
+    fc->size                    = sizeof(nvm_flash_cfg_t);
+    fc->key                     = 36;
+    fc->startupImuDtMs          = 1;
+    fc->startupGPSDtMs          = 200;
+    fc->startupNavDtMs          = 4;
+    fc->ser0BaudRate            = IS_BAUDRATE_921600;
+    fc->ser1BaudRate            = IS_BAUDRATE_921600;
+    fc->ser2BaudRate            = IS_BAUDRATE_921600;
+    fc->lastLlaUpdateDistance   = 1000.0f;
+    fc->ioConfig                = IO_CONFIG_DEFAULT;
+    fc->platformConfig          = PLATFORM_CFG_TYPE_NONE;
+    fc->gpsTimeSyncPeriodMs     = 1000;
+    fc->dynamicModel            = DEFAULT_DYNAMIC_MODEL;
+    fc->gnssSatSigConst         = GNSS_SAT_SIG_CONST_DEFAULT;
+    fc->sensorConfig            = (SENSOR_CFG_GYR_FS_MAX<<SENSOR_CFG_GYR_FS_OFFSET) |
+                                  (SENSOR_CFG_ACC_FS_MAX<<SENSOR_CFG_ACC_FS_OFFSET);
+    fc->gpsMinimumElevation     = DEFAULT_GNSS_MIN_ELEVATION_ANGLE;
+    fc->gnssCn0Minimum          = DEFAULT_GNSS_RTK_CN0_MINIMUM;
+    fc->gnssCn0DynMinOffset     = DEFAULT_GNSS_RTK_CN0_DYN_MIN_OFFSET;
+    fc->magInterferenceThreshold = 3.0f;
+    fc->magCalibrationQualityThreshold = 10.0f;
+    fc->imuRejectThreshGyroLow  = 2;
+    fc->imuRejectThreshGyroHigh = 3;
+}
+
+static void flashCfgDefaultsGPX(gpx_flash_cfg_t* fc)
+{
+    memset(fc, 0, sizeof(gpx_flash_cfg_t));
+    fc->size                    = sizeof(gpx_flash_cfg_t);
+    fc->key                     = 2;
+    fc->dynamicModel            = DEFAULT_DYNAMIC_MODEL;
+    fc->gpsTimeSyncPeriodMs     = 1000;         // GPX_MINIMUM_SYNC_RATE_MS
+    fc->startupGPSDtMs          = 200;          // GPX_DEFAULT_GPS_DT_MS
+    fc->gnssSatSigConst         = GNSS_SAT_SIG_CONST_DEFAULT;
+    fc->ser0BaudRate            = IS_BAUDRATE_921600;
+    fc->ser1BaudRate            = IS_BAUDRATE_921600;
+    fc->ser2BaudRate            = IS_BAUDRATE_921600;
+    fc->gpsMinimumElevation     = DEFAULT_GNSS_MIN_ELEVATION_ANGLE;
+    fc->gnssCn0Minimum          = DEFAULT_GNSS_RTK_CN0_MINIMUM;
+    fc->gnssCn0DynMinOffset     = DEFAULT_GNSS_RTK_CN0_DYN_MIN_OFFSET;
+}
+
+string cLogStats::FormatFlashConfigDiffSection(uint32_t did, const char* label)
+{
+    auto it = m_diagCache.find(did);
+    if (it == m_diagCache.end() || !it->second.observed)
+        return "";
+
+    const DiagnosticDIDCache& cache = it->second;
+
+    // Generate defaults for comparison
+    std::vector<uint8_t> defaultBuf;
+    if (did == DID_FLASH_CONFIG)
+    {
+        defaultBuf.resize(sizeof(nvm_flash_cfg_t), 0);
+        flashCfgDefaultsIMX(reinterpret_cast<nvm_flash_cfg_t*>(defaultBuf.data()));
+    }
+    else if (did == DID_GPX_FLASH_CFG)
+    {
+        defaultBuf.resize(sizeof(gpx_flash_cfg_t), 0);
+        flashCfgDefaultsGPX(reinterpret_cast<gpx_flash_cfg_t*>(defaultBuf.data()));
+    }
+    else
+    {
+        return "";
+    }
+
+    const map_name_to_info_t* infoMap = cISDataMappings::NameToInfoMap(did);
+    if (!infoMap)
+        return "";
+
+    data_mapping_string_t stringBuffer;
+    std::stringstream diffFields;
+    int diffCount = 0;
+
+    for (const auto& entry : *infoMap)
+    {
+        const data_info_t& info = entry.second;
+
+        // Skip metadata fields
+        if (info.name == "size" || info.name == "checksum" || info.name == "key")
+            continue;
+
+        uint32_t offset = info.offset;
+        uint32_t fieldSize = info.size;
+
+        if (info.arraySize > 0)
+        {
+            for (int i = 0; i < (int)info.arraySize; i++)
+            {
+                uint32_t elemOffset = offset + i * fieldSize;
+                if (elemOffset + fieldSize > cache.data.size() || elemOffset + fieldSize > defaultBuf.size())
+                    continue;
+
+                if (memcmp(cache.data.data() + elemOffset, defaultBuf.data() + elemOffset, fieldSize) != 0)
+                {
+                    if (cISDataMappings::DataToString(info, nullptr, cache.data.data(), stringBuffer, i))
+                    {
+                        diffFields << info.name << "[" << i << "] = " << stringBuffer << endl;
+                        diffCount++;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (offset + fieldSize > cache.data.size() || offset + fieldSize > defaultBuf.size())
+                continue;
+
+            if (memcmp(cache.data.data() + offset, defaultBuf.data() + offset, fieldSize) != 0)
+            {
+                if (cISDataMappings::DataToString(info, nullptr, cache.data.data(), stringBuffer))
+                {
+                    diffFields << info.name << " = " << stringBuffer << endl;
+                    diffCount++;
+                }
+            }
+        }
+    }
+
+    if (diffCount == 0)
+        return "";
+
+    std::stringstream ss;
+    ss << "=== " << label << " Flash Config (non-default) ===" << endl;
+    ss << "(last received: " << FormatTimestamp(cache.timestamp) << ")" << endl;
+    ss << diffFields.str();
+    ss << endl;
+    return ss.str();
+}
+
+string cLogStats::FormatCuratedSection(uint32_t did, const char* label, const std::string& fields)
+{
+    auto it = m_diagCache.find(did);
+    if (it == m_diagCache.end() || !it->second.observed)
+        return "";
+
+    const DiagnosticDIDCache& cache = it->second;
+
+    std::string output;
+    if (!cISDataMappings::DidBufferToString(did, cache.data.data(), output, fields))
+        return "";
+
+    std::stringstream ss;
+    ss << "=== " << label << " ===" << endl;
+    ss << "(last received: " << FormatTimestamp(cache.timestamp) << ")" << endl;
+    ss << output;
+    ss << endl;
+    return ss.str();
+}
+
+string cLogStats::DiagnosticSummary()
+{
+    std::stringstream ss;
+
+    // Device Info sections (at top)
+    ss << FormatDevInfoSection(DID_DEV_INFO, "IMX");
+    ss << FormatDevInfoSection(DID_GPX_DEV_INFO, "GPX");
+
+    // Flash Config diff sections
+    ss << FormatFlashConfigDiffSection(DID_FLASH_CONFIG, "IMX");
+    ss << FormatFlashConfigDiffSection(DID_GPX_FLASH_CFG, "GPX");
+
+    // BIT sections
+    ss << FormatCuratedSection(DID_BIT, "BIT (IMX)", "hdwBitStatus,calBitStatus");
+    ss << FormatCuratedSection(DID_GPX_BIT, "BIT (GPX)", "results,state,testMode,detectedHardwareId");
+
+    // SysParams / Status sections
+    ss << FormatCuratedSection(DID_SYS_PARAMS, "SysParams (IMX)", "insStatus,hdwStatus,genFaultCode,imuTemp,baroTemp,mcuTemp");
+    ss << FormatCuratedSection(DID_GPX_STATUS, "Status (GPX)", "status,hdwStatus,mcuTemp,gnssStatus0.initState,gnssStatus0.runState,gnssStatus1.initState,gnssStatus1.runState,rtkMode");
+
+    return ss.str();
 }

--- a/src/ISLogStats.h
+++ b/src/ISLogStats.h
@@ -16,6 +16,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string>
 #include <cstdint>
 #include <map>
+#include <set>
+#include <vector>
 
 #include "data_sets.h"
 #include "ISComm.h"
@@ -53,6 +55,12 @@ struct sLogStatPType
     unsigned int errors;                    // total error count
 };
 
+struct DiagnosticDIDCache {
+    std::vector<uint8_t> data;
+    double timestamp = 0.0;
+    bool observed = false;
+};
+
 class cLogStats
 {
 public:
@@ -63,11 +71,23 @@ public:
     void Clear();
     void LogError(const p_data_hdr_t* hdr, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA);
     void LogData(protocol_type_t ptype, int id, int bytes, double timeMs=0.0);
+    void CacheDiagnosticData(uint32_t did, const uint8_t* data, uint32_t size, double timestamp, uint32_t offset=0);
     unsigned int Count();
     unsigned int Errors();
     std::string MessageStats(protocol_type_t ptype, sLogStatPType &msg, bool showDeltaTime=true, bool showErrors=false);
     std::string Stats();
+    std::string DiagnosticSummary();
     void WriteToFile(const std::string& fileName);
+
+private:
+    std::map<uint32_t, DiagnosticDIDCache> m_diagCache;
+    static const std::set<uint32_t> s_diagnosticDIDs;
+
+    std::string FormatDevInfoSection(uint32_t did, const char* label);
+    std::string FormatFlashConfigDiffSection(uint32_t did, const char* label);
+    std::string FormatBitSection(uint32_t did, const char* label, const std::string& fields);
+    std::string FormatCuratedSection(uint32_t did, const char* label, const std::string& fields);
+    std::string FormatTimestamp(double timestamp);
 };
 
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -6124,8 +6124,8 @@ void profiler_maintenance_1s(runtime_profiler_t *p);
  * - Move spoofing/jamming status into gps_pos_t.status and reclaim gps_pos_t.status2 as resevered.
  * - Change $INFO to conform to NMEA 0183 standard. $INFO is a proprietary message and should start with $P and have max of 79 characters. see SN-6231
  * 
- * 
- * 
+ * - GNSS rename references to GPSn to GNSSn
+ *
  * 
  * 
  * 


### PR DESCRIPTION
## Motivation

When support receives a PPD log from a customer, the first questions are always: *what firmware is this device running, how is it configured, and were there any faults?* Today, answering those questions requires loading the raw `.dat`/`.raw` log into EvalTool or cltool and manually locating the relevant DIDs. The existing `stats_SN{serial}.txt` file only contains message counts and timing statistics — no device identity, configuration, or diagnostic information.

This PR enriches the per-device log summary so that a support engineer can open a single text file and immediately see the answers.

## What changed

The stats file is **renamed** from `stats_SN{serial}.txt` to `summary_SN{serial}.txt` and now includes diagnostic DID snapshots prepended before the existing message statistics (which are fully preserved).

### Diagnostic sections added

Each section is **only included** if its corresponding DID was observed during the log:

| Section | DID(s) | What it shows |
|---|---|---|
| Device Info (IMX) | `DID_DEV_INFO` | Serial number, hardware type/version, firmware version, protocol version via `devInfoToString()` |
| Device Info (GPX) | `DID_GPX_DEV_INFO` | Same as above for GPX processor |
| IMX Flash Config (non-default) | `DID_FLASH_CONFIG` | Only fields that differ from factory defaults — highlights intentional configuration changes |
| GPX Flash Config (non-default) | `DID_GPX_FLASH_CFG` | Same for GPX config |
| BIT (IMX) | `DID_BIT` | `hdwBitStatus`, `calBitStatus` with hex values |
| BIT (GPX) | `DID_GPX_BIT` | `results`, `state`, `testMode`, `detectedHardwareId` |
| SysParams (IMX) | `DID_SYS_PARAMS` | `insStatus`, `hdwStatus`, `genFaultCode`, `imuTemp`, `baroTemp`, `mcuTemp` |
| Status (GPX) | `DID_GPX_STATUS` | `status`, `hdwStatus`, `mcuTemp`, `gnssStatus[0..1]`, `rtkMode` |

All sections use the **most recent** value observed during the log and include a timestamp.

### Example output

From a 30-second log capture with an IMX-5 + GPX-1 device:

```
=== Device Info (IMX) ===
SN519465: IMX-5.0.5 fw3.0.0-devel.185 7f3e2aae aff42.0 20260318 171338.001 (P16 I2 G3.0.0-dev.194)
(last received: 1775071912.063s)

=== Device Info (GPX) ===
SN825308454: GPX-1.0.2 fw3.0.0-devel.194 bc37fe09 f3c6e.0 20260321 183416.027 (GPX-1)
(last received: 1775071913.945s)

=== IMX Flash Config (non-default) ===
(last received: 1775071913.991s)
ioConfig = 0x06DB2046
lastLla[0] = 40.197639300
lastLla[1] = -111.620623600
platformConfig = 0x00000090
startupNavDtMs = 7
sysCfgBits = 0x00000100
...

=== BIT (IMX) ===
(last received: 1775071913.991s)
DID_BIT (64)
calBitStatus = 0x00100130
hdwBitStatus = 0x00000032

=== SysParams (IMX) ===
(last received: 329501.959s)
DID_SYS_PARAMS (10)
insStatus = 0x01445966
hdwStatus = 0x03680050
genFaultCode = 0x00000000
imuTemp = 24.21
baroTemp = 26.47
mcuTemp = 0.00

=== Status (GPX) ===
(last received: 329531.800s)
DID_GPX_STATUS (123)
gnssStatus0.initState = 19
gnssStatus0.runState = 2
gnssStatus1.initState = 19
gnssStatus1.runState = 2
hdwStatus = 0x00000000
mcuTemp = 34.2
status = 0x00000060

Total: count 2179
ISB: count 2019, errors 0 _____________________
 ID Name                     Count  dtMs(avg  min  max)   Bps Irreg
  1 DID_DEV_INFO                18  ( 1647   929  2003)    45    10
 10 DID_SYS_PARAMS               2  (    5     5     5)     0     0
 ...
```

### Implementation details

- **Data capture**: `cDeviceLog::SaveData()` and `cDeviceLogRaw::SaveData()` now call `cLogStats::CacheDiagnosticData()` which caches the most recent value for each diagnostic DID. Partial DID updates (common in the raw log path) are handled via offset-based merging into a full-size buffer.
- **Flash config diff**: SDK-side default generators (`flashCfgDefaultsIMX()`, `flashCfgDefaultsGPX()`) produce baseline configs; fields are compared using `NameToInfoMap()` iteration with byte-level `memcmp`, and only differing fields are formatted via `DataToString()`.
- **New render functions**: `renderImxHdwBitStatus()`, `renderImxCalBitStatus()`, `renderGpxBitResults()`, `renderGpxBitState()` — registered on the BIT field mappings for use in extended display and the summary.

## Files changed

| File | Changes |
|---|---|
| `ISLogStats.h` | `DiagnosticDIDCache` struct, cache map, `CacheDiagnosticData()` / `DiagnosticSummary()` methods |
| `ISLogStats.cpp` | Diagnostic caching, summary generation, flash config defaults, updated `WriteToFile()` |
| `ISDataMappings.cpp` | 4 new render functions + registration on BIT/GPX_BIT field mappings |
| `DeviceLog.cpp` | File rename `stats_` → `summary_`, caching hook in `SaveData()` |
| `DeviceLogRaw.cpp` | Caching hook with offset in raw log `SaveData()` path |
| `data_sets.h` | Minor comment update |

## Test plan
- [x] SDK library builds cleanly (74/74 units, no errors)
- [x] cltool builds and links against updated library
- [x] 30s log capture with `-presetPPD -presetGPXPPD` produces `summary_SN{serial}.txt` with all diagnostic sections
- [x] Sections correctly omitted when their DIDs are not streamed
- [x] Existing message stats output unchanged at bottom of file
- [ ] Replay existing PPD log to verify backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)