### PR TITLE
D-09 (SN-7899): built-in derivation catalog — 10 v1 entries + registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ file(GLOB SOURCES_SDK
 	"${CMAKE_CURRENT_LIST_DIR}/src/protocol/*.h"
 	"${CMAKE_CURRENT_LIST_DIR}/src/util/*.cpp"
 	"${CMAKE_CURRENT_LIST_DIR}/src/util/*.h"
+	"${CMAKE_CURRENT_LIST_DIR}/src/derivations/*.cpp"
+	"${CMAKE_CURRENT_LIST_DIR}/src/derivations/*.h"
 	"${CMAKE_CURRENT_LIST_DIR}/hw-libs/bootloader/bootloaderShared.c"
 	"${CMAKE_CURRENT_LIST_DIR}/tests/runtime/*.cpp"
 	"${CMAKE_CURRENT_LIST_DIR}/tests/runtime/*.h"
@@ -100,6 +102,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         src
         src/util
         src/protocol
+        src/derivations
         src/libusb
         src/libusb/libusb
         src/yaml-cpp

--- a/ExampleProjects/Derivations/CMakeLists.txt
+++ b/ExampleProjects/Derivations/CMakeLists.txt
@@ -1,0 +1,7 @@
+# ExampleProjects/Derivations/CMakeLists.txt — D-09 / SN-7899 stub.
+# Full example lands with D-11 / SN-7900.
+
+cmake_minimum_required(VERSION 3.16)
+project(Derivations_example LANGUAGES CXX)
+
+message(STATUS "ExampleProjects/Derivations: stub (D-09); full example lands with D-11.")

--- a/ExampleProjects/Derivations/README.md
+++ b/ExampleProjects/Derivations/README.md
@@ -1,0 +1,56 @@
+# Built-in derivations — registry walk *(stub — D-11 fills out the full example)*
+
+Placeholder slot reserved by **D-09 / SN-7899**. Full code drops in
+with **D-11 / SN-7900** (Doxygen + ExampleProjects).
+
+## Quickstart
+
+```cpp
+#include "ISLogReader.h"
+#include "derivations/DerivationRegistry.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0]
+                  << " <segment.raw> <derivation_name>\n";
+        return 1;
+    }
+
+    using namespace inertial_sense;
+    auto reader = ISLogReader::openSegment(argv[1]);
+    if (!reader) {
+        std::cerr << "open failed: " << reader.error().message << "\n";
+        return 2;
+    }
+
+    auto d = derivations::DerivationRegistry::instance().get(argv[2]);
+    if (!d) {
+        std::cerr << "unknown derivation: " << argv[2] << "\n";
+        std::cerr << "available:\n";
+        for (auto* e : derivations::DerivationRegistry::instance().all()) {
+            std::cerr << "  " << e->name << "  (" << e->outputUnit << ")\n";
+        }
+        return 3;
+    }
+
+    derivations::DerivationContext ctx{ *reader };
+    auto r = (*d)->evaluate(ctx);
+    if (!r) {
+        std::cerr << "evaluate failed: " << r.error().message << "\n";
+        return 4;
+    }
+
+    std::cout << "samples: " << r->samples.size()
+              << "  unit: "    << r->outputUnit
+              << "  frame: '"  << r->outputFrame << "'\n";
+    return 0;
+}
+```
+
+## Related
+
+- API: [`SDK/src/derivations/DerivationRegistry.h`](../../src/derivations/DerivationRegistry.h)
+- Story: [SN-7899](https://inertialsense.atlassian.net/browse/SN-7899)
+- Follow-up: [SN-7900 (D-11)](https://inertialsense.atlassian.net/browse/SN-7900)

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -524,6 +524,11 @@ uint64_t ISLogReader::fileSize() const noexcept {
     return rawSource_ ? rawSource_->size() : 0;
 }
 
+std::pair<const uint8_t*, std::size_t> ISLogReader::rawBytes() const noexcept {
+    if (!rawSource_) return { nullptr, 0 };
+    return { rawSource_->data(), rawSource_->size() };
+}
+
 void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
     deviceId_ = 0;
 

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -151,6 +151,22 @@ public:
     uint64_t fileSize() const noexcept;
 
     /**
+     * Direct accessor for the segment's underlying byte buffer.
+     *
+     * Most callers should iterate via `records()` / `allRecords()`
+     * — this hatch is for code that needs to re-parse the raw stream
+     * (e.g. the derivation catalog at D-09, which extracts typed
+     * payload structs that the index-record-shared-offset semantics
+     * don't expose cleanly through `ISRecordView::bytes()`).
+     *
+     * @return  `{ data, size }`. `data` aliases the mmap'd region
+     *          (or buffer fallback); the lifetime is tied to this
+     *          reader. Empty pair if the segment was opened against
+     *          a zero-byte source.
+     */
+    std::pair<const uint8_t*, std::size_t> rawBytes() const noexcept;
+
+    /**
      * Side-channel diagnostic strings collected during open.
      * Categories observed today (added by D-04):
      *

--- a/src/derivations/DerivationRegistry.cpp
+++ b/src/derivations/DerivationRegistry.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file DerivationRegistry.cpp
+ * @brief Singleton registration of the v1 built-in derivation catalog.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "DerivationRegistry.h"
+
+#include "data_sets.h"
+
+namespace inertial_sense {
+namespace derivations {
+
+namespace {
+
+/// Helper that builds + registers one entry. Inserts into both the
+/// keyed map and the order vector.
+void addEntry(std::map<std::string, Derivation>& entries,
+              std::vector<const Derivation*>&   order,
+              Derivation                        d) {
+    auto [it, inserted] = entries.emplace(std::string(d.name), std::move(d));
+    if (inserted) {
+        order.push_back(&it->second);
+    }
+}
+
+} // namespace
+
+DerivationRegistry::DerivationRegistry() {
+    // ---- Pose -----------------------------------------------------------
+    addEntry(entries_, order_, Derivation{
+        "quat_to_euler",
+        "Roll/pitch/yaw from INS_2.qn2b (Hamilton, body→nav).",
+        "rad", "body→NED",
+        { { DID_INS_2, "qn2b" } },
+        {},
+        &evalQuatToEuler,
+    });
+    addEntry(entries_, order_, Derivation{
+        "heading_from_quat",
+        "Yaw component of INS_2.qn2b, wrapped per `wrap` parameter.",
+        "rad", "NED",
+        { { DID_INS_2, "qn2b" } },
+        { { "wrap", "signed", "signed → [-pi, pi]; positive → [0, 2pi]" } },
+        &evalHeadingFromQuat,
+    });
+
+    // ---- Position -------------------------------------------------------
+    addEntry(entries_, order_, Derivation{
+        "lla_to_ned@first_fix",
+        "INS_2.lla projected to NED with origin at the first record's "
+        "lla. Falls back to first record if no fix-quality marker is "
+        "available.",
+        "m", "NED",
+        { { DID_INS_2, "lla" } },
+        {},
+        &evalLlaToNedFirstFix,
+    });
+    addEntry(entries_, order_, Derivation{
+        "lla_to_ned@user_origin",
+        "INS_2.lla projected to NED with origin from `origin_lla` "
+        "parameter (comma-separated `lat,lon,alt`).",
+        "m", "NED",
+        { { DID_INS_2, "lla" } },
+        { { "origin_lla", "", "lat_deg,lon_deg,alt_m" } },
+        &evalLlaToNedUserOrigin,
+    });
+
+    // ---- Magnitudes (frame-invariant scalars) ---------------------------
+    addEntry(entries_, order_, Derivation{
+        "velocity_magnitude",
+        "‖uvw‖ from INS_2 (frame-invariant; equal to ‖vNED‖).",
+        "m/s", "",
+        { { DID_INS_2, "uvw" } },
+        {},
+        &evalVelocityMagnitude,
+    });
+    addEntry(entries_, order_, Derivation{
+        "accel_magnitude",
+        "‖I.acc‖ from IMU.",
+        "m/s²", "",
+        { { DID_IMU, "I.acc" } },
+        {},
+        &evalAccelMagnitude,
+    });
+    addEntry(entries_, order_, Derivation{
+        "rate_magnitude",
+        "‖I.pqr‖ from IMU.",
+        "rad/s", "",
+        { { DID_IMU, "I.pqr" } },
+        {},
+        &evalRateMagnitude,
+    });
+
+    // ---- Body→NED rotations --------------------------------------------
+    addEntry(entries_, order_, Derivation{
+        "body_accel_to_ned_accel",
+        "Rotates IMU.I.acc into NED via INS_2.qn2b. `include_gravity` "
+        "parameter controls whether g is removed (default = true: "
+        "physics-as-measured; false subtracts +9.80665 m/s² from D).",
+        "m/s²", "NED",
+        { { DID_IMU, "I.acc" }, { DID_INS_2, "qn2b" } },
+        { { "include_gravity", "true", "true → leave gravity in; false → subtract g from D component" } },
+        &evalBodyAccelToNed,
+    });
+    addEntry(entries_, order_, Derivation{
+        "body_rate_to_euler_rate",
+        "Body angular rates (IMU.I.pqr) expressed as Euler-angle "
+        "derivatives (roll/pitch/yaw rates) using the current Euler "
+        "angles from INS_2.qn2b.",
+        "rad/s", "Euler",
+        { { DID_IMU, "I.pqr" }, { DID_INS_2, "qn2b" } },
+        {},
+        &evalBodyRateToEulerRate,
+    });
+
+    // ---- Heading --------------------------------------------------------
+    addEntry(entries_, order_, Derivation{
+        "heading_from_velocity",
+        "atan2(vEast, vNorth) using NED velocity rotated from "
+        "INS_2.uvw via INS_2.qn2b.",
+        "rad", "NED",
+        { { DID_INS_2, "uvw" }, { DID_INS_2, "qn2b" } },
+        { { "wrap", "signed", "signed → [-pi, pi]; positive → [0, 2pi]" } },
+        &evalHeadingFromVelocity,
+    });
+}
+
+const DerivationRegistry& DerivationRegistry::instance() {
+    static const DerivationRegistry r;
+    return r;
+}
+
+std::optional<const Derivation*> DerivationRegistry::get(std::string_view name) const {
+    auto it = entries_.find(std::string(name));
+    if (it == entries_.end()) return std::nullopt;
+    return std::optional<const Derivation*>{ &it->second };
+}
+
+std::vector<const Derivation*> DerivationRegistry::all() const {
+    return order_;
+}
+
+} // namespace derivations
+} // namespace inertial_sense

--- a/src/derivations/DerivationRegistry.h
+++ b/src/derivations/DerivationRegistry.h
@@ -1,0 +1,242 @@
+/**
+ * @file DerivationRegistry.h
+ * @brief Built-in derivation catalog — D-09 / SN-7899.
+ *
+ * D0037 / D0042: a curated catalog of named, tested derivation
+ * functions that take one or more SDK record streams and produce a
+ * value-semantic stream of derived samples. Templates (D-40+) and
+ * the derived-series dispatch (D-44) reference these entries by
+ * name; the exprtk formula path (D-43) coexists as an alternative
+ * for ad-hoc math.
+ *
+ * **Pure C++17.** No Qt, no exceptions. Failures travel via
+ * `ISExpected<T>`.
+ *
+ * **Stable names.** Each entry's `name` is part of the public surface
+ * — once shipped, plot templates depend on it. Don't rename without
+ * a deprecation cycle.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include "ISError.h"
+#include "ISLogReader.h"
+#include "ISTimeStamp.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace inertial_sense {
+namespace derivations {
+
+/**
+ * @brief Declares one input-data dependency a derivation needs.
+ *
+ * A derivation that requires `DID_INS_2.qn2b` declares
+ * `InputSpec{ DID_INS_2, "qn2b" }`. The `fieldPath` is documentation
+ * only — actual field access happens inside the evaluator's body via
+ * the underlying payload struct.
+ *
+ * `optional` marks inputs that may be replaced or supplied via
+ * parameters (e.g. `lla_to_ned@user_origin`'s LLA reference).
+ */
+struct InputSpec {
+    uint32_t        did;
+    std::string_view fieldPath;
+    bool            optional = false;
+};
+
+/**
+ * @brief A single output sample produced by a derivation.
+ *
+ * `values` is variable-length to support both scalar and multi-channel
+ * derivations under one type:
+ *   - 1 element for scalar (e.g. `velocity_magnitude`).
+ *   - 3 elements for vector outputs (e.g. `quat_to_euler` produces
+ *     `[roll, pitch, yaw]`).
+ *
+ * The `time` field carries the same `TimeStamp` provenance as the
+ * underlying record(s) — `source = PayloadToW`, `confidence = Exact`
+ * for raw inputs; `Resolved` / `Approximate` once D-07 lands and
+ * derivations consume resolved inputs.
+ */
+struct DerivedSample {
+    TimeStamp           time;
+    std::vector<double> values;
+};
+
+/**
+ * @brief A derivation's evaluation result.
+ *
+ * Per-channel naming + unit + frame travel with the data so the
+ * UI (D-91) can label axes and the playback engine (D-60) can scrub
+ * across derivations consistently.
+ */
+struct DerivationResult {
+    /// One name per element of `DerivedSample::values`. For
+    /// `quat_to_euler`: `["roll", "pitch", "yaw"]`. Single-channel
+    /// outputs typically use the derivation's name itself.
+    std::vector<std::string> channelNames;
+
+    /// Output unit string — e.g. "rad", "m", "m/s". Echoes the
+    /// `Derivation::outputUnit` advertised at registration time.
+    std::string outputUnit;
+
+    /// Output frame — e.g. "NED", "body", "" for frame-invariant
+    /// scalars like magnitudes.
+    std::string outputFrame;
+
+    /// Samples in input arrival order (not necessarily timestamp-
+    /// monotonic; D-07 will sort). Same semantics as the underlying
+    /// reader's `allRecords()`.
+    std::vector<DerivedSample> samples;
+};
+
+/**
+ * @brief Documents a parameter the derivation accepts via
+ *        `DerivationContext::setParam`.
+ */
+struct DerivationParameter {
+    std::string_view name;
+    std::string_view defaultValue;
+    std::string_view description;
+};
+
+/**
+ * @brief Per-evaluation inputs + parameter map.
+ *
+ * Holds a non-owning pointer to one source `ISLogReader`. Multi-
+ * device contexts will follow when D-32 lands the series cache; for
+ * v1, one segment per evaluation is sufficient.
+ */
+class DerivationContext {
+public:
+    /// Constructs a context bound to one source reader. The reader's
+    /// lifetime must outlive the evaluation.
+    explicit DerivationContext(const ISLogReader& reader) noexcept
+        : reader_(&reader) {}
+
+    /// @return  Bound source reader. Aliased pointer, do not store
+    ///          past the evaluation.
+    const ISLogReader& reader() const noexcept { return *reader_; }
+
+    /**
+     * Sets a string-valued parameter. Derivations that declare
+     * parameters (`lla_to_ned@user_origin`'s `origin_lla`, etc.)
+     * read the value via `param()`. Unknown names are accepted
+     * (forward-compatibility for templates that pass extras).
+     *
+     * @param name   Parameter name (must match the derivation's
+     *               declared parameter name).
+     * @param value  String form; derivation parses it.
+     */
+    void setParam(std::string_view name, std::string value) {
+        params_[std::string(name)] = std::move(value);
+    }
+
+    /// @return  Value previously set via `setParam`, or `nullopt` if
+    ///          the name wasn't set.
+    std::optional<std::string_view> param(std::string_view name) const {
+        auto it = params_.find(std::string(name));
+        if (it == params_.end()) return std::nullopt;
+        return std::optional<std::string_view>{ it->second };
+    }
+
+private:
+    const ISLogReader*               reader_;
+    std::map<std::string, std::string> params_;
+};
+
+/// Function-pointer signature every derivation implements.
+using EvaluateFn = ISExpected<DerivationResult> (*)(const DerivationContext&);
+
+/**
+ * @brief Static descriptor for one named derivation.
+ *
+ * Registered once at SDK startup via the registry's internal init
+ * list. Consumers retrieve by `DerivationRegistry::get(name)` and
+ * call `evaluate(ctx)`.
+ */
+struct Derivation {
+    std::string_view                 name;
+    std::string_view                 description;
+    std::string_view                 outputUnit;
+    std::string_view                 outputFrame;
+    std::vector<InputSpec>           inputs;
+    std::vector<DerivationParameter> parameters;
+    EvaluateFn                       evaluate;
+};
+
+/**
+ * @brief Registry of all built-in derivations.
+ *
+ * Singleton. Construction populates the catalog at first call.
+ * Lookups are O(log N); enumeration is O(N).
+ *
+ * @code
+ *   const auto& reg = derivations::DerivationRegistry::instance();
+ *   if (auto d = reg.get("quat_to_euler")) {
+ *       derivations::DerivationContext ctx{ reader };
+ *       auto r = (*d)->evaluate(ctx);
+ *       // ...
+ *   }
+ * @endcode
+ */
+class DerivationRegistry {
+public:
+    /// @return  Singleton instance. Thread-safe (Meyers' singleton).
+    static const DerivationRegistry& instance();
+
+    /// @return  Pointer to the entry with the given name, or
+    ///          `nullopt` if absent.
+    std::optional<const Derivation*> get(std::string_view name) const;
+
+    /// @return  All registered entries, in registration order.
+    std::vector<const Derivation*> all() const;
+
+    /// @return  Count of registered entries.
+    std::size_t size() const noexcept { return entries_.size(); }
+
+    DerivationRegistry(const DerivationRegistry&)            = delete;
+    DerivationRegistry& operator=(const DerivationRegistry&) = delete;
+
+private:
+    DerivationRegistry();
+
+    /// Backing storage. `std::string` keys (not `string_view`) so
+    /// the map owns its keys and string-view lookups stay safe even
+    /// when callers pass through temporaries.
+    std::map<std::string, Derivation> entries_;
+
+    /// Insertion-order list for `all()` enumerations.
+    std::vector<const Derivation*>    order_;
+};
+
+// ---------------------------------------------------------------------------
+// Built-in derivation evaluator declarations.
+//
+// One per entry in the v1 catalog. Implementations live in the
+// matching .cpp files; the registry knits them into the catalog at
+// init.
+// ---------------------------------------------------------------------------
+
+ISExpected<DerivationResult> evalQuatToEuler(const DerivationContext&);
+ISExpected<DerivationResult> evalLlaToNedFirstFix(const DerivationContext&);
+ISExpected<DerivationResult> evalLlaToNedUserOrigin(const DerivationContext&);
+ISExpected<DerivationResult> evalVelocityMagnitude(const DerivationContext&);
+ISExpected<DerivationResult> evalAccelMagnitude(const DerivationContext&);
+ISExpected<DerivationResult> evalRateMagnitude(const DerivationContext&);
+ISExpected<DerivationResult> evalBodyAccelToNed(const DerivationContext&);
+ISExpected<DerivationResult> evalBodyRateToEulerRate(const DerivationContext&);
+ISExpected<DerivationResult> evalHeadingFromVelocity(const DerivationContext&);
+ISExpected<DerivationResult> evalHeadingFromQuat(const DerivationContext&);
+
+} // namespace derivations
+} // namespace inertial_sense

--- a/src/derivations/derivation_helpers.h
+++ b/src/derivations/derivation_helpers.h
@@ -1,0 +1,161 @@
+/**
+ * @file derivation_helpers.h
+ * @brief Internal helpers shared across built-in derivation evaluators.
+ *
+ * `ISRecordView::bytes()` exposes the chunk-input range a record was
+ * parsed from — for production logs that range may contain several
+ * packets sharing one offset. The clean way to extract a typed payload
+ * is to re-parse the segment's raw byte buffer via
+ * `is_comm_parse_byte`. `walkPayloads<T>()` does that once per
+ * derivation evaluation.
+ *
+ * Not part of the SDK's public API surface.
+ */
+
+#pragma once
+
+#include "DerivationRegistry.h"
+
+#include "ISComm.h"
+#include "ISDataMappings.h"
+#include "ISLogReader.h"
+#include "ISPose.h"
+#include "ISEarth.h"
+#include "data_sets.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace inertial_sense {
+namespace derivations {
+namespace detail {
+
+inline constexpr double kStandardGravity = 9.80665;
+
+/// Wraps a heading to either [-pi, pi] (default) or [0, 2pi].
+inline double wrapHeading(double h, bool positiveOnly) {
+    constexpr double kTwoPi = 2.0 * M_PI;
+    h = std::fmod(h, kTwoPi);
+    if (positiveOnly) {
+        if (h < 0.0) h += kTwoPi;
+        return h;
+    }
+    if (h >  M_PI) h -= kTwoPi;
+    if (h < -M_PI) h += kTwoPi;
+    return h;
+}
+
+/// Reads the `wrap` parameter (`"signed"` (default) or `"positive"`/
+/// `"unsigned"`).
+inline bool parseWrapPositive(const DerivationContext& ctx) {
+    auto v = ctx.param("wrap");
+    if (!v) return false;
+    return *v == std::string_view{"positive"} || *v == std::string_view{"unsigned"};
+}
+
+/// Parses the `origin_lla` parameter as `lat,lon,alt` (lat/lon in
+/// degrees, alt in metres). Returns nullopt on malformed input.
+inline std::optional<std::array<double, 3>> parseLlaCsv(std::string_view s) {
+    std::array<double, 3> out{};
+    std::size_t prev = 0;
+    int field = 0;
+    while (field < 3) {
+        std::size_t comma = s.find(',', prev);
+        std::string_view tok = s.substr(prev, comma - prev);
+        try {
+            out[field++] = std::stod(std::string(tok));
+        } catch (...) {
+            return std::nullopt;
+        }
+        if (comma == std::string_view::npos) break;
+        prev = comma + 1;
+    }
+    if (field != 3) return std::nullopt;
+    return out;
+}
+
+/// Walks the segment's raw bytes via `is_comm_parse_byte`, invoking
+/// `cb(timestamp, payload)` for every ISB packet whose DID equals
+/// `did` and whose payload size equals `sizeof(T)`. Mismatched sizes
+/// (incomplete packets, alternate format DIDs) are silently skipped.
+///
+/// This is the canonical way for derivations to consume payload
+/// structs, working independently of how the index was built.
+template <class T, class Fn>
+void walkPayloads(const ISLogReader& reader, uint32_t did, Fn cb) {
+    auto bytes = reader.rawBytes();
+    if (!bytes.first || bytes.second == 0) return;
+
+    is_comm_instance_t comm{};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
+    is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
+
+    for (std::size_t i = 0; i < bytes.second; ++i) {
+        protocol_type_t p = is_comm_parse_byte(&comm, bytes.first[i]);
+        if (p != _PTYPE_INERTIAL_SENSE_DATA && p != _PTYPE_INERTIAL_SENSE_CMD) {
+            continue;
+        }
+        if (comm.rxPkt.dataHdr.id != did) continue;
+        if (comm.rxPkt.dataHdr.size != sizeof(T)) continue;
+
+        const double tsSec = cISDataMappings::TimestampOrCurrentTime(
+            &comm.rxPkt.dataHdr, comm.rxPkt.data.ptr);
+        const uint64_t tsMs = static_cast<uint64_t>(tsSec * 1000.0);
+        TimeStamp ts{ tsMs, TimeSource::PayloadToW, TimeConfidence::Exact,
+                      reader.deviceId() };
+
+        T copy;
+        std::memcpy(&copy, comm.rxPkt.data.ptr, sizeof(T));
+        cb(ts, copy);
+    }
+}
+
+/// Materializes one DID's payloads into a vector for multi-input
+/// derivations that need to scan secondary inputs by timestamp.
+template <class T>
+std::vector<std::pair<TimeStamp, T>> collectPayloads(const ISLogReader& reader,
+                                                     uint32_t did) {
+    std::vector<std::pair<TimeStamp, T>> out;
+    walkPayloads<T>(reader, did, [&](TimeStamp ts, const T& v) {
+        out.emplace_back(ts, v);
+    });
+    return out;
+}
+
+/// Find the entry with timestamp closest to `t`. O(N); D-07's
+/// timestamp-monotonic outputs will let callers binary-search later.
+/// Returns `nullptr` if `samples` is empty.
+template <class T>
+const T* closestByTimestamp(const std::vector<std::pair<TimeStamp, T>>& samples,
+                            TimeStamp t) {
+    if (samples.empty()) return nullptr;
+    const T* best = &samples.front().second;
+    uint64_t bestDelta = (samples.front().first.value > t.value)
+                       ? (samples.front().first.value - t.value)
+                       : (t.value - samples.front().first.value);
+    for (const auto& [ts, val] : samples) {
+        const uint64_t d = (ts.value > t.value)
+                         ? (ts.value - t.value)
+                         : (t.value - ts.value);
+        if (d < bestDelta) { bestDelta = d; best = &val; }
+    }
+    return best;
+}
+
+/// Convenience: builds an `ISError` for "required input not found".
+inline tl::unexpected<ISError> missingInput(uint32_t did, std::string_view field) {
+    std::string m = "derivation: required input DID=" + std::to_string(did)
+                  + " field='" + std::string(field) + "' not present in segment";
+    return fail(ISErrorCode::NotFound, std::move(m));
+}
+
+} // namespace detail
+} // namespace derivations
+} // namespace inertial_sense

--- a/src/derivations/derivations_lla.cpp
+++ b/src/derivations/derivations_lla.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file derivations_lla.cpp
+ * @brief LLA → NED projection — both `@first_fix` and `@user_origin`.
+ *
+ * Uses the SDK's `lla2ned_d` (`ISEarth.h`) for the actual geodetic
+ * math. lla[0]/lla[1] in degrees, lla[2] in metres above WGS84
+ * ellipsoid — matches the documented INS_2 convention.
+ *
+ * The `@first_fix` variant uses the first record's lla as the origin.
+ * Today we don't have a fix-quality field exposed via this surface, so
+ * we always pick the first record; D-07 era can refine to "first
+ * record where `eGpsStatusFix` is Fix-or-better" by re-parsing the
+ * GPS records alongside.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "derivation_helpers.h"
+
+namespace inertial_sense {
+namespace derivations {
+
+namespace {
+
+DerivationResult makeShell() {
+    DerivationResult r;
+    r.channelNames = { "n", "e", "d" };
+    r.outputUnit   = "m";
+    r.outputFrame  = "NED";
+    return r;
+}
+
+void appendNed(DerivationResult& out, TimeStamp t,
+               const double origin[3], const double lla[3]) {
+    double mutableOrigin[3] = { origin[0], origin[1], origin[2] };
+    double mutableLla[3]    = { lla[0],    lla[1],    lla[2]    };
+    ixVector3 ned;
+    // INS_2.lla is documented as WGS84 lat/lon in *degrees*; use the
+    // degree-input variant (the bare `lla2ned_d` expects radians).
+    llaDeg2ned_d(mutableOrigin, mutableLla, ned);
+    out.samples.push_back({
+        t,
+        { static_cast<double>(ned[0]),
+          static_cast<double>(ned[1]),
+          static_cast<double>(ned[2]) },
+    });
+}
+
+} // namespace
+
+ISExpected<DerivationResult> evalLlaToNedFirstFix(const DerivationContext& ctx) {
+    DerivationResult out = makeShell();
+    bool   haveOrigin = false;
+    double origin[3]  = { 0.0, 0.0, 0.0 };
+
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            if (!haveOrigin) {
+                origin[0] = ins.lla[0];
+                origin[1] = ins.lla[1];
+                origin[2] = ins.lla[2];
+                haveOrigin = true;
+            }
+            appendNed(out, ts, origin, ins.lla);
+        });
+    if (!haveOrigin) return detail::missingInput(DID_INS_2, "lla");
+    return out;
+}
+
+ISExpected<DerivationResult> evalLlaToNedUserOrigin(const DerivationContext& ctx) {
+    auto userOrigin = ctx.param("origin_lla");
+    if (!userOrigin) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "lla_to_ned@user_origin: missing required parameter "
+                    "'origin_lla' (expected 'lat_deg,lon_deg,alt_m')");
+    }
+    auto parsed = detail::parseLlaCsv(*userOrigin);
+    if (!parsed) {
+        return fail(ISErrorCode::InvalidArgument,
+                    "lla_to_ned@user_origin: malformed 'origin_lla' "
+                    "(expected 'lat_deg,lon_deg,alt_m')");
+    }
+    const double origin[3] = { (*parsed)[0], (*parsed)[1], (*parsed)[2] };
+
+    DerivationResult out = makeShell();
+    bool any = false;
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            any = true;
+            appendNed(out, ts, origin, ins.lla);
+        });
+    if (!any) return detail::missingInput(DID_INS_2, "lla");
+    return out;
+}
+
+} // namespace derivations
+} // namespace inertial_sense

--- a/src/derivations/derivations_motion.cpp
+++ b/src/derivations/derivations_motion.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file derivations_motion.cpp
+ * @brief Motion-derived scalars + body→NED rotations.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "derivation_helpers.h"
+
+namespace inertial_sense {
+namespace derivations {
+
+namespace {
+
+inline double norm3(const float v[3]) {
+    return std::sqrt(static_cast<double>(v[0]) * v[0]
+                   + static_cast<double>(v[1]) * v[1]
+                   + static_cast<double>(v[2]) * v[2]);
+}
+
+} // namespace
+
+ISExpected<DerivationResult> evalVelocityMagnitude(const DerivationContext& ctx) {
+    DerivationResult out;
+    out.channelNames = { "speed" };
+    out.outputUnit   = "m/s";
+    out.outputFrame  = "";  // magnitude is frame-invariant
+
+    bool any = false;
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            any = true;
+            out.samples.push_back({ ts, { norm3(ins.uvw) } });
+        });
+    if (!any) return detail::missingInput(DID_INS_2, "uvw");
+    return out;
+}
+
+ISExpected<DerivationResult> evalAccelMagnitude(const DerivationContext& ctx) {
+    DerivationResult out;
+    out.channelNames = { "accel" };
+    out.outputUnit   = "m/s²";
+    out.outputFrame  = "";
+
+    bool any = false;
+    detail::walkPayloads<imu_t>(
+        ctx.reader(), DID_IMU,
+        [&](TimeStamp ts, const imu_t& imu) {
+            any = true;
+            out.samples.push_back({ ts, { norm3(imu.I.acc) } });
+        });
+    if (!any) return detail::missingInput(DID_IMU, "I.acc");
+    return out;
+}
+
+ISExpected<DerivationResult> evalRateMagnitude(const DerivationContext& ctx) {
+    DerivationResult out;
+    out.channelNames = { "rate" };
+    out.outputUnit   = "rad/s";
+    out.outputFrame  = "";
+
+    bool any = false;
+    detail::walkPayloads<imu_t>(
+        ctx.reader(), DID_IMU,
+        [&](TimeStamp ts, const imu_t& imu) {
+            any = true;
+            out.samples.push_back({ ts, { norm3(imu.I.pqr) } });
+        });
+    if (!any) return detail::missingInput(DID_IMU, "I.pqr");
+    return out;
+}
+
+ISExpected<DerivationResult> evalBodyAccelToNed(const DerivationContext& ctx) {
+    auto qn2bs = detail::collectPayloads<ins_2_t>(ctx.reader(), DID_INS_2);
+    if (qn2bs.empty()) return detail::missingInput(DID_INS_2, "qn2b");
+
+    bool keepGravity = true;
+    if (auto p = ctx.param("include_gravity")) {
+        keepGravity = !(*p == std::string_view{"false"} || *p == std::string_view{"0"});
+    }
+
+    DerivationResult out;
+    out.channelNames = { "n", "e", "d" };
+    out.outputUnit   = "m/s²";
+    out.outputFrame  = "NED";
+
+    bool anyImu = false;
+    detail::walkPayloads<imu_t>(
+        ctx.reader(), DID_IMU,
+        [&](TimeStamp ts, const imu_t& imu) {
+            anyImu = true;
+            const ins_2_t* ins = detail::closestByTimestamp(qn2bs, ts);
+            if (!ins) return;
+
+            ixVector3 body = { imu.I.acc[0], imu.I.acc[1], imu.I.acc[2] };
+            ixVector3 nav;
+            ixQuat    q = { ins->qn2b[0], ins->qn2b[1], ins->qn2b[2], ins->qn2b[3] };
+            // quatRot rotates a body-frame vector by `q` (body→nav)
+            // into the nav frame.
+            quatRot(nav, q, body);
+
+            double n = nav[0], e = nav[1], d = nav[2];
+            if (!keepGravity) {
+                d -= detail::kStandardGravity;
+            }
+            out.samples.push_back({ ts, { n, e, d } });
+        });
+    if (!anyImu) return detail::missingInput(DID_IMU, "I.acc");
+    return out;
+}
+
+ISExpected<DerivationResult> evalHeadingFromVelocity(const DerivationContext& ctx) {
+    const bool positive = detail::parseWrapPositive(ctx);
+
+    DerivationResult out;
+    out.channelNames = { "heading" };
+    out.outputUnit   = "rad";
+    out.outputFrame  = "NED";
+
+    bool any = false;
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            any = true;
+            ixVector3 uvw = { ins.uvw[0], ins.uvw[1], ins.uvw[2] };
+            ixVector3 vNed;
+            ixQuat    q = { ins.qn2b[0], ins.qn2b[1], ins.qn2b[2], ins.qn2b[3] };
+            quatRot(vNed, q, uvw);
+
+            // Skip near-zero velocity samples — heading is undefined at
+            // rest. Threshold matches the typical INS noise floor for
+            // body-frame velocity (~1 cm/s).
+            const double horiz = std::sqrt(
+                static_cast<double>(vNed[0]) * vNed[0]
+              + static_cast<double>(vNed[1]) * vNed[1]);
+            if (horiz < 0.01) return;
+
+            const double h = std::atan2(static_cast<double>(vNed[1]),
+                                        static_cast<double>(vNed[0]));
+            out.samples.push_back({
+                ts,
+                { detail::wrapHeading(h, positive) },
+            });
+        });
+    if (!any) return detail::missingInput(DID_INS_2, "uvw");
+    return out;
+}
+
+} // namespace derivations
+} // namespace inertial_sense

--- a/src/derivations/derivations_pose.cpp
+++ b/src/derivations/derivations_pose.cpp
@@ -1,0 +1,126 @@
+/**
+ * @file derivations_pose.cpp
+ * @brief Quaternion-driven derivations: quat→euler, heading-from-quat,
+ *        body-rate→euler-rate.
+ *
+ * Quaternion convention: per `data_sets.h`, INS_2.qn2b is a Hamilton
+ * quaternion (W,X,Y,Z) representing body→nav rotation. We feed it
+ * directly to the SDK's `quat2euler`, which yields (roll, pitch, yaw)
+ * in radians. No frame remapping happens here.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "derivation_helpers.h"
+
+namespace inertial_sense {
+namespace derivations {
+
+using detail::missingInput;
+using detail::parseWrapPositive;
+using detail::wrapHeading;
+
+ISExpected<DerivationResult> evalQuatToEuler(const DerivationContext& ctx) {
+    DerivationResult out;
+    out.channelNames = { "roll", "pitch", "yaw" };
+    out.outputUnit   = "rad";
+    out.outputFrame  = "body→NED";
+
+    bool any = false;
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            any = true;
+            ixEuler theta;
+            ixQuat  q = { ins.qn2b[0], ins.qn2b[1], ins.qn2b[2], ins.qn2b[3] };
+            quat2euler(q, theta);
+            out.samples.push_back({
+                ts,
+                { static_cast<double>(theta[0]),
+                  static_cast<double>(theta[1]),
+                  static_cast<double>(theta[2]) },
+            });
+        });
+    if (!any) return missingInput(DID_INS_2, "qn2b");
+    return out;
+}
+
+ISExpected<DerivationResult> evalHeadingFromQuat(const DerivationContext& ctx) {
+    const bool positive = parseWrapPositive(ctx);
+
+    DerivationResult out;
+    out.channelNames = { "heading" };
+    out.outputUnit   = "rad";
+    out.outputFrame  = "NED";
+
+    bool any = false;
+    detail::walkPayloads<ins_2_t>(
+        ctx.reader(), DID_INS_2,
+        [&](TimeStamp ts, const ins_2_t& ins) {
+            any = true;
+            ixEuler theta;
+            ixQuat  q = { ins.qn2b[0], ins.qn2b[1], ins.qn2b[2], ins.qn2b[3] };
+            quat2euler(q, theta);
+            out.samples.push_back({
+                ts,
+                { wrapHeading(static_cast<double>(theta[2]), positive) },
+            });
+        });
+    if (!any) return missingInput(DID_INS_2, "qn2b");
+    return out;
+}
+
+ISExpected<DerivationResult> evalBodyRateToEulerRate(const DerivationContext& ctx) {
+    auto qn2bs = detail::collectPayloads<ins_2_t>(ctx.reader(), DID_INS_2);
+    if (qn2bs.empty()) return missingInput(DID_INS_2, "qn2b");
+
+    DerivationResult out;
+    out.channelNames = { "roll_rate", "pitch_rate", "yaw_rate" };
+    out.outputUnit   = "rad/s";
+    out.outputFrame  = "Euler";
+
+    bool anyImu = false;
+    detail::walkPayloads<imu_t>(
+        ctx.reader(), DID_IMU,
+        [&](TimeStamp ts, const imu_t& imu) {
+            anyImu = true;
+            const ins_2_t* ins = detail::closestByTimestamp(qn2bs, ts);
+            if (!ins) return;
+
+            ixEuler theta;
+            ixQuat  q = { ins->qn2b[0], ins->qn2b[1], ins->qn2b[2], ins->qn2b[3] };
+            quat2euler(q, theta);
+            const double roll  = static_cast<double>(theta[0]);
+            const double pitch = static_cast<double>(theta[1]);
+
+            const double cr = std::cos(roll),  sr = std::sin(roll);
+            const double cp = std::cos(pitch);
+            // Singularity guard: pitch close to ±π/2.
+            const double tp = (std::abs(cp) > 1e-6) ? (std::sin(pitch) / cp)
+                                                    : (std::sin(pitch) / 1e-6);
+
+            const double p  = static_cast<double>(imu.I.pqr[0]);
+            const double q_ = static_cast<double>(imu.I.pqr[1]);
+            const double r  = static_cast<double>(imu.I.pqr[2]);
+
+            // Standard 3-2-1 Euler-rate transform:
+            //   φ̇ = p + sin(φ) tan(θ) q + cos(φ) tan(θ) r
+            //   θ̇ =      cos(φ)        q -      sin(φ)        r
+            //   ψ̇ =      sin(φ)/cos(θ) q +      cos(φ)/cos(θ) r
+            const double rollRate  = p + sr * tp * q_ + cr * tp * r;
+            const double pitchRate = cr * q_ - sr * r;
+            const double yawRate   = (std::abs(cp) > 1e-6)
+                                   ? ((sr / cp) * q_ + (cr / cp) * r)
+                                   : 0.0;
+
+            out.samples.push_back({
+                ts,
+                { rollRate, pitchRate, yawRate },
+            });
+        });
+    if (!anyImu) return missingInput(DID_IMU, "I.pqr");
+    return out;
+}
+
+} // namespace derivations
+} // namespace inertial_sense

--- a/tests/test_derivations.cpp
+++ b/tests/test_derivations.cpp
@@ -1,0 +1,444 @@
+/**
+ * @file test_derivations.cpp
+ * @brief D-09 / SN-7899 — built-in derivation catalog tests.
+ *
+ * Strategy: hand-build a tiny ISLogReader fixture by writing a few
+ * INS_2 + IMU records via the cISLogger framework, then run each
+ * derivation against it and assert numerical results within
+ * documented tolerances. Numerical references are computed locally
+ * (Hamilton quat → ZYX Euler, lla→NED via `lla2ned_d` itself) so
+ * the tests don't depend on a Python reference at this story's
+ * scope (deferred to D-11).
+ */
+
+#include <gtest/gtest.h>
+
+#include "com_manager.h"  // first
+
+#include "derivations/DerivationRegistry.h"
+#include "DeviceLog.h"
+#include "ISFileManager.h"
+#include "ISLogger.h"
+#include "ISLogReader.h"
+#include "ISPose.h"
+#include "ISEarth.h"
+#include "data_sets.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <list>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace inertial_sense;
+using namespace inertial_sense::derivations;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint16_t kFixtureHwId   = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
+constexpr uint32_t kFixtureSerial = 999333u;
+
+struct FixturePaths {
+    fs::path directory;
+    fs::path rawFile;
+};
+
+FixturePaths buildFixture(const std::string& hint,
+                          const std::vector<ins_2_t>& insSamples,
+                          const std::vector<imu_t>&   imuSamples) {
+    FixturePaths f;
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf),
+                  "/tmp/test_derivations_%s_%d_%ld",
+                  hint.c_str(), ::getpid(),
+                  static_cast<long>(::time(nullptr)));
+    f.directory = dirBuf;
+    ISFileManager::DeleteDirectory(f.directory.string());
+
+    cISLogger logger;
+    cISLogger::sSaveOptions opts;
+    opts.logType               = cISLogger::LOGTYPE_RAW;
+    opts.useSubFolderTimestamp = false;
+    if (!logger.InitSave(f.directory.string(), opts)) return f;
+    auto devLogger = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+    if (!devLogger) return f;
+    logger.EnableLogging(true);
+
+    auto wrap = [](uint32_t did, void* payload, std::size_t size) {
+        std::vector<uint8_t> out;
+        is_comm_instance_t comm{};
+        uint8_t buf[1024];
+        is_comm_init(&comm, buf, sizeof(buf), NULL);
+        uint8_t pkt[2048];
+        const int n = is_comm_data_to_buf(pkt, sizeof(pkt), &comm,
+                                          static_cast<uint16_t>(did),
+                                          static_cast<uint16_t>(size), 0,
+                                          payload);
+        if (n > 0) out.assign(pkt, pkt + n);
+        return out;
+    };
+
+    for (const auto& s : insSamples) {
+        ins_2_t copy = s;
+        auto bytes = wrap(DID_INS_2, &copy, sizeof(copy));
+        if (!bytes.empty()) {
+            logger.LogData(devLogger, bytes.size(), bytes.data());
+        }
+    }
+    for (const auto& s : imuSamples) {
+        imu_t copy = s;
+        auto bytes = wrap(DID_IMU, &copy, sizeof(copy));
+        if (!bytes.empty()) {
+            logger.LogData(devLogger, bytes.size(), bytes.data());
+        }
+    }
+    logger.CloseAllFiles();
+
+    std::vector<ISFileManager::file_info_t> rawFiles;
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true,
+                                          "\\.raw$", rawFiles);
+    if (!rawFiles.empty()) f.rawFile = rawFiles.front().name;
+    return f;
+}
+
+void teardown(FixturePaths& f) {
+    if (!f.directory.empty() && fs::exists(f.directory)) {
+        ISFileManager::DeleteDirectory(f.directory.string());
+    }
+}
+
+// Build an INS_2 sample at a given timeOfWeek with quat / uvw / lla.
+ins_2_t makeIns(double tow, const float quat[4], const float uvw[3],
+                const double lla[3]) {
+    ins_2_t s{};
+    s.week       = 2300;
+    s.timeOfWeek = tow;
+    s.insStatus  = 0;
+    s.hdwStatus  = 0;
+    std::memcpy(s.qn2b, quat, sizeof(s.qn2b));
+    std::memcpy(s.uvw,  uvw,  sizeof(s.uvw));
+    std::memcpy(s.lla,  lla,  sizeof(s.lla));
+    return s;
+}
+
+imu_t makeImu(double t, const float pqr[3], const float acc[3]) {
+    imu_t s{};
+    s.time = t;
+    s.status = 0;
+    std::memcpy(s.I.pqr, pqr, sizeof(s.I.pqr));
+    std::memcpy(s.I.acc, acc, sizeof(s.I.acc));
+    return s;
+}
+
+class DerivationTest : public ::testing::Test {
+protected:
+    FixturePaths f;
+    void TearDown() override { teardown(f); }
+};
+
+// ---------------------------------------------------------------------------
+// Registry sanity: every advertised derivation is present and reachable.
+// ---------------------------------------------------------------------------
+TEST(DerivationRegistry, AllV1EntriesPresent) {
+    const auto& reg = DerivationRegistry::instance();
+    const std::vector<std::string> expected = {
+        "quat_to_euler",
+        "heading_from_quat",
+        "lla_to_ned@first_fix",
+        "lla_to_ned@user_origin",
+        "velocity_magnitude",
+        "accel_magnitude",
+        "rate_magnitude",
+        "body_accel_to_ned_accel",
+        "body_rate_to_euler_rate",
+        "heading_from_velocity",
+    };
+    EXPECT_EQ(reg.size(), expected.size());
+    for (const auto& name : expected) {
+        auto d = reg.get(name);
+        ASSERT_TRUE(d.has_value()) << "missing entry: " << name;
+        EXPECT_NE((*d)->evaluate, nullptr) << name;
+        EXPECT_FALSE((*d)->outputUnit.empty()) << name;
+    }
+}
+
+TEST(DerivationRegistry, UnknownNameReturnsNullopt) {
+    const auto& reg = DerivationRegistry::instance();
+    EXPECT_FALSE(reg.get("definitely_not_a_real_derivation").has_value());
+}
+
+// ---------------------------------------------------------------------------
+// quat_to_euler: identity quat → all zeros; +90° yaw quat → yaw == π/2.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, QuatToEulerIdentityAndYaw) {
+    const float identity[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    // Hamilton (W,X,Y,Z) for +90° rotation about Z: (cos(45°), 0, 0, sin(45°))
+    const float yaw90  [4] = { 0.7071068f, 0.0f, 0.0f, 0.7071068f };
+    const float uvw[3]     = { 0.0f, 0.0f, 0.0f };
+    const double lla[3]    = { 40.0, -111.0, 1400.0 };
+
+    f = buildFixture("quat", {
+        makeIns(100.0, identity, uvw, lla),
+        makeIns(100.1, yaw90,    uvw, lla),
+    }, {});
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+
+    auto d = DerivationRegistry::instance().get("quat_to_euler");
+    ASSERT_TRUE(d.has_value());
+    auto r = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    ASSERT_EQ(r->samples.size(), 2u);
+
+    EXPECT_NEAR(r->samples[0].values[0], 0.0, 1e-5);  // roll
+    EXPECT_NEAR(r->samples[0].values[1], 0.0, 1e-5);  // pitch
+    EXPECT_NEAR(r->samples[0].values[2], 0.0, 1e-5);  // yaw
+
+    EXPECT_NEAR(r->samples[1].values[0], 0.0,    1e-5);
+    EXPECT_NEAR(r->samples[1].values[1], 0.0,    1e-5);
+    EXPECT_NEAR(r->samples[1].values[2], M_PI/2, 1e-5);
+}
+
+// ---------------------------------------------------------------------------
+// velocity_magnitude / accel_magnitude / rate_magnitude.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, MagnitudesComputeNorms) {
+    const float quat[4]    = { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float uvw[3]     = { 3.0f, 4.0f, 0.0f };  // ‖·‖ = 5
+    const double lla[3]    = { 0.0, 0.0, 0.0 };
+    const float pqr[3]     = { 0.6f, 0.8f, 0.0f };  // ‖·‖ = 1.0
+    const float acc[3]     = { 1.0f, 2.0f, 2.0f };  // ‖·‖ = 3
+
+    f = buildFixture("mags",
+                     { makeIns(100.0, quat, uvw, lla) },
+                     { makeImu(0.5, pqr, acc) });
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+
+    {
+        auto d = DerivationRegistry::instance().get("velocity_magnitude");
+        ASSERT_TRUE(d.has_value());
+        auto r = (*d)->evaluate(ctx);
+        ASSERT_TRUE(r.has_value()) << r.error().message;
+        ASSERT_EQ(r->samples.size(), 1u);
+        EXPECT_NEAR(r->samples[0].values[0], 5.0, 1e-5);
+    }
+    {
+        auto d = DerivationRegistry::instance().get("accel_magnitude");
+        ASSERT_TRUE(d.has_value());
+        auto r = (*d)->evaluate(ctx);
+        ASSERT_TRUE(r.has_value()) << r.error().message;
+        ASSERT_EQ(r->samples.size(), 1u);
+        EXPECT_NEAR(r->samples[0].values[0], 3.0, 1e-5);
+    }
+    {
+        auto d = DerivationRegistry::instance().get("rate_magnitude");
+        ASSERT_TRUE(d.has_value());
+        auto r = (*d)->evaluate(ctx);
+        ASSERT_TRUE(r.has_value()) << r.error().message;
+        ASSERT_EQ(r->samples.size(), 1u);
+        EXPECT_NEAR(r->samples[0].values[0], 1.0, 1e-5);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// lla_to_ned@first_fix: first record is the origin (0,0,0); second is
+// 1° North → expect ~111 km positive North, ~0 East, ~0 Down.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, LlaToNedFirstFix) {
+    const float quat[4]    = { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float uvw[3]     = { 0.0f, 0.0f, 0.0f };
+    const double origin[3] = { 40.0,  -111.0, 1400.0 };
+    const double oneDegN[3]= { 41.0,  -111.0, 1400.0 };
+
+    f = buildFixture("lla_first", {
+        makeIns(100.0, quat, uvw, origin),
+        makeIns(100.1, quat, uvw, oneDegN),
+    }, {});
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+
+    auto d = DerivationRegistry::instance().get("lla_to_ned@first_fix");
+    ASSERT_TRUE(d.has_value());
+    auto r = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    ASSERT_EQ(r->samples.size(), 2u);
+
+    EXPECT_NEAR(r->samples[0].values[0], 0.0, 0.5);
+    EXPECT_NEAR(r->samples[0].values[1], 0.0, 0.5);
+    EXPECT_NEAR(r->samples[0].values[2], 0.0, 0.5);
+
+    EXPECT_GT(r->samples[1].values[0],  100000.0);  // ≥ 100 km North
+    EXPECT_LT(r->samples[1].values[0],  120000.0);  // ≤ 120 km
+    EXPECT_NEAR(r->samples[1].values[1], 0.0, 100.0);
+    EXPECT_NEAR(r->samples[1].values[2], 0.0, 5.0);
+}
+
+// ---------------------------------------------------------------------------
+// lla_to_ned@user_origin: missing parameter → InvalidArgument.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, LlaToNedUserOriginNeedsParam) {
+    const float quat[4]  = { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float uvw[3]   = { 0.0f, 0.0f, 0.0f };
+    const double lla[3]  = { 40.0, -111.0, 1400.0 };
+    f = buildFixture("lla_user", { makeIns(100.0, quat, uvw, lla) }, {});
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+    auto d = DerivationRegistry::instance().get("lla_to_ned@user_origin");
+    ASSERT_TRUE(d.has_value());
+
+    auto r = (*d)->evaluate(ctx);
+    EXPECT_FALSE(r.has_value());
+    EXPECT_EQ(r.error().code, ISErrorCode::InvalidArgument);
+
+    ctx.setParam("origin_lla", "39.9,-111.0,1400.0");
+    r = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    ASSERT_EQ(r->samples.size(), 1u);
+    EXPECT_GT(r->samples[0].values[0], 0.0);  // sample is North of origin
+}
+
+// ---------------------------------------------------------------------------
+// heading_from_quat: identity quat → 0; +90° yaw quat → π/2.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, HeadingFromQuat) {
+    const float identity[4]= { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float yaw90  [4] = { 0.7071068f, 0.0f, 0.0f, 0.7071068f };
+    const float uvw[3]     = { 0.0f, 0.0f, 0.0f };
+    const double lla[3]    = { 0.0, 0.0, 0.0 };
+
+    f = buildFixture("hdg_q", {
+        makeIns(100.0, identity, uvw, lla),
+        makeIns(100.1, yaw90,    uvw, lla),
+    }, {});
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+    auto d = DerivationRegistry::instance().get("heading_from_quat");
+    ASSERT_TRUE(d.has_value());
+
+    auto r = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    ASSERT_EQ(r->samples.size(), 2u);
+    EXPECT_NEAR(r->samples[0].values[0], 0.0,    1e-5);
+    EXPECT_NEAR(r->samples[1].values[0], M_PI/2, 1e-5);
+
+    // wrap=positive — same numeric values for inputs in [0, π).
+    ctx.setParam("wrap", "positive");
+    auto r2 = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_NEAR(r2->samples[0].values[0], 0.0,    1e-5);
+    EXPECT_NEAR(r2->samples[1].values[0], M_PI/2, 1e-5);
+}
+
+// ---------------------------------------------------------------------------
+// body_accel_to_ned_accel: identity quat + body acc (0,0,9.80665) →
+// NED (0, 0, 9.80665). With include_gravity=false → (0, 0, 0).
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, BodyAccelToNedGravityToggle) {
+    const float identity[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float uvw[3]      = { 0.0f, 0.0f, 0.0f };
+    const double lla[3]     = { 0.0, 0.0, 0.0 };
+    const float pqr[3]      = { 0.0f, 0.0f, 0.0f };
+    const float accDown[3]  = { 0.0f, 0.0f, 9.80665f };
+
+    f = buildFixture("body2ned", {
+        makeIns(100.0, identity, uvw, lla),
+    }, {
+        makeImu(100.0, pqr, accDown),
+    });
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+    auto d = DerivationRegistry::instance().get("body_accel_to_ned_accel");
+    ASSERT_TRUE(d.has_value());
+
+    auto withG = (*d)->evaluate(ctx);
+    ASSERT_TRUE(withG.has_value()) << withG.error().message;
+    ASSERT_EQ(withG->samples.size(), 1u);
+    EXPECT_NEAR(withG->samples[0].values[0], 0.0,    1e-5);
+    EXPECT_NEAR(withG->samples[0].values[1], 0.0,    1e-5);
+    EXPECT_NEAR(withG->samples[0].values[2], 9.80665, 1e-4);
+
+    ctx.setParam("include_gravity", "false");
+    auto noG = (*d)->evaluate(ctx);
+    ASSERT_TRUE(noG.has_value());
+    ASSERT_EQ(noG->samples.size(), 1u);
+    EXPECT_NEAR(noG->samples[0].values[2], 0.0, 1e-4);
+}
+
+// ---------------------------------------------------------------------------
+// Missing-input error: call quat_to_euler on a fixture with only IMU.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, MissingInputProducesError) {
+    const float pqr[3] = { 0.0f, 0.0f, 0.0f };
+    const float acc[3] = { 0.0f, 0.0f, 9.80665f };
+    f = buildFixture("missing", {}, { makeImu(100.0, pqr, acc) });
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+    auto d = DerivationRegistry::instance().get("quat_to_euler");
+    ASSERT_TRUE(d.has_value());
+
+    auto r = (*d)->evaluate(ctx);
+    EXPECT_FALSE(r.has_value());
+    EXPECT_EQ(r.error().code, ISErrorCode::NotFound);
+}
+
+// ---------------------------------------------------------------------------
+// body_rate_to_euler_rate: identity quat → output rates equal input rates.
+// ---------------------------------------------------------------------------
+TEST_F(DerivationTest, BodyRateToEulerRateIdentity) {
+    const float identity[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    const float uvw[3]      = { 0.0f, 0.0f, 0.0f };
+    const double lla[3]     = { 0.0, 0.0, 0.0 };
+    const float pqr[3]      = { 0.1f, 0.2f, 0.3f };
+    const float acc[3]      = { 0.0f, 0.0f, 9.80665f };
+
+    f = buildFixture("ber", {
+        makeIns(100.0, identity, uvw, lla),
+    }, {
+        makeImu(100.0, pqr, acc),
+    });
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto reader = ISLogReader::openSegment(f.rawFile);
+    ASSERT_TRUE(reader.has_value());
+    DerivationContext ctx{ reader.value() };
+    auto d = DerivationRegistry::instance().get("body_rate_to_euler_rate");
+    ASSERT_TRUE(d.has_value());
+
+    auto r = (*d)->evaluate(ctx);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    ASSERT_EQ(r->samples.size(), 1u);
+    // At zero roll/pitch the transform reduces to identity.
+    EXPECT_NEAR(r->samples[0].values[0], 0.1, 1e-5);
+    EXPECT_NEAR(r->samples[0].values[1], 0.2, 1e-5);
+    EXPECT_NEAR(r->samples[0].values[2], 0.3, 1e-5);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Curated catalog of named derivation functions that plot templates (D-40+) and the derived-series dispatch (D-44) reference by stable string name. Per D0042, this is the built-in path; ad-hoc exprtk formula derivations (D-43) coexist as the freeform alternative.

### Framework

- `Derivation` — name + description + unit + frame + inputs + parameters + EvaluateFn.
- `DerivationContext` — bound source reader + string parameter map.
- `DerivationResult` — channel names + unit + frame + per-sample `(TimeStamp, vector<double>)`.
- `DerivationRegistry` — singleton; `get(name)`, `all()`, `size()`.

### v1 catalog (10 entries)

| Name | Inputs | Output | Unit |
|---|---|---|---|
| `quat_to_euler` | INS_2.qn2b | (roll, pitch, yaw) | rad |
| `heading_from_quat` | INS_2.qn2b | yaw | rad |
| `lla_to_ned@first_fix` | INS_2.lla | (N, E, D) | m |
| `lla_to_ned@user_origin` | INS_2.lla + `origin_lla` param | (N, E, D) | m |
| `velocity_magnitude` | INS_2.uvw | ‖·‖ | m/s |
| `accel_magnitude` | IMU.I.acc | ‖·‖ | m/s² |
| `rate_magnitude` | IMU.I.pqr | ‖·‖ | rad/s |
| `body_accel_to_ned_accel` | IMU.I.acc + INS_2.qn2b | (N, E, D) | m/s² |
| `body_rate_to_euler_rate` | IMU.I.pqr + INS_2.qn2b | (φ̇, θ̇, ψ̇) | rad/s |
| `heading_from_velocity` | INS_2.uvw + INS_2.qn2b | heading | rad |

### Implementation notes

- All math goes through the existing SDK helpers: `quat2euler`, `quatRot`, `llaDeg2ned_d` (degree-input variant; the bare `lla2ned_d` expects radians and silently produces 60× wrong results — a footgun worth flagging in the broader SDK docs).
- Each derivation walks the segment's raw bytes once via `is_comm_parse_byte` and pulls typed payload structs (see `walkPayloads<T>` in `derivation_helpers.h`). This dodges the chunk-shared-offset problem that makes `ISRecordView::bytes()` unreliable for typed extraction at this story's scope; D-03's `DIDTraits` will offer a cleaner API.
- Multi-input derivations (body_accel_to_ned, body_rate_to_euler_rate) materialize the secondary stream and look up by closest-timestamp (O(N)). D-07's monotonic resolved timestamps will enable binary search later.

### Side-quest

`ISLogReader::rawBytes()` accessor — small additive helper exposing the underlying mmap'd buffer so derivations can fresh-parse without re-opening the file. Documented as the escape hatch for code that needs to re-parse the raw stream.

### Tests (10 new, all green locally)

- `DerivationRegistry.AllV1EntriesPresent` / `UnknownNameReturnsNullopt`.
- `QuatToEulerIdentityAndYaw`, `HeadingFromQuat`, `MagnitudesComputeNorms`, `LlaToNedFirstFix`, `LlaToNedUserOriginNeedsParam`, `BodyAccelToNedGravityToggle`, `BodyRateToEulerRateIdentity`, `MissingInputProducesError`.
- 25 reader/index regression tests still green (the `rawBytes()` addition is additive).

### What's not done here

- Python reference comparison: deferred to D-11 era. Numerical sanity is enforced via hand-computed expectations (3-4-5 norms, identity quaternion→0, etc.).
- Fix-quality-aware origin selection in `lla_to_ned@first_fix`: today it picks the first record unconditionally; D-07 era will refine.
- Per-tile evaluation context: AC mentions both per-sample and per-tile; v1 is per-sample only.

## Test plan

- [x] `ctest -R DerivationTest -R DerivationRegistry` green (10/10) on Linux Ubuntu 22.04
- [x] Reader-side regression tests still green (25/25 LogReaderTest + LogIndexTest + DeviceLogTest)
- [ ] Same on Windows runner via Logalyzer's build-Logalyzer workflow once submodule lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)