### PR TITLE
SN-7964: Fix version regression at exact 256-commit multiples past tag

### DIFF
--- a/scripts/lib/version_tools.py
+++ b/scripts/lib/version_tools.py
@@ -192,7 +192,9 @@ class RepositoryInfo:
         self.tag = get_env_or_default("0.0.0" if self.repo is None else self.git_cmd.describe(["--tags", "--abbrev=0"]), "REPO_TAG")
 
         try:
-            self.distance_from_tag = int(get_env_or_default(None if self.repo is None else self.git_cmd.rev_list(["--count", self.tag + "..HEAD"]), "REPO_DISTANCE")) % 256     # Wrap to uint8 range (0-255) to match size of dev_info_t.firmwareVer[3]
+            # Keep raw distance: distance == 0 has special meaning ("on a release tag") in get_latest_version().
+            # The uint8 wrap for dev_info_t.firmwareVer[3] is applied by get_prerelease_number() at the point of use.
+            self.distance_from_tag = int(get_env_or_default(None if self.repo is None else self.git_cmd.rev_list(["--count", self.tag + "..HEAD"]), "REPO_DISTANCE"))
         except TypeError:
             self.distance_from_tag = None
 


### PR DESCRIPTION
## Summary
Drops the `% 256` wrap on `distance_from_tag` in `scripts/lib/version_tools.py`. Commit `0782d50f` ("Version prerelease parity", #1060) replaced `min(distance, 255)` with `distance % 256` — the wrap is correct for the uint8 `dev_info_t.firmwareVer[3]` byte, but applying it to the canonical `distance_from_tag` value means *any* HEAD that lands exactly N×256 commits past the latest tag wraps to 0, which trips the `if distance == 0` "Official Release" branch in `get_latest_version()` and pins the emitted version to the tag string.

This regressed develop builds today: is-common HEAD is exactly 256 commits past tag 2.7.0, so firmware was reporting 2.7.0 instead of 3.0.0 (per the semver file).

The uint8 wrap still happens — `get_prerelease_number()` does its own `% 256` when packing the prerelease number into `firmwareVer[3]`, so the firmware-field semantics are unchanged.

## Test plan
- [x] `update_version_files.sh` on is-common@develop (256 past 2.7.0) now emits `3.0.0-devel.256+...` with `REPO_VERSION_MAJOR 3 / MINOR 0 / REVIS 0`
- [x] `REPO_VERSION_PRERELEASE` is still `0` (256 % 256), preserving firmwareVer[3] behaviour
- [ ] Reviewer: spot-check that build numbers stay sane on commits ≥ 256 past tag (no 8-bit assumptions left elsewhere on `distance_from_tag`)

Paired with inertialsense/imx PR for the IMX-5 factory image bootloader-header fix (same branch name; bumps this SDK pointer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)