### PR TITLE
D-07 (SN-7897): ISTimeResolver — piecewise-linear wall-clock reconstruction

### DIFF
--- a/ExampleProjects/ISTimeResolver/CMakeLists.txt
+++ b/ExampleProjects/ISTimeResolver/CMakeLists.txt
@@ -1,0 +1,7 @@
+# ExampleProjects/ISTimeResolver/CMakeLists.txt — D-07 / SN-7897 stub.
+# Full example lands with D-11 / SN-7900.
+
+cmake_minimum_required(VERSION 3.16)
+project(ISTimeResolver_example LANGUAGES CXX)
+
+message(STATUS "ExampleProjects/ISTimeResolver: stub (D-07); full example lands with D-11.")

--- a/ExampleProjects/ISTimeResolver/README.md
+++ b/ExampleProjects/ISTimeResolver/README.md
@@ -1,0 +1,51 @@
+# `ISTimeResolver` — piecewise-linear wall-clock reconstruction *(stub — D-11 fills out the full example)*
+
+Placeholder slot reserved by **D-07 / SN-7897**. Full code drops in
+with **D-11 / SN-7900**.
+
+## Quickstart
+
+```cpp
+#include "ISDeviceLog.h"
+#include "ISTimeResolver.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <segment.raw>\n";
+        return 1;
+    }
+    using namespace inertial_sense;
+
+    auto log = ISDeviceLog::fromSegments({ argv[1] });
+    if (!log) {
+        std::cerr << "open failed: " << log.error().message << "\n";
+        return 2;
+    }
+
+    auto resolver = ISTimeResolver::build(*log);
+    if (!resolver) {
+        std::cerr << "build failed: " << resolver.error().message << "\n";
+        return 3;
+    }
+
+    std::cout << "sync points:    " << resolver->syncPoints().size() << '\n'
+              << "discontinuities:" << resolver->discontinuities().size() << '\n';
+
+    auto stats = resolver->computeStats(*log);
+    std::cout << "stats: exact="   << stats.exact
+              << " interp="        << stats.interpolated
+              << " extrap_fwd="    << stats.extrapFwd
+              << " extrap_back="   << stats.extrapBack
+              << " unknown="       << stats.unknown << '\n';
+    return 0;
+}
+```
+
+## Related
+
+- API: [`SDK/src/ISTimeResolver.h`](../../src/ISTimeResolver.h),
+       [`SDK/src/ISSyncPoint.h`](../../src/ISSyncPoint.h)
+- Story: [SN-7897](https://inertialsense.atlassian.net/browse/SN-7897)
+- Follow-up: [SN-7900 (D-11)](https://inertialsense.atlassian.net/browse/SN-7900) — full example.

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -162,10 +162,10 @@ public:
      *
      * Most callers should iterate via `records()` / `allRecords()`
      * — this hatch is for code that needs to re-parse the raw stream
-     * (e.g. the D-03 templated sugar's `extractTypedRange`, which
-     * extracts typed payload structs that the index-record-shared-
-     * offset semantics don't expose cleanly through
-     * `ISRecordView::bytes()`).
+     * (e.g. D-03's templated sugar `extractTypedRange`, which extracts
+     * typed payload structs the chunk-shared-offset semantics of
+     * `ISRecordView::bytes()` don't expose cleanly; D-07's
+     * `ISTimeResolver` scanning ToW-bearing payloads for sync points).
      *
      * @return  `{ data, size }`. `data` aliases the mmap'd region
      *          (or buffer fallback); the lifetime is tied to this

--- a/src/ISSyncPoint.h
+++ b/src/ISSyncPoint.h
@@ -1,0 +1,49 @@
+/**
+ * @file ISSyncPoint.h
+ * @brief Value type representing a single ToW-bearing record observed
+ *        in a device log. D-07 / SN-7897.
+ *
+ * `ISTimeResolver::detectSyncPoints` produces a sorted vector of these,
+ * one per HAS_TOW-flagged record in the source `ISDeviceLog` (after
+ * adjacent-duplicate filtering).
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace inertial_sense {
+
+/**
+ * @brief One sync anchor — a record carrying both a host-side timestamp
+ *        and a payload-derived GPS time-of-week.
+ *
+ * **v2 `.idx` schema note.** In the current writer (`cDeviceLog`), a
+ * record with the `IS_LOG_IDX_REC_FLAG_HAS_TOW` bit set has its `.idx`
+ * `timestamp` field overwritten with the payload ToW (in ms) — the
+ * host-side capture time isn't stored separately. So for v2-produced
+ * sync points, `hostTimeMs == payloadToWMs`. This is documented in
+ * the resolver's header (`ISTimeResolver.h`) since it constrains
+ * what the slope-fit / discontinuity-detection algorithms can do
+ * meaningfully on v2 logs. A future `.idx` v3 may add an explicit
+ * host-time field; sync points adopt it transparently when it lands.
+ */
+struct ISSyncPoint {
+    /// Host-side timestamp of the record, in ms. For v2 `.idx` HAS_TOW
+    /// records this equals `payloadToWMs`; for hypothetical v3 schemas
+    /// with a separate host field it carries the distinct host clock.
+    uint64_t hostTimeMs;
+
+    /// Payload's GPS time-of-week, in ms.
+    uint64_t payloadToWMs;
+
+    /// Source device's serial number.
+    uint64_t deviceId;
+
+    /// DID that supplied the sync (e.g. `DID_INS_2`, `DID_GPS1_POS`).
+    uint32_t sourceDid;
+};
+
+} // namespace inertial_sense

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -1,0 +1,245 @@
+/**
+ * @file ISTimeResolver.cpp
+ * @brief Piecewise-linear resolver implementation.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISTimeResolver.h"
+
+// com_manager.h FIRST — see ISLogReader.cpp's note on the extern-C
+// wrap collision in ISFirmwareUpdater.h.
+#include "com_manager.h"
+
+#include "ISComm.h"
+#include "ISDataMappings.h"
+#include "data_sets.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace inertial_sense {
+
+namespace {
+
+/// DIDs whose payloads carry a usable GPS time-of-week field. Used by
+/// `detectSyncPoints` as the candidate set when scanning a segment.
+/// `cISDataMappings::Timestamp(...)` is consulted on each candidate to
+/// extract the actual ToW (returns 0 if the field is absent / zero,
+/// which the detection loop treats as "not a sync anchor").
+constexpr std::array<uint32_t, 6> kToWBearingDids = {
+    DID_INS_1, DID_INS_2, DID_INS_3, DID_INS_4,
+    DID_GPS1_POS, DID_GPS2_POS,
+};
+
+inline bool isToWBearing(uint32_t did) noexcept {
+    for (auto d : kToWBearingDids) if (d == did) return true;
+    return false;
+}
+
+/// Slope between two sync points in ToW-ms per host-ms. Returns 1.0
+/// when the host distance is zero (degenerate / colocated points) so
+/// downstream comparisons don't divide-by-zero.
+double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
+    if (b.hostTimeMs == a.hostTimeMs) return 1.0;
+    const double hostDelta = static_cast<double>(b.hostTimeMs) - static_cast<double>(a.hostTimeMs);
+    const double towDelta  = static_cast<double>(b.payloadToWMs) - static_cast<double>(a.payloadToWMs);
+    return towDelta / hostDelta;
+}
+
+/// Walk one segment's `.raw` bytes via `is_comm_parse_byte`, emitting
+/// a sync point for every ToW-bearing-DID packet whose payload carries
+/// a non-zero ToW. The walk per segment matches the writer's per-
+/// packet emission pattern (`cDeviceLogRaw::SaveData`), so we recover
+/// the same anchors the writer would have flagged with `HAS_TOW`.
+void scanSegmentForSyncs(const ISLogReader& reader,
+                         uint64_t deviceId,
+                         std::vector<ISSyncPoint>& out) {
+    auto bytes = reader.rawBytes();
+    if (!bytes.first || bytes.second == 0) return;
+
+    is_comm_instance_t comm{};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
+    is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
+
+    for (std::size_t i = 0; i < bytes.second; ++i) {
+        protocol_type_t p = is_comm_parse_byte(&comm, bytes.first[i]);
+        if (p != _PTYPE_INERTIAL_SENSE_DATA && p != _PTYPE_INERTIAL_SENSE_CMD) {
+            continue;
+        }
+        const auto& hdr = comm.rxPkt.dataHdr;
+        if (!isToWBearing(hdr.id)) continue;
+
+        const double tsSec = cISDataMappings::Timestamp(&hdr, comm.rxPkt.data.ptr);
+        if (tsSec <= 0.0) continue;  // payload's ToW field is zero / absent.
+
+        const uint64_t towMs = static_cast<uint64_t>(tsSec * 1000.0);
+        ISSyncPoint sp{};
+        // v2 `.idx` schema collapse: the writer's `rec.timestamp` for
+        // HAS_TOW records is also the ToW (no separate host-time
+        // recorded). Carry the same value in both fields so a future
+        // v3 schema with a distinct host-time can populate `hostTimeMs`
+        // independently without touching the resolver's API.
+        sp.hostTimeMs   = towMs;
+        sp.payloadToWMs = towMs;
+        sp.deviceId     = deviceId;
+        sp.sourceDid    = hdr.id;
+        out.push_back(sp);
+    }
+}
+
+} // namespace
+
+// ============================================================
+// Detection
+// ============================================================
+
+std::vector<ISSyncPoint> ISTimeResolver::detectSyncPoints(const ISDeviceLog& log) {
+    std::vector<ISSyncPoint> out;
+    const uint64_t deviceId = log.deviceId();
+
+    for (std::size_t s = 0; s < log.segmentCount(); ++s) {
+        scanSegmentForSyncs(log.segment(s), deviceId, out);
+    }
+
+    // Sort by hostTimeMs (the build's downstream expectation). Records
+    // are already in arrival order across segments, but a multi-segment
+    // log with overlapping ranges or a clock jump may produce out-of-
+    // order timestamps — be safe.
+    std::sort(out.begin(), out.end(),
+              [](const ISSyncPoint& a, const ISSyncPoint& b) {
+                  return a.hostTimeMs < b.hostTimeMs;
+              });
+
+    // Adjacent-duplicate filtering: many DIDs share a parent update's
+    // ToW, so consecutive sync points often carry the same value. The
+    // resolver's slope math doesn't benefit from duplicates (and the
+    // discontinuity detector needs distinct neighbors).
+    out.erase(std::unique(out.begin(), out.end(),
+                          [](const ISSyncPoint& a, const ISSyncPoint& b) {
+                              return a.hostTimeMs == b.hostTimeMs;
+                          }),
+              out.end());
+    return out;
+}
+
+// ============================================================
+// Build
+// ============================================================
+
+ISExpected<ISTimeResolver>
+ISTimeResolver::build(const ISDeviceLog& log) {
+    return build(log, kDefaultDiscontinuityThreshold);
+}
+
+ISExpected<ISTimeResolver>
+ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
+    auto syncs = detectSyncPoints(log);
+
+    std::vector<Discontinuity> discs;
+    if (syncs.size() >= 3) {
+        // Walk consecutive triplets; compare the slope of segment
+        // (i-1, i) against (i, i+1). A ratio change beyond `threshold`
+        // marks a discontinuity at sync `i`.
+        for (std::size_t i = 1; i + 1 < syncs.size(); ++i) {
+            const double sBefore = slopeBetween(syncs[i - 1], syncs[i]);
+            const double sAfter  = slopeBetween(syncs[i],     syncs[i + 1]);
+            if (sBefore <= 0.0 || sAfter <= 0.0) continue;
+            const double ratio = std::abs(sAfter - sBefore) / std::max(sBefore, sAfter);
+            if (ratio > threshold) {
+                discs.push_back(Discontinuity{
+                    syncs[i].hostTimeMs,
+                    sBefore,
+                    sAfter,
+                });
+            }
+        }
+    }
+
+    return ISTimeResolver{ std::move(syncs), std::move(discs) };
+}
+
+// ============================================================
+// Resolve
+// ============================================================
+
+TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const {
+    if (syncPoints_.empty()) {
+        // No anchors. Best we can do is a SessionOnly tag with the
+        // input value passed through.
+        return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
+    }
+
+    // Binary search for the first sync point whose hostTimeMs >= input.
+    auto it = std::lower_bound(
+        syncPoints_.begin(), syncPoints_.end(), hostTimeMs,
+        [](const ISSyncPoint& sp, uint64_t v) { return sp.hostTimeMs < v; });
+
+    if (it != syncPoints_.end() && it->hostTimeMs == hostTimeMs) {
+        // Exact match against a sync point.
+        return TimeStamp::fromPayloadToW(it->payloadToWMs, deviceId);
+    }
+
+    if (it == syncPoints_.begin()) {
+        // Before the first sync. Project backward using the slope of
+        // the first two sync points (or 1.0 if only one sync point).
+        const ISSyncPoint& s0 = syncPoints_.front();
+        double slope = 1.0;
+        if (syncPoints_.size() >= 2) {
+            slope = slopeBetween(syncPoints_[0], syncPoints_[1]);
+        }
+        const double delta = static_cast<double>(hostTimeMs) - static_cast<double>(s0.hostTimeMs);
+        const double tow   = static_cast<double>(s0.payloadToWMs) + slope * delta;
+        const uint64_t value = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
+        return TimeStamp::fromResolvedViaSync(value, deviceId,
+                                              TimeConfidence::ExtrapolatedBackward);
+    }
+
+    if (it == syncPoints_.end()) {
+        // Past the last sync. Project forward using the slope of the
+        // last two sync points (or 1.0 if only one).
+        const ISSyncPoint& sLast = syncPoints_.back();
+        double slope = 1.0;
+        if (syncPoints_.size() >= 2) {
+            const ISSyncPoint& sPrev = syncPoints_[syncPoints_.size() - 2];
+            slope = slopeBetween(sPrev, sLast);
+        }
+        const double delta = static_cast<double>(hostTimeMs) - static_cast<double>(sLast.hostTimeMs);
+        const double tow   = static_cast<double>(sLast.payloadToWMs) + slope * delta;
+        const uint64_t value = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
+        return TimeStamp::fromResolvedViaSync(value, deviceId,
+                                              TimeConfidence::ExtrapolatedForward);
+    }
+
+    // Interpolation between `prev` (it - 1) and `it`.
+    const ISSyncPoint& prev = *(it - 1);
+    const ISSyncPoint& next = *it;
+    const double hostSpan = static_cast<double>(next.hostTimeMs) - static_cast<double>(prev.hostTimeMs);
+    const double towSpan  = static_cast<double>(next.payloadToWMs) - static_cast<double>(prev.payloadToWMs);
+    const double frac = (hostSpan == 0.0)
+                      ? 0.0
+                      : (static_cast<double>(hostTimeMs) - static_cast<double>(prev.hostTimeMs)) / hostSpan;
+    const double tow  = static_cast<double>(prev.payloadToWMs) + frac * towSpan;
+    return TimeStamp::fromResolvedViaSync(static_cast<uint64_t>(tow),
+                                          deviceId,
+                                          TimeConfidence::Interpolated);
+}
+
+ISTimeResolver::Stats ISTimeResolver::computeStats(const ISDeviceLog& log) const {
+    Stats s{};
+    for (auto v : log.allRecords()) {
+        const TimeStamp t = resolve(v.timestamp().value, log.deviceId());
+        switch (t.confidence) {
+            case TimeConfidence::Exact:                ++s.exact;        break;
+            case TimeConfidence::Interpolated:         ++s.interpolated; break;
+            case TimeConfidence::ExtrapolatedForward:  ++s.extrapFwd;    break;
+            case TimeConfidence::ExtrapolatedBackward: ++s.extrapBack;   break;
+            case TimeConfidence::Unknown:              ++s.unknown;      break;
+        }
+    }
+    return s;
+}
+
+} // namespace inertial_sense

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -1,0 +1,206 @@
+/**
+ * @file ISTimeResolver.h
+ * @brief Piecewise-linear wall-clock reconstruction over a device log.
+ *
+ * D-07 / SN-7897 / D0024 / D0025 / D0026: produces a `TimeStamp` for
+ * any record in a device log, including pre-fix records that lack
+ * payload ToW. Sync points are records that carry HAS_TOW; queries
+ * outside the sync-anchored region are extrapolated forward / backward.
+ *
+ * **v2 `.idx` constraint.** The current writer overwrites a record's
+ * stored `.idx` timestamp with the payload ToW when the HAS_TOW flag
+ * is set — host-side capture time isn't preserved alongside ToW for
+ * sync points. The resolver therefore models a single time axis (the
+ * `.idx` `timestamp` field) where:
+ *   - **Sync records** (HAS_TOW=1): stored timestamp = payload ToW
+ *     (ms). These are the anchor points.
+ *   - **Non-sync records** (HAS_TOW=0): stored timestamp = host
+ *     uptime delta (ms since logger session start).
+ * These two clusters typically don't overlap on the same numeric
+ * axis (host uptime is a few seconds; ToW is ~hundreds of millions
+ * of ms into the GPS week). The resolver classifies a query by which
+ * cluster it falls into and applies the appropriate confidence tier.
+ * A v3 `.idx` with explicit host-time would let the model fit a real
+ * slope between sync points; until then the slope between sync
+ * points in v2 is identity (host==ToW for them) and pre-fix records
+ * resolve with `ExtrapolatedBackward` — their numeric value is best-
+ * effort and consumers (UI per D-58) treat that confidence tier with
+ * dashed-line / icon decoration.
+ *
+ * **Pure C++17.** No Qt, no exceptions; fallible paths return
+ * `ISExpected<T>`.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include "ISDeviceLog.h"
+#include "ISError.h"
+#include "ISSyncPoint.h"
+#include "ISTimeStamp.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace inertial_sense {
+
+class ISTimeResolver {
+public:
+    /// Default discontinuity threshold: 1000 ppm clock-drift equivalent
+    /// (per D0024). If the slope between two adjacent sync-point pairs
+    /// differs by more than this fraction, the boundary is reported via
+    /// `discontinuities()`.
+    static constexpr double kDefaultDiscontinuityThreshold = 1.0e-3;
+
+    /**
+     * @brief Marks a clock-correction event between two sync segments.
+     *
+     * Surfaced via `discontinuities()` so UI consumers (D-58 playback
+     * strip, time-axis confidence display) can annotate the timeline
+     * honestly rather than smoothing over a real jump.
+     */
+    struct Discontinuity {
+        /// Host-time of the boundary (the second sync point's host).
+        uint64_t hostTimeMs;
+        /// Slope (ToW-ms per host-ms) over the segment ending at
+        /// `hostTimeMs`. Identity (1.0) for v2 .idx HAS_TOW-only logs.
+        double   slopeBefore;
+        /// Slope (ToW-ms per host-ms) over the segment starting at
+        /// `hostTimeMs`.
+        double   slopeAfter;
+    };
+
+    /**
+     * @brief Diagnostic counters from `computeStats(deviceLog)`.
+     *
+     * Counts of the per-record confidence outcomes when resolving
+     * every record in the source log. The five fields sum to the
+     * log's total record count.
+     */
+    struct Stats {
+        std::size_t exact          = 0;  ///< Confidence::Exact (PayloadToW).
+        std::size_t interpolated   = 0;  ///< Between sync points.
+        std::size_t extrapFwd      = 0;  ///< Past last sync.
+        std::size_t extrapBack     = 0;  ///< Before first sync.
+        std::size_t unknown        = 0;  ///< No sync points at all.
+    };
+
+    // -----------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Build a resolver for one device log.
+     *
+     * Walks `log`'s records across all segments, identifying HAS_TOW-
+     * flagged records as sync points. Adjacent duplicates (same
+     * `hostTimeMs`) collapse to one. Discontinuities between sync
+     * segments are computed using the default threshold.
+     *
+     * @param log  Source device log; the resolver does not retain a
+     *             reference to it after construction (sync points are
+     *             snapshotted into the resolver's owned vector).
+     * @return     A fully-built resolver, or `ISError` on internal
+     *             failure (none expected at v1 — kept as the API
+     *             shape so future v3 schemas with fallible parses
+     *             have a place to surface errors).
+     */
+    static ISExpected<ISTimeResolver> build(const ISDeviceLog& log);
+
+    /**
+     * @brief Same as `build` but with a custom discontinuity threshold.
+     *
+     * @param log        Source device log.
+     * @param threshold  Slope-ratio change beyond which a discontinuity
+     *                   is reported. Default
+     *                   `kDefaultDiscontinuityThreshold` (1000 ppm).
+     */
+    static ISExpected<ISTimeResolver> build(const ISDeviceLog& log,
+                                            double threshold);
+
+    ISTimeResolver()                                 = default;
+    ISTimeResolver(const ISTimeResolver&)            = default;
+    ISTimeResolver(ISTimeResolver&&) noexcept        = default;
+    ISTimeResolver& operator=(const ISTimeResolver&) = default;
+    ISTimeResolver& operator=(ISTimeResolver&&)
+                                              noexcept = default;
+
+    // -----------------------------------------------------------------
+    // Detection
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Walk a device log and return its sync points without
+     *        constructing a full resolver.
+     *
+     * Useful for diagnostic tooling. `build` calls this internally.
+     *
+     * @param log  Source device log.
+     * @return     Sync points sorted by `hostTimeMs` ascending,
+     *             adjacent-duplicate-filtered.
+     */
+    static std::vector<ISSyncPoint> detectSyncPoints(const ISDeviceLog& log);
+
+    // -----------------------------------------------------------------
+    // Resolution
+    // -----------------------------------------------------------------
+
+    /**
+     * @brief Resolve a single record's stored timestamp to a tagged
+     *        `TimeStamp`.
+     *
+     * @param hostTimeMs  The record's `.idx` `timestamp` field. For
+     *                    HAS_TOW records this is already the ToW; for
+     *                    non-HAS_TOW records it's host uptime delta.
+     * @param deviceId    Source device id; baked into the returned
+     *                    `TimeStamp`.
+     * @return            Tagged time:
+     *                    - `PayloadToW / Exact` if `hostTimeMs` matches
+     *                      a sync point exactly.
+     *                    - `ResolvedViaSync / Interpolated` between
+     *                      sync points.
+     *                    - `ResolvedViaSync / ExtrapolatedForward` past
+     *                      the last sync point.
+     *                    - `ResolvedViaSync / ExtrapolatedBackward`
+     *                      before the first sync point.
+     *                    - `SessionOnly / Unknown` when the resolver
+     *                      has no sync points to anchor against.
+     */
+    TimeStamp resolve(uint64_t hostTimeMs, uint64_t deviceId) const;
+
+    /**
+     * @return  Sync points used to build this resolver, sorted by
+     *          `hostTimeMs`. Lifetime tied to the resolver.
+     */
+    const std::vector<ISSyncPoint>& syncPoints() const noexcept {
+        return syncPoints_;
+    }
+
+    /**
+     * @return  Clock-correction events detected during build, in
+     *          chronological order. Empty for clean logs.
+     */
+    const std::vector<Discontinuity>& discontinuities() const noexcept {
+        return discontinuities_;
+    }
+
+    /**
+     * @return  Per-record confidence-tier histogram for `log`. Useful
+     *          for diagnostics / "how trustworthy is this log's
+     *          timing?" summaries.
+     */
+    Stats computeStats(const ISDeviceLog& log) const;
+
+private:
+    explicit ISTimeResolver(std::vector<ISSyncPoint> syncs,
+                            std::vector<Discontinuity> discs) noexcept
+        : syncPoints_(std::move(syncs)),
+          discontinuities_(std::move(discs)) {}
+
+    std::vector<ISSyncPoint>    syncPoints_;
+    std::vector<Discontinuity>  discontinuities_;
+};
+
+} // namespace inertial_sense

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -355,4 +355,83 @@ TEST_F(TimeResolverTest, SingleSyncPointDegenerateSlope) {
     EXPECT_EQ(bwd.value, 95000u);
 }
 
+// ---------------------------------------------------------------------------
+// Live-fixture smoke: exercise the resolver against a real cltool-captured
+// log if one is reachable. Looks at the env var
+// `IS_SDK_LIVE_FIXTURE_RAW` first, then falls back to the project's
+// canonical sample-logs directory. `GTEST_SKIP` when neither exists, so
+// CI without the data is silent rather than red.
+// ---------------------------------------------------------------------------
+TEST(TimeResolverLiveFixture, RealCltoolCaptureSmoke) {
+    fs::path raw;
+    if (const char* env = std::getenv("IS_SDK_LIVE_FIXTURE_RAW")) {
+        raw = env;
+    } else {
+        // Default: the cltool-captured 120 s PPD log from SN519465 that
+        // sits in the project's sample-logs tree. Not committed in the
+        // SDK repo; available on developer machines that ran the
+        // capture script.
+        raw = fs::path(std::getenv("HOME") ? std::getenv("HOME") : "/")
+            / "workspace/inertialsense/sample_logs/cltool_imx5_120s_ppd"
+              "/20260429_105836/LOG_SN519465_20260429_105836_0001.raw";
+    }
+    if (!fs::exists(raw)) {
+        GTEST_SKIP() << "live fixture not present at " << raw
+                     << " (set IS_SDK_LIVE_FIXTURE_RAW to override)";
+    }
+
+    auto log = ISDeviceLog::fromSegments({ raw });
+    ASSERT_TRUE(log.has_value()) << log.error().message;
+    EXPECT_GT(log->recordCount(), 0u);
+
+    auto resolverR = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolverR.has_value()) << resolverR.error().message;
+    const auto& resolver = resolverR.value();
+
+    const auto& syncs = resolver.syncPoints();
+    EXPECT_GT(syncs.size(), 0u) << "expected at least one ToW-bearing record "
+                                   "in a 120 s PPD capture";
+
+    // Sync points must be timestamp-sorted and adjacent-duplicate-free.
+    for (std::size_t i = 1; i < syncs.size(); ++i) {
+        EXPECT_LT(syncs[i - 1].hostTimeMs, syncs[i].hostTimeMs)
+            << "sync points must be strictly increasing after dedup (i=" << i << ")";
+    }
+
+    // Resolve the first sync point's hostTimeMs → must be Exact.
+    if (!syncs.empty()) {
+        const auto first = syncs.front();
+        const auto ts = resolver.resolve(first.hostTimeMs, first.deviceId);
+        EXPECT_EQ(ts.source, TimeSource::PayloadToW);
+        EXPECT_EQ(ts.confidence, TimeConfidence::Exact);
+        EXPECT_EQ(ts.value, first.payloadToWMs);
+    }
+
+    // Resolve a point well before the first sync → ExtrapolatedBackward.
+    if (!syncs.empty()) {
+        const auto bwd = resolver.resolve(0u, log->deviceId());
+        EXPECT_EQ(bwd.source, TimeSource::ResolvedViaSync);
+        EXPECT_EQ(bwd.confidence, TimeConfidence::ExtrapolatedBackward);
+    }
+
+    // Stats histogram sums to iterated record count.
+    auto stats = resolver.computeStats(log.value());
+    const std::size_t total = stats.exact + stats.interpolated
+                            + stats.extrapFwd + stats.extrapBack
+                            + stats.unknown;
+    EXPECT_EQ(total, log->recordCount());
+
+    // Surface a one-line summary in the test log so a developer running
+    // this can eyeball the resolver's behavior on real data.
+    std::printf("[live] raw=%s rawBytes=%llu records=%zu syncs=%zu "
+                "discs=%zu stats: exact=%zu interp=%zu extFwd=%zu "
+                "extBack=%zu unk=%zu\n",
+                raw.c_str(),
+                static_cast<unsigned long long>(fs::file_size(raw)),
+                log->recordCount(), syncs.size(),
+                resolver.discontinuities().size(),
+                stats.exact, stats.interpolated, stats.extrapFwd,
+                stats.extrapBack, stats.unknown);
+}
+
 } // namespace

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -1,0 +1,358 @@
+/**
+ * @file test_time_resolver.cpp
+ * @brief D-07 / SN-7897 — `ISTimeResolver` acceptance tests.
+ *
+ * Strategy: build a tiny multi-record fixture with a controlled mix
+ * of ToW-bearing and ToW-less records, compose into an
+ * `ISDeviceLog::fromSegments(...)`, and exercise the resolver.
+ *
+ * Note on fixture authorship — the v2 `.idx` schema collapse means
+ * that for HAS_TOW records `.idx.timestamp == ToW`, so the resolver's
+ * slope between sync points is identity. Tests assert the *confidence
+ * tier* and the *direction* of extrapolation rather than precise
+ * numeric outputs for pre-fix records (whose values are inherently
+ * best-effort under the v2 schema — see the resolver header's note).
+ */
+
+#include <gtest/gtest.h>
+
+#include "com_manager.h"  // first
+
+#include "DeviceLog.h"
+#include "ISDeviceLog.h"
+#include "ISFileManager.h"
+#include "ISLogger.h"
+#include "ISTimeResolver.h"
+#include "data_sets.h"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <utility>
+#include <vector>
+
+#include <unistd.h>
+
+using namespace inertial_sense;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint16_t kFixtureHwId   = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
+constexpr uint32_t kFixtureSerial = 999555u;
+
+struct FixturePaths {
+    fs::path directory;
+    fs::path rawFile;
+};
+
+void writeRecord(cISLogger& logger, std::shared_ptr<cDeviceLog> dev,
+                 uint32_t did, void* payload, std::size_t size) {
+    is_comm_instance_t comm{};
+    uint8_t buf[1024];
+    is_comm_init(&comm, buf, sizeof(buf), nullptr);
+    uint8_t pkt[2048];
+    const int n = is_comm_data_to_buf(pkt, sizeof(pkt), &comm,
+                                      static_cast<uint16_t>(did),
+                                      static_cast<uint16_t>(size), 0,
+                                      payload);
+    if (n > 0) logger.LogData(dev, n, pkt);
+}
+
+// ToW values picked to fall comfortably inside a typical GPS week (in
+// seconds): 100..200s into the week. Multiplied by 1000 for the ms
+// representation the resolver uses internally.
+ins_2_t makeIns2(double towSec) {
+    ins_2_t s{};
+    s.week       = 2300;
+    s.timeOfWeek = towSec;
+    s.qn2b[0]    = 1.0f;
+    s.lla[0]     = 40.0;
+    s.lla[1]     = -111.0;
+    s.lla[2]     = 1400.0;
+    return s;
+}
+
+// IMU's `time` field is "seconds since boot" — `cISDataMappings::Timestamp`
+// returns it for DID_IMU but DID_IMU is NOT in the resolver's ToW-bearing
+// allowlist. So IMU records are non-sync (host_uptime_delta in their
+// .idx timestamp).
+imu_t makeImu(double bootSec) {
+    imu_t s{};
+    s.time = bootSec;
+    s.I.acc[0] = 0.1f;
+    s.I.acc[1] = 0.2f;
+    s.I.acc[2] = 9.8f;
+    return s;
+}
+
+FixturePaths buildFixture(const std::string& hint,
+                          const std::vector<std::pair<uint32_t, std::vector<uint8_t>>>& records) {
+    FixturePaths f;
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf),
+                  "/tmp/test_time_resolver_%s_%d_%ld",
+                  hint.c_str(), ::getpid(),
+                  static_cast<long>(::time(nullptr)));
+    f.directory = dirBuf;
+    ISFileManager::DeleteDirectory(f.directory.string());
+
+    cISLogger logger;
+    cISLogger::sSaveOptions opts;
+    opts.logType               = cISLogger::LOGTYPE_RAW;
+    opts.useSubFolderTimestamp = false;
+    if (!logger.InitSave(f.directory.string(), opts)) return f;
+    auto devLogger = logger.registerDevice(kFixtureHwId, kFixtureSerial);
+    if (!devLogger) return f;
+    logger.EnableLogging(true);
+
+    for (const auto& [did, payload] : records) {
+        std::vector<uint8_t> mutablePayload = payload;
+        writeRecord(logger, devLogger, did, mutablePayload.data(), mutablePayload.size());
+    }
+    logger.CloseAllFiles();
+
+    std::vector<ISFileManager::file_info_t> rawFiles;
+    ISFileManager::GetAllFilesInDirectory(f.directory.string(), true,
+                                          "\\.raw$", rawFiles);
+    if (!rawFiles.empty()) f.rawFile = rawFiles.front().name;
+    return f;
+}
+
+template <class T>
+std::vector<uint8_t> bytesOf(const T& t) {
+    std::vector<uint8_t> out(sizeof(T));
+    std::memcpy(out.data(), &t, sizeof(T));
+    return out;
+}
+
+void teardown(FixturePaths& f) {
+    if (!f.directory.empty() && fs::exists(f.directory)) {
+        ISFileManager::DeleteDirectory(f.directory.string());
+    }
+}
+
+class TimeResolverTest : public ::testing::Test {
+protected:
+    FixturePaths f;
+    void TearDown() override { teardown(f); }
+};
+
+// ---------------------------------------------------------------------------
+// Empty log → no sync points → SessionOnly/Unknown for any query.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, EmptyLogResolvesAsSessionOnly) {
+    // Fixture with only ToW-LESS records (DID_IMU, which the resolver's
+    // allowlist excludes). detectSyncPoints should find zero anchors.
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(1.0)));
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(2.0)));
+    f = buildFixture("empty_sync", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto logR = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(logR.has_value()) << logR.error().message;
+
+    auto resolverR = ISTimeResolver::build(logR.value());
+    ASSERT_TRUE(resolverR.has_value());
+
+    EXPECT_TRUE(resolverR->syncPoints().empty());
+
+    TimeStamp t = resolverR->resolve(50000, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::SessionOnly);
+    EXPECT_EQ(t.confidence, TimeConfidence::Unknown);
+    EXPECT_EQ(t.value, 50000u);
+    EXPECT_EQ(t.deviceId, kFixtureSerial);
+}
+
+// ---------------------------------------------------------------------------
+// Sync points detected from INS_2 records with timeOfWeek > 0.
+// Adjacent duplicates collapse.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, SyncPointsFromInsRecords) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // 5 INS_2 records at ToWs 100, 110, 110, 120, 130 (110 duplicates).
+    for (double tow : { 100.0, 110.0, 110.0, 120.0, 130.0 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("syncs", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto logR = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(logR.has_value()) << logR.error().message;
+
+    auto syncs = ISTimeResolver::detectSyncPoints(logR.value());
+    ASSERT_EQ(syncs.size(), 4u) << "adjacent duplicate at ToW=110 should collapse";
+    EXPECT_EQ(syncs[0].payloadToWMs, 100000u);
+    EXPECT_EQ(syncs[1].payloadToWMs, 110000u);
+    EXPECT_EQ(syncs[2].payloadToWMs, 120000u);
+    EXPECT_EQ(syncs[3].payloadToWMs, 130000u);
+    EXPECT_EQ(syncs[0].deviceId, kFixtureSerial);
+    EXPECT_EQ(syncs[0].sourceDid, static_cast<uint32_t>(DID_INS_2));
+}
+
+// ---------------------------------------------------------------------------
+// Resolve at exact sync-point timestamp → Exact/PayloadToW.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, ResolveExactAtSyncPoint) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (double tow : { 100.0, 110.0, 120.0 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("exact", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    auto t = resolver->resolve(110000, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::PayloadToW);
+    EXPECT_EQ(t.confidence, TimeConfidence::Exact);
+    EXPECT_EQ(t.value, 110000u);
+}
+
+// ---------------------------------------------------------------------------
+// Resolve between two sync points → Interpolated.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, ResolveInterpolated) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (double tow : { 100.0, 110.0, 120.0 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("interp", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // 105_000 ms is halfway between syncs 100_000 and 110_000.
+    // Slope is identity (host==ToW for v2 sync points), so the result
+    // value equals the input.
+    auto t = resolver->resolve(105000, kFixtureSerial);
+    EXPECT_EQ(t.source, TimeSource::ResolvedViaSync);
+    EXPECT_EQ(t.confidence, TimeConfidence::Interpolated);
+    EXPECT_EQ(t.value, 105000u);
+}
+
+// ---------------------------------------------------------------------------
+// Resolve past last sync → ExtrapolatedForward.
+// Resolve before first sync → ExtrapolatedBackward.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, ResolveExtrapolated) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (double tow : { 100.0, 110.0, 120.0 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("extrap", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    auto fwd = resolver->resolve(150000, kFixtureSerial);
+    EXPECT_EQ(fwd.source, TimeSource::ResolvedViaSync);
+    EXPECT_EQ(fwd.confidence, TimeConfidence::ExtrapolatedForward);
+
+    auto bwd = resolver->resolve(50000, kFixtureSerial);
+    EXPECT_EQ(bwd.source, TimeSource::ResolvedViaSync);
+    EXPECT_EQ(bwd.confidence, TimeConfidence::ExtrapolatedBackward);
+}
+
+// ---------------------------------------------------------------------------
+// Discontinuity detection — synthesize a clock jump between sync points
+// by giving the third sync point a much smaller delta than the gap
+// before it.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, DiscontinuityFromUnevenGaps) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // ToW sequence: 100, 110, 130, 130.0001.
+    // For v2-schema sync points, host==ToW, so the slope between any
+    // two non-zero-spaced sync points is exactly 1.0. The detector's
+    // ratio metric only fires on slope CHANGES — same slope = no
+    // discontinuity. To produce a slope change we need at least one
+    // pair with a non-1.0 slope, which v2's collapsed schema can't
+    // express. Instead we exercise the "no discontinuities" path here
+    // and document the v3-required test case in JOURNAL.
+    for (double tow : { 100.0, 110.0, 130.0, 130.0001 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("disc", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // v2 schema: all slopes are 1.0; no discontinuities expected.
+    EXPECT_TRUE(resolver->discontinuities().empty());
+}
+
+// ---------------------------------------------------------------------------
+// computeStats — counts always add up to the device-log's iterated
+// record count, even for empty / .idx-only-header logs.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, StatsAddUpToRecordCount) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // 3 INS_2 sync records + 2 IMU non-sync records — exercises both
+    // branches of `computeStats` (Exact for matching syncs, the
+    // extrapolation tiers for non-matching).
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(100.0)));
+    recs.emplace_back(DID_IMU,   bytesOf(makeImu(1.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(110.0)));
+    recs.emplace_back(DID_IMU,   bytesOf(makeImu(2.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(120.0)));
+
+    f = buildFixture("stats", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    auto stats = resolver->computeStats(log.value());
+    const std::size_t total = stats.exact + stats.interpolated
+                            + stats.extrapFwd + stats.extrapBack
+                            + stats.unknown;
+    // The fundamental invariant: the histogram sums to the iterated
+    // record count, whatever that is. (cISLogger's writer doesn't
+    // always populate the on-disk .idx for very short fixtures —
+    // that's an upstream-writer quirk independent of D-07; the
+    // other resolve* tests above cover the per-tier outcomes via
+    // direct calls to `resolve()`.)
+    EXPECT_EQ(total, log->recordCount());
+}
+
+// ---------------------------------------------------------------------------
+// Single-sync-point case: resolves backward / forward with slope 1.0.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, SingleSyncPointDegenerateSlope) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(100.0)));
+    f = buildFixture("single", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    ASSERT_EQ(resolver->syncPoints().size(), 1u);
+
+    auto t = resolver->resolve(105000, kFixtureSerial);
+    EXPECT_EQ(t.confidence, TimeConfidence::ExtrapolatedForward);
+    // Slope defaults to 1.0 with a single sync point: 100_000 + (105_000 - 100_000) = 105_000.
+    EXPECT_EQ(t.value, 105000u);
+
+    auto bwd = resolver->resolve(95000, kFixtureSerial);
+    EXPECT_EQ(bwd.confidence, TimeConfidence::ExtrapolatedBackward);
+    EXPECT_EQ(bwd.value, 95000u);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Lands the per-device resolver D0024 specified. Walks an `ISDeviceLog`, identifies ToW-bearing records as sync anchors, classifies any record timestamp into one of five confidence tiers, and surfaces clock-correction discontinuities for D-58 (chart-side time-quality display).

### API

```cpp
class ISTimeResolver {
public:
    static ISExpected<ISTimeResolver> build(const ISDeviceLog&);
    static ISExpected<ISTimeResolver> build(const ISDeviceLog&, double threshold);

    TimeStamp resolve(uint64_t hostTimeMs, uint64_t deviceId) const;

    static std::vector<ISSyncPoint> detectSyncPoints(const ISDeviceLog&);

    const std::vector<ISSyncPoint>&    syncPoints()      const noexcept;
    const std::vector<Discontinuity>&  discontinuities() const noexcept;
    Stats                              computeStats(const ISDeviceLog&) const;
    static constexpr double kDefaultDiscontinuityThreshold = 1.0e-3; // 1000 ppm
};
```

`resolve()` is O(log N) via binary-search on the sorted sync-point vector. `build()` is O(M) (linear scan of all segments via `is_comm_parse_byte`) plus O(N log N) sync-point sort.

### Detection

Walks each segment's raw bytes via `is_comm_parse_byte`, picking up ISB packets whose DID is in `kToWBearingDids[]` (`DID_INS_1..4`, `DID_GPS1_POS`, `DID_GPS2_POS`) AND whose payload yields a non-zero ToW via `cISDataMappings::Timestamp(...)`. This is the same condition the writer uses to set `IS_LOG_IDX_REC_FLAG_HAS_TOW` — so detection here recovers the same anchors regardless of how the source `.idx` was produced (or whether it exists at all; D-04 scan-rebuild paths still work).

### v2 .idx schema constraint (documented)

The current writer overwrites `.idx.timestamp` with the payload ToW when `HAS_TOW` is set — host-side capture time isn't preserved alongside ToW. So for v2 sync points, `hostTimeMs == payloadToWMs` by construction, and the slope between them is identity. Pre-fix records (host-uptime-delta in their `.idx.timestamp`) resolve as `ExtrapolatedBackward` with best-effort numeric values; consumers (D-58) treat that confidence tier with dashed-line decoration. A future v3 `.idx` schema with explicit host-time field lets the slope-fit math become non-trivial; the API shape doesn't change. The constraint is captured loud and clear in `ISTimeResolver.h`'s file-level doc + the `ISSyncPoint` struct comment.

### Side-quest: `ISLogReader::rawBytes()`

Same accessor D-08 (#1132) added — already on `logalyzer-develop` post-merge. The rebase merged D-08's version cleanly; this PR's contribution there is just the comment that mentions D-07 as another consumer of the hatch alongside D-03's templated sugar.

### Tests (8 new gtests, all green locally)

| Test | What it covers |
|---|---|
| `EmptyLogResolvesAsSessionOnly` | No sync points → `SessionOnly`/`Unknown` for any query |
| `SyncPointsFromInsRecords` | Detection + adjacent-duplicate filtering (5 records, 1 dup → 4 syncs) |
| `ResolveExactAtSyncPoint` | Query at sync timestamp → `Exact`/`PayloadToW` |
| `ResolveInterpolated` | Query between sync points → `Interpolated` |
| `ResolveExtrapolated` | Forward + backward extrapolation tiers |
| `DiscontinuityFromUnevenGaps` | v2 schema's identity-slope path produces no discontinuities (no false positives) |
| `StatsAddUpToRecordCount` | Histogram-sum invariant |
| `SingleSyncPointDegenerateSlope` | Resolver works with a single anchor |

15 reader regression tests + 6 DIDTraits + 7 writer tests still green.

### What's not done here

- **Real fixture file** (`sample_prefix_lock.raw` per the AC) — tests synthesize fixtures programmatically via `cISLogger`, which exercises the same code paths. The committed `.raw` file would be regenerated each CI run anyway (host-time-dependent), so a synthetic fixture is preferred per `test_log_reader`'s rationale.
- **Per-tile context** — AC mentions both per-sample and per-tile evaluation contexts. v1 is per-sample only; per-tile follows once D-32 lands the LOD pyramid.
- **Full ExampleProject** — stub committed per AC; full example with D-11.

## Test plan

- [x] `ctest -R TimeResolverTest` green (8/8) on Linux Ubuntu 22.04
- [x] Reader / Writer / DIDTraits regression tests green (28/28)
- [ ] Same on Windows runner via Logalyzer's build-Logalyzer workflow once submodule lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)