### PR TITLE
SN-7706: Discovery deadline, FORCE_REVALIDATION fix, GPX flash config checksum

### DIFF
--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -50,6 +50,8 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
         for (auto d : *this) {
             if (d && d->hasDeviceInfo() && (d->port == port)) {
                 if (options & DISCOVERY__FORCE_REVALIDATION) {
+                    // Clear device info so hasDeviceInfo() returns false,
+                    // forcing full revalidation via Phase 2+3.
                     d->devInfo.hdwRunState = HDW_STATE_UNKNOWN;
                     memset(d->devInfo.firmwareVer, 0, sizeof(d->devInfo.firmwareVer));
                 } else {
@@ -75,7 +77,7 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
 
         // Check if DeviceManager already has a device for this port
         device_handle_t existingDev = getDevice(port);
-        if (existingDev) {
+        if (existingDev && !(options & DISCOVERY__FORCE_REVALIDATION)) {
             if (existingDev->matchesHdwId(hdwId)) {
                 if (!existingDev->port)
                     existingDev->assignPort(port);
@@ -118,8 +120,22 @@ bool DeviceManager::discoverDevices(uint16_t hdwId, uint32_t timeoutMs, uint32_t
         log_debug(IS_LOG_DEVICE_MANAGER, "Concurrently validating %zu port(s) across %zu factory(ies)",
             pending.size(), factories.size());
 
+        uint32_t loopDeadline = (timeoutMs > 0) ? timeoutMs : DISCOVERY__DEFAULT_TIMEOUT;
+        uint32_t loopStartMs = current_timeMs();
+
         bool allResolved = false;
         while (!allResolved) {
+            if ((current_timeMs() - loopStartMs) > loopDeadline) {
+                log_debug(IS_LOG_DEVICE_MANAGER, "Discovery validation loop deadline reached (%dms). Resolving remaining ports.", loopDeadline);
+                for (auto& pp : pending) {
+                    if (!pp.resolved) {
+                        pp.resolved = true;
+                        if (options & DISCOVERY__CLOSE_PORT_ON_FAILURE)
+                            portClose(pp.port);
+                    }
+                }
+                break;
+            }
             allResolved = true;
             for (auto& pp : pending) {
                 if (pp.resolved)

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -994,6 +994,8 @@ bool ISDevice::SetImxFlashConfig(nvm_flash_cfg_t& flashCfg) {
 bool ISDevice::SetGpxFlashConfig(gpx_flash_cfg_t& flashCfg) {
     std::lock_guard<std::recursive_mutex> lock(portMutex);
 
+    flashCfg.checksum = flashChecksum32(&flashCfg, sizeof(gpx_flash_cfg_t));
+
     bool success = UploadFlashConfigDiff(
         reinterpret_cast<uint8_t*>(&flashCfg),
         reinterpret_cast<uint8_t*>(&gpxFlashCfg),


### PR DESCRIPTION
## Summary
- DeviceManager: add deadline to Phase 2+3 validation loop (prevents non-IS ports like STLink from blocking discovery indefinitely)
- DeviceManager: skip blocking validate() shortcut when FORCE_REVALIDATION is set — use Phase 2+3 concurrent path
- ISDevice: compute GPX flash config checksum in SetGpxFlashConfig() (was missing — caused "upload rejected" on every GPX config write)

## Test plan
- [x] `test_flash_config_imx` — PASSED
- [x] `test_flash_config_gpx` (direct) — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)