### PR TITLE
chore(cmake): export YAML_CPP_STATIC_DEFINE to consumers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,13 @@ endif()
 
 # Other settings
 if (WIN32)
-    # yamlcpp needs to know it's a static lib.
-    add_definitions(-DYAML_CPP_STATIC_DEFINE)
+    # yamlcpp needs to know it's a static lib. PUBLIC so consumers of
+    # InertialSenseSDK (e.g. Logalyzer) inherit the define — without
+    # it, yaml-cpp headers emit __declspec(dllimport) symbols that the
+    # linker can't satisfy against the SDK's static lib (LNK2019 on
+    # YAML::Node::AssignData and similar). add_definitions() is
+    # directory-scoped and doesn't propagate to consumers.
+    target_compile_definitions(${PROJECT_NAME} PUBLIC YAML_CPP_STATIC_DEFINE)
 
     # Windows specific include dir for libusb config.h
     if (MSVC)


### PR DESCRIPTION
## Summary

One-line fix surfaced by Logalyzer's D-202 CI workflow on Windows. `add_definitions(-DYAML_CPP_STATIC_DEFINE)` is directory-scoped — it only applies to targets defined inside the SDK's CMakeLists. Downstream consumers (Logalyzer's `Logalyzer`, `test_zen_mode`, `test_workspace`) include yaml-cpp headers via the SDK's PUBLIC include dirs but don't see the static-define macro, so the headers emit `__declspec(dllimport)` symbols that the linker can't resolve against the SDK's static lib.

```
LNK2019: unresolved external symbol
  "__declspec(dllimport) private: void __cdecl
   YAML::Node::AssignData(class YAML::Node const &)"
```

Switching to `target_compile_definitions(InertialSenseSDK PUBLIC YAML_CPP_STATIC_DEFINE)` attaches the define to the target's `INTERFACE_COMPILE_DEFINITIONS` so consumers inherit it automatically. No behavior change for the SDK's own translation units (they still see the same macro, now via the target's `COMPILE_DEFINITIONS` rather than directory-level).

Linux/macOS unaffected — the WIN32 guard is unchanged and they don't need this define anyway.

## Test plan

- [x] SDK still builds on Linux (pre-merge: identical to current logalyzer-develop tip on Linux side; the file change is inside `if(WIN32)`)
- [ ] Logalyzer's D-202 CI Windows job (PR #14) flips green after this merges + a Logalyzer-side submodule bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)