### PR TITLE
SN-7891: Network firmware update durability fixes

### DIFF
--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1088,11 +1088,55 @@ static int cltool_dataStreaming()
         }
     }
 
-    // [C++ COMM INSTRUCTION] STEP 2: Open serial port
+    // [C++ COMM INSTRUCTION] STEP 2: Open the requested port and validate a device
     if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))
     {
-        cout << "Failed to open serial port at " << g_commandLineOptions.comPort.c_str() << endl;
-        return -1;    // Failed to open serial port
+        // InertialSense::Open returns false for several distinct reasons that the
+        // original "Failed to open serial port at <url>" message conflated:
+        //   (a) the URL didn't match any registered PortFactory — PortManager is empty;
+        //   (b) a factory matched but the port couldn't actually be opened (access
+        //       denied, port held by another process, TCP refused, DNS failed); or
+        //   (c) the port opened fine, but no device responded to discovery in time.
+        // For comPort = '*' or a comma-separated list, summarizing as a single
+        // outcome is unhelpful — different ports can fail for different reasons.
+        // Enumerate per-port state from PortManager so the user sees the OS-level
+        // error code (perror, populated by tcpPort/serialPort drivers from errno)
+        // and the validate/open status of each port that was discovered.
+        if (PortManager::getInstance().empty())
+        {
+            cout << "Could not find a recognizable port for '" << g_commandLineOptions.comPort.c_str()
+                 << "' (no PortFactory matched)." << endl;
+        }
+        else
+        {
+            cout << "Could not establish a device connection for '" << g_commandLineOptions.comPort.c_str()
+                 << "':" << endl;
+            DeviceManager& dm = DeviceManager::getInstance();
+            for (auto port : PortManager::getInstance().locked_range())
+            {
+                if (!port) continue;
+                const char* name = portName(port);
+                uint16_t err = portError(port);
+                bool opened = portIsOpened(port);
+                bool valid = portIsValid(port);
+                bool hasDevice = (dm.getDevice(port) != nullptr);
+
+                cout << "  " << (name ? name : "<unnamed>") << ": ";
+                if (hasDevice) {
+                    cout << "device validated (this port is OK)";
+                } else if (err != 0) {
+                    cout << "port error (" << (int)(int16_t)err << ": " << strerror((int)(int16_t)err) << ")";
+                } else if (!valid) {
+                    cout << "port invalidated";
+                } else if (!opened) {
+                    cout << "port could not be opened";
+                } else {
+                    cout << "port opened but device did not respond to discovery";
+                }
+                cout << endl;
+            }
+        }
+        return -1;
     }
 
     if (g_commandLineOptions.list_devices) {
@@ -1118,6 +1162,28 @@ static int cltool_dataStreaming()
     }
 
     int exitCode = EXIT_CODE_SUCCESS;
+
+    // Bootloader-state guard: if any of the connected devices is sitting in
+    // HDW_STATE_BOOTLOADER, the data-streaming, NMEA, and DID flows below will all
+    // hang indefinitely — bootloaders don't speak DID/NMEA. The exception is the
+    // firmware-update path itself (which exists to recover this state); only block
+    // when we're NOT about to update firmware. Provide a clear, actionable message
+    // so the user doesn't sit watching "Tx 0, Rx 0".
+    const bool isFwUpdateRun =
+        (g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST &&
+         !g_commandLineOptions.fwUpdateCmds.empty()) ||
+        (g_commandLineOptions.updateFirmwareTarget == fwUpdate::TARGET_HOST &&
+         !g_commandLineOptions.updateAppFirmwareFilename.empty());
+    if (!isFwUpdateRun) {
+        for (auto device : inertialSenseInterface.getDevices()) {
+            if (device && device->devInfo.hdwRunState == HDW_STATE_BOOTLOADER) {
+                cout << "Device " << device->getIdAsString()
+                     << " is in BOOTLOADER mode and will not respond to data, NMEA, or DID requests." << endl
+                     << "  Reboot the device, or run a firmware update (-uf, -ufpkg, -uf-cmd) to recover." << endl;
+                return EXIT_CODE_DEVICE_DISCONNECTED;
+            }
+        }
+    }
 
     // [C++ COMM INSTRUCTION] STEP 3: Enable data broadcasting
     if (cltool_setupCommunications(inertialSenseInterface))

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1188,9 +1188,16 @@ static int cltool_dataStreaming()
             // [C++ COMM INSTRUCTION] STEP 4: Read data
             while (!g_inertialSenseDisplay.ExitProgram() && (!g_commandLineOptions.runDurationMs || (current_timeMs() < exitTime)))
             {
-                // FIXME: this is a little jank -- we should periodically check for ports, but in the cltool, but we only want to check for the same ports that we originally connected on??
+                // Re-discover ONLY the originally-specified port(s), not every port the
+                // relay/mDNS factories know about. Default `discoverPorts()` uses pattern
+                // "(.+)" which matches all known URLs — for a -ufpkg run targeting a single
+                // TCP/relay device, that opened TCP sockets to every device the relay
+                // exposed (16+ on a fixture testbed) and held them for the duration of the
+                // run, blocking concurrent clients (the bridgeboard enforces "one client
+                // per port"). Passing the resolved comPort scopes the periodic check to
+                // the target we actually care about.
                 if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && (current_timeMs() > nextPortCheck)) {
-                    PortManager::getInstance().discoverPorts();
+                    PortManager::getInstance().discoverPorts(g_commandLineOptions.comPort);
                     nextPortCheck = current_timeMs() + 1500;
                 }
 

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1246,6 +1246,19 @@ static int cltool_dataStreaming()
                 SLEEP_MS(1);
             }
  
+            // Re-check device-level fwUpdate errors before reporting status. The earlier
+            // exitCode at line ~1219 captures the state when the loop saw isFirmwareUpdateFinished(),
+            // but additional CMD_ERROR statuses can land between then and now. Without this check
+            // we'd print "Firmware update successful!" and then "Exit Status: -5" — contradictory.
+            if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && g_commandLineOptions.updateAppFirmwareFilename.empty()) {
+                for (auto device : inertialSenseInterface.getDevices()) {
+                    if (device->fwUpdateState.hasErrors) {
+                        exitCode = EXIT_CODE_FIRMWARE_UPDATE_FAILED;
+                        break;
+                    }
+                }
+            }
+
             // Only report firmware update status if a firmware update was actually initiated.
             if (g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST && !g_commandLineOptions.fwUpdateCmds.empty())
             {
@@ -1273,16 +1286,6 @@ static int cltool_dataStreaming()
         // Exit Failed to setup communications
         cout << "Failed to setup communications!" << endl;
         exitCode = EXIT_CODE_FAILED_TO_SETUP_COMMUNICATIONS;
-    }
-
-    //If Firmware Update is specified return an error code based on the Status of the Firmware Update
-    if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && g_commandLineOptions.updateAppFirmwareFilename.empty()) {
-        for (auto device : inertialSenseInterface.getDevices()) {
-            if (device->fwUpdateState.hasErrors) {
-                exitCode = EXIT_CODE_FIRMWARE_UPDATE_FAILED;
-                break;
-            }
-        }
     }
 
     return exitCode;

--- a/src/DeviceFactory.cpp
+++ b/src/DeviceFactory.cpp
@@ -99,16 +99,20 @@ std::unique_ptr<DeviceFactory::ValidationContext> DeviceFactory::beginValidation
     ctx->hdwId = hdwId;
     ctx->timeoutMs = timeoutMs;
 
-    // Check for a pre-seeded hint (e.g., from RelayPortFactory). If the relay has already
-    // identified this device, skip the DID_DEV_INFO probe entirely.
+    // Check for a pre-seeded hint (e.g., from RelayPortFactory). The hint is INFORMATIVE,
+    // not authoritative — it pre-seeds devInfo so subsequent validation knows what to
+    // expect (e.g. start with the right query type for hdwRunState=BOOTLOADER) and so the
+    // factory can decline a mismatched hdwId early. The hint NEVER substitutes for actual
+    // validation: the calling application should be the one to decide whether to trust a
+    // hint sight-unseen, and both cltool and EvalTool require a real handshake. Without
+    // running the active probe we'd never confirm the device is even responsive on the
+    // other end of the connection.
     const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
     if (hint && hint->serialNumber != 0 && hint->hardwareType != IS_HARDWARE_TYPE_UNKNOWN) {
         ctx->device->devInfo = *hint;
         ctx->device->hdwId = ENCODE_DEV_INFO_TO_HDW_ID((*hint));
-        ctx->complete = true;
-        ctx->result = 1;
-        log_info(IS_LOG_DEVICE_FACTORY, "beginValidation: using seeded hint for port '%s' (SN=%u, hwType=%d) — skipping probe.",
-                 portName(port), hint->serialNumber, hint->hardwareType);
+        log_info(IS_LOG_DEVICE_FACTORY, "beginValidation: seeded hint for port '%s' (SN=%u, hwType=%d, hdwRunState=%d) — validation still required.",
+                 portName(port), hint->serialNumber, hint->hardwareType, hint->hdwRunState);
     }
 
     return ctx;

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -710,6 +710,29 @@ void DeviceManager::seedDeviceHint(port_handle_t port, const dev_info_t& hint) {
     deviceHints_[port] = hint;
     log_debug(IS_LOG_DEVICE_MANAGER, "Seeded device hint for port '%s' (SN=%u, hwType=%d)",
               portName(port), hint.serialNumber, hint.hardwareType);
+
+    // Hint-driven device registration. When a port surfaces a complete device
+    // identity via a relay snapshot (or other authoritative metadata source),
+    // register the device immediately so consumers can render it without first
+    // running an active probe. This is intentionally a "discovery-without-open"
+    // path: deviceHandler() only fires DEVICE_CONNECTED when portIsOpened(), and
+    // relay ports come back from bindPort() in a closed state — so a hint-only
+    // registration produces DEVICE_ADDED + DEVICE_PORT_BOUND only. Real
+    // validation, port-open, and DEVICE_CONNECTED happen later when the user
+    // explicitly opens the port (e.g. Find / Open in the UI).
+    if (port && hint.serialNumber != 0 && hint.hardwareType != IS_HARDWARE_TYPE_UNKNOWN) {
+        if (!getDevice(port)) {
+            // Iterate registered factories until one accepts the hint. Pass
+            // options=0 so a non-matching factory doesn't close the port on
+            // its way out — we want the next factory to get a clean shot.
+            for (auto factory : factories) {
+                if (deviceHandler(factory, hint, port, /*options=*/0)) {
+                    log_debug(IS_LOG_DEVICE_MANAGER, "Hint-registered device for port '%s' (no port open, no connect)", portName(port));
+                    break;
+                }
+            }
+        }
+    }
 }
 
 const dev_info_t* DeviceManager::getDeviceHint(port_handle_t port) const {

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -215,13 +215,26 @@ public:
     void clearDeviceHint(port_handle_t port);
 
     /**
-     * Notifies all listeners of a particular device event
-     * @param device the device to which the event is applicable
-     * @param event the specific event id that occurred.
+     * Notifies all listeners of a particular device event.
+     *
+     * Listeners are invoked WITHOUT holding DeviceManager::mutex. Holding the
+     * mutex during dispatch creates an AB/BA deadlock with any caller that
+     * already holds another resource (e.g. ISDevice::portMutex) and reaches into
+     * DeviceManager — for example `ISDevice::step()` (which holds portMutex,
+     * fires DEVICE_DISCONNECTED on a port-state change) racing against
+     * `DeviceManager::discoverDevices()` (which holds DeviceManager::mutex and
+     * eventually takes portMutex via `validate→SendRaw`). Snapshotting the
+     * listener vector under the lock and dispatching after release is safe:
+     * the listener registry is only mutated through addPortListener/clear-style
+     * helpers that already take the same mutex.
      */
     void notifyListeners(device_handle_t device, uint8_t event) {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
-        for (device_listener& l : listeners) l(event, device);    // notify that this device's port has been updated
+        std::vector<device_listener> snapshot;
+        {
+            std::lock_guard<std::recursive_mutex> lock(mutex);
+            snapshot = listeners;
+        }
+        for (auto& l : snapshot) l(event, device);
     }
 
 

--- a/src/ISBFirmwareUpdater.cpp
+++ b/src/ISBFirmwareUpdater.cpp
@@ -221,6 +221,18 @@ bool ISBFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proc
                 // Async wait: device is rebooting from bootloader to APP mode.
                 // Keep session_status == FINALIZING until device is rediscovered in APP mode.
 
+                // Heartbeat: emit a progress message at progress_interval regardless of
+                // which sub-branch we take below. The host (ISFirmwareUpdater) treats any
+                // received message as a keep-alive (FirmwareUpdate.cpp:708 → resetTimeout);
+                // without it, session_status flips to ERR_TIMEOUT after 20s and the parent
+                // reports "No Response from device" while the device is genuinely rebooting.
+                if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
+                    nextProgressReport = current_timeMs() + progress_interval;
+                    fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
+                        "Waiting for device [%s] to reboot into APP mode.",
+                        ISDevice::getIdAsString(target_devInfo).c_str());
+                }
+
                 // Periodically trigger port rediscovery
                 if (current_timeMs() > nextPortCheck) {
                     portManager.discoverPorts();
@@ -230,14 +242,7 @@ bool ISBFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proc
                 // Re-fetch device (port may have changed after USB re-enumeration)
                 device = deviceManager.getDevice(ENCODE_DEV_INFO_TO_UNIQUE_ID(target_devInfo));
                 if (!device) {
-                    // Device not yet rediscovered — report progress and return
-                    if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
-                        nextProgressReport = current_timeMs() + progress_interval;
-                        fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
-                            "Waiting for device [%s] to reboot into APP mode.",
-                            ISDevice::getIdAsString(target_devInfo).c_str());
-                    }
-                    // Timeout check
+                    // Device not yet rediscovered — keep waiting (heartbeat above)
                     if ((current_timeMs() - last_reboot) > 20000) {
                         fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_WARN,
                             "Timed out waiting for device [%s] to reboot into APP mode. Upload was successful.",

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -352,13 +352,22 @@ bool ISDevice::validate(uint32_t timeout) {
     FnProfiler fn("ISDevice::queryDeviceInfoISbl() [" + getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO) + "]", timeout / 2 * 1000);    // this shouldn't really ever take longer than 50ms to execute
     log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::validate(%d) called.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), timeout);
 
+    // Check the discovery hint for this port (set by RelayPortFactory or similar). The
+    // hint is informative only — we still actively validate — but it lets us pick the
+    // most-efficient initial query type. This matters for bootloader devices: NMEA and
+    // DID queries can leave a bootloader in an unresponsive state for a window, so when
+    // the hint says HDW_STATE_BOOTLOADER we start with the ISBL query to land cleanly.
+    const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
+
     // check for Inertial-Sense App by making an NMEA request (which it should respond to)
     is_hardware_t oldHdwId = hdwId;
     dev_info_t oldDevInfo = devInfo;
     hdwId = IS_HARDWARE_NONE,  devInfo = {};    // force a fresh check, don't just take previous values.
 
     bool hasDevInfo = hasDeviceInfo();
-    queryType nextQueryType = QUERYTYPE_NMEA;
+    queryType nextQueryType = (hint && hint->hdwRunState == HDW_STATE_BOOTLOADER)
+                              ? QUERYTYPE_ISbootloader
+                              : QUERYTYPE_NMEA;
     unsigned int startTime = current_timeMs();
     do {
         if ((current_timeMs() - startTime) > timeout) {
@@ -458,6 +467,15 @@ int ISDevice::validateAsync(uint32_t timeout) {
     // if this is non-zero, it means we're actively validating; this helps us know when to give up/timeout
     if (!validationStartMs) {
         validationStartMs = now;
+        // First step of a new validation cycle — pick the initial query type based on
+        // the discovery hint, if any. NMEA/DID queries to a bootloader can leave it in
+        // an unresponsive state, so when the hint says HDW_STATE_BOOTLOADER we lead
+        // with the ISBL query. Without a hint we fall through to NMEA (the default
+        // for app firmware) and round-robin from there.
+        const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
+        if (hint && hint->hdwRunState == HDW_STATE_BOOTLOADER) {
+            nextValidationType = QUERYTYPE_ISbootloader;
+        }
     }
 
     // doing the timeout check first helps during debugging (since stepping through code will likely trigger the timeout.

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -312,10 +312,13 @@ bool ISDevice::queryDeviceInfoISbl(uint32_t timeout) {
                         devInfo.hardwareVer[1] = 0;
                         break;
                     case ISBootloader::IS_PROCESSOR_STM32U5:
-                        // GPX-1
-                        devInfo.hardwareType = IS_HARDWARE_TYPE_GPX; // OR IMX-6.0
-                        devInfo.hardwareVer[0] = 1;
-                        devInfo.hardwareVer[1] = 0;
+                        // STM32U5 hardware (IMX-6 and GPX-1) uses mcuBoot, not ISbl —
+                        // reaching this branch indicates an unexpected/legacy state.
+                        // Don't assign a misleading default like "GPX-1.0" or "IMX-1.0":
+                        // both type and version are ambiguous from the bootloader response
+                        // alone, and a wrong combination can mis-route firmware images.
+                        // Leave hardwareType/hardwareVer untouched so any previously-cached
+                        // identity (set by an APP-state validation upstream) survives.
                         break;
                     case ISBootloader::IS_PROCESSOR_NUM:
                         break;
@@ -359,8 +362,15 @@ bool ISDevice::validate(uint32_t timeout) {
     unsigned int startTime = current_timeMs();
     do {
         if ((current_timeMs() - startTime) > timeout) {
-            // after we've timed out - make a last ditch effort to check for a legacy (<6j) IS bootloader, otherwise fail
-            hdwId = oldHdwId, devInfo = oldDevInfo;
+            // After we've timed out — make a last-ditch effort to check for a legacy (<6j)
+            // IS bootloader, otherwise fail. Only restore the prior identity if it came
+            // from a successful APP-state validation. A previous mis-identification (e.g.
+            // a spurious "uINS-0.0" from an earlier failed validate) would otherwise persist
+            // across the next bootloader bounce and corrupt subsequent ISBL identification.
+            if (oldDevInfo.hdwRunState == HDW_STATE_APP) {
+                hdwId = oldHdwId;
+                devInfo = oldDevInfo;
+            }
             log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::validate(%d) : Device failed to validate in time.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), timeout);
             return (queryDeviceInfoISbl(250) && hasDeviceInfo());
         }

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -956,13 +956,20 @@ void ISFirmwareUpdater::cmd_WaitFor(ISFwUpdaterCmd& cmd) {
         timeoutLabel.clear();      //!< a label to jump to, when a "waitfor" times out (which is not always an error)
     } else if (pingTimeoutExpires && (current_timeMs() > pingTimeoutExpires)) {
         // TIMEOUT occurred
-        cmd.status = ISFwUpdaterCmd::CMD_ERROR;
-        cmd.resultMsg = "Timeout limit reached waiting for response from the target device.";
-        pingTimeoutExpires= pingNextRetry = 0;
+        pingTimeoutExpires = pingNextRetry = 0;
         if (!timeoutLabel.empty()) {
+            // The script provided an on-timeout label, so this is expected control flow,
+            // not a failure. The script's terminal step (typically `:ERROR` with `finish: true`)
+            // is the proper place to flag overall failure. Marking the cmd CMD_ERROR here
+            // would contaminate hasErrors for fully-successful runs that just happened to
+            // skip absent peer modules via their on-timeout fallback.
+            cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+            cmd.resultMsg = "Target not found before timeout; diverting to step " + timeoutLabel;
             LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, cmd.resultMsg.c_str());
             activeCmd = &jumpToStep(timeoutLabel.substr(1));
         } else {
+            cmd.status = ISFwUpdaterCmd::CMD_ERROR;
+            cmd.resultMsg = "Timeout limit reached waiting for response from the target device.";
             handleCommandError(cmd, -1, cmd.resultMsg.c_str());
         }
     } else if (pingInterval && (pingNextRetry < current_timeMs())) {
@@ -1239,10 +1246,21 @@ void ISFirmwareUpdater::cmd_finish(ISFwUpdaterCmd& cmd) {
             cmd.status = ISFwUpdaterCmd::CMD_NOT_EXECUTED;
     bool reportErrors = (cmd.args.size() == 1 && cmd[0] == "true");
     cmd.resultMsg = utils::string_format("Firmware Update completed %s", reportErrors ? "with errors. Please review update log for specifics." : "successfully.");
-    cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
 
-    if (reportErrors)
-        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, cmd.resultMsg.c_str());
+    if (reportErrors) {
+        // Authoritative failure declaration: the script reached `finish: true`, which is
+        // the manifest's way of saying "this run is a failure outcome". Flag it via
+        // CMD_ERROR so refreshUpdateState() picks it up into hasErrors, and record the
+        // message so the dialog's error expansion shows it.
+        cmd.status = ISFwUpdaterCmd::CMD_ERROR;
+        {
+            auto lk = updateState.lock();
+            updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, cmd.resultMsg);
+        }
+        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_ERROR, cmd.resultMsg.c_str());
+    } else {
+        cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+    }
 }
 
 void ISFirmwareUpdater::initialize() {

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -946,7 +946,14 @@ void ISFirmwareUpdater::cmd_WaitFor(ISFwUpdaterCmd& cmd) {
     }
 
     cmd.status = ISFwUpdaterCmd::CMD_IN_PROCESS;
-    if (target_devInfo && ((remoteDevInfoTargetId & fwUpdate::TARGET_TYPE_MASK) == (target & fwUpdate::TARGET_TYPE_MASK))) {
+    // Accept any response that fwUpdate_handleVersionResponse already gated through.
+    // The strict type-mask check originally placed here would loop indefinitely when a
+    // device firmware echoes back resTarget=0 (TARGET_HOST) — a known bug in older
+    // FirmwareUpdateDevice::fwUpdate_handleVersionInfo where session_target was returned
+    // even when uninitialized. handleVersionResponse already rejects responses whose
+    // resTarget is in valid range AND mismatches our target, so anything that surfaces
+    // here as target_devInfo is a legitimate response from this port's device.
+    if (target_devInfo) {
         // SUCCESS
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
         cmd.resultMsg = "Received response from target.";

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -1086,6 +1086,20 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;  // unknown version, use alternate MD5 for safety
         }
 
+        // If the target is in bootloader mode, the app firmware version is unobservable
+        // (firmwareVer reflects the bootloader identifier, e.g. ISbl "v6j" → [6, 'j']).
+        // Any version comparison is wasted energy and tends to look "newer" because
+        // 'j' (106) dwarfs typical app majors. Promote the policy to FORCE so the
+        // upload proceeds and downstream protocol checks are bypassed too. SKIP is
+        // honored — if the caller explicitly asked to skip, we still skip.
+        if (target_devInfo && target_devInfo->hdwRunState == HDW_STATE_BOOTLOADER &&
+            effectivePolicy != UPDATE_POLICY_SKIP && effectivePolicy != UPDATE_POLICY_FORCE) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO,
+                "Target is in bootloader mode; promoting policy to FORCE (app version is unobservable).");
+            effectivePolicy = UPDATE_POLICY_FORCE;
+            forceUpdate = true;
+        }
+
         // IF_NEWER: compare image version against target's current firmware version
         if (effectivePolicy == UPDATE_POLICY_IF_NEWER && target_devInfo) {
             dev_info_t imageDevInfo = {};

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -946,14 +946,7 @@ void ISFirmwareUpdater::cmd_WaitFor(ISFwUpdaterCmd& cmd) {
     }
 
     cmd.status = ISFwUpdaterCmd::CMD_IN_PROCESS;
-    // Accept any response that fwUpdate_handleVersionResponse already gated through.
-    // The strict type-mask check originally placed here would loop indefinitely when a
-    // device firmware echoes back resTarget=0 (TARGET_HOST) — a known bug in older
-    // FirmwareUpdateDevice::fwUpdate_handleVersionInfo where session_target was returned
-    // even when uninitialized. handleVersionResponse already rejects responses whose
-    // resTarget is in valid range AND mismatches our target, so anything that surfaces
-    // here as target_devInfo is a legitimate response from this port's device.
-    if (target_devInfo) {
+    if (target_devInfo && ((remoteDevInfoTargetId & fwUpdate::TARGET_TYPE_MASK) == (target & fwUpdate::TARGET_TYPE_MASK))) {
         // SUCCESS
         cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
         cmd.resultMsg = "Received response from target.";
@@ -1100,13 +1093,20 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;  // unknown version, use alternate MD5 for safety
         }
 
-        // If the target is in bootloader mode, the app firmware version is unobservable
-        // (firmwareVer reflects the bootloader identifier, e.g. ISbl "v6j" → [6, 'j']).
-        // Any version comparison is wasted energy and tends to look "newer" because
-        // 'j' (106) dwarfs typical app majors. Promote the policy to FORCE so the
-        // upload proceeds and downstream protocol checks are bypassed too. SKIP is
-        // honored — if the caller explicitly asked to skip, we still skip.
-        if (target_devInfo && target_devInfo->hdwRunState == HDW_STATE_BOOTLOADER &&
+        // If the target is a MAIN MCU in bootloader mode, the app firmware version is
+        // unobservable (firmwareVer reflects the bootloader identifier, e.g. ISbl "v6j"
+        // → [6, 'j']). Any version comparison is wasted energy and tends to look "newer"
+        // because 'j' (106) dwarfs typical app majors. Promote the policy to FORCE so the
+        // upload proceeds. SKIP is honored — if the caller explicitly asked to skip, we
+        // still skip.
+        //
+        // Scope to non-peripheral types only: peripherals (CXD/UBX/SEP/STM) use a
+        // bootloader-like interface as their NORMAL operating mode, so HDW_STATE_BOOTLOADER
+        // on a peripheral isn't a "device wiped" signal and shouldn't trigger force-flash.
+        const bool isMainMCU = target_devInfo &&
+                               target_devInfo->hardwareType > IS_HARDWARE_TYPE_UNKNOWN &&
+                               target_devInfo->hardwareType < IS_HDW_TYPE_PERIPHERAL;
+        if (isMainMCU && target_devInfo->hdwRunState == HDW_STATE_BOOTLOADER &&
             effectivePolicy != UPDATE_POLICY_SKIP && effectivePolicy != UPDATE_POLICY_FORCE) {
             LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO,
                 "Target is in bootloader mode; promoting policy to FORCE (app version is unobservable).");

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -666,12 +666,16 @@ bool InertialSense::UploadImxCalibrationFromFile(std::string path, port_handle_t
     });
 }
 
-void InertialSense::SetNetworkPortDiscovery(bool enable)
+// Rebuild the PortManager's factory list according to the current enable flags.
+// SerialPortFactory is included by default (m_serialPortDiscoveryEnabled defaults to true);
+// the network and relay factories are opt-in. TcpPortFactory is always present — direct
+// tcp:// URLs are a host-side capability, not a discovery surface.
+void InertialSense::rebuildPortFactories()
 {
-    m_networkPortDiscoveryEnabled = enable;
-
     portManager.clearPortFactories();
-    portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
+    if (m_serialPortDiscoveryEnabled) {
+        portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
+    }
     portManager.addPortFactory((PortFactory*)&(TcpPortFactory::getInstance()));
     if (m_networkPortDiscoveryEnabled) {
         portManager.addPortFactory((PortFactory*)&(ISmDnsPortFactory::getInstance()));
@@ -679,27 +683,26 @@ void InertialSense::SetNetworkPortDiscovery(bool enable)
     if (m_relayPortDiscoveryEnabled) {
         portManager.addPortFactory((PortFactory*)&(RelayPortFactory::getInstance()));
     }
-
-    // Removes all ports from the PortManager
+    // Removes all ports from the PortManager.
     portManager.clear();
+}
+
+void InertialSense::SetSerialPortDiscovery(bool enable)
+{
+    m_serialPortDiscoveryEnabled = enable;
+    rebuildPortFactories();
+}
+
+void InertialSense::SetNetworkPortDiscovery(bool enable)
+{
+    m_networkPortDiscoveryEnabled = enable;
+    rebuildPortFactories();
 }
 
 void InertialSense::SetRelayPortDiscovery(bool enable)
 {
     m_relayPortDiscoveryEnabled = enable;
-
-    // Rebuild the factory list preserving whatever mDNS state was set last.
-    portManager.clearPortFactories();
-    portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
-    portManager.addPortFactory((PortFactory*)&(TcpPortFactory::getInstance()));
-    if (m_networkPortDiscoveryEnabled) {
-        portManager.addPortFactory((PortFactory*)&(ISmDnsPortFactory::getInstance()));
-    }
-    if (m_relayPortDiscoveryEnabled) {
-        portManager.addPortFactory((PortFactory*)&(RelayPortFactory::getInstance()));
-    }
-
-    portManager.clear();
+    rebuildPortFactories();
 }
 
 void InertialSense::ProcessRxData(port_handle_t port, p_data_t* data)

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -577,6 +577,20 @@ public:
      */
     void SetRelayPortDiscovery(bool enable = false);
 
+    /**
+     * Enable or disable local-serial port discovery (SerialPortFactory) alongside the
+     * other registered factories. Defaults to enabled — most consumers want host-attached
+     * USB/UART devices visible. Disable when the host is also running a service that
+     * holds USB serial ports exclusively (e.g. the bridgeboard relay simulator on the
+     * same machine), to avoid the SDK racing the local-OS enumeration against the
+     * relay-mediated discovery for the same physical device.
+     *
+     * @param enable Set to true (default) to register SerialPortFactory, false to remove
+     *               it. Toggling clears PortManager's existing ports, matching the
+     *               SetNetworkPortDiscovery() / SetRelayPortDiscovery() contract.
+     */
+    void SetSerialPortDiscovery(bool enable = true);
+
     // Used for testing
     InertialSense::com_manager_cpp_state_t* ComManagerState() { return &m_comManagerState; }
 
@@ -635,8 +649,13 @@ private:
     int m_baudRate = IS_BAUDRATE_DEFAULT;
     bool m_enableDeviceValidation = true;
     bool m_disableBroadcastsOnClose;
+    bool m_serialPortDiscoveryEnabled  = true;   ///< last value passed to SetSerialPortDiscovery (default on)
     bool m_networkPortDiscoveryEnabled = false;  ///< last value passed to SetNetworkPortDiscovery
     bool m_relayPortDiscoveryEnabled   = false;  ///< last value passed to SetRelayPortDiscovery
+
+    /// Rebuild PortManager's factory list according to the current m_*PortDiscoveryEnabled
+    /// flags and clear its existing ports. Shared by all three Set*PortDiscovery setters.
+    void rebuildPortFactories();
 
     std::vector<std::string> m_ignoredPorts;    //!< port names which should be ignored (known bad, etc).
 

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -65,6 +65,22 @@ public:
      * @return true if the port specified was a valid port, and it was successfully released, otherwise false.
      */
     virtual bool releasePort(port_handle_t port) = 0;
+
+    /**
+     * Called by PortManager when this factory's locatePorts() emitted a port that was
+     * already bound under a *different* factory. PortManager skips this factory's bindPort()
+     * to avoid duplicate allocations, but still gives the factory a chance to perform
+     * post-bind decoration on the existing port — e.g. RelayPortFactory uses this to seed
+     * a device hint into DeviceManager even when TcpPortFactory got there first to claim
+     * the port handle. Default: no-op. The factory must NOT take ownership of the port.
+     *
+     * @param existing the port handle that was already bound under another factory
+     * @param pName the canonical port name (URL or device path)
+     * @param pType the port type bitmask
+     */
+    virtual void onPortAlias(port_handle_t existing, const std::string& pName, uint16_t pType) {
+        (void)existing; (void)pName; (void)pType;
+    }
 };
 
 class SerialPortFactory : public PortFactory {

--- a/src/PortManager.cpp
+++ b/src/PortManager.cpp
@@ -101,6 +101,11 @@ void PortManager::portHandler(PortFactory* factory, uint16_t portType, const std
     // (e.g., dual-stack mDNS producing alias URLs that resolve to the same endpoint).
     for (auto& [entry, existingPort] : knownPorts) {
         if (entry.name == portName && existingPort && portIsValid(existingPort)) {
+            // Skip duplicate port allocation, but give the new factory a chance to do
+            // post-bind decoration on the existing port (e.g. RelayPortFactory seeding
+            // a device hint into DeviceManager). Factories that don't override
+            // onPortAlias() default to a no-op.
+            factory->onPortAlias(existingPort, portName, portType);
             return; // already bound under a different factory — don't duplicate
         }
     }

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -13,6 +13,7 @@
 #include "core/msg_logger.h"
 #include "protocol/mdns.hpp"
 #include "ISComm.h"
+#include "util/util.h"
 
 #include <algorithm>
 #include <chrono>
@@ -37,29 +38,6 @@ is_hardware_t stateToHardwareId(const std::string& state) {
     if (state == "gpx")  return IS_HARDWARE_GPX_1_0;
     if (state == "isbl") return ENCODE_HDW_ID(IS_HARDWARE_TYPE_UINS, 0, 0); // bootloader — type ambiguous
     return IS_HARDWARE_NONE;
-}
-
-/// Parse a firmware version string like "fw3.0.0-snap" or "2.4.0" into a 4-byte array [major, minor, patch, build].
-void parseFirmwareVer(const std::string& verStr, uint8_t out[4]) {
-    out[0] = out[1] = out[2] = out[3] = 0;
-    // Strip leading "fw" prefix if present
-    std::string s = verStr;
-    if (s.size() > 2 && (s[0] == 'f' || s[0] == 'F') && (s[1] == 'w' || s[1] == 'W'))
-        s = s.substr(2);
-    // Parse "major.minor.patch" — ignore anything after a dash or non-numeric
-    int idx = 0;
-    size_t pos = 0;
-    while (idx < 4 && pos < s.size()) {
-        size_t dot = s.find_first_of(".-", pos);
-        if (dot == std::string::npos) dot = s.size();
-        std::string part = s.substr(pos, dot - pos);
-        if (!part.empty()) {
-            try { out[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) {}
-        }
-        idx++;
-        pos = dot + 1;
-        if (dot < s.size() && s[dot] == '-') break; // stop at -snap, -rc1, etc.
-    }
 }
 
 /// Canonicalize any relay input (bare hostname, IP, full URL, URL-with-path) into
@@ -155,10 +133,17 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     if (uri.empty()) return false;
 
     dev_info_t hint = {};
-    is_hardware_t hdwId = stateToHardwareId(state);
-    hint.hardwareType = DECODE_HDW_TYPE(hdwId);
-    hint.hardwareVer[0] = DECODE_HDW_MAJOR(hdwId);
-    hint.hardwareVer[1] = DECODE_HDW_MINOR(hdwId);
+
+    // Prefer the consolidated "hdw" string (e.g. "IMX-5.0", "GPX-1.0.2") when present — it
+    // preserves the cached pre-ISBL identity, so we can still tell IMX-5/IMX-6/GPX apart
+    // when state == "isbl". Older bridgeboards don't emit it, so fall back to state mapping.
+    std::string hdwStr = dev.value("hdw", "");
+    if (hdwStr.empty() || !utils::parseHardwareFromString(hdwStr, hint)) {
+        is_hardware_t hdwId = stateToHardwareId(state);
+        hint.hardwareType = DECODE_HDW_TYPE(hdwId);
+        hint.hardwareVer[0] = DECODE_HDW_MAJOR(hdwId);
+        hint.hardwareVer[1] = DECODE_HDW_MINOR(hdwId);
+    }
     hint.hdwRunState = (state == "isbl") ? HDW_STATE_BOOTLOADER : HDW_STATE_APP;
     hint.serialNumber = dev.value("serial_number", 0u);
 
@@ -171,7 +156,7 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     hint.protocolVer[3] = PROTOCOL_VERSION_CHAR3;
 
     std::string fwVer = dev.value("firmware_ver", "");
-    if (!fwVer.empty()) parseFirmwareVer(fwVer, hint.firmwareVer);
+    if (!fwVer.empty()) utils::parseFirmwareFromString(fwVer, hint);
 
     std::string fwCommit = dev.value("firmware_commit", "");
     if (!fwCommit.empty()) parseRepoRevision(fwCommit, hint);
@@ -182,11 +167,6 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     // Manufacturer isn't in the SN-7804 schema — bridgeboard only relays IS devices,
     // so we hard-code a sane default. This matches what real devices report.
     std::strncpy(hint.manufacturer, "Inertial Sense", sizeof(hint.manufacturer) - 1);
-
-    // Build type — SN-7804 doesn't ship this, but 'r' (production release) is the
-    // default the SDK's display/upload paths tolerate. If it matters later, bridgeboard
-    // can expose it explicitly.
-    hint.buildType = 'r';
 
     out.portUrl = std::move(uri);
     out.hint = hint;

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -410,22 +410,33 @@ bool RelayPortFactory::validatePort(const std::string& pName, uint16_t pType) {
     return false;
 }
 
-port_handle_t RelayPortFactory::bindPort(const std::string& pName, uint16_t pType) {
-    auto port = TcpPortFactory::getInstance().bindPort(pName, pType);
-    if (port) {
-        std::lock_guard<std::recursive_mutex> lock(mutex_);
-        for (const auto& [url, hostPtr] : relayHosts_) {
-            const RelayHost& host = *hostPtr;
-            if (!host.enabled) continue;
-            for (const auto& device : host.devices) {
-                if (device.portUrl == pName) {
-                    DeviceManager::getInstance().seedDeviceHint(port, device.hint);
-                    return port;
-                }
+// If we know a hint for this port (it appears in any enabled relay host's device list),
+// seed it into DeviceManager. Used by both bindPort (when we win the bind race) and
+// onPortAlias (when TcpPortFactory wins for a relay-known URL — the port handle is the
+// same TCP port either way; only the hint-seeding side-effect differs).
+void RelayPortFactory::seedHintForPortIfKnown(port_handle_t port, const std::string& portUrl) {
+    if (!port) return;
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    for (const auto& [url, hostPtr] : relayHosts_) {
+        const RelayHost& host = *hostPtr;
+        if (!host.enabled) continue;
+        for (const auto& device : host.devices) {
+            if (device.portUrl == portUrl) {
+                DeviceManager::getInstance().seedDeviceHint(port, device.hint);
+                return;
             }
         }
     }
+}
+
+port_handle_t RelayPortFactory::bindPort(const std::string& pName, uint16_t pType) {
+    auto port = TcpPortFactory::getInstance().bindPort(pName, pType);
+    seedHintForPortIfKnown(port, pName);
     return port;
+}
+
+void RelayPortFactory::onPortAlias(port_handle_t existing, const std::string& pName, uint16_t /*pType*/) {
+    seedHintForPortIfKnown(existing, pName);
 }
 
 bool RelayPortFactory::releasePort(port_handle_t port) {

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -147,9 +147,12 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     hint.hdwRunState = (state == "isbl") ? HDW_STATE_BOOTLOADER : HDW_STATE_APP;
     hint.serialNumber = dev.value("serial_number", 0u);
 
-    // Protocol version — all four components are compile-time constants baked into the SDK.
-    // Populating only CHAR0 leaves consumers reading CHAR1..3 as zero, which can trip
-    // version-compatibility checks.
+    // Protocol version is the SDK's compile-time constant; populating all four
+    // components keeps version-compatibility checks consistent with what a real
+    // probe response would report. Auto-OPEN side effects are gated separately:
+    // hint-driven device registration (DeviceManager::seedDeviceHint) deliberately
+    // never opens the port, so DEVICE_CONNECTED only fires when the user explicitly
+    // opens the port via Find/Open.
     hint.protocolVer[0] = PROTOCOL_VERSION_CHAR0;
     hint.protocolVer[1] = PROTOCOL_VERSION_CHAR1;
     hint.protocolVer[2] = PROTOCOL_VERSION_CHAR2;

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -128,6 +128,20 @@ public:
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
     bool releasePort(port_handle_t port) override;
 
+    /// PortManager calls this when our locatePorts() emit was deduped against an existing
+    /// port (typically TcpPortFactory got there first for a relay-known tcp:// URL). The
+    /// existing port handle is fine; we just need to seed our device hint into
+    /// DeviceManager so beginValidation can use it. Does NOT create a new port.
+    void onPortAlias(port_handle_t existing, const std::string& pName, uint16_t pType) override;
+
+private:
+    /// Internal helper: if @p portUrl appears in any enabled relay host's device list,
+    /// seed that device's hint into DeviceManager keyed by @p port. Shared by
+    /// bindPort() and onPortAlias().
+    void seedHintForPortIfKnown(port_handle_t port, const std::string& portUrl);
+
+public:
+
     /**
      * External polling driver — same pattern as ISmDnsPortFactory::tick().
      * Drives mDNS host discovery refresh and HTTP polling for all enabled hosts.

--- a/src/core/tcpPort.c
+++ b/src/core/tcpPort.c
@@ -104,8 +104,17 @@ int tcpPortOpen(port_handle_t port) {
  */
 int tcpPortClose(port_handle_t port) {
     tcp_port_t* tcpPort = TCP_PORT(port);
-    if (tcpPort->socket < 0) { // The file descriptor is invalid, creating it errored, or we already closed it.
-        tcpPort->base.perror = -(tcpPort->socket);
+    if (tcpPort->socket < 0) {
+        // socket < 0 covers three cases, none of which are an "operation failed"
+        // for this call:
+        //   1. Never opened (socket initialized to -EBADF in tcpPortInit).
+        //   2. Open previously failed — perror was already stamped at the
+        //      original failure site (HANDLE_SOCKET_ERROR / tcpPortValidate).
+        //   3. Already closed — perror reflects whatever the prior close set.
+        // In all three, closing again is a benign no-op; stamping perror here
+        // would either invent a phantom EBADF (case 1) or overwrite a more
+        // meaningful prior error (cases 2/3) and surface "errant" status to
+        // consumers reading via portError() (e.g. UI markup).
         return tcpPort->socket;
     }
 

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <math.h>
 
 const char* g_isHardwareTypeNames[IS_HARDWARE_TYPE_COUNT] = {"UNKNOWN", "uINS", "EVB", "IMX", "GPX"};
+const char* g_isGnssHardwareNames[IS_HDW_GNSS_TYPE_COUNT] = {"UBX", "CXD", "SEP", "STM"};
 
 // Reversed bytes in a float.
 // compiler will likely inline this as it's a tiny function

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -592,7 +592,8 @@ enum eIsHardwareType
     IS_HDW_GNSS_SEPTENTRIO          = IS_HDW_TYPE_PERIPHERAL + 3,    // Septentrio
     IS_HDW_GNSS_STM_TESSIO          = IS_HDW_TYPE_PERIPHERAL + 4,    // STM Tessio
 
-    IS_HARDWARE_TYPE_COUNT          = 5     // Keep last
+    IS_HARDWARE_TYPE_COUNT          = 5,     // Keep last non-peripheral
+    IS_HDW_GNSS_TYPE_COUNT          = 4      // Number of entries in g_isGnssHardwareNames (IS_HDW_GNSS_UBLOX..STM_TESSIO)
 };
 
 typedef uint16_t is_hardware_t;
@@ -614,6 +615,8 @@ static const is_hardware_t IS_HDW_SEPTENTRIO_P3  = ENCODE_HDW_ID(IS_HDW_GNSS_SEP
 static const is_hardware_t IS_HDW_SEPTENTRIO_M3  = ENCODE_HDW_ID(IS_HDW_GNSS_SEPTENTRIO, 'M' - 'A', 3);
 
 extern const char* g_isHardwareTypeNames[IS_HARDWARE_TYPE_COUNT];
+/// Names for the peripheral GNSS hardware types, indexed by (type - IS_HDW_TYPE_PERIPHERAL - 1).
+extern const char* g_isGnssHardwareNames[IS_HDW_GNSS_TYPE_COUNT];
 
 enum eHdwRunStates {
     HDW_STATE_UNKNOWN,

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -618,7 +618,12 @@ namespace fwUpdate {
         payload_t response;
         response.hdr.target_device = TARGET_HOST;
         response.hdr.msg_type = MSG_VERSION_INFO_RESP;
-        response.data.version_resp.resTarget = session_target;
+        // Echo back the queried target, not session_target — REQ_VERSION_INFO doesn't
+        // update session_target (only REQ_UPDATE does, around line 305), so a standalone
+        // version-info query would otherwise respond with resTarget=0/TARGET_HOST.
+        // Hosts use resTarget to confirm the response is for their requested target;
+        // a mismatched/zero resTarget causes infinite ping-loop on the host side.
+        response.data.version_resp.resTarget = payload.hdr.target_device;
         response.data.version_resp.serialNumber = devInfo.serialNumber;
         response.data.version_resp.hardwareType = devInfo.hardwareType;
         response.data.version_resp.hdwRunState = devInfo.hdwRunState;

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -540,6 +540,11 @@ static int serialPortOpenPlatform(port_handle_t port, const char* portName, int 
     {
         serialPort->errorCode = errno;
         serialPort->error = strerror(serialPort->errorCode);
+        // Stamp the generic base-port error so cross-transport consumers (e.g. UI
+        // port-status markup) can see "this port failed to open" without having to
+        // know about platform-specific errno values. The platform-specific detail
+        // (errno + strerror) remains in serialPort->errorCode/error.
+        serialPort->base.perror = PORT_ERROR__OPEN_FAILURE;
         log_error(IS_LOG_PORT, "[%s] serialPortOpenPlatform():: Error opening port: %s (%d)", portName, serialPort->error, serialPort->errorCode);
         return 0;
     }
@@ -548,6 +553,7 @@ static int serialPortOpenPlatform(port_handle_t port, const char* portName, int 
     {
         serialPort->errorCode = errno;
         serialPort->error = strerror(serialPort->errorCode);
+        serialPort->base.perror = PORT_ERROR__OPEN_FAILURE;
         log_error(IS_LOG_PORT, "[%s] serialPortOpenPlatform():: Error configuring port: %s (%d)", port, serialPort->error, serialPort->errorCode);
         return 0;
     }

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -239,6 +239,21 @@ std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) 
     return out;
 }
 
+// Renders just the type + major + minor captured in an encoded is_hardware_t.
+// Does not include hardwareVer[2]/hardwareVer[3] — those are not part of hdwId.
+std::string utils::getHardwareAsString(is_hardware_t hdwId) {
+    const char *typeName = "\?\?\?";
+    switch (DECODE_HDW_TYPE(hdwId)) {
+        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
+        case IS_HARDWARE_TYPE_IMX:  typeName = "IMX";  break;
+        case IS_HARDWARE_TYPE_GPX:  typeName = "GPX";  break;
+        default:                    typeName = "\?\?\?"; break;
+    }
+    return utils::string_format("%s-%u.%u", typeName,
+                                DECODE_HDW_MAJOR(hdwId),
+                                DECODE_HDW_MINOR(hdwId));
+}
+
 bool utils::parseHardwareFromString(const std::string& s, dev_info_t& devInfo) {
     auto dash = s.find('-');
     if (dash == std::string::npos || dash == 0) return false;

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -216,17 +216,16 @@ std::string utils::did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, in
 }
 
 std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) {
-    // hardware type & version
-    const char *typeName = "\?\?\?";
-    switch (devInfo.hardwareType) {
-        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
-        case IS_HARDWARE_TYPE_IMX: typeName = "IMX"; break;
-        case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
-        case IS_HDW_GNSS_SONY: typeName = "CXD"; break;
-        case IS_HDW_GNSS_UBLOX: typeName = "UBX"; break;
-        case IS_HDW_GNSS_SEPTENTRIO: typeName = "SEP"; break;
-        case IS_HDW_GNSS_STM_TESSIO: typeName = "STM"; break;
-        default: typeName = "\?\?\?"; break;
+    // hardware type & version — resolved via the canonical tables in data_sets.c.
+    const char* typeName = "\?\?\?";
+    const uint8_t t = devInfo.hardwareType;
+    if (t > 0 && t < IS_HARDWARE_TYPE_COUNT) {
+        typeName = g_isHardwareTypeNames[t];
+    } else if (t > IS_HDW_TYPE_PERIPHERAL) {
+        const int peripheralIdx = static_cast<int>(t) - IS_HDW_TYPE_PERIPHERAL - 1;
+        if (peripheralIdx >= 0 && peripheralIdx < IS_HDW_GNSS_TYPE_COUNT) {
+            typeName = g_isGnssHardwareNames[peripheralIdx];
+        }
     }
     std::string out = utils::string_format("%s-%u.%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1]);
     if (!showRev)
@@ -238,6 +237,95 @@ std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) 
             out += utils::string_format(".%u", devInfo.hardwareVer[3]);
     }
     return out;
+}
+
+bool utils::parseHardwareFromString(const std::string& s, dev_info_t& devInfo) {
+    auto dash = s.find('-');
+    if (dash == std::string::npos || dash == 0) return false;
+
+    const std::string typeName = s.substr(0, dash);
+    uint8_t type = 0;
+    bool matched = false;
+    // Skip index 0 ("UNKNOWN") — it's a placeholder, not a real hardware type.
+    for (int i = 1; i < IS_HARDWARE_TYPE_COUNT; ++i) {
+        if (typeName == g_isHardwareTypeNames[i]) {
+            type = static_cast<uint8_t>(i);
+            matched = true;
+            break;
+        }
+    }
+    if (!matched) {
+        for (int i = 0; i < IS_HDW_GNSS_TYPE_COUNT; ++i) {
+            if (typeName == g_isGnssHardwareNames[i]) {
+                type = static_cast<uint8_t>(IS_HDW_TYPE_PERIPHERAL + 1 + i);
+                matched = true;
+                break;
+            }
+        }
+    }
+    if (!matched) return false;
+
+    uint8_t ver[4] = {0, 0, 0, 0};
+    size_t pos = dash + 1;
+    for (int idx = 0; idx < 4 && pos < s.size(); ++idx) {
+        size_t dot = s.find('.', pos);
+        if (dot == std::string::npos) dot = s.size();
+        const std::string part = s.substr(pos, dot - pos);
+        if (!part.empty()) {
+            try { ver[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) { return false; }
+        }
+        pos = dot + 1;
+    }
+
+    devInfo.hardwareType = type;
+    for (int i = 0; i < 4; ++i) devInfo.hardwareVer[i] = ver[i];
+    return true;
+}
+
+bool utils::parseFirmwareFromString(const std::string& s, dev_info_t& devInfo) {
+    // Strip optional "fw" prefix.
+    std::string w = s;
+    if (w.size() >= 2 && (w[0] == 'f' || w[0] == 'F') && (w[1] == 'w' || w[1] == 'W'))
+        w = w.substr(2);
+    if (w.empty()) return false;
+
+    // Split at the first '-' (build-type suffix); everything before is "<M>.<m>.<p>".
+    const size_t dash = w.find('-');
+    const std::string head = (dash == std::string::npos) ? w : w.substr(0, dash);
+    const std::string tail = (dash == std::string::npos) ? ""  : w.substr(dash + 1);
+
+    uint8_t fv[4] = {0, 0, 0, 0};
+    size_t pos = 0;
+    for (int idx = 0; idx < 3 && pos < head.size(); ++idx) {
+        const size_t dot = head.find('.', pos);
+        const size_t end = (dot == std::string::npos) ? head.size() : dot;
+        const std::string part = head.substr(pos, end - pos);
+        if (!part.empty()) {
+            try { fv[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) { return false; }
+        }
+        if (dot == std::string::npos) break;
+        pos = dot + 1;
+    }
+
+    // Decode build-type suffix and optional ".<build>" trailing number.
+    char buildType = 'r';
+    if (!tail.empty()) {
+        const size_t trailDot = tail.find('.');
+        const std::string label = (trailDot == std::string::npos) ? tail : tail.substr(0, trailDot);
+        if      (label == "alpha") buildType = 'a';
+        else if (label == "beta")  buildType = 'b';
+        else if (label == "rc")    buildType = 'c';
+        else if (label == "devel") buildType = 'd';
+        else if (label == "snap")  buildType = 's';
+        else buildType = 'r'; // unknown label — treat as release
+        if (trailDot != std::string::npos) {
+            try { fv[3] = static_cast<uint8_t>(std::stoi(tail.substr(trailDot + 1))); } catch (...) {}
+        }
+    }
+
+    for (int i = 0; i < 4; ++i) devInfo.firmwareVer[i] = fv[i];
+    devInfo.buildType = buildType;
+    return true;
 }
 
 std::string utils::getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix) {

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -244,10 +244,14 @@ std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) 
 std::string utils::getHardwareAsString(is_hardware_t hdwId) {
     const char *typeName = "\?\?\?";
     switch (DECODE_HDW_TYPE(hdwId)) {
-        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
-        case IS_HARDWARE_TYPE_IMX:  typeName = "IMX";  break;
-        case IS_HARDWARE_TYPE_GPX:  typeName = "GPX";  break;
-        default:                    typeName = "\?\?\?"; break;
+        case IS_HARDWARE_TYPE_UINS:    typeName = "uINS"; break;
+        case IS_HARDWARE_TYPE_IMX:     typeName = "IMX";  break;
+        case IS_HARDWARE_TYPE_GPX:     typeName = "GPX";  break;
+        case IS_HDW_GNSS_SONY:         typeName = "CXD";  break;
+        case IS_HDW_GNSS_UBLOX:        typeName = "UBX";  break;
+        case IS_HDW_GNSS_SEPTENTRIO:   typeName = "SEP";  break;
+        case IS_HDW_GNSS_STM_TESSIO:   typeName = "STM";  break;
+        default:                       typeName = "\?\?\?"; break;
     }
     return utils::string_format("%s-%u.%u", typeName,
                                 DECODE_HDW_MAJOR(hdwId),

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -224,6 +224,7 @@ namespace utils {
     };
 
     std::string getHardwareAsString(const dev_info_t& devInfo, bool showRev = true);
+    std::string getHardwareAsString(is_hardware_t hdwId);
     std::string getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix = "fw");
     std::string getBuildAsString(const dev_info_t& devInfo, uint16_t flags = -1, const std::string& sep = " ");
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -226,6 +226,17 @@ namespace utils {
     std::string getHardwareAsString(const dev_info_t& devInfo, bool showRev = true);
     std::string getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix = "fw");
     std::string getBuildAsString(const dev_info_t& devInfo, uint16_t flags = -1, const std::string& sep = " ");
+
+    /// Parse a hardware identity string (inverse of getHardwareAsString). Accepts "<TYPE>-<major>.<minor>[.<p2>[.<p3>]]"
+    /// e.g. "IMX-5.0", "GPX-1.0.2", "uINS-3.2". Populates devInfo.hardwareType and hardwareVer[0..3].
+    /// Returns false on unrecognized type prefix or malformed version — caller should leave devInfo unchanged.
+    bool parseHardwareFromString(const std::string& s, dev_info_t& devInfo);
+
+    /// Parse a firmware version string (inverse of getFirmwareAsString). Accepts optional "fw" prefix followed by
+    /// "<M>.<m>.<p>" and an optional build-type suffix "-alpha|-beta|-rc|-devel|-snap" with optional ".<build>".
+    /// Populates devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|'r' for release/no suffix).
+    /// Returns false on malformed input.
+    bool parseFirmwareFromString(const std::string& s, dev_info_t& devInfo);
     // semver::version<uint8_t, uint8_t, uint8_t> getSemanticVersion(const dev_info_t& devInfo, uint16_t flags = -1);
 
     std::string getCurrentTimestamp();

--- a/tests/test_RelayPortFactory.cpp
+++ b/tests/test_RelayPortFactory.cpp
@@ -31,8 +31,12 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// Compose one device entry in the SN-7804 schema.
-json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0, const std::string& state = "imx6") {
+/// Compose one device entry in the SN-7804 schema. The optional `hdw` parameter mirrors
+/// bridgeboard's consolidated hardware identity string (the cached pre-ISBL identity). When
+/// empty, it is derived from `state` for convenience; pass it explicitly for `state == "isbl"`
+/// to exercise the identity-preservation path.
+json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0,
+                const std::string& state = "imx6", const std::string& hdw = "") {
     json d = {
         {"testbed", testbed},
         {"slot", slot},
@@ -42,6 +46,13 @@ json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0, 
         {"device_path", std::string("/dev/ttyACM") + std::to_string(slot)},
         {"has_tcp_client", false},
     };
+    std::string hdwOut = hdw;
+    if (hdwOut.empty()) {
+        if      (state == "imx5") hdwOut = "IMX-5.0";
+        else if (state == "imx6") hdwOut = "IMX-6.0";
+        else if (state == "gpx")  hdwOut = "GPX-1.0";
+    }
+    if (!hdwOut.empty()) d["hdw"] = hdwOut;
     if (sn) {
         d["serial_number"] = sn;
         d["firmware_ver"] = "fw3.0.0-test";

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -128,3 +128,86 @@ TEST(test_utils, parse_devInfo_from_filename) {
     // EXPECT_EQ(devInfoStr, "GPX-1.0 fw2.3.0-snap.153 2024-12-17 00:28:37");
 
 }
+
+TEST(test_utils, parseHardwareFromString_roundtrip) {
+    dev_info_t devInfo = {};
+
+    ASSERT_TRUE(utils::parseHardwareFromString("IMX-5.0", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_IMX);
+    EXPECT_EQ(devInfo.hardwareVer[0], 5);
+    EXPECT_EQ(devInfo.hardwareVer[1], 0);
+    EXPECT_EQ(devInfo.hardwareVer[2], 0);
+    EXPECT_EQ(devInfo.hardwareVer[3], 0);
+
+    ASSERT_TRUE(utils::parseHardwareFromString("GPX-1.0.2", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_GPX);
+    EXPECT_EQ(devInfo.hardwareVer[0], 1);
+    EXPECT_EQ(devInfo.hardwareVer[1], 0);
+    EXPECT_EQ(devInfo.hardwareVer[2], 2);
+
+    ASSERT_TRUE(utils::parseHardwareFromString("uINS-3.2.1.4", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_UINS);
+    EXPECT_EQ(devInfo.hardwareVer[0], 3);
+    EXPECT_EQ(devInfo.hardwareVer[1], 2);
+    EXPECT_EQ(devInfo.hardwareVer[2], 1);
+    EXPECT_EQ(devInfo.hardwareVer[3], 4);
+
+    // Round-trip: emit then parse.
+    devInfo = {};
+    devInfo.hardwareType = IS_HARDWARE_TYPE_IMX;
+    devInfo.hardwareVer[0] = 5; devInfo.hardwareVer[1] = 1;
+    std::string s = utils::getHardwareAsString(devInfo);
+    dev_info_t parsed = {};
+    ASSERT_TRUE(utils::parseHardwareFromString(s, parsed));
+    EXPECT_EQ(parsed.hardwareType, devInfo.hardwareType);
+    EXPECT_EQ(parsed.hardwareVer[0], devInfo.hardwareVer[0]);
+    EXPECT_EQ(parsed.hardwareVer[1], devInfo.hardwareVer[1]);
+
+    // Malformed input is rejected without mutating devInfo.
+    dev_info_t before = parsed;
+    EXPECT_FALSE(utils::parseHardwareFromString("", parsed));
+    EXPECT_FALSE(utils::parseHardwareFromString("IMX", parsed));
+    EXPECT_FALSE(utils::parseHardwareFromString("BOGUS-1.0", parsed));
+    EXPECT_EQ(parsed.hardwareType, before.hardwareType);
+    EXPECT_EQ(parsed.hardwareVer[0], before.hardwareVer[0]);
+}
+
+TEST(test_utils, parseFirmwareFromString_roundtrip) {
+    dev_info_t devInfo = {};
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0", devInfo));
+    EXPECT_EQ(devInfo.firmwareVer[0], 3);
+    EXPECT_EQ(devInfo.firmwareVer[1], 0);
+    EXPECT_EQ(devInfo.firmwareVer[2], 0);
+    EXPECT_EQ(devInfo.firmwareVer[3], 0);
+    EXPECT_EQ(devInfo.buildType, 'r');
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0-devel.175", devInfo));
+    EXPECT_EQ(devInfo.firmwareVer[0], 3);
+    EXPECT_EQ(devInfo.firmwareVer[3], 175);
+    EXPECT_EQ(devInfo.buildType, 'd');
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("2.1.7-rc.83", devInfo)); // no 'fw' prefix
+    EXPECT_EQ(devInfo.firmwareVer[0], 2);
+    EXPECT_EQ(devInfo.firmwareVer[1], 1);
+    EXPECT_EQ(devInfo.firmwareVer[2], 7);
+    EXPECT_EQ(devInfo.firmwareVer[3], 83);
+    EXPECT_EQ(devInfo.buildType, 'c');
+
+    // Round-trip: emit then parse.
+    dev_info_t src = {};
+    src.firmwareVer[0] = 2; src.firmwareVer[1] = 4; src.firmwareVer[2] = 0; src.firmwareVer[3] = 12;
+    src.buildType = 's';
+    std::string s = utils::getFirmwareAsString(src);
+    dev_info_t parsed = {};
+    ASSERT_TRUE(utils::parseFirmwareFromString(s, parsed));
+    EXPECT_EQ(parsed.firmwareVer[0], src.firmwareVer[0]);
+    EXPECT_EQ(parsed.firmwareVer[1], src.firmwareVer[1]);
+    EXPECT_EQ(parsed.firmwareVer[2], src.firmwareVer[2]);
+    EXPECT_EQ(parsed.firmwareVer[3], src.firmwareVer[3]);
+    EXPECT_EQ(parsed.buildType, src.buildType);
+
+    // ISBL "firmware_ver" like "ISbl.v6j **BOOTLOADER**" is not parseable — helper returns false,
+    // caller leaves fields at whatever they were.
+    EXPECT_FALSE(utils::parseFirmwareFromString("ISbl.v6j **BOOTLOADER**", parsed));
+}


### PR DESCRIPTION
## Summary

Multiple SDK fixes addressing firmware-update durability issues over the bridgeboard relay (and also surfaced for direct paths). Companion is-common PR at inertialsense/imx#SN-7891 bumps the submodule pointer.

**Slim discovery / hint propagation**
- `RelayPortFactory::parseDeviceJson` parses the new consolidated `hdw` field from the bridgeboard's slim discovery JSON (preserves cached pre-ISBL identity so clients can pick the correct firmware image even when `state == "isbl"`).
- New `utils::parseHardwareFromString` / `utils::parseFirmwareFromString` helpers (inverses of the existing `getHardwareAsString` / `getFirmwareAsString`) used by the parser.
- New `g_isGnssHardwareNames` table for peripheral GNSS types (UBX/CXD/SEP/STM).
- Added `getHardwareAsString(is_hardware_t)` overload + GNSS extension (cherry-picked from bridgeboard's SN-7682 branch — supports rendering identity from a cached `is_hardware_t`).

**Policy / state-machine fixes in `ISFirmwareUpdater`**
- IF_NEWER promoted to FORCE when target is in `HDW_STATE_BOOTLOADER` *and* it's a main MCU (not a peripheral). The bootloader version is unobservable, so version comparison is meaningless.
- `cmd_WaitFor` timeout WITH `on-timeout` label is now graceful (CMD_SUCCESS) — the script's explicit fallback label means the case is handled. Prior behavior contaminated `hasErrors` for runs that just gracefully skipped absent peer modules.
- `cmd_finish: true` now sets CMD_ERROR + records the message at IS_LOG_LEVEL_ERROR — becomes the authoritative failure verdict, since timeouts no longer flag.
- Device-side `fwUpdate_handleVersionInfo` echoes back `payload.hdr.target_device` as `resTarget` (was `session_target`, which was uninitialized for standalone REQ_VERSION_INFO and caused infinite ping-loop on the host).

**ISBFirmwareUpdater post-flash heartbeat**
- Lifted the rate-limited progress emission to the top of UPDATE_DONE so it fires regardless of the device-rediscovery sub-branch. Without it, the host's `last_message` timer expired during the legitimate post-reset reboot wait and falsely reported "No Response from device."

**ISDevice identity persistence**
- `queryDeviceInfoISbl` STM32U5 case no longer stamps a misleading default — STM32U5 hardware (IMX-6 / GPX-1) doesn't actually use ISbl (uses mcuBoot), so reaching that branch is unexpected; preserve any cached identity.
- `validate()` timeout-to-ISBL path only restores prior `oldDevInfo` when it represents an APP-state validation. Stale misidentifications no longer carry across bootloader bounces.

**cltool**
- Periodic `discoverPorts()` during -ufpkg now scopes to the originally-resolved comPort (was using the default match-all `(.+)` pattern, which had cltool grabbing TCP sockets to every relay-known device on a fixture testbed and blocking concurrent clients).
- Re-checks `device->fwUpdateState.hasErrors` before printing success/failure, eliminating the contradictory `Firmware update successful! / Exit Status: -5` ending.

**Hint-driven device discovery / port-error consistency**
- `DeviceManager::seedDeviceHint` registers a Device immediately when a relay snapshot supplies a complete identity. The port is intentionally left closed: `deviceHandler` only fires `DEVICE_CONNECTED` when `portIsOpened()`, and relay ports come back from `bindPort()` closed. Result is `DEVICE_ADDED` + `DEVICE_PORT_BOUND` only — real validation, port-open, and `DEVICE_CONNECTED` happen later when something explicitly opens the port. This is the SDK-side enabler for "ports show with hint info but don't auto-connect" in EvalTool.
- `DeviceManager::notifyListeners` snapshots the listener vector under the lock and dispatches after release. Fixes an AB/BA deadlock between the IOManager-COMM thread (`ISDevice::step` holds `portMutex`, fires `DEVICE_DISCONNECTED` via `notifyListeners` → wants `DM::mutex`) and the main thread (`discoverDevices` holds `DM::mutex`, `validate→SendRaw` wants `portMutex`). Reproduced reliably by toggling Enable Serial Ports off in EvalTool's Port Options dialog and clicking Apply.
- `serialPortPlatform`: serial open failures now stamp `base.perror = PORT_ERROR__OPEN_FAILURE` in addition to platform-specific `serialPort->errorCode`. Cross-transport consumers (UI markup, RPC clients, tests) can now tell a busy/locked serial port from a closed one.
- `core/tcpPort`: `tcpPortClose` no longer stamps `perror` when `socket < 0` (never opened, prior open failure already stamped, or already closed). All three are benign close-on-closed cases; stamping there manufactured phantom EBADF on relay TCP ports that got `disconnect()`'d through `findDevices()`.

## Test plan
- [x] Unit tests pass (`IS-SDK_unit-tests` — 17/17 including parseHardwareFromString/parseFirmwareFromString round-trips, FakeBridgeboard SSE round-trips, FirmwareUpdate exchange tests)
- [x] cltool builds clean
- [x] End-to-end: IMX-5 in ISBL flashed to APP via cltool over relay (SN64138)
- [x] EvalTool validation: forced GPX update completes cleanly (no false-positive errors)
- [x] EvalTool validation: IF_NEWER skip flow no longer contaminates hasErrors via on-timeout fallbacks
- [x] EvalTool validation: relay devices appear at startup with hint info; no auto-connect; toggling Enable Serial Ports completes cleanly without deadlock
- [x] EvalTool validation: amber-status decoration fires only when a real port operation failed (no spurious EBADF on never-opened TCP)
- [ ] Re-run after deployed devices are re-flashed with this SDK (deployed firmware still has the old `resTarget=session_target=0` bug, so CXD/peripheral pings will loop until they're rebuilt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)