### PR TITLE
Adjust RMS thresholds

### DIFF
--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -436,7 +436,7 @@ class Log:
                 # AHRS
                 thresholdAtt[:2] = 0.1  # (deg) Att (roll, pitch)
                 thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
-        if hardware == 6:
+        elif hardware == 6:
             # Nav - Thresholds for IMX-6
             thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
             thresholdUVW = np.array([0.023, 0.023, 0.047])  # (m/s) UVW
@@ -445,7 +445,8 @@ class Log:
                 # AHRS
                 thresholdAtt[:2] = 0.09 # (deg) Att (roll, pitch)
                 thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
-        else:   # Unsupported hardware
+        elif hardware != 0:
+            # Unsupported hardware
             print(RED + "Hardware type " + str(hardware) + " is not supported!!!" + RESET)
             sys.exit(1)
 
@@ -474,7 +475,7 @@ class Log:
         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         f.write('** IMX Performance Report - %s - %s\n' % (now, self.directory))
         f.write('\n')
-        mode = ('IMX-5' if hardware == 5 else 'IMX-6' if hardware == 6 else 'UNKNOWN')
+        mode = ('MIXED' if hardware == 0 else 'IMX-5' if hardware == 5 else 'IMX-6' if hardware == 6 else 'UNKNOWN')
         mode += (", NAV" if self.navMode else ", AHRS")
         if self.rtk:        mode += ", RTK"
         if self.compassing: mode += ", DUAL GNSS"

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -427,18 +427,17 @@ class Log:
                 # Use default value if not all devices use the same hardware
                 hardware = 0
 
-        # Thresholds for uINS-3
-        # Nav
-        thresholdNED = np.array([0.35,  0.35, 0.8])     # (m)   NED
-        thresholdUVW = np.array([0.04,  0.04, 0.07])    # (m/s) UVW
-        thresholdAtt = np.array([0.11,  0.11, 0.3])     # (deg) Att (roll, pitch, yaw)
-        if not self.navMode:
-            # AHRS
-            thresholdAtt[2]  = 2.0  # (deg) Att (yaw)
-
-        # Thresholds for IMX-5
-        if hardware == 5:
-            # Nav 
+        if hardware == 6:
+            # Nav - Thresholds for IMX-6
+            thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
+            thresholdUVW = np.array([0.035, 0.035, 0.07])   # (m/s) UVW
+            thresholdAtt = np.array([0.033, 0.033, 0.11])   # (deg) Att (roll, pitch, yaw)
+            if not self.navMode: 
+                # AHRS
+                thresholdAtt[:2] = 0.09 # (deg) Att (roll, pitch)
+                thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
+        elif hardware == 5:
+            # Nav - Thresholds for IMX-5
             thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
             thresholdUVW = np.array([0.035, 0.035, 0.07])   # (m/s) UVW
             thresholdAtt = np.array([0.045, 0.045, 0.16])   # (deg) Att (roll, pitch, yaw)
@@ -446,6 +445,9 @@ class Log:
                 # AHRS
                 thresholdAtt[:2] = 0.1  # (deg) Att (roll, pitch)
                 thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
+        else:   # Unsupported hardware
+            print(RED + "Hardware type " + str(hardware) + " is not supported!!!" + RESET)
+            sys.exit(1)
 
         if self.compassing:
             thresholdNED[:2] = 0.5
@@ -472,7 +474,7 @@ class Log:
         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         f.write('** IMX Performance Report - %s - %s\n' % (now, self.directory))
         f.write('\n')
-        mode = ('IMX-5' if hardware == 5 else 'uINS-3')
+        mode = ('IMX-6' if hardware == 6 else 'IMX-5')
         mode += (", NAV" if self.navMode else ", AHRS")
         if self.rtk:        mode += ", RTK"
         if self.compassing: mode += ", DUAL GNSS"

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -447,7 +447,7 @@ class Log:
                 thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
         elif hardware != 0:
             # Unsupported hardware
-            print(RED + "Hardware type " + str(hardware) + " is not supported!!!" + RESET)
+            print(RED + "Hardware type " + str(hardware) + " is not supported. Supported hardware types are 5 and 6; 0 may indicate mixed or unknown hardware across devices." + RESET)
             sys.exit(1)
 
         if self.compassing:

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -439,7 +439,7 @@ class Log:
         if hardware == 6:
             # Nav - Thresholds for IMX-6
             thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
-            thresholdUVW = np.array([0.035, 0.035, 0.07])   # (m/s) UVW
+            thresholdUVW = np.array([0.023, 0.023, 0.047])  # (m/s) UVW
             thresholdAtt = np.array([0.033, 0.033, 0.11])   # (deg) Att (roll, pitch, yaw)
             if not self.navMode: 
                 # AHRS
@@ -496,7 +496,7 @@ class Log:
 
         for n, dev in enumerate(device_idx):
             devInfo = self.data[dev,DID_DEV_INFO][0]
-            line = '%2d SN%d      ' % (n, devInfo['serialNumber'])
+            line = '%2d SN%-10d ' % (n, devInfo['serialNumber'])
             line += '[ %6.4f  %6.4f  %6.4f ]' % (
             self.RMSAtt[n, 0] * RAD2DEG, self.RMSAtt[n, 1] * RAD2DEG, self.RMSAtt[n, 2] * RAD2DEG)
             if self.navMode:
@@ -566,7 +566,7 @@ class Log:
         f.write('Device       Euler Biases[   (deg)     (deg)     (deg) ]\n')
         for dev in device_idx:
             devInfo = self.data[dev, DID_DEV_INFO][0]
-            f.write('%2d SN%d               [ %7.4f   %7.4f   %7.4f ]\n' % (
+            f.write('%2d SN%-10d          [ %7.4f   %7.4f   %7.4f ]\n' % (
                 n, devInfo['serialNumber'], 
                 self.mount_bias_euler[dev, 0] * RAD2DEG, 
                 self.mount_bias_euler[dev, 1] * RAD2DEG,
@@ -574,11 +574,11 @@ class Log:
         f.write('\n')
 
         f.write("----------------- Average Attitude ---------------------\n")
-        f.write("Dev:  \t[ Roll\t\tPitch\t\tYaw ]\n")
+        f.write("Device  \t[ Roll\t\tPitch\t\tYaw ]\n")
         for i in range(self.numIns):
             qavg = meanOfQuat(self.stateArray[i, :, 7:])[0]
             euler = quat2euler(qavg.T) * 180.0 / np.pi
-            f.write("%d\t%f\t%f\t%f\n" % (self.serials[device_idx[i]], euler[0], euler[1], euler[2]))
+            f.write("%-10d\t%f\t%f\t%f\n" % (self.serials[device_idx[i]], euler[0], euler[1], euler[2]))
 
         # Print Device Information
         f.write('\n')

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -427,6 +427,15 @@ class Log:
                 # Use default value if not all devices use the same hardware
                 hardware = 0
 
+        if hardware == 5:
+            # Nav - Thresholds for IMX-5
+            thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
+            thresholdUVW = np.array([0.035, 0.035, 0.07])   # (m/s) UVW
+            thresholdAtt = np.array([0.045, 0.045, 0.16])   # (deg) Att (roll, pitch, yaw)
+            if not self.navMode: 
+                # AHRS
+                thresholdAtt[:2] = 0.1  # (deg) Att (roll, pitch)
+                thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
         if hardware == 6:
             # Nav - Thresholds for IMX-6
             thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
@@ -435,15 +444,6 @@ class Log:
             if not self.navMode: 
                 # AHRS
                 thresholdAtt[:2] = 0.09 # (deg) Att (roll, pitch)
-                thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
-        elif hardware == 5:
-            # Nav - Thresholds for IMX-5
-            thresholdNED = np.array([0.35,  0.35,  0.8])    # (m)   NED
-            thresholdUVW = np.array([0.035, 0.035, 0.07])   # (m/s) UVW
-            thresholdAtt = np.array([0.045, 0.045, 0.16])   # (deg) Att (roll, pitch, yaw)
-            if not self.navMode: 
-                # AHRS
-                thresholdAtt[:2] = 0.1  # (deg) Att (roll, pitch)
                 thresholdAtt[2]  = 1.0  # (deg) Att (yaw)
         else:   # Unsupported hardware
             print(RED + "Hardware type " + str(hardware) + " is not supported!!!" + RESET)
@@ -474,7 +474,7 @@ class Log:
         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         f.write('** IMX Performance Report - %s - %s\n' % (now, self.directory))
         f.write('\n')
-        mode = ('IMX-6' if hardware == 6 else 'IMX-5')
+        mode = ('IMX-5' if hardware == 5 else 'IMX-6' if hardware == 6 else 'UNKNOWN')
         mode += (", NAV" if self.navMode else ", AHRS")
         if self.rtk:        mode += ", RTK"
         if self.compassing: mode += ", DUAL GNSS"


### PR DESCRIPTION
This PR adds correct RMS test thresholds that align with the target accuracy of the IMX-6.

This pull request updates the IMX performance reporting logic in `logReader.py` to support IMX-6 hardware, improves hardware-specific threshold handling, and enhances error reporting for unsupported hardware types.

**Hardware support and threshold handling:**

* Added explicit support for IMX-6 hardware, including new threshold values for position (`thresholdNED`), velocity (`thresholdUVW`), and attitude (`thresholdAtt`), and adjusted AHRS mode thresholds for IMX-6.
* Updated the hardware mode string in the report output to correctly display "IMX-6" for IMX-6 hardware, instead of previously using "uINS-3".
* Added error handling for unsupported hardware types: prints an error message and exits if the hardware is not IMX-5 or IMX-6.