### PR TITLE
D-08 (SN-7898): ISLogWriter — RAW + .idx v2 sidecar

### DIFF
--- a/ExampleProjects/ISLogWriter/CMakeLists.txt
+++ b/ExampleProjects/ISLogWriter/CMakeLists.txt
@@ -1,0 +1,7 @@
+# ExampleProjects/ISLogWriter/CMakeLists.txt — D-08 / SN-7898 stub.
+# Full example lands with D-11 / SN-7900.
+
+cmake_minimum_required(VERSION 3.16)
+project(ISLogWriter_example LANGUAGES CXX)
+
+message(STATUS "ExampleProjects/ISLogWriter: stub (D-08); full example lands with D-11.")

--- a/ExampleProjects/ISLogWriter/README.md
+++ b/ExampleProjects/ISLogWriter/README.md
@@ -1,0 +1,59 @@
+# `ISLogWriter` — RAW + `.idx` v2 sidecar writer *(stub — D-11 fills out the full example)*
+
+Placeholder slot reserved by **D-08 / SN-7898** for the `ISLogWriter`
+walkthrough — typically a bake-trim-style demo: read records from a
+source `.raw`, filter through a predicate, write the matches into a
+new `.raw` + `.idx` pair. Full code drops in with **D-11 / SN-7900**
+(Doxygen + ExampleProjects).
+
+## Quickstart
+
+```cpp
+#include "ISLogReader.h"
+#include "ISLogWriter.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " <in.raw> <out.raw>\n";
+        return 1;
+    }
+
+    using namespace inertial_sense;
+    auto reader = ISLogReader::openSegment(argv[1]);
+    if (!reader) {
+        std::cerr << "open failed: " << reader.error().message << "\n";
+        return 2;
+    }
+
+    auto writer = ISLogWriter::create(argv[2], reader->deviceId());
+    if (!writer) {
+        std::cerr << "create failed: " << writer.error().message << "\n";
+        return 3;
+    }
+
+    auto count = writer->appendFiltered(
+        reader->allRecords(),
+        [](const ISRecordView&) { return true; });  // example: copy all
+    if (!count) {
+        std::cerr << "append failed: " << count.error().message << "\n";
+        return 4;
+    }
+
+    auto fin = writer->finalize();
+    if (!fin) {
+        std::cerr << "finalize failed: " << fin.error().message << "\n";
+        return 5;
+    }
+
+    std::cout << "wrote " << count.value() << " records to " << argv[2] << "\n";
+    return 0;
+}
+```
+
+## Related
+
+- API: [`SDK/src/ISLogWriter.h`](../../src/ISLogWriter.h)
+- Story: [SN-7898](https://inertialsense.atlassian.net/browse/SN-7898)
+- Follow-up: [SN-7900 (D-11)](https://inertialsense.atlassian.net/browse/SN-7900)

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -643,6 +643,7 @@ ISRecordView ISLogReader::viewAt(std::size_t recordIdx) const noexcept {
         rec.offset,
         dataPtr,
         dataLen,
+        rec.flags,
     };
 }
 

--- a/src/ISLogWriter.cpp
+++ b/src/ISLogWriter.cpp
@@ -1,0 +1,349 @@
+/**
+ * @file ISLogWriter.cpp
+ * @brief Implementation of the narrow-scope SDK 3.0 writer.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISLogWriter.h"
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <system_error>
+#include <utility>
+
+namespace inertial_sense {
+
+namespace {
+
+constexpr uint32_t kProducerVersion = 0x00030000u;  // SDK 3.0 marker
+
+std::filesystem::path deriveIdxPath(const std::filesystem::path& raw) {
+    if (raw.extension() == ".raw") {
+        std::filesystem::path out = raw;
+        out.replace_extension(".idx");
+        return out;
+    }
+    std::filesystem::path out = raw;
+    out += ".idx";
+    return out;
+}
+
+std::filesystem::path withTmpSuffix(const std::filesystem::path& p) {
+    std::filesystem::path out = p;
+    out += ".tmp";
+    return out;
+}
+
+} // namespace
+
+// ----- Lifecycle -----------------------------------------------------------
+
+ISExpected<ISLogWriter> ISLogWriter::create(Options opts) {
+    if (opts.rawOutPath.empty()) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::create: rawOutPath is empty");
+    }
+
+    const auto rawOut = opts.rawOutPath;
+    const auto idxOut = deriveIdxPath(rawOut);
+
+    if (!rawOut.parent_path().empty()) {
+        std::error_code ec;
+        if (!std::filesystem::is_directory(rawOut.parent_path(), ec)) {
+            return fail(ISErrorCode::InvalidArgument,
+                        "ISLogWriter::create: parent directory does not exist: "
+                        + rawOut.parent_path().string());
+        }
+    }
+
+    std::error_code ec;
+    if (!opts.overwrite) {
+        if (std::filesystem::exists(rawOut, ec)) {
+            return fail(ISErrorCode::InvalidArgument,
+                        "ISLogWriter::create: output already exists: "
+                        + rawOut.string());
+        }
+        if (std::filesystem::exists(idxOut, ec)) {
+            return fail(ISErrorCode::InvalidArgument,
+                        "ISLogWriter::create: output already exists: "
+                        + idxOut.string());
+        }
+    }
+
+    const auto rawTmp = withTmpSuffix(rawOut);
+    const auto idxTmp = withTmpSuffix(idxOut);
+
+    // Best-effort cleanup of stale tempfiles from a previous crashed session
+    // — we own these names by convention.
+    std::filesystem::remove(rawTmp, ec);
+    std::filesystem::remove(idxTmp, ec);
+
+    ISLogWriter w;
+    w.rawOutPath_     = rawOut;
+    w.idxOutPath_     = idxOut;
+    w.rawTmpPath_     = rawTmp;
+    w.idxTmpPath_     = idxTmp;
+    w.sourceDeviceId_ = opts.sourceDeviceId;
+    w.lineageNote_    = std::move(opts.lineageNote);
+    w.header_         = idx::makeDefaultHeader(kProducerVersion,
+                                               opts.tsUnits,
+                                               opts.tsSource);
+
+    w.rawStream_.open(rawTmp,
+                      std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!w.rawStream_.is_open()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::create: cannot open " + rawTmp.string());
+    }
+
+    w.idxStream_.open(idxTmp,
+                      std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!w.idxStream_.is_open()) {
+        w.rawStream_.close();
+        std::filesystem::remove(rawTmp, ec);
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::create: cannot open " + idxTmp.string());
+    }
+
+    // Seed the .idx with a placeholder header. `finalize()` will seek
+    // back to offset 0 and rewrite it with real stats + FINALIZED.
+    uint8_t buf[idx::IS_LOG_IDX_HEADER_SIZE];
+    idx::serializeHeader(buf, w.header_);
+    w.idxStream_.write(reinterpret_cast<const char*>(buf),
+                       idx::IS_LOG_IDX_HEADER_SIZE);
+    if (!w.idxStream_.good()) {
+        w.cleanupTempfiles();
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::create: failed writing placeholder header");
+    }
+
+    w.initialized_ = true;
+    return w;
+}
+
+ISExpected<ISLogWriter> ISLogWriter::create(
+    std::filesystem::path rawOutPath,
+    uint64_t sourceDeviceId,
+    std::optional<std::string> lineageNote) {
+    Options o;
+    o.rawOutPath     = std::move(rawOutPath);
+    o.sourceDeviceId = sourceDeviceId;
+    o.lineageNote    = std::move(lineageNote);
+    return create(std::move(o));
+}
+
+ISLogWriter::~ISLogWriter() {
+    if (initialized_ && !finalized_) {
+        std::cerr << "[ISLogWriter] destroyed without finalize() — "
+                  << "removing tempfiles for " << rawOutPath_.string()
+                  << std::endl;
+        cleanupTempfiles();
+    }
+}
+
+ISLogWriter::ISLogWriter(ISLogWriter&& other) noexcept
+    : rawOutPath_(std::move(other.rawOutPath_)),
+      idxOutPath_(std::move(other.idxOutPath_)),
+      rawTmpPath_(std::move(other.rawTmpPath_)),
+      idxTmpPath_(std::move(other.idxTmpPath_)),
+      rawStream_(std::move(other.rawStream_)),
+      idxStream_(std::move(other.idxStream_)),
+      header_(other.header_),
+      sourceDeviceId_(other.sourceDeviceId_),
+      lineageNote_(std::move(other.lineageNote_)),
+      recordCount_(other.recordCount_),
+      firstTimestamp_(other.firstTimestamp_),
+      lastTimestamp_(other.lastTimestamp_),
+      syncPointCount_(other.syncPointCount_),
+      rawOffset_(other.rawOffset_),
+      initialized_(other.initialized_),
+      finalized_(other.finalized_) {
+    other.initialized_ = false;
+    other.finalized_   = false;
+}
+
+ISLogWriter& ISLogWriter::operator=(ISLogWriter&& other) noexcept {
+    if (this != &other) {
+        if (initialized_ && !finalized_) {
+            cleanupTempfiles();
+        }
+        rawOutPath_     = std::move(other.rawOutPath_);
+        idxOutPath_     = std::move(other.idxOutPath_);
+        rawTmpPath_     = std::move(other.rawTmpPath_);
+        idxTmpPath_     = std::move(other.idxTmpPath_);
+        rawStream_      = std::move(other.rawStream_);
+        idxStream_      = std::move(other.idxStream_);
+        header_         = other.header_;
+        sourceDeviceId_ = other.sourceDeviceId_;
+        lineageNote_    = std::move(other.lineageNote_);
+        recordCount_    = other.recordCount_;
+        firstTimestamp_ = other.firstTimestamp_;
+        lastTimestamp_  = other.lastTimestamp_;
+        syncPointCount_ = other.syncPointCount_;
+        rawOffset_      = other.rawOffset_;
+        initialized_    = other.initialized_;
+        finalized_      = other.finalized_;
+        other.initialized_ = false;
+        other.finalized_   = false;
+    }
+    return *this;
+}
+
+// ----- Append --------------------------------------------------------------
+
+ISExpected<void> ISLogWriter::append(const ISRecordView& view) {
+    if (!initialized_) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::append: writer is uninitialized (moved-from?)");
+    }
+    if (finalized_) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::append: writer was already finalized");
+    }
+    auto bytes = view.bytes();
+    if (bytes.first == nullptr || bytes.second == 0) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::append: empty record view");
+    }
+    if (sourceDeviceId_ != 0) {
+        const uint64_t recordDevice = view.timestamp().deviceId;
+        if (recordDevice != sourceDeviceId_) {
+            char msg[256];
+            std::snprintf(msg, sizeof(msg),
+                          "ISLogWriter::append: record device id %llu "
+                          "does not match writer's sourceDeviceId %llu",
+                          static_cast<unsigned long long>(recordDevice),
+                          static_cast<unsigned long long>(sourceDeviceId_));
+            return fail(ISErrorCode::InvalidArgument, msg);
+        }
+    }
+
+    // Write payload bytes verbatim.
+    rawStream_.write(reinterpret_cast<const char*>(bytes.first),
+                     static_cast<std::streamsize>(bytes.second));
+    if (!rawStream_.good()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::append: short write on .raw");
+    }
+
+    // Build and emit the .idx record. Offset is the raw write position
+    // BEFORE this record's bytes — derived from our own running counter
+    // rather than tellp() so the value is well-defined even when the
+    // underlying stream is unseekable (pipes in tests, etc.).
+    const uint64_t recordOffset = rawOffset_;
+    rawOffset_ += bytes.second;
+
+    idx::is_log_idx_record_v2_t rec{};
+    rec.timestamp = view.timestamp().value;
+    rec.offset    = recordOffset;
+    rec.did       = view.did();
+    rec.flags     = view.flags();
+    rec.reserved  = 0;
+
+    uint8_t buf[idx::IS_LOG_IDX_RECORD_V2_SIZE];
+    idx::serializeRecord(buf, rec);
+    idxStream_.write(reinterpret_cast<const char*>(buf),
+                     idx::IS_LOG_IDX_RECORD_V2_SIZE);
+    if (!idxStream_.good()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::append: short write on .idx");
+    }
+
+    // Stats.
+    if (recordCount_ == 0) {
+        firstTimestamp_ = rec.timestamp;
+    }
+    lastTimestamp_ = rec.timestamp;
+    if ((rec.flags & idx::IS_LOG_IDX_REC_FLAG_HAS_TOW) != 0) {
+        ++syncPointCount_;
+    }
+    ++recordCount_;
+    return {};
+}
+
+// ----- Finalize ------------------------------------------------------------
+
+ISExpected<void> ISLogWriter::writeFinalHeader() {
+    header_.total_records      = recordCount_;
+    header_.first_timestamp_ms = firstTimestamp_;
+    header_.last_timestamp_ms  = lastTimestamp_;
+    header_.sync_point_count   = syncPointCount_;
+    header_.flags             |= idx::IS_LOG_IDX_HDR_FLAG_FINALIZED;
+
+    idxStream_.flush();
+    idxStream_.seekp(0, std::ios::beg);
+    if (!idxStream_.good()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::finalize: seek to header failed");
+    }
+
+    uint8_t buf[idx::IS_LOG_IDX_HEADER_SIZE];
+    idx::serializeHeader(buf, header_);
+    idxStream_.write(reinterpret_cast<const char*>(buf),
+                     idx::IS_LOG_IDX_HEADER_SIZE);
+    if (!idxStream_.good()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::finalize: rewriting header failed");
+    }
+    idxStream_.flush();
+    return {};
+}
+
+ISExpected<void> ISLogWriter::finalize() {
+    if (!initialized_) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::finalize: writer is uninitialized");
+    }
+    if (finalized_) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "ISLogWriter::finalize: already finalized");
+    }
+
+    // Flush + close raw before the rename so the OS commits its
+    // buffers. ofstream::close() flushes automatically but we
+    // double-tap to make the failure visible if it short-writes.
+    rawStream_.flush();
+    if (!rawStream_.good()) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::finalize: flushing .raw failed");
+    }
+    rawStream_.close();
+
+    auto hdr = writeFinalHeader();
+    if (!hdr) return hdr;
+    idxStream_.close();
+
+    std::error_code ec;
+    std::filesystem::rename(rawTmpPath_, rawOutPath_, ec);
+    if (ec) {
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::finalize: rename .raw failed: " + ec.message());
+    }
+    std::filesystem::rename(idxTmpPath_, idxOutPath_, ec);
+    if (ec) {
+        // Pretty bad — .raw is in place but .idx isn't. Leave the
+        // tempfile behind so an admin can recover; the .raw is
+        // independently readable (D-04 will scan-rebuild a fresh .idx).
+        return fail(ISErrorCode::Io,
+                    "ISLogWriter::finalize: rename .idx failed (.raw landed, "
+                    ".idx still at " + idxTmpPath_.string() + "): " + ec.message());
+    }
+
+    finalized_ = true;
+    return {};
+}
+
+// ----- Cleanup -------------------------------------------------------------
+
+void ISLogWriter::cleanupTempfiles() noexcept {
+    if (rawStream_.is_open()) rawStream_.close();
+    if (idxStream_.is_open()) idxStream_.close();
+    std::error_code ec;
+    if (!rawTmpPath_.empty()) std::filesystem::remove(rawTmpPath_, ec);
+    if (!idxTmpPath_.empty()) std::filesystem::remove(idxTmpPath_, ec);
+    initialized_ = false;
+}
+
+} // namespace inertial_sense

--- a/src/ISLogWriter.h
+++ b/src/ISLogWriter.h
@@ -1,0 +1,294 @@
+/**
+ * @file ISLogWriter.h
+ * @brief Narrow-scope writer for SDK 3.0 — emits `.raw` + v2 `.idx` pairs.
+ *
+ * D-08 / SN-7898 / D0035 / D0049: the output side of Logalyzer's
+ * Bake-Trim (D-72). Takes records from an `ISLogReader` (or any
+ * source that produces `ISRecordView`s) and writes a fresh `.raw`
+ * segment whose bytes are bit-identical to the inputs, alongside a
+ * matching v2 `.idx` sidecar. **Bytes are never re-packetized.**
+ *
+ * **No legacy formats.** RAW + sidecar only. CSV / KML / JSON / v1
+ * `.idx` are out of scope per D0049 — `cISLogger` keeps owning those
+ * paths for now.
+ *
+ * **Atomic semantics.** All writes go to `<path>.tmp` files. On
+ * `finalize()` the tempfiles are renamed in place; if the process
+ * dies before `finalize()`, the destructor deletes the tempfiles
+ * and a `.raw` does not appear at the final path. Mirrors the D-04
+ * `.idx` write path so any reader-side handling (D-04 truncation
+ * detection) applies symmetrically if the rename happens but the
+ * caller crashes mid-stream before finalize.
+ *
+ * **Thread-safety.** A single `ISLogWriter` is **not** thread-safe —
+ * `append` / `finalize` calls must be serialized externally. The
+ * reader-side `const`-safe-concurrent-iteration guarantee does not
+ * have an analog here; writers serialize a single output stream.
+ *
+ * **Move-only.** Owning two write sessions to the same tempfiles
+ * would corrupt them; copy ops are deleted, move ops are noexcept.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include "ISError.h"
+#include "ISLogIndex.h"
+#include "ISRecordView.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace inertial_sense {
+
+class ISLogWriter {
+public:
+    /**
+     * @brief Settings bag for `create()`.
+     *
+     * Default-constructed values match the most-conservative behavior
+     * (fail if output exists, host uptime ms timestamps). Callers
+     * generally only override `overwrite`, `tsUnits`, and `tsSource`
+     * when they have a reason to.
+     */
+    struct Options {
+        /// Output `.raw` path. Required; the matching `.idx` is
+        /// derived by replacing the `.raw` suffix with `.idx`. If the
+        /// suffix isn't `.raw`, `.idx` is appended.
+        std::filesystem::path rawOutPath;
+
+        /// Required device id stamped into the header and validated
+        /// against incoming records. Set to 0 to skip validation.
+        uint64_t sourceDeviceId = 0;
+
+        /// Optional caller note describing where this output came
+        /// from. Held in memory for caller introspection (`lineageNote()`)
+        /// but **not persisted** in the v2 format — the bytes the
+        /// reader sees are bit-identical to the inputs, so any
+        /// out-of-band lineage tracking belongs in a higher-level
+        /// container (workspace `.ilw`, etc.).
+        std::optional<std::string> lineageNote = std::nullopt;
+
+        /// Replace an existing output. Default `false` — `create()`
+        /// returns `InvalidArgument` if the target `.raw` or `.idx`
+        /// already exists. With `true`, the tempfile rename overwrites.
+        bool overwrite = false;
+
+        /// Header `ts_units` (informational; doesn't transform the
+        /// record timestamps written to the `.idx`).
+        idx::TimestampUnits tsUnits = idx::TimestampUnits::HostUptimeMs;
+
+        /// Header `ts_source` (informational).
+        idx::HeaderTimeSource tsSource = idx::HeaderTimeSource::PayloadToW;
+    };
+
+    /**
+     * @brief Open a writer.
+     *
+     * Creates `<rawOutPath>.tmp` and `<idxOutPath>.tmp`, writes a
+     * placeholder `.idx` header (FINALIZED unset), and returns the
+     * writer ready to accept `append()` calls.
+     *
+     * @param opts  Settings; see `Options`.
+     * @return      Open writer, or an `ISError`:
+     *              - `InvalidArgument` if `rawOutPath` is empty,
+     *                already exists (and `!overwrite`), or its parent
+     *                directory doesn't exist.
+     *              - `Io` on tempfile open / initial header write.
+     */
+    static ISExpected<ISLogWriter> create(Options opts);
+
+    /**
+     * @brief Convenience overload taking just the path + device id.
+     *
+     * Equivalent to `create(Options{ rawOutPath, sourceDeviceId,
+     * lineageNote })`.
+     */
+    static ISExpected<ISLogWriter> create(
+        std::filesystem::path rawOutPath,
+        uint64_t sourceDeviceId,
+        std::optional<std::string> lineageNote = std::nullopt);
+
+    ~ISLogWriter();
+
+    ISLogWriter(const ISLogWriter&)            = delete;
+    ISLogWriter& operator=(const ISLogWriter&) = delete;
+
+    /**
+     * Move-construct. Transfers the tempfile handles + accumulated
+     * stats; the source is left in a "moved-from" state where every
+     * method returns `InvalidArgument`.
+     *
+     * @param other  Source writer; safe to destroy.
+     */
+    ISLogWriter(ISLogWriter&&) noexcept;
+
+    /**
+     * Move-assign. If `*this` was an active session, its tempfiles
+     * are deleted (same semantics as the destructor on a non-finalized
+     * writer) before adopting `other`'s state.
+     */
+    ISLogWriter& operator=(ISLogWriter&&) noexcept;
+
+    /**
+     * @brief Append one record.
+     *
+     * Writes the record's bytes verbatim into the output `.raw` and
+     * adds a v2 `.idx` record at the resulting offset. The record's
+     * `flags` (including `HAS_TOW`) are preserved from the source
+     * view; no re-derivation happens at this layer.
+     *
+     * @param view  Source record. Must have `bytes().first != nullptr`
+     *              and `bytes().second > 0`. If `sourceDeviceId` was
+     *              non-zero at `create()` time, `view.timestamp().deviceId`
+     *              must match (first mismatch fails fast with
+     *              `InvalidArgument`).
+     * @return      `Ok` on success, otherwise:
+     *              - `InvalidArgument` — empty view, device-id
+     *                mismatch, writer not initialized, or already
+     *                finalized.
+     *              - `Io` — short write on `.raw` or `.idx`.
+     */
+    ISExpected<void> append(const ISRecordView& view);
+
+    /**
+     * @brief Filter a range and append the matches.
+     *
+     * Equivalent to a manual `for (auto v : range) if (pred(v))
+     * append(v);` loop, with early-exit on the first append failure.
+     *
+     * @tparam RecordRange  Anything iterable yielding `ISRecordView`.
+     * @tparam Predicate    Callable `bool(const ISRecordView&)`.
+     * @param range         Source range.
+     * @param pred          Filter predicate.
+     * @return              Count of records actually written, or the
+     *                      first `ISError` raised by `append()`.
+     */
+    template <class RecordRange, class Predicate>
+    ISExpected<std::size_t> appendFiltered(RecordRange&& range, Predicate&& pred) {
+        std::size_t written = 0;
+        for (const ISRecordView& v : range) {
+            if (!pred(v)) continue;
+            auto r = append(v);
+            if (!r) return tl::unexpected<ISError>{ r.error() };
+            ++written;
+        }
+        return written;
+    }
+
+    /**
+     * @brief Close the session and atomically install the output.
+     *
+     * Patches the `.idx` header with the final record count, first /
+     * last timestamps, and sync-point count; sets `FINALIZED`; flushes
+     * and closes both files; renames `.tmp` → final. Idempotent in
+     * the sense that calling it twice on the same writer returns
+     * `InvalidArgument` on the second call (no further side effects).
+     *
+     * @return  `Ok` on success.
+     *          - `Io` if any flush, seek, write, or rename failed.
+     *          - `InvalidArgument` if the writer was uninitialized or
+     *            already finalized.
+     */
+    ISExpected<void> finalize();
+
+    /**
+     * @return  Number of records successfully appended so far. Survives
+     *          across `finalize()`.
+     */
+    std::size_t recordCount() const noexcept { return recordCount_; }
+
+    /**
+     * @return  First record timestamp written, or 0 if no records
+     *          have been appended.
+     */
+    uint64_t firstTimestamp() const noexcept { return firstTimestamp_; }
+
+    /**
+     * @return  Last record timestamp written, or 0 if no records
+     *          have been appended.
+     */
+    uint64_t lastTimestamp() const noexcept { return lastTimestamp_; }
+
+    /**
+     * @return  Count of records whose `HAS_TOW` flag was set —
+     *          potential sync points for D-07.
+     */
+    uint32_t syncPointCount() const noexcept { return syncPointCount_; }
+
+    /**
+     * @return  `true` once `finalize()` succeeded; otherwise `false`.
+     */
+    bool isFinalized() const noexcept { return finalized_; }
+
+    /**
+     * @return  Caller-supplied lineage note from `Options`, if any.
+     *          Held in memory only — not written to disk.
+     */
+    const std::optional<std::string>& lineageNote() const noexcept {
+        return lineageNote_;
+    }
+
+    /**
+     * @return  Final `.raw` path (the location after `finalize()`
+     *          renames the tempfile).
+     */
+    const std::filesystem::path& rawPath() const noexcept { return rawOutPath_; }
+
+    /**
+     * @return  Final `.idx` path.
+     */
+    const std::filesystem::path& idxPath() const noexcept { return idxOutPath_; }
+
+private:
+    ISLogWriter() = default;
+
+    /**
+     * Closes any open streams and removes the tempfiles. Used by the
+     * destructor and by `operator=(&&)` when the moved-into writer
+     * was an active session. Idempotent.
+     */
+    void cleanupTempfiles() noexcept;
+
+    /**
+     * Patches the on-disk `.idx` header with the final stats and
+     * `FINALIZED` flag. Called from `finalize()`; assumes the idx
+     * stream is open.
+     */
+    ISExpected<void> writeFinalHeader();
+
+    // Final destination paths.
+    std::filesystem::path rawOutPath_;
+    std::filesystem::path idxOutPath_;
+
+    // Tempfiles staged for atomic rename on finalize.
+    std::filesystem::path rawTmpPath_;
+    std::filesystem::path idxTmpPath_;
+
+    std::ofstream rawStream_;
+    std::ofstream idxStream_;
+
+    // Header template — `producer_version`, `ts_units`, `ts_source`
+    // are seeded at create time and stays put. `total_records`,
+    // `first_timestamp_ms`, `last_timestamp_ms`, `sync_point_count`,
+    // `flags` are patched at finalize().
+    idx::is_log_idx_header_t header_{};
+
+    uint64_t                   sourceDeviceId_  = 0;
+    std::optional<std::string> lineageNote_;
+    std::size_t                recordCount_     = 0;
+    uint64_t                   firstTimestamp_  = 0;
+    uint64_t                   lastTimestamp_   = 0;
+    uint32_t                   syncPointCount_  = 0;
+    uint64_t                   rawOffset_       = 0;
+    bool                       initialized_     = false;
+    bool                       finalized_       = false;
+};
+
+} // namespace inertial_sense

--- a/src/ISRecordView.h
+++ b/src/ISRecordView.h
@@ -62,19 +62,25 @@ public:
      *                      `nullptr` for the empty sentinel.
      * @param size          Number of payload bytes addressable from
      *                      `data`.
+     * @param flags         `IS_LOG_IDX_REC_FLAG_*` bitmask from the
+     *                      source `.idx` record. Bit 0
+     *                      (`HAS_TOW`) marks a sync-eligible record.
+     *                      Defaults to 0 for backward compatibility.
      */
     constexpr ISRecordView(uint32_t did,
                            uint64_t timestampMs,
                            uint64_t deviceId,
                            uint64_t offsetInFile,
                            const uint8_t* data,
-                           std::size_t size) noexcept
+                           std::size_t size,
+                           uint16_t flags = 0) noexcept
         : did_(did),
           timestampMs_(timestampMs),
           deviceId_(deviceId),
           offset_(offsetInFile),
           data_(data),
-          size_(size) {}
+          size_(size),
+          flags_(flags) {}
 
     /**
      * Returns the record's data identifier (`DID_*` from `data_sets.h`).
@@ -111,6 +117,17 @@ public:
      * @return  Byte offset (0 == start-of-file).
      */
     constexpr uint64_t offsetInFile() const noexcept { return offset_; }
+
+    /**
+     * Returns the `IS_LOG_IDX_REC_FLAG_*` bitmask from the source
+     * `.idx` record. Bit 0 (`HAS_TOW`) indicates the record's payload
+     * carried a real GPS time-of-week field — used by D-07's
+     * `ISTimeResolver` as a sync anchor and by D-08's `ISLogWriter`
+     * to preserve the flag through bake/trim.
+     *
+     * @return  Flags bitmask, or 0 for the empty sentinel.
+     */
+    constexpr uint16_t flags() const noexcept { return flags_; }
 
     /**
      * Returns the record's bytes as a (pointer, size) pair. The
@@ -159,6 +176,7 @@ private:
     uint64_t       offset_      = 0;
     const uint8_t* data_        = nullptr;
     std::size_t    size_        = 0;
+    uint16_t       flags_       = 0;
 };
 
 /**
@@ -196,12 +214,14 @@ public:
                 uint64_t timestampMs,
                 uint64_t deviceId,
                 uint64_t offsetInFile,
-                std::vector<uint8_t> bytes)
+                std::vector<uint8_t> bytes,
+                uint16_t flags = 0)
         : did_(did),
           timestampMs_(timestampMs),
           deviceId_(deviceId),
           offset_(offsetInFile),
-          bytes_(std::move(bytes)) {}
+          bytes_(std::move(bytes)),
+          flags_(flags) {}
 
     /** @return  The record's DID, or 0 if untagged. */
     uint32_t did() const noexcept { return did_; }
@@ -219,6 +239,12 @@ public:
 
     /** @return  Original byte offset in the source `.raw` segment. */
     uint64_t offsetInFile() const noexcept { return offset_; }
+
+    /**
+     * @return  `IS_LOG_IDX_REC_FLAG_*` bitmask preserved from the
+     *          source view at construction.
+     */
+    uint16_t flags() const noexcept { return flags_; }
 
     /**
      * @return  `{ data, size }` over the owning buffer; `data` may
@@ -248,11 +274,12 @@ private:
     uint64_t             deviceId_    = 0;
     uint64_t             offset_      = 0;
     std::vector<uint8_t> bytes_;
+    uint16_t             flags_       = 0;
 };
 
 inline OwnedRecord ISRecordView::owned() const {
     std::vector<uint8_t> copy(data_, data_ + size_);
-    return OwnedRecord{ did_, timestampMs_, deviceId_, offset_, std::move(copy) };
+    return OwnedRecord{ did_, timestampMs_, deviceId_, offset_, std::move(copy), flags_ };
 }
 
 } // namespace inertial_sense

--- a/tests/test_log_writer.cpp
+++ b/tests/test_log_writer.cpp
@@ -1,0 +1,411 @@
+/**
+ * @file test_log_writer.cpp
+ * @brief D-08 / SN-7898 — ISLogWriter acceptance tests.
+ *
+ * Strategy mirrors test_log_reader / test_truncated_log: synthesize a
+ * fresh fixture under /tmp via cISLogger, open it with ISLogReader,
+ * pipe records through ISLogWriter, then re-open the writer's output
+ * and compare. Byte-for-byte equality of every record's payload is the
+ * single most important property — the writer must never repacketize.
+ */
+
+#include <gtest/gtest.h>
+
+#include "com_manager.h"  // first — see test_log_reader.cpp comment
+
+#include "DeviceLog.h"
+#include "ISFileManager.h"
+#include "ISLogIndex.h"
+#include "ISLogReader.h"
+#include "ISLogWriter.h"
+#include "ISLogger.h"
+#include "test_data_utils.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <list>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace inertial_sense;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint16_t kFixtureHwId   = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
+constexpr uint32_t kFixtureSerial = 999222u;
+
+struct WriterFixture {
+    fs::path                          directory;
+    fs::path                          rawFile;
+    fs::path                          idxFile;
+    std::list<std::vector<uint8_t>*>  messages;
+};
+
+WriterFixture buildFixture(const std::string& hint, float sizeMB = 0.5f) {
+    WriterFixture f;
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf),
+                  "/tmp/test_log_writer_%s_%d_%ld",
+                  hint.c_str(), ::getpid(),
+                  static_cast<long>(::time(nullptr)));
+    f.directory = dirBuf;
+    ISFileManager::DeleteDirectory(f.directory.string());
+
+    GenerateRawLogData(f.messages, sizeMB);
+    if (f.messages.empty()) return f;
+
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions opts;
+        opts.logType               = cISLogger::LOGTYPE_RAW;
+        opts.useSubFolderTimestamp = false;
+        if (!logger.InitSave(f.directory.string(), opts)) return f;
+        auto devLogger = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+        if (!devLogger) return f;
+        logger.EnableLogging(true);
+        for (auto* msg : f.messages) {
+            logger.LogData(devLogger, msg->size(),
+                           reinterpret_cast<const uint8_t*>(msg->data()));
+        }
+        logger.CloseAllFiles();
+    }
+
+    std::vector<ISFileManager::file_info_t> rawFiles, idxFiles;
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true,
+                                          "\\.raw$", rawFiles);
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true,
+                                          "\\.idx$", idxFiles);
+    if (rawFiles.empty()) return f;
+    f.rawFile = rawFiles.front().name;
+    if (!idxFiles.empty()) f.idxFile = idxFiles.front().name;
+    return f;
+}
+
+void teardown(WriterFixture& f) {
+    for (auto* m : f.messages) delete m;
+    f.messages.clear();
+    if (!f.directory.empty() && fs::exists(f.directory)) {
+        ISFileManager::DeleteDirectory(f.directory.string());
+    }
+}
+
+class LogWriterTest : public ::testing::Test {
+protected:
+    WriterFixture fixture;
+
+    void TearDown() override { teardown(fixture); }
+};
+
+// ---------------------------------------------------------------------------
+// Round-trip: read every record, write through ISLogWriter, re-read, compare.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, RoundTripBitIdentical) {
+    fixture = buildFixture("roundtrip");
+    ASSERT_FALSE(fixture.rawFile.empty()) << "fixture generation failed";
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value()) << sourceR.error().message;
+    const ISLogReader& source = sourceR.value();
+    const std::size_t  inCount = source.recordCount();
+    ASSERT_GT(inCount, 0u);
+
+    const fs::path outRaw = fixture.directory / "rebake.raw";
+
+    // Capture every source record into owning copies so we can diff
+    // after the writer has run (its append moves the source's mmap
+    // out from under raw views — the owned copy survives).
+    std::vector<OwnedRecord> sourceRecords;
+    sourceRecords.reserve(inCount);
+    for (auto v : source.allRecords()) {
+        sourceRecords.push_back(v.owned());
+    }
+
+    {
+        auto writerR = ISLogWriter::create(outRaw, source.deviceId());
+        ASSERT_TRUE(writerR.has_value()) << writerR.error().message;
+        ISLogWriter writer = std::move(writerR.value());
+
+        for (auto v : source.allRecords()) {
+            auto r = writer.append(v);
+            ASSERT_TRUE(r.has_value()) << r.error().message;
+        }
+        EXPECT_EQ(writer.recordCount(), inCount);
+
+        auto fin = writer.finalize();
+        ASSERT_TRUE(fin.has_value()) << fin.error().message;
+        EXPECT_TRUE(writer.isFinalized());
+    }
+
+    // Both files exist at final paths; tempfiles do not.
+    EXPECT_TRUE(fs::exists(outRaw));
+    fs::path outIdx = outRaw;
+    outIdx.replace_extension(".idx");
+    EXPECT_TRUE(fs::exists(outIdx));
+    EXPECT_FALSE(fs::exists(fs::path(outRaw.string() + ".tmp")));
+    EXPECT_FALSE(fs::exists(fs::path(outIdx.string() + ".tmp")));
+
+    // Re-read and diff.
+    auto destR = ISLogReader::openSegment(outRaw);
+    ASSERT_TRUE(destR.has_value()) << destR.error().message;
+    const ISLogReader& dest = destR.value();
+    EXPECT_TRUE(dest.hadOnDiskIndex());
+    EXPECT_FALSE(dest.isTruncated());
+    ASSERT_EQ(dest.recordCount(), inCount);
+
+    std::size_t i = 0;
+    for (auto v : dest.allRecords()) {
+        const OwnedRecord& src = sourceRecords[i++];
+        EXPECT_EQ(v.did(), src.did()) << "record " << (i - 1);
+        ASSERT_EQ(v.bytes().second, src.bytes().second) << "size mismatch at " << (i - 1);
+        EXPECT_EQ(0, std::memcmp(v.bytes().first,
+                                 src.bytes().first,
+                                 v.bytes().second))
+            << "byte mismatch at record " << (i - 1);
+    }
+    EXPECT_EQ(i, inCount);
+}
+
+// ---------------------------------------------------------------------------
+// Filtered round-trip via appendFiltered + a timestamp predicate.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, FilteredRoundTrip) {
+    fixture = buildFixture("filter");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value()) << sourceR.error().message;
+    const ISLogReader& source = sourceR.value();
+    ASSERT_GT(source.recordCount(), 4u);
+
+    // Pick a window covering the middle 50% of the records by sampling
+    // their timestamps. The synthetic fixture's record timestamps are
+    // monotonic within a DID; over allRecords() they bounce around per
+    // DID — but the min and max still bracket every record.
+    std::vector<uint64_t> tss;
+    tss.reserve(source.recordCount());
+    for (auto v : source.allRecords()) {
+        tss.push_back(v.timestamp().value);
+    }
+    std::sort(tss.begin(), tss.end());
+    const uint64_t t0 = tss[tss.size() / 4];
+    const uint64_t t1 = tss[3 * tss.size() / 4];
+
+    auto in_window = [t0, t1](const ISRecordView& v) {
+        const uint64_t ts = v.timestamp().value;
+        return ts >= t0 && ts < t1;
+    };
+
+    // Reference: count records the predicate keeps.
+    std::size_t expected = 0;
+    for (auto v : source.allRecords()) if (in_window(v)) ++expected;
+    ASSERT_GT(expected, 0u);
+    ASSERT_LT(expected, source.recordCount());
+
+    const fs::path outRaw = fixture.directory / "filtered.raw";
+    auto writerR = ISLogWriter::create(outRaw, source.deviceId());
+    ASSERT_TRUE(writerR.has_value()) << writerR.error().message;
+    ISLogWriter writer = std::move(writerR.value());
+
+    auto count = writer.appendFiltered(source.allRecords(), in_window);
+    ASSERT_TRUE(count.has_value()) << count.error().message;
+    EXPECT_EQ(count.value(), expected);
+
+    auto fin = writer.finalize();
+    ASSERT_TRUE(fin.has_value()) << fin.error().message;
+
+    auto destR = ISLogReader::openSegment(outRaw);
+    ASSERT_TRUE(destR.has_value()) << destR.error().message;
+    EXPECT_EQ(destR.value().recordCount(), expected);
+    for (auto v : destR.value().allRecords()) {
+        EXPECT_TRUE(in_window(v)) << "record outside the requested window leaked";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State-machine misuse: finalize-without-create, append-after-finalize, etc.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, StateMachineMisuse) {
+    fixture = buildFixture("misuse");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value());
+    const ISLogReader& source = sourceR.value();
+
+    // "finalize without create" via a moved-from writer.
+    {
+        auto writerR = ISLogWriter::create(fixture.directory / "moved.raw",
+                                           source.deviceId());
+        ASSERT_TRUE(writerR.has_value());
+        ISLogWriter src = std::move(writerR.value());
+        ISLogWriter dst = std::move(src);  // src is now moved-from
+
+        auto firstView = *source.allRecords().begin();
+        auto a = src.append(firstView);
+        EXPECT_FALSE(a.has_value());
+        EXPECT_EQ(a.error().code, ISErrorCode::InvalidArgument);
+
+        auto f = src.finalize();
+        EXPECT_FALSE(f.has_value());
+        EXPECT_EQ(f.error().code, ISErrorCode::InvalidArgument);
+
+        // Clean up dst.
+        EXPECT_TRUE(dst.finalize().has_value());
+    }
+
+    // append-after-finalize, double-finalize.
+    {
+        const fs::path out = fixture.directory / "double_finalize.raw";
+        auto writerR = ISLogWriter::create(out, source.deviceId());
+        ASSERT_TRUE(writerR.has_value());
+        ISLogWriter w = std::move(writerR.value());
+        for (auto v : source.allRecords()) {
+            ASSERT_TRUE(w.append(v).has_value());
+        }
+        ASSERT_TRUE(w.finalize().has_value());
+
+        auto firstView = *source.allRecords().begin();
+        auto a = w.append(firstView);
+        EXPECT_FALSE(a.has_value());
+        EXPECT_EQ(a.error().code, ISErrorCode::InvalidArgument);
+
+        auto f = w.finalize();
+        EXPECT_FALSE(f.has_value());
+        EXPECT_EQ(f.error().code, ISErrorCode::InvalidArgument);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Refuses to overwrite an existing path unless `overwrite = true`.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, RefusesExistingPath) {
+    fixture = buildFixture("noclobber");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    const fs::path out = fixture.directory / "exists.raw";
+    {
+        std::ofstream(out) << "existing content";
+    }
+    ASSERT_TRUE(fs::exists(out));
+
+    auto bad = ISLogWriter::create(out, 0);
+    EXPECT_FALSE(bad.has_value());
+    EXPECT_EQ(bad.error().code, ISErrorCode::InvalidArgument);
+
+    ISLogWriter::Options o;
+    o.rawOutPath     = out;
+    o.sourceDeviceId = 0;
+    o.overwrite      = true;
+    auto good = ISLogWriter::create(o);
+    ASSERT_TRUE(good.has_value()) << good.error().message;
+    auto fin = good.value().finalize();
+    EXPECT_TRUE(fin.has_value()) << fin.error().message;
+    EXPECT_TRUE(fs::exists(out));
+}
+
+// ---------------------------------------------------------------------------
+// .idx v2 header reflects actual stats (record count, timestamps,
+// FINALIZED flag) after finalize.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, HeaderReflectsStats) {
+    fixture = buildFixture("header");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value());
+    const ISLogReader& source = sourceR.value();
+
+    const fs::path outRaw = fixture.directory / "stats.raw";
+    auto writerR = ISLogWriter::create(outRaw, source.deviceId());
+    ASSERT_TRUE(writerR.has_value());
+    ISLogWriter writer = std::move(writerR.value());
+    for (auto v : source.allRecords()) {
+        ASSERT_TRUE(writer.append(v).has_value());
+    }
+    ASSERT_TRUE(writer.finalize().has_value());
+
+    auto destR = ISLogReader::openSegment(outRaw);
+    ASSERT_TRUE(destR.has_value());
+    const idx::is_log_idx_header_t& h = destR.value().header();
+    EXPECT_TRUE((h.flags & idx::IS_LOG_IDX_HDR_FLAG_FINALIZED) != 0);
+    EXPECT_EQ(h.total_records, source.recordCount());
+    EXPECT_EQ(h.first_timestamp_ms, writer.firstTimestamp());
+    EXPECT_EQ(h.last_timestamp_ms,  writer.lastTimestamp());
+    EXPECT_EQ(h.sync_point_count,   writer.syncPointCount());
+    EXPECT_EQ(h.version, idx::IS_LOG_IDX_VERSION_V2);
+}
+
+// ---------------------------------------------------------------------------
+// Device-id mismatch fails on the first non-matching record, no partial
+// output left at the final path (tempfiles cleaned up by destructor).
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, DeviceIdMismatchRejected) {
+    fixture = buildFixture("device_mismatch");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value());
+    const ISLogReader& source = sourceR.value();
+    ASSERT_NE(source.deviceId(), 0u);
+
+    const fs::path outRaw = fixture.directory / "mismatch.raw";
+    const uint64_t bogusId = source.deviceId() + 1u;
+    {
+        auto writerR = ISLogWriter::create(outRaw, bogusId);
+        ASSERT_TRUE(writerR.has_value());
+        ISLogWriter writer = std::move(writerR.value());
+
+        auto firstView = *source.allRecords().begin();
+        auto r = writer.append(firstView);
+        EXPECT_FALSE(r.has_value());
+        EXPECT_EQ(r.error().code, ISErrorCode::InvalidArgument);
+        // Drop without finalize — destructor cleans up tempfiles.
+    }
+    EXPECT_FALSE(fs::exists(outRaw));
+    fs::path outIdx = outRaw;
+    outIdx.replace_extension(".idx");
+    EXPECT_FALSE(fs::exists(outIdx));
+    EXPECT_FALSE(fs::exists(fs::path(outRaw.string() + ".tmp")));
+    EXPECT_FALSE(fs::exists(fs::path(outIdx.string() + ".tmp")));
+}
+
+// ---------------------------------------------------------------------------
+// Destructor without finalize leaves no files at the final path and
+// removes the tempfiles.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, AbandonedWriterCleansTempfiles) {
+    fixture = buildFixture("abandoned");
+    ASSERT_FALSE(fixture.rawFile.empty());
+
+    auto sourceR = ISLogReader::openSegment(fixture.rawFile);
+    ASSERT_TRUE(sourceR.has_value());
+    const ISLogReader& source = sourceR.value();
+
+    const fs::path outRaw = fixture.directory / "abandoned.raw";
+    {
+        auto writerR = ISLogWriter::create(outRaw, source.deviceId());
+        ASSERT_TRUE(writerR.has_value());
+        ISLogWriter writer = std::move(writerR.value());
+        // Append a few records, then drop without finalize.
+        std::size_t n = 0;
+        for (auto v : source.allRecords()) {
+            ASSERT_TRUE(writer.append(v).has_value());
+            if (++n >= 5) break;
+        }
+    }
+    fs::path outIdx = outRaw;
+    outIdx.replace_extension(".idx");
+    EXPECT_FALSE(fs::exists(outRaw));
+    EXPECT_FALSE(fs::exists(outIdx));
+    EXPECT_FALSE(fs::exists(fs::path(outRaw.string() + ".tmp")));
+    EXPECT_FALSE(fs::exists(fs::path(outIdx.string() + ".tmp")));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

SDK-side writer for the bake-trim pipeline (D-72). Reads records from `ISLogReader` (or any source that produces `ISRecordView`s) and emits a `.raw` whose bytes are bit-identical to the inputs, plus a matching v2 `.idx`. **No re-packetization** — downstream tools assume on-wire format equivalence; that's the single most important correctness property.

Per D0049, scope is intentionally narrow: RAW + sidecar only. CSV / KML / JSON / v1 idx are out of scope and stay with `cISLogger`.

### API

```cpp
class ISLogWriter {
public:
    static ISExpected<ISLogWriter> create(Options);
    static ISExpected<ISLogWriter> create(path, deviceId, lineageNote = nullopt);
    ISExpected<void>          append(const ISRecordView&);
    template <class Range, class Pred>
    ISExpected<size_t>        appendFiltered(Range&&, Pred&&);
    ISExpected<void>          finalize();
    // ... + accessors for stats and paths
};
```

### Atomicity

- All writes go to `<path>.tmp`; `finalize()` does the rename.
- Destructor without prior `finalize()` removes tempfiles and logs to stderr.
- Idempotent: double-finalize / append-after-finalize → `InvalidArgument`.
- Move-only (copy ops deleted).

### Side-quest: `ISRecordView::flags()` accessor

The writer needs to preserve the source's `HAS_TOW` flag. `ISRecordView` didn't expose `flags`, so this PR adds an additive accessor (default-zero param on the existing constructor — no caller breakage) and threads the value through from `ISLogReader::viewAt()`. Same on `OwnedRecord` for symmetry.

### Tests (7 new gtests, all green locally)

- `RoundTripBitIdentical` — read fixture → pipe through writer → re-read → memcmp every record. record-count + DID + bytes all match.
- `FilteredRoundTrip` — `appendFiltered` with a timestamp window predicate; result matches the in-memory filter.
- `StateMachineMisuse` — finalize on moved-from (≡ "without create"), append-after-finalize, double-finalize.
- `RefusesExistingPath` — default fails; `overwrite = true` succeeds.
- `HeaderReflectsStats` — `total_records`, `first/last_timestamp_ms`, `sync_point_count`, `FINALIZED` flag all set correctly after finalize.
- `DeviceIdMismatchRejected` — first mismatching record fails with `InvalidArgument`; tempfiles cleaned by destructor.
- `AbandonedWriterCleansTempfiles` — drop without finalize, no files at final path, no leftover `.tmp`.

Plus 20 reader/index regression tests still green (the `flags` plumbing change is additive).

### What's not done here

- Disk-full simulation: covered by the existing `Io` short-write paths but the AC's literal "disk-full" test isn't trivial to write portably; will lift if/when it surfaces a real bug.
- `kToWBearingDids[]` re-derivation when source flags are unset: deferred. Today the writer preserves `view.flags()` verbatim — the rebuilt `.idx` from D-04 already sets `HAS_TOW` correctly, so re-derivation is currently a no-op. Re-derivation makes more sense once D-07 ships its canonical list.
- Full ExampleProject: stub committed per D-08 AC; full example lands with D-11.

## Test plan

- [x] `ctest -R LogWriterTest` green (7/7) on Linux Ubuntu 22.04
- [x] Reader-side regression tests green (LogReaderTest, TruncatedLogTest, LogIndexTest)
- [ ] Same on Windows runner via Logalyzer's build-Logalyzer workflow once submodule lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)