### PR TITLE
chore: utils::hdwIdToString / deviceIdString + ISLogReader::hdwId()

### DIFF
--- a/src/ISDeviceLog.h
+++ b/src/ISDeviceLog.h
@@ -81,6 +81,19 @@ public:
     /** @return  Shared device id of every segment in this composition. */
     uint64_t deviceId() const noexcept { return deviceId_; }
 
+    /**
+     * Returns the device's packed hardware id (`is_hardware_t`).
+     * Forwarded from the first segment — within a composition, every
+     * segment shares the same physical device, so the hardware id is
+     * a single shared value (asserted in `compose`).
+     *
+     * @return  Packed hardware id, or 0 if no DEV_INFO record was
+     *          logged in any segment.
+     */
+    uint16_t hdwId() const noexcept {
+        return segments_.empty() ? uint16_t{0} : segments_.front().hdwId();
+    }
+
     /** @return  Total record count across all segments. */
     std::size_t recordCount() const noexcept { return total_; }
 

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -531,35 +531,52 @@ std::pair<const uint8_t*, std::size_t> ISLogReader::rawBytes() const noexcept {
 
 void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
     deviceId_ = 0;
+    hdwId_    = 0;
 
-    // 1) Try to find a DID_DEV_INFO record in the index. We need its
-    //    bytes to read the serialNumber field. dev_info_t is defined
-    //    in data_sets.h with serialNumber as the first field; rather
-    //    than pull the full struct here (which would couple this file
-    //    to a heavy header), we read the first uint32_t at the
-    //    record's offset, which is the serialNumber per the layout.
-    //    DID_DEV_INFO == 1 (data_sets.h:40).
-    constexpr uint32_t kDevInfoDid = 1u;
-    auto it = byDid_.find(kDevInfoDid);
-    if (it != byDid_.end() && !it->second.empty() && rawSource_) {
-        const auto& rec = records_[it->second.front()];
-        if (rec.offset + sizeof(uint32_t) <= rawSource_->size()) {
-            uint32_t sn = 0;
-            std::memcpy(&sn, rawSource_->data() + rec.offset, sizeof(uint32_t));
-            // dev_info_t::serialNumber is little-endian on disk (ARM SDK).
-            // A serial of 0 is implausible for real hardware, so we fall
-            // through to filename parsing if so — protects against the
-            // record being a partial-update where serialNumber wasn't set.
-            if (sn != 0) {
-                deviceId_ = sn;
+    // 1) Walk the raw bytes via `is_comm_parse_byte` looking for the
+    //    first DID_DEV_INFO packet. We can't shortcut to the record's
+    //    `.offset` because that is the ISB packet *start* (framing +
+    //    header + payload + checksum), not the payload offset — we
+    //    need the parser to hand us `comm.rxPkt.data.ptr`, which
+    //    points into the dev_info_t payload proper. Bounded: terminate
+    //    at the first DEV_INFO packet so this is at most a single
+    //    early-exit linear pass.
+    if (rawSource_ && rawSource_->size() > 0) {
+        is_comm_instance_t comm{};
+        uint8_t commBuf[PKT_BUF_SIZE];
+        is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
+        is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
+
+        const uint8_t* base = rawSource_->data();
+        const std::size_t total = rawSource_->size();
+        for (std::size_t i = 0; i < total; ++i) {
+            protocol_type_t p = is_comm_parse_byte(&comm, base[i]);
+            if (p != _PTYPE_INERTIAL_SENSE_DATA &&
+                p != _PTYPE_INERTIAL_SENSE_CMD) {
+                continue;
+            }
+            if (comm.rxPkt.dataHdr.id != DID_DEV_INFO) continue;
+            if (comm.rxPkt.dataHdr.size != sizeof(dev_info_t)) continue;
+
+            dev_info_t info{};
+            std::memcpy(&info, comm.rxPkt.data.ptr, sizeof(info));
+            if (info.serialNumber != 0) {
+                deviceId_ = info.serialNumber;
+                hdwId_    = static_cast<uint16_t>(
+                    ENCODE_DEV_INFO_TO_HDW_ID(info));
                 return;
             }
+            // First DEV_INFO had a zero serial — partial-update record
+            // or test fixture stub. Stop scanning; let the filename
+            // fallback handle it.
+            break;
         }
     }
 
     // 2) Filename fallback. cltool/cISLogger emits names of the form
     //    `LOG_SN<n>_<timestamp>_<seq>.raw`. Extract the digits between
-    //    "SN" and the next underscore.
+    //    "SN" and the next underscore. The fallback can recover the
+    //    serial number but not the hardware id, so `hdwId_` stays 0.
     const std::string stem = rawPath.stem().string();   // strips ".raw"
     const std::size_t snPos = stem.find("SN");
     if (snPos != std::string::npos) {

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -226,6 +226,22 @@ public:
      */
     uint64_t deviceId() const noexcept { return deviceId_; }
 
+    /**
+     * Returns the device's packed hardware id (`is_hardware_t`),
+     * encoding hardware type + major + minor revs. Derived from the
+     * first `DID_DEV_INFO` record's payload via the same scan that
+     * populates `deviceId()`. The filename fallback cannot produce an
+     * `hdwId`, so this returns 0 (`IS_HARDWARE_NONE`) for segments
+     * without a logged DEV_INFO record.
+     *
+     * Pair with `deviceId()` to form a canonical device label via
+     * `utils::deviceIdString(hdwId(), deviceId())`.
+     *
+     * @return  Packed hardware id, or 0 if no DEV_INFO record was
+     *          logged.
+     */
+    uint16_t hdwId() const noexcept { return hdwId_; }
+
     // -----------------------------------------------------------------
     // Iteration
     // -----------------------------------------------------------------
@@ -538,6 +554,7 @@ private:
     bool                                   isTruncated_        = false;
     uint64_t                               truncationOffset_   = 0;
     uint64_t                               deviceId_           = 0;
+    uint16_t                               hdwId_              = 0;
     std::vector<std::string>               warnings_;
     std::filesystem::path                  rawPath_;
     std::filesystem::path                  idxPath_;

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -215,20 +215,39 @@ std::string utils::did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, in
     return std::string(buf);
 }
 
-std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) {
-    // hardware type & version
-    const char *typeName = "\?\?\?";
-    switch (devInfo.hardwareType) {
-        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
-        case IS_HARDWARE_TYPE_IMX: typeName = "IMX"; break;
-        case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
-        case IS_HDW_GNSS_SONY: typeName = "CXD"; break;
-        case IS_HDW_GNSS_UBLOX: typeName = "UBX"; break;
-        case IS_HDW_GNSS_SEPTENTRIO: typeName = "SEP"; break;
-        case IS_HDW_GNSS_STM_TESSIO: typeName = "STM"; break;
-        default: typeName = "\?\?\?"; break;
+namespace {
+
+const char* hardwareTypeName(unsigned type) {
+    switch (type) {
+        case IS_HARDWARE_TYPE_UINS:     return "uINS";
+        case IS_HARDWARE_TYPE_IMX:      return "IMX";
+        case IS_HARDWARE_TYPE_GPX:      return "GPX";
+        case IS_HDW_GNSS_SONY:          return "CXD";
+        case IS_HDW_GNSS_UBLOX:         return "UBX";
+        case IS_HDW_GNSS_SEPTENTRIO:    return "SEP";
+        case IS_HDW_GNSS_STM_TESSIO:    return "STM";
+        default:                        return "\?\?\?";
     }
-    std::string out = utils::string_format("%s-%u.%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1]);
+}
+
+} // namespace
+
+std::string utils::hdwIdToString(uint16_t hdwId) {
+    return utils::string_format("%s-%u.%u",
+                                hardwareTypeName(DECODE_HDW_TYPE(hdwId)),
+                                static_cast<unsigned>(DECODE_HDW_MAJOR(hdwId)),
+                                static_cast<unsigned>(DECODE_HDW_MINOR(hdwId)));
+}
+
+std::string utils::deviceIdString(uint16_t hdwId, uint64_t serial) {
+    return utils::hdwIdToString(hdwId) + "::SN" + std::to_string(serial);
+}
+
+std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) {
+    // Type-major-minor portion comes from the canonical packed-id renderer.
+    // The dev_info_t carries two extra sub-rev bytes (hardwareVer[2..3]) that
+    // the uint16 hdwId form can't represent — append them here when present.
+    std::string out = utils::hdwIdToString(ENCODE_DEV_INFO_TO_HDW_ID(devInfo));
     if (!showRev)
         return out;
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -223,6 +223,42 @@ namespace utils {
         DV_BIT_EXACT_MATCH      = 0x4000,        //!< when matching/comparing, match exactly (version & time)
     };
 
+    /**
+     * Renders the type-major-minor portion of a packed hardware id as
+     * a printable string, e.g. `"IMX-5.0"`, `"GPX-1.0"`, `"UBX-5.9"`.
+     *
+     * Decodes via `DECODE_HDW_TYPE` / `DECODE_HDW_MAJOR` /
+     * `DECODE_HDW_MINOR` and maps the type field through the same
+     * type-name table `getHardwareAsString` uses. Unknown types
+     * render as `"???-<major>.<minor>"`.
+     *
+     * The packed `uint16_t` form does not carry the sub-rev bytes
+     * (`hardwareVer[2..3]`) — those come from a `dev_info_t`. Use
+     * `getHardwareAsString(devInfo, true)` when you need the sub-rev.
+     *
+     * @param hdwId  Packed hardware id (`is_hardware_t`), typically
+     *               obtained via `ENCODE_HDW_ID` or
+     *               `DECODE_UNIQUE_ID_TO_HDW_ID`.
+     * @return       String of the form `"<TYPE>-<major>.<minor>"`.
+     */
+    std::string hdwIdToString(uint16_t hdwId);
+
+    /**
+     * Composes the canonical "device-id" display string from a packed
+     * hardware id and a serial number, of the form
+     * `"<hdwIdString>::SN<serial>"` (e.g. `"IMX-5.0::SN519465"`).
+     *
+     * This is the canonical builder used by Logalyzer's `SeriesId` and
+     * any other call site that wants a stable, parseable device label.
+     * Inlining the format string at call sites is discouraged — call
+     * this so the format stays consistent.
+     *
+     * @param hdwId   Packed hardware id (`is_hardware_t`).
+     * @param serial  Serial number; rendered as decimal.
+     * @return        `"<hdwIdString>::SN<serial>"`.
+     */
+    std::string deviceIdString(uint16_t hdwId, uint64_t serial);
+
     std::string getHardwareAsString(const dev_info_t& devInfo, bool showRev = true);
     std::string getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix = "fw");
     std::string getBuildAsString(const dev_info_t& devInfo, uint16_t flags = -1, const std::string& sep = " ");

--- a/tests/test_log_reader.cpp
+++ b/tests/test_log_reader.cpp
@@ -407,6 +407,37 @@ TEST_F(LogReaderTest, DeviceIdIsDerivedFromFixture) {
     EXPECT_NE(r->deviceId(), 0u);
 }
 
+// ---------------------------------------------------------------------------
+// hdwId derivation against a real cltool 120 s PPD capture (IMX-5.0,
+// SN519465). The synthetic test_data_utils fixture writes DEV_INFO records
+// with all-zero hardwareType/hardwareVer fields, so the synthetic path
+// can only verify that hdwId() returns 0 cleanly when the type byte is
+// zero — it can't prove the parse extracts the right bytes. This live
+// test does. GTEST_SKIPped when the fixture isn't on disk so CI is
+// silent rather than red. Override the path with IS_SDK_LIVE_FIXTURE_RAW.
+// ---------------------------------------------------------------------------
+TEST(LogReaderLiveFixture, HdwIdMatchesImx5_0FromCltoolCapture) {
+    fs::path raw;
+    if (const char* env = std::getenv("IS_SDK_LIVE_FIXTURE_RAW")) {
+        raw = env;
+    } else {
+        raw = fs::path(std::getenv("HOME") ? std::getenv("HOME") : "/")
+            / "workspace/inertialsense/sample_logs/cltool_imx5_120s_ppd"
+              "/20260429_105836/LOG_SN519465_20260429_105836_0001.raw";
+    }
+    if (!fs::exists(raw)) {
+        GTEST_SKIP() << "live fixture not present at " << raw
+                     << " (set IS_SDK_LIVE_FIXTURE_RAW to override)";
+    }
+
+    auto r = ISLogReader::openSegment(raw);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    EXPECT_EQ(r->deviceId(), 519465u);
+    EXPECT_EQ(r->hdwId(),    IS_HARDWARE_IMX_5_0)
+        << "expected IMX-5.0 from this capture; got hdwId=0x"
+        << std::hex << r->hdwId();
+}
+
 // ============================================================
 // Layout-discipline sanity
 // ============================================================

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -128,3 +128,96 @@ TEST(test_utils, parse_devInfo_from_filename) {
     // EXPECT_EQ(devInfoStr, "GPX-1.0 fw2.3.0-snap.153 2024-12-17 00:28:37");
 
 }
+
+// ============================================================
+// hdwIdToString — packed-id renderer for the SeriesId/device-label path.
+// ============================================================
+
+TEST(test_utils, hdwIdToString_renders_imx_5_0) {
+    EXPECT_EQ(utils::hdwIdToString(IS_HARDWARE_IMX_5_0), "IMX-5.0");
+}
+
+TEST(test_utils, hdwIdToString_renders_imx_6_0) {
+    EXPECT_EQ(utils::hdwIdToString(IS_HARDWARE_IMX_6_0), "IMX-6.0");
+}
+
+TEST(test_utils, hdwIdToString_renders_gpx_1_0) {
+    EXPECT_EQ(utils::hdwIdToString(IS_HARDWARE_GPX_1_0), "GPX-1.0");
+}
+
+TEST(test_utils, hdwIdToString_renders_uins_3_2) {
+    EXPECT_EQ(utils::hdwIdToString(IS_HARDWARE_UINS_3_2), "uINS-3.2");
+}
+
+TEST(test_utils, hdwIdToString_renders_peripherals) {
+    EXPECT_EQ(utils::hdwIdToString(IS_HDW_SONY_CXD5610),  "CXD-5.6");
+    EXPECT_EQ(utils::hdwIdToString(IS_HDW_TESSIO_6),      "STM-6.0");
+}
+
+TEST(test_utils, hdwIdToString_unknown_type_renders_question_marks) {
+    // type=63 isn't in eIsHardwareType, so the type-name table falls
+    // through to the placeholder. Major/minor still render.
+    const uint16_t hdwId = ENCODE_HDW_ID(63, 9, 17);
+    EXPECT_EQ(utils::hdwIdToString(hdwId), "\?\?\?-9.17");
+}
+
+TEST(test_utils, hdwIdToString_zero_renders_unknown_zero) {
+    // IS_HARDWARE_NONE — type=UNKNOWN renders as "???"
+    EXPECT_EQ(utils::hdwIdToString(IS_HARDWARE_NONE), "\?\?\?-0.0");
+}
+
+TEST(test_utils, hdwIdToString_matches_getHardwareAsString_when_no_subrev) {
+    // The packed-id form drops sub-rev bytes 2/3; getHardwareAsString
+    // with showRev=true must agree when those bytes are zero. This is
+    // the contract that lets the refactor inline hdwIdToString.
+    dev_info_t info{};
+    info.hardwareType   = IS_HARDWARE_TYPE_IMX;
+    info.hardwareVer[0] = 5;
+    info.hardwareVer[1] = 0;
+    info.hardwareVer[2] = 0;
+    info.hardwareVer[3] = 0;
+    EXPECT_EQ(utils::getHardwareAsString(info, /*showRev=*/true),
+              utils::hdwIdToString(ENCODE_DEV_INFO_TO_HDW_ID(info)));
+}
+
+TEST(test_utils, getHardwareAsString_still_renders_subrev_when_present) {
+    // The refactor must not regress sub-rev rendering.
+    dev_info_t info{};
+    info.hardwareType   = IS_HARDWARE_TYPE_IMX;
+    info.hardwareVer[0] = 5;
+    info.hardwareVer[1] = 0;
+    info.hardwareVer[2] = 1;
+    info.hardwareVer[3] = 0;
+    EXPECT_EQ(utils::getHardwareAsString(info, /*showRev=*/true), "IMX-5.0.1");
+
+    info.hardwareVer[3] = 7;
+    EXPECT_EQ(utils::getHardwareAsString(info, /*showRev=*/true), "IMX-5.0.1.7");
+
+    EXPECT_EQ(utils::getHardwareAsString(info, /*showRev=*/false), "IMX-5.0");
+}
+
+// ============================================================
+// deviceIdString — the canonical "<hdw>::SN<n>" composer.
+// ============================================================
+
+TEST(test_utils, deviceIdString_canonical_format) {
+    EXPECT_EQ(utils::deviceIdString(IS_HARDWARE_IMX_5_0, 519465u),
+              "IMX-5.0::SN519465");
+}
+
+TEST(test_utils, deviceIdString_zero_serial_renders_zero) {
+    EXPECT_EQ(utils::deviceIdString(IS_HARDWARE_GPX_1_0, 0u),
+              "GPX-1.0::SN0");
+}
+
+TEST(test_utils, deviceIdString_unknown_hdw_with_serial) {
+    // Filename-fallback path: serial known, hdwId unknown (zero).
+    EXPECT_EQ(utils::deviceIdString(0u, 12345u), "\?\?\?-0.0::SN12345");
+}
+
+TEST(test_utils, deviceIdString_max_uint64_serial) {
+    // Sanity: large serials don't overflow the std::to_string path.
+    const uint64_t big = static_cast<uint64_t>(1) << 40;
+    EXPECT_EQ(utils::deviceIdString(IS_HARDWARE_IMX_5_0, big),
+              "IMX-5.0::SN1099511627776");
+}


### PR DESCRIPTION
## Summary

Prereq for D-30 (SN-7900, Logalyzer-side SeriesId). Surfaces the
device-label primitives the SeriesId format needs (`IMX-5.0::SN519465`),
and adds a `uint16_t hdwId()` accessor to ISLogReader / ISDeviceLog so
callers don't have to chase a `dev_info_t` to get the packed hardware id.

- **`utils::hdwIdToString(uint16_t)`** — renders the type-major-minor
  portion of a packed hardware id (`IMX-5.0`, `GPX-1.0`, `CXD-5.6`).
  Sub-revs from `hardwareVer[2..3]` aren't representable in the uint16
  form; callers that need them keep using `getHardwareAsString`.
- **`utils::deviceIdString(uint16_t, uint64_t)`** — composes
  `<hdwIdString>::SN<serial>`. Logalyzer's SeriesId will call this
  instead of inlining the format at each call site.
- **`ISLogReader::hdwId()` / `ISDeviceLog::hdwId()`** — populated from
  the first `DID_DEV_INFO` record alongside `deviceId_`; returns 0
  when no DEV_INFO record was logged.
- **`getHardwareAsString` refactor** — delegates to `hdwIdToString`
  for the type-major-minor portion + appends sub-rev when `showRev`
  is set. Drops the duplicated type-name switch.
- **`deriveDeviceId` rewrite** — earlier code read `uint32_t` at
  `rec.offset`, but `rec.offset` is the ISB packet *start* (framing),
  not the `dev_info_t` payload, so the parse path always read garbage
  and fell through to the filename fallback. Cltool fixtures named
  `LOG_SN<n>_*.raw` masked it. Replaced with a bounded
  `is_comm_parse_byte` early-exit walk, which both fixes the latent
  bug and lets the same scan capture `hdwId_`.

## Test plan

- [x] 12 new gtests in `test_utils.cpp` covering `hdwIdToString` (canonical
      types, peripherals, unknown type, zero-id) and `deviceIdString`
      (canonical format, zero serial, unknown hdw, large serial).
- [x] New `LogReaderLiveFixture.HdwIdMatchesImx5_0FromCltoolCapture`
      gated on `IS_SDK_LIVE_FIXTURE_RAW` / `~/workspace/inertialsense/sample_logs/...`
      — verified locally against the SN519465 120 s PPD capture
      (`hdwId == IS_HARDWARE_IMX_5_0`, `deviceId == 519465`). Skips
      silently in CI where the fixture isn't checked in.
- [x] Existing `getHardwareAsString` AC preserved — sub-rev rendering
      regression test added.
- [x] Full SDK suite locally: 248/249 pass, 1 pre-existing skip
      (`protocol_nmea.zda_gps_time_skip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)