### PR TITLE
SN-7863 imx5 bootloader stress test

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -396,6 +396,25 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             g_commandLineOptions.disableBroadcastsOnClose = true;
         }
+        else if (matches(a, "-device") && (i + 1) < argc)
+        {
+            std::string devType = argv[++i];
+            std::transform(devType.begin(), devType.end(), devType.begin(), ::tolower);
+            if      (devType == "imx"  || devType == "imx-5" || devType == "imx5")   g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
+            else if (devType == "imx5.0" || devType == "imx-5.0")                       g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_5_0;
+            else if (devType == "imx6.0" || devType == "imx-6.0" || devType == "imx6" || devType == "imx-6") g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_6_0;
+            else if (devType == "gpx"  || devType == "gpx1" || devType == "gpx-1")    g_commandLineOptions.filterHdwType = IS_HARDWARE_GPX;
+            else if (devType == "uins")                                                 g_commandLineOptions.filterHdwType = IS_HARDWARE_UINS_3_2;
+            else if (devType == "evb")                                                  g_commandLineOptions.filterHdwType = IS_HARDWARE_EVB_2_0;
+            else
+            {
+                cout << "Invalid device type: " << devType << ". Expected: imx, imx5, imx6, gpx, uins, evb." << endl;
+                return false;
+            }
+            // If no port was explicitly set, default to wildcard discovery
+            if (g_commandLineOptions.comPort.empty())
+                g_commandLineOptions.comPort = "*";
+        }
         else if (startsWith(a, "-dur="))
         {
             g_commandLineOptions.runDurationMs = (uint32_t)(atof(&a[5])*1000.0);
@@ -1218,6 +1237,7 @@ void cltool_outputUsage()
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select serial port(s). Options: single port (e.g., COM5 or /dev/ttyUSB0), multiple ports separated by ',' (e.g., COM2,COM4,COM5), \"*\" for all ports, or \"*4\" for first four ports." << endlbOn;
 	cout << "    -sn " << boldOff << "DEVICE_ID   Discover all devices and connect to the one matching the given identifier. Accepts: 129495, SN129495, or IMX-5.0:SN129495. Alternative to -c." << endlbOn;
+	cout << "    -device " << boldOff << "TYPE    Discover all devices and open only those matching TYPE. Options: imx (all IMX), imx5 (IMX-5.x only), imx6 (IMX-6.x only), gpx, uins, evb. Implies -c * if no -c port is given." << endlbOn;
 	cout << "    -dboc" << boldOff << "           Send stop-broadcast command `$STPB` on close." << endlbOn;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -400,12 +400,10 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             std::string devType = argv[++i];
             std::transform(devType.begin(), devType.end(), devType.begin(), ::tolower);
-            if      (devType == "imx"  || devType == "imx-5" || devType == "imx5")   g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
-            else if (devType == "imx5.0" || devType == "imx-5.0")                       g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_5_0;
-            else if (devType == "imx6.0" || devType == "imx-6.0" || devType == "imx6" || devType == "imx-6") g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_6_0;
-            else if (devType == "gpx"  || devType == "gpx1" || devType == "gpx-1")    g_commandLineOptions.filterHdwType = IS_HARDWARE_GPX;
-            else if (devType == "uins")                                                 g_commandLineOptions.filterHdwType = IS_HARDWARE_UINS_3_2;
-            else if (devType == "evb")                                                  g_commandLineOptions.filterHdwType = IS_HARDWARE_EVB_2_0;
+            if      (devType == "imx"  || devType == "imx-5" || devType == "imx5")                              g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
+            else if (devType == "imx5.0" || devType == "imx-5.0")                                               g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_5_0;
+            else if (devType == "imx6.0" || devType == "imx-6.0" || devType == "imx6" || devType == "imx-6")    g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_6_0;
+            else if (devType == "gpx"  || devType == "gpx1" || devType == "gpx-1")                              g_commandLineOptions.filterHdwType = IS_HARDWARE_GPX;
             else
             {
                 cout << "Invalid device type: " << devType << ". Expected: imx, imx5, imx6, gpx, uins, evb." << endl;
@@ -1237,7 +1235,7 @@ void cltool_outputUsage()
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select serial port(s). Options: single port (e.g., COM5 or /dev/ttyUSB0), multiple ports separated by ',' (e.g., COM2,COM4,COM5), \"*\" for all ports, or \"*4\" for first four ports." << endlbOn;
 	cout << "    -sn " << boldOff << "DEVICE_ID   Discover all devices and connect to the one matching the given identifier. Accepts: 129495, SN129495, or IMX-5.0:SN129495. Alternative to -c." << endlbOn;
-	cout << "    -device " << boldOff << "TYPE    Discover all devices and open only those matching TYPE. Options: imx (all IMX), imx5 (IMX-5.x only), imx6 (IMX-6.x only), gpx, uins, evb. Implies -c * if no -c port is given." << endlbOn;
+	cout << "    -device " << boldOff << "TYPE    Discover all devices and open only those matching TYPE. Options: imx, imx5, imx6, gpx. Implies -c * if no -c port is given." << endlbOn;
 	cout << "    -dboc" << boldOff << "           Send stop-broadcast command `$STPB` on close." << endlbOn;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -400,7 +400,8 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             std::string devType = argv[++i];
             std::transform(devType.begin(), devType.end(), devType.begin(), ::tolower);
-            if      (devType == "imx"  || devType == "imx-5" || devType == "imx5")                              g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
+            if      (devType == "imx")                                                                           g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
+            else if (devType == "imx-5" || devType == "imx5")                                                   g_commandLineOptions.filterHdwType = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, -1);
             else if (devType == "imx5.0" || devType == "imx-5.0")                                               g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_5_0;
             else if (devType == "imx6.0" || devType == "imx-6.0" || devType == "imx6" || devType == "imx-6")    g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_6_0;
             else if (devType == "gpx"  || devType == "gpx1" || devType == "gpx-1")                              g_commandLineOptions.filterHdwType = IS_HARDWARE_GPX;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -187,6 +187,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     EVOContainer_t evOCont;
 
     uint64_t targetDeviceId = 0;            // -sn: encoded device identifier (hdwId << 48 | serialNumber). Parsed from "IMX-5.0:SN129495" or just "129495"
+    is_hardware_t filterHdwType = IS_HARDWARE_ANY; // -device: filter to only open ports for this hardware type (e.g. IS_HARDWARE_IMX, IS_HARDWARE_GPX)
     bool disableDeviceValidation = false;   // Keep port(s) open even if no devices response is received.
     bool listenMode = false;                // Disable device verification and don't send stop-broadcast command on start.
 } cmd_options_t;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1038,6 +1038,29 @@ static int cltool_dataStreaming()
         return -1;    // Failed to open serial port
     }
 
+    // Filter devices by hardware type if -device TYPE was specified
+    if (g_commandLineOptions.filterHdwType != IS_HARDWARE_ANY)
+    {
+        DeviceManager& dm = DeviceManager::getInstance();
+        std::vector<device_handle_t> toRelease;
+        for (auto& device : inertialSenseInterface.getDevices())
+        {
+            if (!device->matchesHdwId(g_commandLineOptions.filterHdwType))
+                toRelease.push_back(device);
+        }
+        for (auto& device : toRelease)
+        {
+            printf("[INFO] Skipping non-matching device: %s on %s\n",
+                   device->getIdAsString().c_str(), device->getPortName().c_str());
+            dm.releaseDevice(device, true, true);
+        }
+        if (inertialSenseInterface.getDevices().empty())
+        {
+            cout << "No devices of the requested type found." << endl;
+            return EXIT_CODE_NO_DEVICES_FOUND;
+        }
+    }
+
     if (g_commandLineOptions.list_devices) {
         /**
          * List discovered devices and exit

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1089,33 +1089,10 @@ static int cltool_dataStreaming()
     }
 
     // [C++ COMM INSTRUCTION] STEP 2: Open serial port
-    if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))
+    if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose, g_commandLineOptions.filterHdwType))
     {
         cout << "Failed to open serial port at " << g_commandLineOptions.comPort.c_str() << endl;
         return -1;    // Failed to open serial port
-    }
-
-    // Filter devices by hardware type if -device TYPE was specified
-    if (g_commandLineOptions.filterHdwType != IS_HARDWARE_ANY)
-    {
-        DeviceManager& dm = DeviceManager::getInstance();
-        std::vector<device_handle_t> toRelease;
-        for (auto& device : inertialSenseInterface.getDevices())
-        {
-            if (!device->matchesHdwId(g_commandLineOptions.filterHdwType))
-                toRelease.push_back(device);
-        }
-        for (auto& device : toRelease)
-        {
-            printf("[INFO] Skipping non-matching device: %s on %s\n",
-                   device->getIdAsString().c_str(), device->getPortName().c_str());
-            dm.releaseDevice(device, true, true);
-        }
-        if (inertialSenseInterface.getDevices().empty())
-        {
-            cout << "No devices of the requested type found." << endl;
-            return EXIT_CODE_NO_DEVICES_FOUND;
-        }
     }
 
     if (g_commandLineOptions.list_devices) {

--- a/src/ISBootloaderBase.cpp
+++ b/src/ISBootloaderBase.cpp
@@ -548,11 +548,70 @@ is_operation_result cISBootloaderBase::update_device
     device = obj->check_is_compatible();
     if (device == IS_IMAGE_SIGN_NONE)
     {
-        obj->logStatus(IS_LOG_LEVEL_ERROR, "Device response missing."); // TODO?  are these the same call?
         delete obj;
-        return IS_OP_ERROR;
+        obj = NULL;
+
+        // ISB not responding -- after a DFU bootloader update the "stay in bootloader"
+        // signal (held in RAM) is lost across the hard reset, so the new ISB may need
+        // extra time to initialize, or it may have already jumped to the application.
+        // Strategy: sleep, retry ISB once more, then fall back to APP detection.
+        SLEEP_MS(IS_REBOOT_DELAY_MS);
+
+        serialPortClose(port);
+        if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+        {
+            obj = new cISBootloaderISB(updateProgress, verifyProgress, statusfn, port);
+            device = obj->check_is_compatible();
+        }
+
+        if (device == IS_IMAGE_SIGN_NONE)
+        {
+            delete obj;
+            obj = NULL;
+
+            // ISB still not responding -- device likely booted into APP firmware.
+            // Detect APP mode and, if found, reboot back to ISB before retrying.
+            serialPortClose(port);
+            if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+            {
+                cISBootloaderAPP* appObj = new cISBootloaderAPP(updateProgress, verifyProgress, statusfn, port);
+                serialPortWriteAscii(appObj->m_port, "STPB", 4);
+                uint32_t appDevice = appObj->check_is_compatible();
+
+                const char* enableCmd = NULL;
+                if      ((appDevice & IS_IMAGE_SIGN_APP) & fw_IMX_5)  { appObj->m_filename = filenames.fw_IMX_5.path;  enableCmd = "BLEN"; }
+                else if ((appDevice & IS_IMAGE_SIGN_APP) & fw_EVB_2)  { appObj->m_filename = filenames.fw_EVB_2.path;  enableCmd = "EBLE"; }
+                else if ((appDevice & IS_IMAGE_SIGN_APP) & fw_uINS_3) { appObj->m_filename = filenames.fw_uINS_3.path; enableCmd = "BLEN"; }
+
+                if (enableCmd)
+                {
+                    strncpy(appObj->m_app.enable_command, enableCmd, sizeof(appObj->m_app.enable_command));
+                    appObj->reboot_down();
+                    delete appObj;
+                    SLEEP_MS(IS_REBOOT_DELAY_MS);
+
+                    serialPortClose(port);
+                    if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+                    {
+                        obj = new cISBootloaderISB(updateProgress, verifyProgress, statusfn, port);
+                        device = obj->check_is_compatible();
+                    }
+                }
+                else
+                {
+                    delete appObj;
+                }
+            }
+        }
+
+        if (device == IS_IMAGE_SIGN_NONE)
+        {
+            if (obj) { obj->logStatus(IS_LOG_LEVEL_ERROR, "Device response missing."); delete obj; obj = NULL; }
+            else statusfn(std::any(), IS_LOG_LEVEL_ERROR, "    | %s: Device response missing.", portName(port));
+            return IS_OP_ERROR;
+        }
     }
-    else if (device == IS_IMAGE_SIGN_ERROR)
+    if (device == IS_IMAGE_SIGN_ERROR)
     {
         obj->logStatus(IS_LOG_LEVEL_ERROR, "Invalid device signature.");
         delete obj;

--- a/src/ISBootloaderBase.cpp
+++ b/src/ISBootloaderBase.cpp
@@ -537,7 +537,7 @@ is_operation_result cISBootloaderBase::update_device
         }
     }
 
-    serialPortClose(port);
+    portClose(port);
     if (serialPortOpenRetry(port, portName(port), baud, 1) != PORT_ERROR__NONE)
     {
         statusfn(std::any(), IS_LOG_LEVEL_ERROR, "Unable to open port at %d baud", baud);

--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -177,7 +177,7 @@ eImageSignature cISBootloaderISB::check_is_compatible()
 is_operation_result cISBootloaderISB::reboot_up()
 {
     log_more_debug(IS_LOG_FWUPDATE, "ISBootloaderISB::reboot_up()");
-    m_info_callback(this, IS_LOG_LEVEL_INFO, "(ISB) Rebooting to APP mode...");
+    m_info_callback(this, IS_LOG_LEVEL_INFO, "(ISB) %s (SN%u): Rebooting to APP mode...", portName(m_port), m_sn);
 
     // send the "reboot to program mode" command and the device should start in program mode
     if (portWrite(m_port, (unsigned char*)":020000040300F7", 15) == 15) {

--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -859,6 +859,8 @@ is_operation_result cISBootloaderThread::update(
     beginTimeMs = current_timeMs();
 
     is_operation_result overall_result = IS_OP_OK;
+    int devicesSucceeded = 0;
+    int devicesFailed = 0;
     while (m_continue_update && !true_if_cancelled())
     {
         if (m_waitAction) m_waitAction();
@@ -879,8 +881,13 @@ is_operation_result cISBootloaderThread::update(
                 serialThread->thread = NULL;
 
                 thread_serial_t* t = serialThread;        // set by update_thread_serial
-                if (t->opResult != IS_OP_OK && t->opResult != IS_OP_CANCELLED && t->opResult != IS_OP_CLOSED)
+                if (t->opResult == IS_OP_OK)
                 {
+                    devicesSucceeded++;
+                }
+                else if (t->opResult != IS_OP_CANCELLED && t->opResult != IS_OP_CLOSED)
+                {
+                    devicesFailed++;
                     if (overall_result == IS_OP_OK)      // keep the first non-OK as the return
                     {
                         overall_result = t->opResult;
@@ -960,9 +967,20 @@ is_operation_result cISBootloaderThread::update(
 
     threadJoinAndFree(libusb_thread);
 
-    // Only report run time if the update was successful
-    if (overall_result == IS_OP_OK)
+    // Report final status
+    if (devicesSucceeded > 0 && devicesFailed == 0)
     {
+        tmp = "Update succeeded (" + to_string(devicesSucceeded) + " device(s)) in " + to_string(((double)timeDeltaMs) / 1000) + " seconds.";
+        m_infoProgress(NULL, IS_LOG_LEVEL_INFO, tmp.c_str());
+    }
+    else if (devicesSucceeded > 0 && devicesFailed > 0)
+    {
+        tmp = "Update succeeded on " + to_string(devicesSucceeded) + " device(s), failed on " + to_string(devicesFailed) + " device(s).";
+        m_infoProgress(NULL, IS_LOG_LEVEL_WARN, tmp.c_str());
+    }
+    else if (overall_result == IS_OP_OK)
+    {
+        // No threads ran (edge case) -- keep original success path
         tmp = "Update succeeded in " + to_string(((double)timeDeltaMs) / 1000) + " seconds.";
         m_infoProgress(NULL, IS_LOG_LEVEL_INFO, tmp.c_str());
     }
@@ -1006,7 +1024,7 @@ is_operation_result cISBootloaderThread::update(
     m_update_in_progress = false;
     m_update_mutex.unlock();
 
-    if (overall_result != IS_OP_OK) {
+    if (overall_result != IS_OP_OK && devicesSucceeded == 0) {
         m_infoProgress(NULL, IS_LOG_LEVEL_ERROR, "Update failed!");
         if(m_waitAction) m_waitAction();     // Final UI update
         return overall_result;

--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "intel_hex_utils.h"
 
 #include <algorithm>
+#include <set>
 #include <vector>
 
 #if !PLATFORM_IS_WINDOWS
@@ -62,33 +63,48 @@ void cISBootloaderThread::mgmt_thread_libusb(void* context)
 
     cISBootloaderDFU::m_DFUmutex.lock();
 
-    m_libusb_thread_mutex.lock();
-    cISBootloaderDFU::list_devices(&dfu_list);
-    for (size_t i = 0; i < dfu_list.present; i++)
-    {   // Create contexts for devices in DFU mode
-        bool found = false;
-
-        for (size_t j = 0; j < ctx.size(); j++)
-        {
-            m_ctx_mutex.lock();
-            if (!(ctx[j]->is_serial_device()) && ctx[j]->match_test((void*)dfu_list.id[i].uid) == IS_OP_OK)
-            {   // We found the device in the context list
-                found = true;
-                break;
-            }
-            m_ctx_mutex.unlock();
-        }
-
-        if (!found)
-        {   // If we didn't find the device
-            create_and_start_libusb_thread(update_thread_libusb, dfu_list.id[i].handle_libusb);
-        }
-    }
-    m_libusb_thread_mutex.unlock();
+    std::set<std::string> claimed_uids;         // UIDs of DFU devices already dispatched to a thread
 
     while (m_continue_update)
     {
         m_libusb_thread_mutex.lock();
+
+        // Rescan for newly-enumerated DFU devices each iteration so that devices
+        // which take longer than the initial 2.5s wait to enumerate (e.g. 8
+        // simultaneous ISB->DFU reboots on a shared hub) are still discovered.
+        cISBootloaderDFU::list_devices(&dfu_list);
+        for (size_t i = 0; i < dfu_list.present; i++)
+        {
+            std::string uid(dfu_list.id[i].uid);
+            if (claimed_uids.count(uid))
+            {   // Already launched a thread for this device; close the newly-opened handle.
+                libusb_close(dfu_list.id[i].handle_libusb);
+                continue;
+            }
+
+            // Also skip if already tracked in the context list
+            bool in_ctx = false;
+            m_ctx_mutex.lock();
+            for (size_t j = 0; j < ctx.size(); j++)
+            {
+                if (!ctx[j]->is_serial_device() && ctx[j]->match_test((void*)dfu_list.id[i].uid) == IS_OP_OK)
+                {
+                    in_ctx = true;
+                    break;
+                }
+            }
+            m_ctx_mutex.unlock();
+
+            if (in_ctx)
+            {
+                libusb_close(dfu_list.id[i].handle_libusb);
+                continue;
+            }
+
+            // New DFU device — start an update thread
+            claimed_uids.insert(uid);
+            create_and_start_libusb_thread(update_thread_libusb, dfu_list.id[i].handle_libusb);
+        }
 
         m_libusb_devicesActive = 0;
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -433,7 +433,7 @@ bool InertialSense::Update()
     return anyOpen;
 }
 
-bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsOnClose)
+bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsOnClose, uint16_t filterHdwType)
 {
     // null com port, just use other features of the interface like ntrip
     if (port[0] == '0' && port[1] == '\0')
@@ -443,7 +443,7 @@ bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsO
 
     m_disableBroadcastsOnClose = false;
     m_baudRate = baudRate;
-    if (OpenPorts(port, baudRate))
+    if (OpenPorts(port, baudRate, filterHdwType))
     {
         m_disableBroadcastsOnClose = disableBroadcastsOnClose;
         return true;
@@ -960,7 +960,7 @@ int InertialSense::OnPortError(port_handle_t port, int errCode, const char *errM
     return 0;
 }
 
-bool InertialSense::OpenPorts(const char* portPattern, int baudRate)
+bool InertialSense::OpenPorts(const char* portPattern, int baudRate, uint16_t filterHdwType)
 {
     m_baudRate = baudRate;
 
@@ -1017,7 +1017,7 @@ bool InertialSense::OpenPorts(const char* portPattern, int baudRate)
         for (auto port : portManager.locked_range()) portsToValidate.insert(port);
 
         // attempt to discover devices on all known ports
-        deviceManager.discoverDevices(IS_HARDWARE_ANY, m_comManagerState.discoveryTimeout, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE);  // In this case, We ABSOLUTELY want to open any closes ports (because they are all closed currently)
+        deviceManager.discoverDevices(filterHdwType, m_comManagerState.discoveryTimeout, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE);  // In this case, We ABSOLUTELY want to open any closes ports (because they are all closed currently)
 
         // remove all ports from portToValidate if a device has bound to that port
         for ( auto d : deviceManager ) portsToValidate.erase(d->port);

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -131,7 +131,7 @@ public:
     * @param disableBroadcastsOnClose whether to send a stop broadcasts command to all units on Close
     * @return true if opened, false if failure (i.e. baud rate is bad or port fails to open)
     */
-    bool Open(const char* port, int baudRate=IS_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false);
+    bool Open(const char* port, int baudRate=IS_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false, uint16_t filterHdwType=IS_HARDWARE_ANY);
 
     /**
     * Check if the connection is open
@@ -648,7 +648,7 @@ private:
     bool EnableLogging(const std::string& path, const cISLogger::sSaveOptions& options = cISLogger::sSaveOptions());
     void DisableLogging();
     bool HasReceivedDeviceInfoFromAllDevices();
-    bool OpenPorts(const char* port, int baudRate);
+    bool OpenPorts(const char* port, int baudRate, uint16_t filterHdwType=IS_HARDWARE_ANY);
     void ClosePorts(bool drainBeforeClose = false);
     static void LoggerThread(void* info);
     static void StepLogger(void* ctx, const p_data_t* data, port_handle_t port);


### PR DESCRIPTION
This pull request introduces a new `-device` command-line option to filter and connect only to specific hardware device types, along with improvements to device update robustness and reporting. It also enhances the bootloader update process to better handle devices that may reboot into application firmware, and improves status reporting for multi-device updates.

**Command-line Interface Enhancements:**

* Added a `-device TYPE` option to `cltool`, allowing users to filter and connect only to devices of a specified hardware type (e.g., `imx`, `imx5`, `imx6`, `gpx`). If no port is specified, it defaults to wildcard discovery. Usage information is updated accordingly. [[1]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6R399-R416) [[2]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6R1256) [[3]](diffhunk://#diff-78d48e85a050e8f37f9c68d1debc55c2b5547b6ec95ec7482f661246258a109dR192)
* In the main data streaming function, devices are filtered at runtime based on the specified hardware type, and non-matching devices are skipped and released. If no matching devices are found, the tool exits with a clear message.

**Bootloader Update Robustness:**

* Improved the device update process to handle cases where, after a DFU bootloader update, the device may reboot into application mode instead of the bootloader. The update logic now retries detection and, if necessary, attempts to reboot the device back into bootloader mode before proceeding.
* Enhanced log output for device reboots to include port and serial number information, aiding in debugging and traceability.

**Update Status Reporting:**

* The bootloader thread now tracks the number of devices updated successfully and failed, and reports more detailed summary messages at the end of the update process, including counts of successes and failures. Error reporting is improved to only trigger a global failure if all devices fail. [[1]](diffhunk://#diff-43ea598611e866434c4f03f79fc8be7ac6c21ee1c567367b5ec8a0249523c838R862-R863) [[2]](diffhunk://#diff-43ea598611e866434c4f03f79fc8be7ac6c21ee1c567367b5ec8a0249523c838L882-R890) [[3]](diffhunk://#diff-43ea598611e866434c4f03f79fc8be7ac6c21ee1c567367b5ec8a0249523c838L963-R983) [[4]](diffhunk://#diff-43ea598611e866434c4f03f79fc8be7ac6c21ee1c567367b5ec8a0249523c838L1009-R1027)