### PR TITLE
Fix build warnings

### DIFF
--- a/src/ISDFUFirmwareUpdater.cpp
+++ b/src/ISDFUFirmwareUpdater.cpp
@@ -398,7 +398,7 @@ dfu_error DFUDevice::fetchDeviceInfo() {
 
     if (!isConnected()) {
         auto result = open();
-        if (result != LIBUSB_SUCCESS) {
+        if (result != DFU_ERROR_NONE) {
             log_error(IS_LOG_FWUPDATE, "DFU fetchDeviceInfo [%d:%d]: open() failed (dfu_error=%d)",
                       busNum, devAddr, result);
             return result;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -94,14 +94,12 @@ namespace utils {
      * @param args
      * @return
      */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
+    inline std::string string_format(const std::string& format) {
+        return format;
+    }
+
     template<typename ... Args>
     std::string string_format(const std::string& format, Args ... args) {
-        if constexpr (sizeof...(args) == 0) {
-            return format;  // If no arguments, return the format string as is
-        }
-
         int size_s = std::snprintf((char*)nullptr, 0, format.c_str(), args ...) + 1; // Extra space for '\0'
         if (size_s <= 0) {
             throw std::runtime_error("Error during formatting.");
@@ -112,7 +110,6 @@ namespace utils {
         std::snprintf(buf.get(), size, format.c_str(), args ...);
         return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
     }
-#pragma GCC diagnostic pop
 
     /**
      * Combine all elements of a container denoted by the start and ending iterators, to join into a

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -94,8 +94,8 @@ namespace utils {
      * @param args
      * @return
      */
-//#pragma GCC diagnostic push
-//#pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     template<typename ... Args>
     std::string string_format(const std::string& format, Args ... args) {
         if constexpr (sizeof...(args) == 0) {
@@ -112,7 +112,7 @@ namespace utils {
         std::snprintf(buf.get(), size, format.c_str(), args ...);
         return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
     }
-//#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 
     /**
      * Combine all elements of a container denoted by the start and ending iterators, to join into a


### PR DESCRIPTION
This pull request makes targeted improvements to error handling and utility formatting functions. The most important changes are:

### Error Handling

* In `DFUDevice::fetchDeviceInfo` (`src/ISDFUFirmwareUpdater.cpp`), the check for a successful device open now compares against `DFU_ERROR_NONE` instead of `LIBUSB_SUCCESS`, ensuring the function properly handles DFU-specific error codes.

### Utility Function Improvements

* In `utils::string_format` (`src/util/util.h`), a new overload is added for the case with zero arguments, returning the format string as-is and improving type safety and clarity.
* The previously commented-out GCC diagnostic pragmas are removed, cleaning up the code and making the formatting function more straightforward.