### PR TITLE
SN-7677 imx calibration b

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -206,8 +206,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #if defined(__ZEPHYR__)
     #include <zephyr/irq.h>
-    #define BEGIN_CRITICAL_SECTION  irq_lock();
-    #define END_CRITICAL_SECTION    irq_unlock(0);
+    #define BEGIN_CRITICAL_SECTION  { uint32_t _irq_state = irq_lock();
+    #define END_CRITICAL_SECTION    irq_unlock(_irq_state) }
 #elif !PLATFORM_IS_EMBEDDED
     #define BEGIN_CRITICAL_SECTION
     #define END_CRITICAL_SECTION

--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -206,8 +206,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #if defined(__ZEPHYR__)
     #include <zephyr/irq.h>
-    #define BEGIN_CRITICAL_SECTION  { uint32_t _irq_state = irq_lock();
-    #define END_CRITICAL_SECTION    irq_unlock(_irq_state) }
+    #define BEGIN_CRITICAL_SECTION  uint32_t _irq_state = irq_lock();
+    #define END_CRITICAL_SECTION    irq_unlock(_irq_state);
 #elif !PLATFORM_IS_EMBEDDED
     #define BEGIN_CRITICAL_SECTION
     #define END_CRITICAL_SECTION


### PR DESCRIPTION
This pull request updates how critical sections are handled in Zephyr builds by ensuring that interrupt state is properly saved and restored. The change improves safety and correctness when entering and exiting critical sections.

Improvements to critical section handling (Zephyr):

* Updated the `BEGIN_CRITICAL_SECTION` and `END_CRITICAL_SECTION` macros in `src/ISConstants.h` to save the current interrupt lock state in a local variable (`_irq_state`) and restore it upon exit, rather than using a hardcoded value. This prevents potential issues when nesting or restoring interrupt states.