### PR TITLE
SN-7956 imx6 calibration debug

### DIFF
--- a/python/inertialsense/logInspector/logInspectorInternal.py
+++ b/python/inertialsense/logInspector/logInspectorInternal.py
@@ -91,6 +91,8 @@ class logInspectorInternal(LogInspectorWindow):
         self.addListItem('EKF Biases', 'ekfBiases')
 
     def createListSensors(self):
+        self.addListItem('IMUs Uncal Gyro',  'imusUncalPqr')
+        self.addListItem('IMUs Uncal Accel', 'imusUncalAcc')
         self.addListItem('IMUs Raw Gyro',  'imusRawPqr')
         self.addListItem('IMUs Raw Accel', 'imusRawAcc')
         self.addListItem('IMUs Raw Gyro Combined',  'imusRawPqrCombined')

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -2967,6 +2967,10 @@ class logPlot:
         self.imuPQR(did=DID_IMUS, fig=fig, axs=axs, combineImus=False)
     def imusAcc(self, fig=None, axs=None):
         self.imuAcc(did=DID_IMUS, fig=fig, axs=axs, combineImus=False)
+    def imusUncalPqr(self, fig=None, axs=None):
+        self.imuPQR(did=DID_IMUS_UNCAL, fig=fig, axs=axs, combineImus=False)
+    def imusUncalAcc(self, fig=None, axs=None):
+        self.imuAcc(did=DID_IMUS_UNCAL, fig=fig, axs=axs, combineImus=False)
 
     def imuPQR(self, did=DID_IMU, fig=None, axs=None, combineImus=False):
         if fig is None:

--- a/python/inertialsense/logs/src/log_reader.cpp
+++ b/python/inertialsense/logs/src/log_reader.cpp
@@ -221,9 +221,6 @@ void LogReader::organizeData(shared_ptr<cDeviceLog> devLog) {
             // HANDLE_MSG(DID_RTOS_INFO, dev_log_->rtosInfo);
             HANDLE_MSG(DID_DEBUG_STRING, dev_log_->debugString);
             HANDLE_MSG(DID_DEBUG_ARRAY, dev_log_->debugArray);
-            // HANDLE_MSG(DID_CAL_SC, dev_log_->calSc);
-            // HANDLE_MSG(DID_CAL_SC1, dev_log_->calSc1);
-            // HANDLE_MSG(DID_CAL_SC2, dev_log_->calSc2);
             HANDLE_MSG(DID_SENSORS_ADC_SIGMA, dev_log_->sensorsAdcSigma);
             HANDLE_MSG(DID_INL2_STATES, dev_log_->inl2States);
             HANDLE_MSG(DID_INL2_STATUS, dev_log_->inl2Status);
@@ -340,9 +337,6 @@ void LogReader::forwardData(int device_id) {
     // forward_message(DID_RTOS_INFO, dev_log_->rtosInfo, device_id);
     forward_message(DID_DEBUG_STRING, dev_log_->debugString, device_id);
     forward_message(DID_DEBUG_ARRAY, dev_log_->debugArray, device_id);
-    // forward_message(DID_CAL_SC, dev_log_->calSc, device_id);
-    // forward_message(DID_CAL_SC1, dev_log_->calSc1, device_id);
-    // forward_message(DID_CAL_SC2, dev_log_->calSc2, device_id);
     forward_message(DID_SENSORS_ADC_SIGMA, dev_log_->sensorsAdcSigma, device_id);
     forward_message(DID_INL2_STATES, dev_log_->inl2States, device_id);
     forward_message(DID_INL2_STATUS, dev_log_->inl2Status, device_id);

--- a/python/inertialsense/tools/data_sets.py
+++ b/python/inertialsense/tools/data_sets.py
@@ -44,10 +44,10 @@ DID_DEBUG_STRING                = 37
 DID_RTOS_INFO                   = 38
 DID_DEBUG_ARRAY                 = 39
 DID_SENSORS_MCAL                = 40
-# DID_UNUSED_41                 = 41
-DID_CAL_SC                      = 42
-DID_CAL_SC1                     = 43
-DID_CAL_SC2                     = 44
+DID_GPS1_TIMEPULSE              = 41
+# DID_UNUSED                    = 42
+# DID_UNUSED                    = 43
+# DID_UNUSED                    = 44
 DID_SENSORS_ADC_SIGMA           = 46
 DID_REFERENCE_MAGNETOMETER      = 47
 DID_INL2_STATES                 = 48
@@ -157,9 +157,6 @@ did_name_lookup = {
  DID_DEBUG_STRING : "debugString",
  DID_RTOS_INFO : "rtosInfo",
  DID_DEBUG_ARRAY : "debugArray",
- DID_CAL_SC : "calSc",
- DID_CAL_SC1 : "calSc1",
- DID_CAL_SC2 : "calSc2",
  DID_SENSORS_ADC_SIGMA : "sensorsAdcSigma",
  DID_INL2_STATES : "inl2States",
  DID_INL2_COVARIANCE_LD : "inl2CovarianceLd",

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -516,7 +516,10 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE)
+        if (pkt->data.size <= MAX_DATASET_SIZE ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_GYR ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_ACC ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_MAG)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -535,7 +538,10 @@ static protocol_type_t processIsbPkt(void* v)
         {
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
-            if (get->size <= MAX_DATASET_SIZE)
+            if (get->size <= MAX_DATASET_SIZE ||
+                get->id == DID_CAL_TEMP_COMP_GYR ||
+                get->id == DID_CAL_TEMP_COMP_ACC ||
+                get->id == DID_CAL_TEMP_COMP_MAG)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -464,10 +464,7 @@ static protocol_type_t processIsbPkt(void* v)
     if (isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB)
         return parseErrorResetState(c, EPARSE_INVALID_SIZE);
     if ((isbPkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET) &&
-        (isbPkt->payload.offset + isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB) &&
-        (isbPkt->hdr.id != DID_CAL_SC) &&           // Allow large dataset offsets / (offset+chunk) ranges for calibration data DIDs
-        (isbPkt->hdr.id != DID_CAL_TEMP_COMP) &&
-        (isbPkt->hdr.id != DID_CAL_MOTION) )
+        (isbPkt->payload.offset + isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB))
         return parseErrorResetState(c, EPARSE_INVALID_HEADER);
 
     uint16_t payloadSize = isbPkt->hdr.payloadSize;
@@ -519,10 +516,7 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE || 
-            pkt->hdr.id == DID_CAL_SC || 
-            pkt->hdr.id == DID_CAL_TEMP_COMP ||
-            pkt->hdr.id == DID_CAL_MOTION)
+        if (pkt->data.size <= MAX_DATASET_SIZE)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -541,10 +535,7 @@ static protocol_type_t processIsbPkt(void* v)
         {
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
-            if (get->size <= MAX_DATASET_SIZE ||
-                get->id == DID_CAL_SC || 
-                get->id == DID_CAL_TEMP_COMP ||
-                get->id == DID_CAL_MOTION)
+            if (get->size <= MAX_DATASET_SIZE)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2076,48 +2076,81 @@ static void PopulateMapSensorSCalInfo(data_set_t data_set[DID_COUNT], uint32_t d
     mapper.AddMember2("devSerialNum", offsetof(sensor_cal_info_t, devSerialNum), DATA_TYPE_UINT32, "", "Device serial number", DATA_FLAGS_READ_ONLY);
 }
 
-static void PopulateMapSensorTCalSubsetGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+static void PopulateMapSensorTCalGyrGroup(data_set_t data_set[DID_COUNT], uint32_t did)
 {
-    DataMapper<sensor_tcal_group_subset_t> mapper(data_set, did);
+    DataMapper<sensor_tcal_gyr_group_t> mapper(data_set, did);
 
     // Can be Gyros, Accel, or Magnetometer 
     for (int i=0; i<MAX_IMU_DEVICES; i++)
     {
-        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
         for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
         {
-            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
-            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
         }
     }
 }
 
-static void PopulateMapSensorMCalGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+static void PopulateMapSensorTCalAccGroup(data_set_t data_set[DID_COUNT], uint32_t did)
 {
-    DataMapper<sensor_mcal_group_t> mapper(data_set, did);
+    DataMapper<sensor_tcal_acc_group_t> mapper(data_set, did);
 
-    constexpr int numImu = (int)(sizeof(sensor_mcal_group_t::pqr) / sizeof(sensor_motion_cal_t));
-    constexpr int numMag = (int)(sizeof(sensor_mcal_group_t::mag) / sizeof(sensor_motion_cal_t));
-
-    // Gyros
-    for (int i=0; i<numImu; i++)
+    // Can be Gyros, Accel, or Magnetometer 
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("pqr" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("pqr" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
     }
+}
 
-    // Accels
-    for (int i=0; i<numImu; i++)
+static void PopulateMapSensorTCalMagGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_tcal_mag_group_t> mapper(data_set, did);
+
+    // Can be Gyros, Accel, or Magnetometer 
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
     {
-        mapper.AddArray2("acc" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("acc" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
     }
+}
 
-    // Magnetometers
-    for (int i=0; i<numMag; i++)
+static void PopulateMapSensorMCalGyrGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_gyr_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("mag" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("mag" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_gyr_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_gyr_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
+    }
+}
+
+static void PopulateMapSensorMCalAccGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_acc_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_acc_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_acc_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
+    }
+}
+
+static void PopulateMapSensorMCalMagGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_mag_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    {
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_mag_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_mag_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});
     }
 }
 
@@ -2300,9 +2333,9 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_DEBUG_ARRAY",                  // 39
     "DID_SENSORS_MCAL",                 // 40
     "DID_GPS1_TIMEPULSE",               // 41
-    "DID_CAL_SC",                       // 42
-    "DID_CAL_TEMP_COMP",                // 43
-    "DID_CAL_MOTION",                   // 44
+    "DID_UNUSED_42",                    // 42
+    "DID_UNUSED_43",                    // 43
+    "DID_UNUSED_44",                    // 44
     "DID_GPS1_SIG",                     // 45
     "DID_SENSORS_ADC_SIGMA",            // 46
     "DID_REFERENCE_MAGNETOMETER",       // 47
@@ -2358,25 +2391,25 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_IMU_RAW",                      // 97 
     "DID_FIRMWARE_UPDATE",              // 98 
     "DID_RUNTIME_PROFILER",             // 99 
-    "UNUSED_100",                       // 100
-    "UNUSED_101",                       // 101
-    "UNUSED_102",                       // 102
-    "UNUSED_103",                       // 103
-    "UNUSED_104",                       // 104
-    "UNUSED_105",                       // 105
+    "DID_CAL_TEMP_COMP_GYR",            // 100
+    "DID_CAL_TEMP_COMP_ACC",            // 101
+    "DID_CAL_TEMP_COMP_MAG",            // 102
+    "DID_CAL_MOTION_GYR",               // 103
+    "DID_CAL_MOTION_ACC",               // 104
+    "DID_CAL_MOTION_MAG",               // 105
     "UNUSED_106",                       // 106
     "UNUSED_107",                       // 107
     "UNUSED_108",                       // 108
     "UNUSED_109",                       // 109
-    "DID_EVB_LUNA_FLASH_CFG",           // 110
-    "DID_EVB_LUNA_STATUS",              // 111
-    "DID_EVB_LUNA_SENSORS",             // 112
-    "DID_EVB_LUNA_REMOTE_KILL",         // 113
-    "DID_EVB_LUNA_VELOCITY_CONTROL",    // 114
-    "DID_EVB_LUNA_VELOCITY_COMMAND",    // 115
-    "DID_EVB_LUNA_AUX_COMMAND",         // 116
-    "",                                 // 117
-    "",                                 // 118
+    "UNUSED_110",                       // 110
+    "UNUSED_111",                       // 111
+    "UNUSED_112",                       // 112
+    "UNUSED_113",                       // 113
+    "UNUSED_114",                       // 114
+    "UNUSED_115",                       // 115
+    "UNUSED_116",                       // 116
+    "UNUSED_117",                       // 117
+    "UNUSED_118",                       // 118
     "DID_EVENT",                        // 119
     "DID_GPX_DEV_INFO",                 // 120
     "DID_GPX_FLASH_CFG",                // 121
@@ -2517,10 +2550,13 @@ cISDataMappings::cISDataMappings()
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_TCAL);
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_MCAL);
     PopulateMapSensors(             m_data_set, DID_SENSORS_TC_BIAS);
-    // PopulateMapSensorTCalGroup(m_data_set, DID_CAL_TEMP_COMP);
     PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_SC_INFO);
-    PopulateMapSensorTCalSubsetGroup(m_data_set, DID_CAL_TEMP_COMP);
-    PopulateMapSensorMCalGroup(      m_data_set, DID_CAL_MOTION);
+    PopulateMapSensorTCalGyrGroup(   m_data_set, DID_CAL_TEMP_COMP_GYR);
+    PopulateMapSensorTCalAccGroup(   m_data_set, DID_CAL_TEMP_COMP_ACC);
+    PopulateMapSensorTCalMagGroup(   m_data_set, DID_CAL_TEMP_COMP_MAG);
+    PopulateMapSensorMCalGyrGroup(   m_data_set, DID_CAL_MOTION_GYR);
+    PopulateMapSensorMCalAccGroup(   m_data_set, DID_CAL_MOTION_ACC);
+    PopulateMapSensorMCalMagGroup(   m_data_set, DID_CAL_MOTION_MAG);
     PopulateMapSensorCompensation(   m_data_set, DID_SCOMP);
 
     // This must come last
@@ -2662,9 +2698,14 @@ uint32_t cISDataMappings::DefaultPeriodMultiple(uint32_t did)
     case DID_NVR_USERPAGE_G1:
     case DID_FLASH_CONFIG:
     case DID_CAL_SC_INFO:
-    case DID_CAL_SC:
-    case DID_CAL_TEMP_COMP:
-    case DID_CAL_MOTION:
+    case DID_CAL_TEMP_COMP_GYR:
+    case DID_CAL_TEMP_COMP_ACC:
+    case DID_CAL_TEMP_COMP_MAG:
+    case DID_CAL_MOTION_GYR:
+    case DID_CAL_MOTION_ACC:
+    case DID_CAL_MOTION_MAG:
+    case DID_CAL_TEMP_COMP_GYR:
+    case DID_CAL_MOTION_GYR:
     case DID_RTOS_INFO:
     case DID_SYS_CMD:
     case DID_NMEA_BCAST_PERIOD:

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2704,8 +2704,6 @@ uint32_t cISDataMappings::DefaultPeriodMultiple(uint32_t did)
     case DID_CAL_MOTION_GYR:
     case DID_CAL_MOTION_ACC:
     case DID_CAL_MOTION_MAG:
-    case DID_CAL_TEMP_COMP_GYR:
-    case DID_CAL_MOTION_GYR:
     case DID_RTOS_INFO:
     case DID_SYS_CMD:
     case DID_NMEA_BCAST_PERIOD:

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2365,7 +2365,7 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_WHEEL_ENCODER",                // 71
     "DID_DIAGNOSTIC_MESSAGE",           // 72
     "DID_SURVEY_IN",                    // 73
-    "DID_CAL_SC_INFO",                  // 74
+    "DID_CAL_INFO",                  // 74
     "DID_PORT_MONITOR",                 // 75
     "DID_RTK_STATE",                    // 76
     "DID_RTK_PHASE_RESIDUAL",           // 77
@@ -2550,7 +2550,7 @@ cISDataMappings::cISDataMappings()
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_TCAL);
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_MCAL);
     PopulateMapSensors(             m_data_set, DID_SENSORS_TC_BIAS);
-    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_SC_INFO);
+    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_INFO);
     PopulateMapSensorTCalGyrGroup(   m_data_set, DID_CAL_TEMP_COMP_GYR);
     PopulateMapSensorTCalAccGroup(   m_data_set, DID_CAL_TEMP_COMP_ACC);
     PopulateMapSensorTCalMagGroup(   m_data_set, DID_CAL_TEMP_COMP_MAG);
@@ -2697,7 +2697,7 @@ uint32_t cISDataMappings::DefaultPeriodMultiple(uint32_t did)
     case DID_NVR_USERPAGE_G0:
     case DID_NVR_USERPAGE_G1:
     case DID_FLASH_CONFIG:
-    case DID_CAL_SC_INFO:
+    case DID_CAL_INFO:
     case DID_CAL_TEMP_COMP_GYR:
     case DID_CAL_TEMP_COMP_ACC:
     case DID_CAL_TEMP_COMP_MAG:

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2096,22 +2096,25 @@ static void PopulateMapSensorMCalGroup(data_set_t data_set[DID_COUNT], uint32_t 
 {
     DataMapper<sensor_mcal_group_t> mapper(data_set, did);
 
+    constexpr int numImu = (int)(sizeof(sensor_mcal_group_t::pqr) / sizeof(sensor_motion_cal_t));
+    constexpr int numMag = (int)(sizeof(sensor_mcal_group_t::mag) / sizeof(sensor_motion_cal_t));
+
     // Gyros
-    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    for (int i=0; i<numImu; i++)
     {
         mapper.AddArray2("pqr" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
         mapper.AddArray2("pqr" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
     }
 
     // Accels
-    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    for (int i=0; i<numImu; i++)
     {
         mapper.AddArray2("acc" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
         mapper.AddArray2("acc" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
     }
 
     // Magnetometers
-    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    for (int i=0; i<numMag; i++)
     {
         mapper.AddArray2("mag" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
         mapper.AddArray2("mag" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -233,7 +233,12 @@ public:
 
     ~DataMapper()
     {
-        assert((totalSize == structSize) && "Size of mapped fields does not match struct size");
+        if (totalSize != structSize)
+        {
+            fprintf(stderr, "DataMapper ERROR [%s]: mapped size %u != struct size %u (diff %d bytes)\n",
+                typeid(MAP_TYPE).name(), totalSize, structSize, (int)structSize - (int)totalSize);
+            assert(false && "Size of mapped fields does not match struct size");
+        }
     }
 
     template <typename MemberType>

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -15,8 +15,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <any>
 #include <cinttypes>
+#include <cstdio>
 #include <map>
 #include <string>
+#include <typeinfo>
 #include <vector>
 #include <functional>
 #include <type_traits>

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -993,17 +993,17 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     {
     case 0:     // General Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.info), DID_CAL_SC_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
         }
         break;
 
     case 1:     // Data Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
         }
         break;
 

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -993,65 +993,65 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     {
     case 0:     // General Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.info), DID_CAL_SC_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
         }
         break;
 
     case 1:     // Data Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
         }
         break;
 
     case 2:     // Temp comp - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR) != 0) { return 0; }
         }
         break;
 
     case 3:     // Temp comp - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC) != 0) { return 0; }
         }
         break;
 
     case 4:     // Temp comp - Magnetometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP, NUM_MAG_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, NUM_MAG_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG) != 0) { return 0; }
         }
         break;
 
     case 5:     // Motion cal - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR) != 0) { return 0; }
         }
         break;
 
     case 6:     // Motion cal - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC) != 0) { return 0; }
         }
         break;
 
     case 7:     // Motion cal - Magnetometers (last step)
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION, NUM_MAG_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, NUM_MAG_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG) != 0) { return 0; }
         }
         return 1;    // Done
 

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -1009,49 +1009,49 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 2:     // Temp comp - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, gyr)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, gyr)) != 0) { return 0; }
         }
         break;
 
     case 3:     // Temp comp - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, acc)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, NUM_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, acc)) != 0) { return 0; }
         }
         break;
 
     case 4:     // Temp comp - Magnetometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP, NUM_MAG_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, mag)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, NUM_MAG_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, mag)) != 0) { return 0; }
         }
         break;
 
     case 5:     // Motion cal - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, pqr)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, pqr)) != 0) { return 0; }
         }
         break;
 
     case 6:     // Motion cal - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, acc)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, NUM_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, acc)) != 0) { return 0; }
         }
         break;
 
     case 7:     // Motion cal - Magnetometers (last step)
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION, NUM_MAG_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, mag)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, NUM_MAG_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, mag)) != 0) { return 0; }
         }
         return 1;    // Done
 

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -129,7 +129,17 @@ typedef struct PACKED
 typedef struct PACKED
 {
     nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
-} sensor_tcal_group_subset_t;
+} sensor_tcal_gyr_group_t;
+
+typedef struct PACKED
+{
+    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
+} sensor_tcal_acc_group_t;
+
+typedef struct PACKED
+{
+    nvm_sensor_tcal_3axis_t sensor[MAX_MAG_DEVICES];            // temperature calibration
+} sensor_tcal_mag_group_t;
 
 ////////////////////////////////////////////////
 // MCAL v1.3
@@ -138,6 +148,22 @@ typedef struct PACKED
     float                   orth[9];        // Ortho-normalization matrices (cross-axis and scale factor)
     float                   bias[3];        // Bias
 } sensor_motion_cal_t;
+
+// 1/3 of sensor_mcal_group_t used for uploading calibration
+typedef struct PACKED
+{
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // gyro motion calibration
+} sensor_mcal_gyr_group_t;
+
+typedef struct PACKED
+{
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // accel motion calibration
+} sensor_mcal_acc_group_t;
+
+typedef struct PACKED
+{
+    sensor_motion_cal_t sensor[MAX_MAG_DEVICES];                // mag motion calibration
+} sensor_mcal_mag_group_t;
 
 typedef struct PACKED
 {
@@ -198,6 +224,19 @@ typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;
 typedef sensor_cal_v1p4_t           sensor_cal_t;
 #endif
 
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+
+#define SIZE_OF_SENSOR_TCAL_GYR         (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_ACC         (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_MAG         (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_MCAL_GYR         (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_ACC         (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_MAG         (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
 
 #ifdef __cplusplus
 }

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -231,12 +231,28 @@ typedef sensor_cal_v1p4_t           sensor_cal_t;
 #define SIZE_OF_SENSOR_MCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
 #define SIZE_OF_SENSOR_MCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
 
-#define SIZE_OF_SENSOR_TCAL_GYR         (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_ACC         (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_MAG         (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_MCAL_GYR         (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_ACC         (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_MAG         (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+
+#if defined(IMX_5)
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P3
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P3
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P3
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P3
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P3
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P3
+#else
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P4
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P4
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P4
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P4
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P4
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P4
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -113,16 +113,16 @@ typedef struct PACKED
 
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[MAX_IMU_DEVICES_V1P3];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[MAX_IMU_DEVICES_V1P3];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[MAX_MAG_DEVICES_V1P3];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P3];          // Gyro temperature calibration
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P3];          // Accel temperature calibration
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P3];          // Mag temperature calibration
 } sensor_tcal_group_v1p3_t;
 
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[MAX_IMU_DEVICES_V1P4];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[MAX_IMU_DEVICES_V1P4];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[MAX_MAG_DEVICES_V1P4];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P4];          // Gyro temperature calibration
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P4];          // Accel temperature calibration
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P4];          // Mag temperature calibration
 } sensor_tcal_group_v1p4_t;
 
 // 1/3 of sensor_tcal_group_t used for uploading calibration
@@ -141,16 +141,16 @@ typedef struct PACKED
 
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[MAX_IMU_DEVICES_V1P3];          // Gyros (x3 IMUs)
-    sensor_motion_cal_t     acc[MAX_IMU_DEVICES_V1P3];          // Accelerometers (x3 IMUs)
-    sensor_motion_cal_t     mag[MAX_MAG_DEVICES_V1P3];          // Magnetometers
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P3];          // Gyros (x3 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P3];          // Accelerometers (x3 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P3];          // Magnetometers
 } sensor_mcal_group_v1p3_t;
 
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[MAX_IMU_DEVICES_V1P4];          // Gyros (x5 IMUs)
-    sensor_motion_cal_t     acc[MAX_IMU_DEVICES_V1P4];          // Accelerometers (x5 IMUs)
-    sensor_motion_cal_t     mag[MAX_MAG_DEVICES_V1P4];          // Magnetometers
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P4];          // Gyros (x5 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P4];          // Accelerometers (x5 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P4];          // Magnetometers
 } sensor_mcal_group_v1p4_t;
 
 ////////////////////////////////////////////////
@@ -197,6 +197,7 @@ typedef sensor_mcal_group_v1p4_t    sensor_mcal_group_t;
 typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;
 typedef sensor_cal_v1p4_t           sensor_cal_t;
 #endif
+
 
 #ifdef __cplusplus
 }

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -12,7 +12,7 @@ void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
     if (data == NULL) { return; }
 
     memset(data, 0, sizeof(sensor_cal_v1p4_data_t));
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
         data->mcal.pqr[d].orth[4] = 1;
@@ -22,7 +22,7 @@ void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
         data->mcal.acc[d].orth[4] = 1;
         data->mcal.acc[d].orth[8] = 1;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P4; d++)
     {
         data->mcal.mag[d].orth[0] = 1;
         data->mcal.mag[d].orth[4] = 1;
@@ -38,7 +38,7 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
     if (data == NULL) { return; }
 
     memset(data, 0, sizeof(sensor_cal_v1p3_data_t));
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
         data->mcal.pqr[d].orth[4] = 1;
@@ -48,7 +48,7 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
         data->mcal.acc[d].orth[4] = 1;
         data->mcal.acc[d].orth[8] = 1;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
         data->mcal.mag[d].orth[0] = 1;
         data->mcal.mag[d].orth[4] = 1;
@@ -61,12 +61,12 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
 
 void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p4->gyr[d] = v1p3->gyr[d];
         v1p4->acc[d] = v1p3->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p4->mag[d] = v1p3->mag[d];
     }
@@ -74,12 +74,12 @@ void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal
 
 void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p4->pqr[d] = v1p3->pqr[d];
         v1p4->acc[d] = v1p3->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p4->mag[d] = v1p3->mag[d];
     }
@@ -104,12 +104,12 @@ void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v
 
 void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p3->gyr[d] = v1p4->gyr[d];
         v1p3->acc[d] = v1p4->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p3->mag[d] = v1p4->mag[d];
     }
@@ -117,12 +117,12 @@ void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal
 
 void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p3->pqr[d] = v1p4->pqr[d];
         v1p3->acc[d] = v1p4->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p3->mag[d] = v1p4->mag[d];
     }

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -529,7 +529,7 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 71: DID_WHEEL_ENCODER
         diagMsgOffsets,         // 72: DID_DIAGNOSTIC_MESSAGE
         0,                      // 73: DID_SURVEY_IN
-        0,                      // 74: DID_CAL_SC_INFO
+        0,                      // 74: DID_CAL_INFO
         0,                      // 75: DID_PORT_MONITOR
         0,                      // 76: DID_RTK_STATE
         0,                      // 77: DID_RTK_RESIDUAL

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -307,9 +307,9 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetsDebugArray,      // 39: DID_DEBUG_ARRAY
         0,                      // 40: DID_SENSORS_MCAL
         offsetsGpsTimepulse,    // 41: DID_GPS1_TIMEPULSE
-        0,                      // 42: DID_CAL_SC
-        0,                      // 43: DID_CAL_SC1
-        0,                      // 44: DID_CAL_SC2
+        0,                      // 42: DID_UNUSED
+        0,                      // 43: DID_UNUSED
+        0,                      // 44: DID_UNUSED
         0,                      // 45: DID_GPS1_SIG
         offsetsOnlyTimeFirst,   // 46: DID_SENSORS_ADC_SIGMA
         offsetsOnlyTimeFirst,   // 47: DID_REFERENCE_MAGNETOMETER
@@ -365,26 +365,26 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetsOnlyTimeFirst,   // 97: DID_IMU_RAW
         0,                      // 98: DID_FIRMWARE_UPDATE
         0,                      // 99: DID_RUNTIME_PROFILER
-        0,                      // 100: 
-        0,                      // 101: 
-        0,                      // 102: 
-        0,                      // 103: 
-        0,                      // 104: 
-        0,                      // 105:
-        0,                      // 106:
-        0,                      // 107:
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
-        0,                      // 113:
-        0,                      // 114:
-        0,                      // 115:
-        0,                      // 116:
-        0,                      // 117:
-        0,                      // 118:
-        0,                      // 119:
+        0,                      // 100: DID_CAL_TEMP_COMP_GYR
+        0,                      // 101: DID_CAL_TEMP_COMP_ACC
+        0,                      // 102: DID_CAL_TEMP_COMP_MAG
+        0,                      // 103: DID_CAL_MOTION_GYR
+        0,                      // 104: DID_CAL_MOTION_ACC
+        0,                      // 105: DID_CAL_MOTION_MAG
+        0,                      // 106: 
+        0,                      // 107: 
+        0,                      // 108: 
+        0,                      // 109: 
+        0,                      // 110: 
+        0,                      // 111: 
+        0,                      // 112: 
+        0,                      // 113: 
+        0,                      // 114: 
+        0,                      // 115: 
+        0,                      // 116: 
+        0,                      // 117: 
+        0,                      // 118: 
+        0,                      // 119: 
         0,                      // 120: DID_GPX_DEV_INFO
         0,                      // 121: DID_GPX_FLASH_CFG
         0,                      // 122: DID_GPX_RTOS_INFO
@@ -496,11 +496,11 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         rtosTaskOffsets,        // 38: DID_RTOS_INFO
         0,                      // 39: DID_DEBUG_ARRAY
         0,                      // 40: DID_SENSORS_MCAL
-        0,                      // 41: 
-        0,                      // 42: DID_CAL_SC
-        0,                      // 43: DID_CAL_SC1
-        0,                      // 44: DID_CAL_SC2
-        0,                      // 45:
+        0,                      // 41: DID_GPS1_TIMEPULSE
+        0,                      // 42: DID_UNUSED
+        0,                      // 43: DID_UNUSED
+        0,                      // 44: DID_UNUSED
+        0,                      // 45: DID_GPS1_SIG
         0,                      // 46: DID_SENSORS_ADC_SIGMA
         0,                      // 47: DID_REFERENCE_MAGNETOMETER
         0,                      // 48: DID_INL2_STATES
@@ -555,26 +555,26 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 97: DID_IMU_RAW
         0,                      // 98: DID_FIRMWARE_UPDATE
         0,                      // 99: DID_RUNTIME_PROFILER
-        0,                      // 100: 
-        0,                      // 101: 
-        0,                      // 102: 
-        0,                      // 103: 
-        0,                      // 104: 
-        0,                      // 105:
-        0,                      // 106:
-        0,                      // 107:
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
-        0,                      // 113:
-        0,                      // 114:
-        0,                      // 115:
-        0,                      // 116:
-        0,                      // 117:
-        0,                      // 118:
-        0,                      // 119:
+        0,                      // 100: DID_CAL_TEMP_COMP_GYR
+        0,                      // 101: DID_CAL_TEMP_COMP_ACC
+        0,                      // 102: DID_CAL_TEMP_COMP_MAG
+        0,                      // 103: DID_CAL_MOTION_GYR
+        0,                      // 104: DID_CAL_MOTION_ACC
+        0,                      // 105: DID_CAL_MOTION_MAG
+        0,                      // 106: 
+        0,                      // 107: 
+        0,                      // 108: 
+        0,                      // 109: 
+        0,                      // 110: 
+        0,                      // 111: 
+        0,                      // 112: 
+        0,                      // 113: 
+        0,                      // 114: 
+        0,                      // 115: 
+        0,                      // 116: 
+        0,                      // 117: 
+        0,                      // 118: 
+        0,                      // 119: 
         0,                      // 120: DID_GPX_DEV_INFO
         0,                      // 121: DID_GPX_FLASH_CFG
         0,                      // 122: DID_GPX_RTOS_INFO

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -111,7 +111,7 @@ typedef uint32_t eDataIDs;
 #define DID_WHEEL_ENCODER               (eDataIDs)71 /** (wheel_encoder_t) Wheel encoder data to be fused with GPS-INS measurements, set DID_GROUND_VEHICLE for configuration before sending this message */
 #define DID_DIAGNOSTIC_MESSAGE          (eDataIDs)72 /** (diag_msg_t) Diagnostic message */
 #define DID_SURVEY_IN                   (eDataIDs)73 /** (survey_in_t) Survey in, used to determine position for RTK base station. Base correction output cannot run during a survey and will be automatically disabled if a survey is started. */
-#define DID_CAL_SC_INFO                 (eDataIDs)74 /** INTERNAL USE ONLY (sensor_cal_info_t) */
+#define DID_CAL_INFO                    (eDataIDs)74 /** INTERNAL USE ONLY (sensor_cal_info_t) */
 #define DID_PORT_MONITOR                (eDataIDs)75 /** (port_monitor_t) Data rate and status monitoring for each communications port. */
 #define DID_RTK_STATE                   (eDataIDs)76 /** INTERNAL USE ONLY (rtk_state_t) */
 #define DID_RTK_PHASE_RESIDUAL          (eDataIDs)77 /** INTERNAL USE ONLY (rtk_residual_t) */

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -195,20 +195,15 @@ typedef uint32_t eDataIDs;
 #define RECEIVER_INDEX_GPS2             3 // DO NOT CHANGE
 
 // Version 1.3 of sensor calibration format supports up to 3 IMUs and 2 mags, with separate orthonormalization and bias calibration for each device
-#define MAX_IMU_DEVICES_V1P3    3
-#define MAX_MAG_DEVICES_V1P3    2
-// Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
-#define MAX_IMU_DEVICES_V1P4    5
-#define MAX_MAG_DEVICES_V1P4    1
+#define NUM_IMU_DEVICES_V1P3    3
+#define NUM_MAG_DEVICES_V1P3    2
+// // Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
+#define NUM_IMU_DEVICES_V1P4    5
+#define NUM_MAG_DEVICES_V1P4    1
 // Per-build-target native counts. SN-7966: IMX-5 hardware is permanently Cal v1.3,
 // IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) uses v1.4.
-#if defined(IMX_5)
-#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P3
-#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P3
-#else
-#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P4
-#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P4
-#endif
+#define MAX_IMU_DEVICES         NUM_IMU_DEVICES_V1P4
+#define MAX_MAG_DEVICES         NUM_MAG_DEVICES_V1P4
 
 /** INS status flags */
 enum eInsStatusFlags

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -202,7 +202,7 @@ typedef uint32_t eDataIDs;
 // Version 1.3 of sensor calibration format supports up to 3 IMUs and 2 mags, with separate orthonormalization and bias calibration for each device
 #define NUM_IMU_DEVICES_V1P3    3
 #define NUM_MAG_DEVICES_V1P3    2
-// // Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
+// Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
 #define NUM_IMU_DEVICES_V1P4    5
 #define NUM_MAG_DEVICES_V1P4    1
 // Per-build-target native counts. SN-7966: IMX-5 hardware is permanently Cal v1.3,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -79,9 +79,9 @@ typedef uint32_t eDataIDs;
 #define DID_DEBUG_ARRAY                 (eDataIDs)39 /** INTERNAL USE ONLY (debug_array_t) */
 #define DID_SENSORS_MCAL                (eDataIDs)40 /** INTERNAL USE ONLY (sensors_w_temp_t) Temperature compensated and motion calibrated IMU output. */
 #define DID_GPS1_TIMEPULSE              (eDataIDs)41 /** (gps_timepulse_t) GPS1 PPS time synchronization. */
-#define DID_CAL_SC                      (eDataIDs)42 /** INTERNAL USE ONLY (sensor_cal_t) */
-#define DID_CAL_TEMP_COMP               (eDataIDs)43 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
-#define DID_CAL_MOTION                  (eDataIDs)44 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_UNUSED_42                   (eDataIDs)42 /** unused */
+#define DID_UNUSED_43                   (eDataIDs)43 /** unused */
+#define DID_UNUSED_44                   (eDataIDs)44 /** unused */
 #define DID_GPS1_SIG                    (eDataIDs)45 /** (gps_sig_t) GPS 1 GNSS signal information. */
 #define DID_SENSORS_ADC_SIGMA           (eDataIDs)46 /** INTERNAL USE ONLY (sys_sensors_adc_t) */
 #define DID_REFERENCE_MAGNETOMETER      (eDataIDs)47 /** (magnetometer_t) Reference or truth magnetometer used for manufacturing calibration and testing */
@@ -137,6 +137,12 @@ typedef uint32_t eDataIDs;
 #define DID_IMU_RAW                     (eDataIDs)97 /** (imu_t) IMU data averaged from DID_IMUS_RAW.  Use this IMU data for output data rates faster than DID_FLASH_CONFIG.startupNavDtMs.  Otherwise we recommend use of DID_IMU or DID_PIMU as they are oversampled and contain less noise. */
 #define DID_FIRMWARE_UPDATE             (eDataIDs)98 /** (firmware_payload_t) firmware update payload */
 #define DID_RUNTIME_PROFILER            (eDataIDs)99 /** INTERNAL USE ONLY (runtime_profiler_t) System runtime profiler */
+#define DID_CAL_TEMP_COMP_GYR           (eDataIDs)100 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_TEMP_COMP_ACC           (eDataIDs)101 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_TEMP_COMP_MAG           (eDataIDs)102 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_MOTION_GYR              (eDataIDs)103 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_CAL_MOTION_ACC              (eDataIDs)104 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_CAL_MOTION_MAG              (eDataIDs)105 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
 
 #define DID_EVENT                       (eDataIDs)119 /** INTERNAL USE ONLY (did_event_t)*/
 
@@ -162,7 +168,6 @@ typedef uint32_t eDataIDs;
 
 /** Count of data ids (including null data id 0) - MUST BE MULTPLE OF 4 and larger than last DID number! */
 #define DID_COUNT       (eDataIDs)132    // Used in SDK
-#define DID_COUNT_UINS  (eDataIDs)100    // Used in IMX
 
 /** Maximum number of data ids */
 #define DID_MAX_COUNT   256

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -1184,7 +1184,9 @@ static int serialPortWritePlatform(port_handle_t port, const unsigned char* buff
  * On other platforms, it uses `poll` and `ioctl` with `FIONREAD`.
  *
  * @param port The port handle.
- * @return int The number of bytes available to read, or PORT_ERROR__INVALID on error.
+ * @return int The number of bytes available to read, PORT_ERROR__INVALID if the port
+ *         handle is invalid, or PORT_ERROR__NOT_CONNECTED if the internal handle is NULL
+ *         (i.e., the port has not been opened or has been closed).
  */
 static int serialPortGetByteCountAvailableToReadPlatform(port_handle_t port)
 {
@@ -1196,7 +1198,11 @@ static int serialPortGetByteCountAvailableToReadPlatform(port_handle_t port)
     serial_port_t* serialPort = (serial_port_t*)port;
     serialPortHandle* handle = (serialPortHandle*)serialPort->handle;
     if (!handle)
+    {
+        serialPort->errorCode = ENOENT;
+        serialPort->error = "Internal port handle is NULL; Port is closed.";
         return PORT_ERROR__NOT_CONNECTED;
+    }
 
 #if PLATFORM_IS_WINDOWS
 

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -1195,6 +1195,8 @@ static int serialPortGetByteCountAvailableToReadPlatform(port_handle_t port)
 
     serial_port_t* serialPort = (serial_port_t*)port;
     serialPortHandle* handle = (serialPortHandle*)serialPort->handle;
+    if (!handle)
+        return PORT_ERROR__NOT_CONNECTED;
 
 #if PLATFORM_IS_WINDOWS
 

--- a/tests/test_ISDeviceCal.cpp
+++ b/tests/test_ISDeviceCal.cpp
@@ -319,13 +319,13 @@ static void buildV1p4Sample(sensor_cal_v1p4_t &cal, uint32_t serialNum = 60010)
     cal.info.devSerialNum = serialNum;
     cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
         cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
         cal.data.mcal.acc[d].orth[4] = 1.0f + 0.02f * d;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P4; d++)
     {
         cal.data.mcal.mag[d].orth[0] = 2.5f;
         cal.data.mcal.mag[d].bias[1] = 0.5f;
@@ -343,12 +343,12 @@ static void buildV1p3Sample(sensor_cal_v1p3_t &cal, uint32_t serialNum = 60010)
     cal.info.devSerialNum = serialNum;
     cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
         cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
         cal.data.mcal.mag[d].orth[0] = 2.5f + 0.1f * d;
     }
@@ -370,8 +370,8 @@ TEST(ISDeviceCalConvert, V1p4ToV1p3PreservesSharedFields)
     EXPECT_EQ(v1p3.info.version[1], 3);
     EXPECT_EQ(v1p3.info.devSerialNum, 60010u);
 
-    // First MAX_IMU_DEVICES_V1P3 IMUs survive the downgrade
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    // First NUM_IMU_DEVICES_V1P3 IMUs survive the downgrade
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].orth[0], v1p4.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].bias[0], v1p4.data.mcal.pqr[d].bias[0]);
@@ -396,14 +396,14 @@ TEST(ISDeviceCalConvert, V1p3ToV1p4PreservesSharedFields)
     EXPECT_EQ(v1p4.info.version[1], 4);
     EXPECT_EQ(v1p4.info.devSerialNum, 60011u);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], v1p3.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].bias[0], v1p3.data.mcal.pqr[d].bias[0]);
     }
     EXPECT_FLOAT_EQ(v1p4.data.mcal.mag[0].orth[0], v1p3.data.mcal.mag[0].orth[0]);
     // v1p4 IMU slots beyond v1p3 are identity
-    for (int d = MAX_IMU_DEVICES_V1P3; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = NUM_IMU_DEVICES_V1P3; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], 1.0f);
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[4], 1.0f);
@@ -438,7 +438,7 @@ TEST(ISDeviceCalConvert, RoundTripV1p4ToV1p3ToV1p4PreservesSharedSlots)
 
     EXPECT_EQ(out.info.devSerialNum, orig.info.devSerialNum);
     // Slots that fit in v1.3 (first 3 IMUs, first mag) round-trip exactly
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].orth[0], orig.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].bias[0], orig.data.mcal.pqr[d].bias[0]);


### PR DESCRIPTION
This pull request makes several significant updates to the sensor calibration and dataset mapping infrastructure, focusing on refactoring and expanding calibration dataset support, updating data ID assignments, and improving error reporting. The main themes are: refactoring calibration dataset handling to be more granular and organized, updating code to match the new dataset structure, and enhancing developer diagnostics.

**Calibration dataset refactoring and expansion:**

* Deprecated the old combined calibration dataset IDs (`DID_CAL_SC`, `DID_CAL_SC1`, `DID_CAL_SC2`, `DID_CAL_TEMP_COMP`, `DID_CAL_MOTION`) and replaced them with new, more specific dataset IDs for each sensor type (gyro, accel, mag) for both temperature compensation and motion calibration (`DID_CAL_TEMP_COMP_GYR`, `DID_CAL_TEMP_COMP_ACC`, `DID_CAL_TEMP_COMP_MAG`, `DID_CAL_MOTION_GYR`, `DID_CAL_MOTION_ACC`, `DID_CAL_MOTION_MAG`). Also updated their mappings and names throughout the codebase. [[1]](diffhunk://#diff-bf92fad8bb36bf782d87b46a20db14fdd3adc1b87e777be6bfa6dd8bad157d98L47-R50) [[2]](diffhunk://#diff-15616930ceb6137f31663d29bce29be21de2ba7a403f8b01429cdf3e316124c6L2300-R2338) [[3]](diffhunk://#diff-15616930ceb6137f31663d29bce29be21de2ba7a403f8b01429cdf3e316124c6L2332-R2368) [[4]](diffhunk://#diff-15616930ceb6137f31663d29bce29be21de2ba7a403f8b01429cdf3e316124c6L2358-R2412) [[5]](diffhunk://#diff-15616930ceb6137f31663d29bce29be21de2ba7a403f8b01429cdf3e316124c6L2517-R2559) [[6]](diffhunk://#diff-15616930ceb6137f31663d29bce29be21de2ba7a403f8b01429cdf3e316124c6L2661-R2706)

* Refactored and expanded the mapping functions in `ISDataMappings.cpp` to handle the new calibration groups for gyros, accels, and magnetometers separately, improving code clarity and maintainability.

**Code and protocol updates:**

* Updated protocol logic in `ISComm.c` to remove special handling for the old calibration dataset IDs and instead use the new, more granular dataset IDs for validation and payload offset checks. [[1]](diffhunk://#diff-0304793fbea089137a2dd2049ecf85f7314ef7b1199f4c92c4b3a93edb87d8aaL467-R467) [[2]](diffhunk://#diff-0304793fbea089137a2dd2049ecf85f7314ef7b1199f4c92c4b3a93edb87d8aaL523-R522) [[3]](diffhunk://#diff-0304793fbea089137a2dd2049ecf85f7314ef7b1199f4c92c4b3a93edb87d8aaL545-R544)

* Removed references to deprecated calibration datasets in Python tools and logging code, ensuring consistency with the new dataset structure. [[1]](diffhunk://#diff-b327b3a54916368dadb7e02cbe52f346c911312ce768d8a34ee41d217d175d17L224-L226) [[2]](diffhunk://#diff-b327b3a54916368dadb7e02cbe52f346c911312ce768d8a34ee41d217d175d17L343-L345) [[3]](diffhunk://#diff-bf92fad8bb36bf782d87b46a20db14fdd3adc1b87e777be6bfa6dd8bad157d98L160-L162)

**Developer diagnostics and error reporting:**

* Improved error reporting in the `DataMapper` destructor by printing a detailed error message before asserting if the mapped size does not match the struct size, aiding in debugging mapping issues.

**Python log inspector enhancements:**

* Added support for plotting and listing uncalibrated IMU gyro and accel data in the log inspector tools, increasing visibility into raw sensor data. [[1]](diffhunk://#diff-24beb270307aede485c52961bde480950a6555e48e8e578d1c41369df9588a7aR94-R95) [[2]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dR2970-R2973)