### PR TITLE
chore: merge develop into logalyzer-develop (2026-05)

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,6 +1,8 @@
 name: Code Linter (C++)
 
 on:
+  # Auto-triggers disabled: linter findings cluttered PR review without
+  # adding value. Workflow remains available via manual workflow_dispatch.
   workflow_dispatch:
     inputs:
       logLevel:
@@ -12,13 +14,6 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - '**'
-    pull_request:
-      - 'development'
-      - 'dev_v2'
-      - 'master'
 
 jobs:
   cpp-linter:

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -396,6 +396,24 @@ bool cltool_parseCommandLine(int argc, char* argv[])
         {
             g_commandLineOptions.disableBroadcastsOnClose = true;
         }
+        else if (matches(a, "-device") && (i + 1) < argc)
+        {
+            std::string devType = argv[++i];
+            std::transform(devType.begin(), devType.end(), devType.begin(), ::tolower);
+            if      (devType == "imx")                                                                           g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX;
+            else if (devType == "imx-5" || devType == "imx5")                                                   g_commandLineOptions.filterHdwType = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, -1);
+            else if (devType == "imx5.0" || devType == "imx-5.0")                                               g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_5_0;
+            else if (devType == "imx6.0" || devType == "imx-6.0" || devType == "imx6" || devType == "imx-6")    g_commandLineOptions.filterHdwType = IS_HARDWARE_IMX_6_0;
+            else if (devType == "gpx"  || devType == "gpx1" || devType == "gpx-1")                              g_commandLineOptions.filterHdwType = IS_HARDWARE_GPX;
+            else
+            {
+                cout << "Invalid device type: " << devType << ". Expected: imx, imx5, imx6, gpx, uins, evb." << endl;
+                return false;
+            }
+            // If no port was explicitly set, default to wildcard discovery
+            if (g_commandLineOptions.comPort.empty())
+                g_commandLineOptions.comPort = "*";
+        }
         else if (startsWith(a, "-dur="))
         {
             g_commandLineOptions.runDurationMs = (uint32_t)(atof(&a[5])*1000.0);
@@ -1235,6 +1253,7 @@ void cltool_outputUsage()
 	cout << "    -baud=" << boldOff << "BAUDRATE  Set serial port baudrate.  Options: " << IS_BAUDRATE_115200 << ", " << IS_BAUDRATE_230400 << ", " << IS_BAUDRATE_460800 << ", " << IS_BAUDRATE_921600 << " (default)" << endlbOn;
 	cout << "    -c " << boldOff << "DEVICE_PORT  Select serial port(s). Options: single port (e.g., COM5 or /dev/ttyUSB0), multiple ports separated by ',' (e.g., COM2,COM4,COM5), \"*\" for all ports, or \"*4\" for first four ports." << endlbOn;
 	cout << "    -sn " << boldOff << "DEVICE_ID   Discover all devices and connect to the one matching the given identifier. Accepts: 129495, SN129495, or IMX-5.0:SN129495. Alternative to -c." << endlbOn;
+	cout << "    -device " << boldOff << "TYPE    Discover all devices and open only those matching TYPE. Options: imx, imx5, imx6, gpx. Implies -c * if no -c port is given." << endlbOn;
 	cout << "    -dboc" << boldOff << "           Send stop-broadcast command `$STPB` on close." << endlbOn;
 	cout << "    -h --help" << boldOff << "       Display this help menu." << endlbOn;
     cout << "    -list-devices" << boldOff << "   Discovers and prints a list of discovered Inertial Sense devices and connected ports." << endlbOn;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -189,6 +189,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     EVOContainer_t evOCont;
 
     uint64_t targetDeviceId = 0;            // -sn: encoded device identifier (hdwId << 48 | serialNumber). Parsed from "IMX-5.0:SN129495" or just "129495"
+    is_hardware_t filterHdwType = IS_HARDWARE_ANY; // -device: filter to only open ports for this hardware type (e.g. IS_HARDWARE_IMX, IS_HARDWARE_GPX)
     bool disableDeviceValidation = false;   // Keep port(s) open even if no devices response is received.
     bool listenMode = false;                // Disable device verification and don't send stop-broadcast command on start.
 } cmd_options_t;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1088,11 +1088,55 @@ static int cltool_dataStreaming()
         }
     }
 
-    // [C++ COMM INSTRUCTION] STEP 2: Open serial port
+    // [C++ COMM INSTRUCTION] STEP 2: Open the requested port and validate a device
     if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose, g_commandLineOptions.filterHdwType))
     {
-        cout << "Failed to open serial port at " << g_commandLineOptions.comPort.c_str() << endl;
-        return -1;    // Failed to open serial port
+        // InertialSense::Open returns false for several distinct reasons that the
+        // original "Failed to open serial port at <url>" message conflated:
+        //   (a) the URL didn't match any registered PortFactory — PortManager is empty;
+        //   (b) a factory matched but the port couldn't actually be opened (access
+        //       denied, port held by another process, TCP refused, DNS failed); or
+        //   (c) the port opened fine, but no device responded to discovery in time.
+        // For comPort = '*' or a comma-separated list, summarizing as a single
+        // outcome is unhelpful — different ports can fail for different reasons.
+        // Enumerate per-port state from PortManager so the user sees the OS-level
+        // error code (perror, populated by tcpPort/serialPort drivers from errno)
+        // and the validate/open status of each port that was discovered.
+        if (PortManager::getInstance().empty())
+        {
+            cout << "Could not find a recognizable port for '" << g_commandLineOptions.comPort.c_str()
+                 << "' (no PortFactory matched)." << endl;
+        }
+        else
+        {
+            cout << "Could not establish a device connection for '" << g_commandLineOptions.comPort.c_str()
+                 << "':" << endl;
+            DeviceManager& dm = DeviceManager::getInstance();
+            for (auto port : PortManager::getInstance().locked_range())
+            {
+                if (!port) continue;
+                const char* name = portName(port);
+                uint16_t err = portError(port);
+                bool opened = portIsOpened(port);
+                bool valid = portIsValid(port);
+                bool hasDevice = (dm.getDevice(port) != nullptr);
+
+                cout << "  " << (name ? name : "<unnamed>") << ": ";
+                if (hasDevice) {
+                    cout << "device validated (this port is OK)";
+                } else if (err != 0) {
+                    cout << "port error (" << (int)(int16_t)err << ": " << strerror((int)(int16_t)err) << ")";
+                } else if (!valid) {
+                    cout << "port invalidated";
+                } else if (!opened) {
+                    cout << "port could not be opened";
+                } else {
+                    cout << "port opened but device did not respond to discovery";
+                }
+                cout << endl;
+            }
+        }
+        return -1;
     }
 
     if (g_commandLineOptions.list_devices) {
@@ -1118,6 +1162,28 @@ static int cltool_dataStreaming()
     }
 
     int exitCode = EXIT_CODE_SUCCESS;
+
+    // Bootloader-state guard: if any of the connected devices is sitting in
+    // HDW_STATE_BOOTLOADER, the data-streaming, NMEA, and DID flows below will all
+    // hang indefinitely — bootloaders don't speak DID/NMEA. The exception is the
+    // firmware-update path itself (which exists to recover this state); only block
+    // when we're NOT about to update firmware. Provide a clear, actionable message
+    // so the user doesn't sit watching "Tx 0, Rx 0".
+    const bool isFwUpdateRun =
+        (g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST &&
+         !g_commandLineOptions.fwUpdateCmds.empty()) ||
+        (g_commandLineOptions.updateFirmwareTarget == fwUpdate::TARGET_HOST &&
+         !g_commandLineOptions.updateAppFirmwareFilename.empty());
+    if (!isFwUpdateRun) {
+        for (auto device : inertialSenseInterface.getDevices()) {
+            if (device && device->devInfo.hdwRunState == HDW_STATE_BOOTLOADER) {
+                cout << "Device " << device->getIdAsString()
+                     << " is in BOOTLOADER mode and will not respond to data, NMEA, or DID requests." << endl
+                     << "  Reboot the device, or run a firmware update (-uf, -ufpkg, -uf-cmd) to recover." << endl;
+                return EXIT_CODE_DEVICE_DISCONNECTED;
+            }
+        }
+    }
 
     // [C++ COMM INSTRUCTION] STEP 3: Enable data broadcasting
     if (cltool_setupCommunications(inertialSenseInterface))
@@ -1188,9 +1254,16 @@ static int cltool_dataStreaming()
             // [C++ COMM INSTRUCTION] STEP 4: Read data
             while (!g_inertialSenseDisplay.ExitProgram() && (!g_commandLineOptions.runDurationMs || (current_timeMs() < exitTime)))
             {
-                // FIXME: this is a little jank -- we should periodically check for ports, but in the cltool, but we only want to check for the same ports that we originally connected on??
+                // Re-discover ONLY the originally-specified port(s), not every port the
+                // relay/mDNS factories know about. Default `discoverPorts()` uses pattern
+                // "(.+)" which matches all known URLs — for a -ufpkg run targeting a single
+                // TCP/relay device, that opened TCP sockets to every device the relay
+                // exposed (16+ on a fixture testbed) and held them for the duration of the
+                // run, blocking concurrent clients (the bridgeboard enforces "one client
+                // per port"). Passing the resolved comPort scopes the periodic check to
+                // the target we actually care about.
                 if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && (current_timeMs() > nextPortCheck)) {
-                    PortManager::getInstance().discoverPorts();
+                    PortManager::getInstance().discoverPorts(g_commandLineOptions.comPort);
                     nextPortCheck = current_timeMs() + 1500;
                 }
 
@@ -1246,6 +1319,19 @@ static int cltool_dataStreaming()
                 SLEEP_MS(1);
             }
  
+            // Re-check device-level fwUpdate errors before reporting status. The earlier
+            // exitCode at line ~1219 captures the state when the loop saw isFirmwareUpdateFinished(),
+            // but additional CMD_ERROR statuses can land between then and now. Without this check
+            // we'd print "Firmware update successful!" and then "Exit Status: -5" — contradictory.
+            if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && g_commandLineOptions.updateAppFirmwareFilename.empty()) {
+                for (auto device : inertialSenseInterface.getDevices()) {
+                    if (device->fwUpdateState.hasErrors) {
+                        exitCode = EXIT_CODE_FIRMWARE_UPDATE_FAILED;
+                        break;
+                    }
+                }
+            }
+
             // Only report firmware update status if a firmware update was actually initiated.
             if (g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST && !g_commandLineOptions.fwUpdateCmds.empty())
             {
@@ -1273,16 +1359,6 @@ static int cltool_dataStreaming()
         // Exit Failed to setup communications
         cout << "Failed to setup communications!" << endl;
         exitCode = EXIT_CODE_FAILED_TO_SETUP_COMMUNICATIONS;
-    }
-
-    //If Firmware Update is specified return an error code based on the Status of the Firmware Update
-    if ((g_commandLineOptions.updateFirmwareTarget != fwUpdate::TARGET_HOST) && g_commandLineOptions.updateAppFirmwareFilename.empty()) {
-        for (auto device : inertialSenseInterface.getDevices()) {
-            if (device->fwUpdateState.hasErrors) {
-                exitCode = EXIT_CODE_FIRMWARE_UPDATE_FAILED;
-                break;
-            }
-        }
     }
 
     return exitCode;

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1089,7 +1089,7 @@ static int cltool_dataStreaming()
     }
 
     // [C++ COMM INSTRUCTION] STEP 2: Open serial port
-    if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose))
+    if (!inertialSenseInterface.Open(g_commandLineOptions.comPort.c_str(), g_commandLineOptions.baudRate, g_commandLineOptions.disableBroadcastsOnClose, g_commandLineOptions.filterHdwType))
     {
         cout << "Failed to open serial port at " << g_commandLineOptions.comPort.c_str() << endl;
         return -1;    // Failed to open serial port

--- a/python/inertialsense/logInspector/logInspectorInternal.py
+++ b/python/inertialsense/logInspector/logInspectorInternal.py
@@ -91,6 +91,8 @@ class logInspectorInternal(LogInspectorWindow):
         self.addListItem('EKF Biases', 'ekfBiases')
 
     def createListSensors(self):
+        self.addListItem('IMUs Uncal Gyro',  'imusUncalPqr')
+        self.addListItem('IMUs Uncal Accel', 'imusUncalAcc')
         self.addListItem('IMUs Raw Gyro',  'imusRawPqr')
         self.addListItem('IMUs Raw Accel', 'imusRawAcc')
         self.addListItem('IMUs Raw Gyro Combined',  'imusRawPqrCombined')

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -2967,6 +2967,10 @@ class logPlot:
         self.imuPQR(did=DID_IMUS, fig=fig, axs=axs, combineImus=False)
     def imusAcc(self, fig=None, axs=None):
         self.imuAcc(did=DID_IMUS, fig=fig, axs=axs, combineImus=False)
+    def imusUncalPqr(self, fig=None, axs=None):
+        self.imuPQR(did=DID_IMUS_UNCAL, fig=fig, axs=axs, combineImus=False)
+    def imusUncalAcc(self, fig=None, axs=None):
+        self.imuAcc(did=DID_IMUS_UNCAL, fig=fig, axs=axs, combineImus=False)
 
     def imuPQR(self, did=DID_IMU, fig=None, axs=None, combineImus=False):
         if fig is None:

--- a/python/inertialsense/logs/src/log_reader.cpp
+++ b/python/inertialsense/logs/src/log_reader.cpp
@@ -221,9 +221,6 @@ void LogReader::organizeData(shared_ptr<cDeviceLog> devLog) {
             // HANDLE_MSG(DID_RTOS_INFO, dev_log_->rtosInfo);
             HANDLE_MSG(DID_DEBUG_STRING, dev_log_->debugString);
             HANDLE_MSG(DID_DEBUG_ARRAY, dev_log_->debugArray);
-            // HANDLE_MSG(DID_CAL_SC, dev_log_->calSc);
-            // HANDLE_MSG(DID_CAL_SC1, dev_log_->calSc1);
-            // HANDLE_MSG(DID_CAL_SC2, dev_log_->calSc2);
             HANDLE_MSG(DID_SENSORS_ADC_SIGMA, dev_log_->sensorsAdcSigma);
             HANDLE_MSG(DID_INL2_STATES, dev_log_->inl2States);
             HANDLE_MSG(DID_INL2_STATUS, dev_log_->inl2Status);
@@ -340,9 +337,6 @@ void LogReader::forwardData(int device_id) {
     // forward_message(DID_RTOS_INFO, dev_log_->rtosInfo, device_id);
     forward_message(DID_DEBUG_STRING, dev_log_->debugString, device_id);
     forward_message(DID_DEBUG_ARRAY, dev_log_->debugArray, device_id);
-    // forward_message(DID_CAL_SC, dev_log_->calSc, device_id);
-    // forward_message(DID_CAL_SC1, dev_log_->calSc1, device_id);
-    // forward_message(DID_CAL_SC2, dev_log_->calSc2, device_id);
     forward_message(DID_SENSORS_ADC_SIGMA, dev_log_->sensorsAdcSigma, device_id);
     forward_message(DID_INL2_STATES, dev_log_->inl2States, device_id);
     forward_message(DID_INL2_STATUS, dev_log_->inl2Status, device_id);

--- a/python/inertialsense/tools/data_sets.py
+++ b/python/inertialsense/tools/data_sets.py
@@ -44,10 +44,10 @@ DID_DEBUG_STRING                = 37
 DID_RTOS_INFO                   = 38
 DID_DEBUG_ARRAY                 = 39
 DID_SENSORS_MCAL                = 40
-# DID_UNUSED_41                 = 41
-DID_CAL_SC                      = 42
-DID_CAL_SC1                     = 43
-DID_CAL_SC2                     = 44
+DID_GPS1_TIMEPULSE              = 41
+# DID_UNUSED                    = 42
+# DID_UNUSED                    = 43
+# DID_UNUSED                    = 44
 DID_SENSORS_ADC_SIGMA           = 46
 DID_REFERENCE_MAGNETOMETER      = 47
 DID_INL2_STATES                 = 48
@@ -157,9 +157,6 @@ did_name_lookup = {
  DID_DEBUG_STRING : "debugString",
  DID_RTOS_INFO : "rtosInfo",
  DID_DEBUG_ARRAY : "debugArray",
- DID_CAL_SC : "calSc",
- DID_CAL_SC1 : "calSc1",
- DID_CAL_SC2 : "calSc2",
  DID_SENSORS_ADC_SIGMA : "sensorsAdcSigma",
  DID_INL2_STATES : "inl2States",
  DID_INL2_COVARIANCE_LD : "inl2CovarianceLd",

--- a/scripts/lib/version_tools.py
+++ b/scripts/lib/version_tools.py
@@ -192,7 +192,9 @@ class RepositoryInfo:
         self.tag = get_env_or_default("0.0.0" if self.repo is None else self.git_cmd.describe(["--tags", "--abbrev=0"]), "REPO_TAG")
 
         try:
-            self.distance_from_tag = int(get_env_or_default(None if self.repo is None else self.git_cmd.rev_list(["--count", self.tag + "..HEAD"]), "REPO_DISTANCE")) % 256     # Wrap to uint8 range (0-255) to match size of dev_info_t.firmwareVer[3]
+            # Keep raw distance: distance == 0 has special meaning ("on a release tag") in get_latest_version().
+            # The uint8 wrap for dev_info_t.firmwareVer[3] is applied by get_prerelease_number() at the point of use.
+            self.distance_from_tag = int(get_env_or_default(None if self.repo is None else self.git_cmd.rev_list(["--count", self.tag + "..HEAD"]), "REPO_DISTANCE"))
         except TypeError:
             self.distance_from_tag = None
 

--- a/src/DeviceFactory.cpp
+++ b/src/DeviceFactory.cpp
@@ -99,16 +99,20 @@ std::unique_ptr<DeviceFactory::ValidationContext> DeviceFactory::beginValidation
     ctx->hdwId = hdwId;
     ctx->timeoutMs = timeoutMs;
 
-    // Check for a pre-seeded hint (e.g., from RelayPortFactory). If the relay has already
-    // identified this device, skip the DID_DEV_INFO probe entirely.
+    // Check for a pre-seeded hint (e.g., from RelayPortFactory). The hint is INFORMATIVE,
+    // not authoritative — it pre-seeds devInfo so subsequent validation knows what to
+    // expect (e.g. start with the right query type for hdwRunState=BOOTLOADER) and so the
+    // factory can decline a mismatched hdwId early. The hint NEVER substitutes for actual
+    // validation: the calling application should be the one to decide whether to trust a
+    // hint sight-unseen, and both cltool and EvalTool require a real handshake. Without
+    // running the active probe we'd never confirm the device is even responsive on the
+    // other end of the connection.
     const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
     if (hint && hint->serialNumber != 0 && hint->hardwareType != IS_HARDWARE_TYPE_UNKNOWN) {
         ctx->device->devInfo = *hint;
         ctx->device->hdwId = ENCODE_DEV_INFO_TO_HDW_ID((*hint));
-        ctx->complete = true;
-        ctx->result = 1;
-        log_info(IS_LOG_DEVICE_FACTORY, "beginValidation: using seeded hint for port '%s' (SN=%u, hwType=%d) — skipping probe.",
-                 portName(port), hint->serialNumber, hint->hardwareType);
+        log_info(IS_LOG_DEVICE_FACTORY, "beginValidation: seeded hint for port '%s' (SN=%u, hwType=%d, hdwRunState=%d) — validation still required.",
+                 portName(port), hint->serialNumber, hint->hardwareType, hint->hdwRunState);
     }
 
     return ctx;

--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -710,6 +710,29 @@ void DeviceManager::seedDeviceHint(port_handle_t port, const dev_info_t& hint) {
     deviceHints_[port] = hint;
     log_debug(IS_LOG_DEVICE_MANAGER, "Seeded device hint for port '%s' (SN=%u, hwType=%d)",
               portName(port), hint.serialNumber, hint.hardwareType);
+
+    // Hint-driven device registration. When a port surfaces a complete device
+    // identity via a relay snapshot (or other authoritative metadata source),
+    // register the device immediately so consumers can render it without first
+    // running an active probe. This is intentionally a "discovery-without-open"
+    // path: deviceHandler() only fires DEVICE_CONNECTED when portIsOpened(), and
+    // relay ports come back from bindPort() in a closed state — so a hint-only
+    // registration produces DEVICE_ADDED + DEVICE_PORT_BOUND only. Real
+    // validation, port-open, and DEVICE_CONNECTED happen later when the user
+    // explicitly opens the port (e.g. Find / Open in the UI).
+    if (port && hint.serialNumber != 0 && hint.hardwareType != IS_HARDWARE_TYPE_UNKNOWN) {
+        if (!getDevice(port)) {
+            // Iterate registered factories until one accepts the hint. Pass
+            // options=0 so a non-matching factory doesn't close the port on
+            // its way out — we want the next factory to get a clean shot.
+            for (auto factory : factories) {
+                if (deviceHandler(factory, hint, port, /*options=*/0)) {
+                    log_debug(IS_LOG_DEVICE_MANAGER, "Hint-registered device for port '%s' (no port open, no connect)", portName(port));
+                    break;
+                }
+            }
+        }
+    }
 }
 
 const dev_info_t* DeviceManager::getDeviceHint(port_handle_t port) const {

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -215,13 +215,26 @@ public:
     void clearDeviceHint(port_handle_t port);
 
     /**
-     * Notifies all listeners of a particular device event
-     * @param device the device to which the event is applicable
-     * @param event the specific event id that occurred.
+     * Notifies all listeners of a particular device event.
+     *
+     * Listeners are invoked WITHOUT holding DeviceManager::mutex. Holding the
+     * mutex during dispatch creates an AB/BA deadlock with any caller that
+     * already holds another resource (e.g. ISDevice::portMutex) and reaches into
+     * DeviceManager — for example `ISDevice::step()` (which holds portMutex,
+     * fires DEVICE_DISCONNECTED on a port-state change) racing against
+     * `DeviceManager::discoverDevices()` (which holds DeviceManager::mutex and
+     * eventually takes portMutex via `validate→SendRaw`). Snapshotting the
+     * listener vector under the lock and dispatching after release is safe:
+     * the listener registry is only mutated through addPortListener/clear-style
+     * helpers that already take the same mutex.
      */
     void notifyListeners(device_handle_t device, uint8_t event) {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
-        for (device_listener& l : listeners) l(event, device);    // notify that this device's port has been updated
+        std::vector<device_listener> snapshot;
+        {
+            std::lock_guard<std::recursive_mutex> lock(mutex);
+            snapshot = listeners;
+        }
+        for (auto& l : snapshot) l(event, device);
     }
 
 

--- a/src/ISBFirmwareUpdater.cpp
+++ b/src/ISBFirmwareUpdater.cpp
@@ -221,6 +221,18 @@ bool ISBFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proc
                 // Async wait: device is rebooting from bootloader to APP mode.
                 // Keep session_status == FINALIZING until device is rediscovered in APP mode.
 
+                // Heartbeat: emit a progress message at progress_interval regardless of
+                // which sub-branch we take below. The host (ISFirmwareUpdater) treats any
+                // received message as a keep-alive (FirmwareUpdate.cpp:708 → resetTimeout);
+                // without it, session_status flips to ERR_TIMEOUT after 20s and the parent
+                // reports "No Response from device" while the device is genuinely rebooting.
+                if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
+                    nextProgressReport = current_timeMs() + progress_interval;
+                    fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
+                        "Waiting for device [%s] to reboot into APP mode.",
+                        ISDevice::getIdAsString(target_devInfo).c_str());
+                }
+
                 // Periodically trigger port rediscovery
                 if (current_timeMs() > nextPortCheck) {
                     portManager.discoverPorts();
@@ -230,14 +242,7 @@ bool ISBFirmwareUpdater::fwUpdate_step(fwUpdate::msg_types_e msg_type, bool proc
                 // Re-fetch device (port may have changed after USB re-enumeration)
                 device = deviceManager.getDevice(ENCODE_DEV_INFO_TO_UNIQUE_ID(target_devInfo));
                 if (!device) {
-                    // Device not yet rediscovered — report progress and return
-                    if ((progress_interval > 0) && (nextProgressReport < current_timeMs())) {
-                        nextProgressReport = current_timeMs() + progress_interval;
-                        fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_INFO,
-                            "Waiting for device [%s] to reboot into APP mode.",
-                            ISDevice::getIdAsString(target_devInfo).c_str());
-                    }
-                    // Timeout check
+                    // Device not yet rediscovered — keep waiting (heartbeat above)
                     if ((current_timeMs() - last_reboot) > 20000) {
                         fwUpdate_sendProgressFormatted(IS_LOG_LEVEL_WARN,
                             "Timed out waiting for device [%s] to reboot into APP mode. Upload was successful.",

--- a/src/ISBootloaderBase.cpp
+++ b/src/ISBootloaderBase.cpp
@@ -537,7 +537,7 @@ is_operation_result cISBootloaderBase::update_device
         }
     }
 
-    serialPortClose(port);
+    portClose(port);
     if (serialPortOpenRetry(port, portName(port), baud, 1) != PORT_ERROR__NONE)
     {
         statusfn(std::any(), IS_LOG_LEVEL_ERROR, "Unable to open port at %d baud", baud);
@@ -548,11 +548,70 @@ is_operation_result cISBootloaderBase::update_device
     device = obj->check_is_compatible();
     if (device == IS_IMAGE_SIGN_NONE)
     {
-        obj->logStatus(IS_LOG_LEVEL_ERROR, "Device response missing."); // TODO?  are these the same call?
         delete obj;
-        return IS_OP_ERROR;
+        obj = NULL;
+
+        // ISB not responding -- after a DFU bootloader update the "stay in bootloader"
+        // signal (held in RAM) is lost across the hard reset, so the new ISB may need
+        // extra time to initialize, or it may have already jumped to the application.
+        // Strategy: sleep, retry ISB once more, then fall back to APP detection.
+        SLEEP_MS(IS_REBOOT_DELAY_MS);
+
+        serialPortClose(port);
+        if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+        {
+            obj = new cISBootloaderISB(updateProgress, verifyProgress, statusfn, port);
+            device = obj->check_is_compatible();
+        }
+
+        if (device == IS_IMAGE_SIGN_NONE)
+        {
+            delete obj;
+            obj = NULL;
+
+            // ISB still not responding -- device likely booted into APP firmware.
+            // Detect APP mode and, if found, reboot back to ISB before retrying.
+            serialPortClose(port);
+            if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+            {
+                cISBootloaderAPP* appObj = new cISBootloaderAPP(updateProgress, verifyProgress, statusfn, port);
+                serialPortWriteAscii(appObj->m_port, "STPB", 4);
+                uint32_t appDevice = appObj->check_is_compatible();
+
+                const char* enableCmd = NULL;
+                if      ((appDevice & IS_IMAGE_SIGN_APP) & fw_IMX_5)  { appObj->m_filename = filenames.fw_IMX_5.path;  enableCmd = "BLEN"; }
+                else if ((appDevice & IS_IMAGE_SIGN_APP) & fw_EVB_2)  { appObj->m_filename = filenames.fw_EVB_2.path;  enableCmd = "EBLE"; }
+                else if ((appDevice & IS_IMAGE_SIGN_APP) & fw_uINS_3) { appObj->m_filename = filenames.fw_uINS_3.path; enableCmd = "BLEN"; }
+
+                if (enableCmd)
+                {
+                    strncpy(appObj->m_app.enable_command, enableCmd, sizeof(appObj->m_app.enable_command));
+                    appObj->reboot_down();
+                    delete appObj;
+                    SLEEP_MS(IS_REBOOT_DELAY_MS);
+
+                    serialPortClose(port);
+                    if (serialPortOpenRetry(port, portName(port), baud, 1) == PORT_ERROR__NONE)
+                    {
+                        obj = new cISBootloaderISB(updateProgress, verifyProgress, statusfn, port);
+                        device = obj->check_is_compatible();
+                    }
+                }
+                else
+                {
+                    delete appObj;
+                }
+            }
+        }
+
+        if (device == IS_IMAGE_SIGN_NONE)
+        {
+            if (obj) { obj->logStatus(IS_LOG_LEVEL_ERROR, "Device response missing."); delete obj; obj = NULL; }
+            else statusfn(std::any(), IS_LOG_LEVEL_ERROR, "    | %s: Device response missing.", portName(port));
+            return IS_OP_ERROR;
+        }
     }
-    else if (device == IS_IMAGE_SIGN_ERROR)
+    if (device == IS_IMAGE_SIGN_ERROR)
     {
         obj->logStatus(IS_LOG_LEVEL_ERROR, "Invalid device signature.");
         delete obj;

--- a/src/ISBootloaderISB.cpp
+++ b/src/ISBootloaderISB.cpp
@@ -177,7 +177,7 @@ eImageSignature cISBootloaderISB::check_is_compatible()
 is_operation_result cISBootloaderISB::reboot_up()
 {
     log_more_debug(IS_LOG_FWUPDATE, "ISBootloaderISB::reboot_up()");
-    m_info_callback(this, IS_LOG_LEVEL_INFO, "(ISB) Rebooting to APP mode...");
+    m_info_callback(this, IS_LOG_LEVEL_INFO, "(ISB) %s (SN%u): Rebooting to APP mode...", portName(m_port), m_sn);
 
     // send the "reboot to program mode" command and the device should start in program mode
     if (portWrite(m_port, (unsigned char*)":020000040300F7", 15) == 15) {

--- a/src/ISBootloaderThread.cpp
+++ b/src/ISBootloaderThread.cpp
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "intel_hex_utils.h"
 
 #include <algorithm>
+#include <set>
 #include <vector>
 
 #if !PLATFORM_IS_WINDOWS
@@ -62,33 +63,48 @@ void cISBootloaderThread::mgmt_thread_libusb(void* context)
 
     cISBootloaderDFU::m_DFUmutex.lock();
 
-    m_libusb_thread_mutex.lock();
-    cISBootloaderDFU::list_devices(&dfu_list);
-    for (size_t i = 0; i < dfu_list.present; i++)
-    {   // Create contexts for devices in DFU mode
-        bool found = false;
-
-        for (size_t j = 0; j < ctx.size(); j++)
-        {
-            m_ctx_mutex.lock();
-            if (!(ctx[j]->is_serial_device()) && ctx[j]->match_test((void*)dfu_list.id[i].uid) == IS_OP_OK)
-            {   // We found the device in the context list
-                found = true;
-                break;
-            }
-            m_ctx_mutex.unlock();
-        }
-
-        if (!found)
-        {   // If we didn't find the device
-            create_and_start_libusb_thread(update_thread_libusb, dfu_list.id[i].handle_libusb);
-        }
-    }
-    m_libusb_thread_mutex.unlock();
+    std::set<std::string> claimed_uids;         // UIDs of DFU devices already dispatched to a thread
 
     while (m_continue_update)
     {
         m_libusb_thread_mutex.lock();
+
+        // Rescan for newly-enumerated DFU devices each iteration so that devices
+        // which take longer than the initial 2.5s wait to enumerate (e.g. 8
+        // simultaneous ISB->DFU reboots on a shared hub) are still discovered.
+        cISBootloaderDFU::list_devices(&dfu_list);
+        for (size_t i = 0; i < dfu_list.present; i++)
+        {
+            std::string uid(dfu_list.id[i].uid);
+            if (claimed_uids.count(uid))
+            {   // Already launched a thread for this device; close the newly-opened handle.
+                libusb_close(dfu_list.id[i].handle_libusb);
+                continue;
+            }
+
+            // Also skip if already tracked in the context list
+            bool in_ctx = false;
+            m_ctx_mutex.lock();
+            for (size_t j = 0; j < ctx.size(); j++)
+            {
+                if (!ctx[j]->is_serial_device() && ctx[j]->match_test((void*)dfu_list.id[i].uid) == IS_OP_OK)
+                {
+                    in_ctx = true;
+                    break;
+                }
+            }
+            m_ctx_mutex.unlock();
+
+            if (in_ctx)
+            {
+                libusb_close(dfu_list.id[i].handle_libusb);
+                continue;
+            }
+
+            // New DFU device — start an update thread
+            claimed_uids.insert(uid);
+            create_and_start_libusb_thread(update_thread_libusb, dfu_list.id[i].handle_libusb);
+        }
 
         m_libusb_devicesActive = 0;
 
@@ -859,6 +875,8 @@ is_operation_result cISBootloaderThread::update(
     beginTimeMs = current_timeMs();
 
     is_operation_result overall_result = IS_OP_OK;
+    int devicesSucceeded = 0;
+    int devicesFailed = 0;
     while (m_continue_update && !true_if_cancelled())
     {
         if (m_waitAction) m_waitAction();
@@ -879,8 +897,13 @@ is_operation_result cISBootloaderThread::update(
                 serialThread->thread = NULL;
 
                 thread_serial_t* t = serialThread;        // set by update_thread_serial
-                if (t->opResult != IS_OP_OK && t->opResult != IS_OP_CANCELLED && t->opResult != IS_OP_CLOSED)
+                if (t->opResult == IS_OP_OK)
                 {
+                    devicesSucceeded++;
+                }
+                else if (t->opResult != IS_OP_CANCELLED && t->opResult != IS_OP_CLOSED)
+                {
+                    devicesFailed++;
                     if (overall_result == IS_OP_OK)      // keep the first non-OK as the return
                     {
                         overall_result = t->opResult;
@@ -960,9 +983,20 @@ is_operation_result cISBootloaderThread::update(
 
     threadJoinAndFree(libusb_thread);
 
-    // Only report run time if the update was successful
-    if (overall_result == IS_OP_OK)
+    // Report final status
+    if (devicesSucceeded > 0 && devicesFailed == 0)
     {
+        tmp = "Update succeeded (" + to_string(devicesSucceeded) + " device(s)) in " + to_string(((double)timeDeltaMs) / 1000) + " seconds.";
+        m_infoProgress(NULL, IS_LOG_LEVEL_INFO, tmp.c_str());
+    }
+    else if (devicesSucceeded > 0 && devicesFailed > 0)
+    {
+        tmp = "Update succeeded on " + to_string(devicesSucceeded) + " device(s), failed on " + to_string(devicesFailed) + " device(s).";
+        m_infoProgress(NULL, IS_LOG_LEVEL_WARN, tmp.c_str());
+    }
+    else if (overall_result == IS_OP_OK)
+    {
+        // No threads ran (edge case) -- keep original success path
         tmp = "Update succeeded in " + to_string(((double)timeDeltaMs) / 1000) + " seconds.";
         m_infoProgress(NULL, IS_LOG_LEVEL_INFO, tmp.c_str());
     }
@@ -1006,7 +1040,7 @@ is_operation_result cISBootloaderThread::update(
     m_update_in_progress = false;
     m_update_mutex.unlock();
 
-    if (overall_result != IS_OP_OK) {
+    if (overall_result != IS_OP_OK && devicesSucceeded == 0) {
         m_infoProgress(NULL, IS_LOG_LEVEL_ERROR, "Update failed!");
         if(m_waitAction) m_waitAction();     // Final UI update
         return overall_result;

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -464,10 +464,7 @@ static protocol_type_t processIsbPkt(void* v)
     if (isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB)
         return parseErrorResetState(c, EPARSE_INVALID_SIZE);
     if ((isbPkt->hdr.flags & ISB_FLAGS_PAYLOAD_W_OFFSET) &&
-        (isbPkt->payload.offset + isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB) &&
-        (isbPkt->hdr.id != DID_CAL_SC) &&           // Allow large dataset offsets / (offset+chunk) ranges for calibration data DIDs
-        (isbPkt->hdr.id != DID_CAL_TEMP_COMP) &&
-        (isbPkt->hdr.id != DID_CAL_MOTION) )
+        (isbPkt->payload.offset + isbPkt->hdr.payloadSize > MAX_MSG_LENGTH_ISB))
         return parseErrorResetState(c, EPARSE_INVALID_HEADER);
 
     uint16_t payloadSize = isbPkt->hdr.payloadSize;
@@ -519,10 +516,10 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE || 
-            pkt->hdr.id == DID_CAL_SC || 
-            pkt->hdr.id == DID_CAL_TEMP_COMP ||
-            pkt->hdr.id == DID_CAL_MOTION)
+        if (pkt->data.size <= MAX_DATASET_SIZE ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_GYR ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_ACC ||
+            pkt->hdr.id == DID_CAL_TEMP_COMP_MAG)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -542,9 +539,9 @@ static protocol_type_t processIsbPkt(void* v)
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
             if (get->size <= MAX_DATASET_SIZE ||
-                get->id == DID_CAL_SC || 
-                get->id == DID_CAL_TEMP_COMP ||
-                get->id == DID_CAL_MOTION)
+                get->id == DID_CAL_TEMP_COMP_GYR ||
+                get->id == DID_CAL_TEMP_COMP_ACC ||
+                get->id == DID_CAL_TEMP_COMP_MAG)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2076,45 +2076,81 @@ static void PopulateMapSensorSCalInfo(data_set_t data_set[DID_COUNT], uint32_t d
     mapper.AddMember2("devSerialNum", offsetof(sensor_cal_info_t, devSerialNum), DATA_TYPE_UINT32, "", "Device serial number", DATA_FLAGS_READ_ONLY);
 }
 
-static void PopulateMapSensorTCalSubsetGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+static void PopulateMapSensorTCalGyrGroup(data_set_t data_set[DID_COUNT], uint32_t did)
 {
-    DataMapper<sensor_tcal_group_subset_t> mapper(data_set, did);
+    DataMapper<sensor_tcal_gyr_group_t> mapper(data_set, did);
 
     // Can be Gyros, Accel, or Magnetometer 
     for (int i=0; i<MAX_IMU_DEVICES; i++)
     {
-        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
         for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
         {
-            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
-            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_group_subset_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_gyr_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
         }
     }
 }
 
-static void PopulateMapSensorMCalGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+static void PopulateMapSensorTCalAccGroup(data_set_t data_set[DID_COUNT], uint32_t did)
 {
-    DataMapper<sensor_mcal_group_t> mapper(data_set, did);
+    DataMapper<sensor_tcal_acc_group_t> mapper(data_set, did);
 
-    // Gyros
+    // Can be Gyros, Accel, or Magnetometer 
     for (int i=0; i<MAX_IMU_DEVICES; i++)
     {
-        mapper.AddArray2("pqr" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("pqr" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, pqr[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_acc_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
     }
+}
 
-    // Accels
-    for (int i=0; i<MAX_IMU_DEVICES; i++)
-    {
-        mapper.AddArray2("acc" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("acc" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, acc[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
-    }
+static void PopulateMapSensorTCalMagGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_tcal_mag_group_t> mapper(data_set, did);
 
-    // Magnetometers
+    // Can be Gyros, Accel, or Magnetometer 
     for (int i=0; i<MAX_MAG_DEVICES; i++)
     {
-        mapper.AddArray2("mag" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
-        mapper.AddArray2("mag" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_group_t, mag[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});
+        mapper.AddMember2("sensor" + std::to_string(i) + ".numPts", i*sizeof(nvm_sensor_tcal_3axis_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].numPts), DATA_TYPE_UINT32, "", "Number of points");
+        for (int p = 0; p < TCAL_MAX_NUM_POINTS; p++)
+        {
+            mapper.AddMember2("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".temp", i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].pt[0].temp), DATA_TYPE_F32, "", "Temperature");
+            mapper.AddArray2 ("sensor" + std::to_string(i) + ".pt" + std::to_string(p) + ".ss",   i*sizeof(nvm_sensor_tcal_3axis_t) + p*sizeof(sensor_tcal_3axis_pt_t) + offsetof(sensor_tcal_mag_group_t, sensor[0].pt[0].ss), DATA_TYPE_F32, 3, {""}, {"Steady state bias X axis"});
+        }
+    }
+}
+
+static void PopulateMapSensorMCalGyrGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_gyr_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_gyr_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Gyr ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_gyr_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Gyr biases (additive to temp comp)"});
+    }
+}
+
+static void PopulateMapSensorMCalAccGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_acc_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_IMU_DEVICES; i++)
+    {
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_acc_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Acc ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_acc_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Acc biases (additive to temp comp)"});
+    }
+}
+
+static void PopulateMapSensorMCalMagGroup(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<sensor_mcal_mag_group_t> mapper(data_set, did);
+    for (int i=0; i<MAX_MAG_DEVICES; i++)
+    {
+        mapper.AddArray2("sensor" + std::to_string(i) + ".orth", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_mag_group_t, sensor[0].orth), DATA_TYPE_F32, 9, {""}, {"Mag ortho-normalization (cross-axis scalars)"});
+        mapper.AddArray2("sensor" + std::to_string(i) + ".bias", i*sizeof(sensor_motion_cal_t) + offsetof(sensor_mcal_mag_group_t, sensor[0].bias), DATA_TYPE_F32, 3, {""}, {"Mag biases (additive to temp comp)"});
     }
 }
 
@@ -2297,9 +2333,9 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_DEBUG_ARRAY",                  // 39
     "DID_SENSORS_MCAL",                 // 40
     "DID_GPS1_TIMEPULSE",               // 41
-    "DID_CAL_SC",                       // 42
-    "DID_CAL_TEMP_COMP",                // 43
-    "DID_CAL_MOTION",                   // 44
+    "DID_UNUSED_42",                    // 42
+    "DID_UNUSED_43",                    // 43
+    "DID_UNUSED_44",                    // 44
     "DID_GPS1_SIG",                     // 45
     "DID_SENSORS_ADC_SIGMA",            // 46
     "DID_REFERENCE_MAGNETOMETER",       // 47
@@ -2329,7 +2365,7 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_WHEEL_ENCODER",                // 71
     "DID_DIAGNOSTIC_MESSAGE",           // 72
     "DID_SURVEY_IN",                    // 73
-    "DID_CAL_SC_INFO",                  // 74
+    "DID_CAL_INFO",                  // 74
     "DID_PORT_MONITOR",                 // 75
     "DID_RTK_STATE",                    // 76
     "DID_RTK_PHASE_RESIDUAL",           // 77
@@ -2355,25 +2391,25 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_IMU_RAW",                      // 97 
     "DID_FIRMWARE_UPDATE",              // 98 
     "DID_RUNTIME_PROFILER",             // 99 
-    "UNUSED_100",                       // 100
-    "UNUSED_101",                       // 101
-    "UNUSED_102",                       // 102
-    "UNUSED_103",                       // 103
-    "UNUSED_104",                       // 104
-    "UNUSED_105",                       // 105
+    "DID_CAL_TEMP_COMP_GYR",            // 100
+    "DID_CAL_TEMP_COMP_ACC",            // 101
+    "DID_CAL_TEMP_COMP_MAG",            // 102
+    "DID_CAL_MOTION_GYR",               // 103
+    "DID_CAL_MOTION_ACC",               // 104
+    "DID_CAL_MOTION_MAG",               // 105
     "UNUSED_106",                       // 106
     "UNUSED_107",                       // 107
     "UNUSED_108",                       // 108
     "UNUSED_109",                       // 109
-    "DID_EVB_LUNA_FLASH_CFG",           // 110
-    "DID_EVB_LUNA_STATUS",              // 111
-    "DID_EVB_LUNA_SENSORS",             // 112
-    "DID_EVB_LUNA_REMOTE_KILL",         // 113
-    "DID_EVB_LUNA_VELOCITY_CONTROL",    // 114
-    "DID_EVB_LUNA_VELOCITY_COMMAND",    // 115
-    "DID_EVB_LUNA_AUX_COMMAND",         // 116
-    "",                                 // 117
-    "",                                 // 118
+    "UNUSED_110",                       // 110
+    "UNUSED_111",                       // 111
+    "UNUSED_112",                       // 112
+    "UNUSED_113",                       // 113
+    "UNUSED_114",                       // 114
+    "UNUSED_115",                       // 115
+    "UNUSED_116",                       // 116
+    "UNUSED_117",                       // 117
+    "UNUSED_118",                       // 118
     "DID_EVENT",                        // 119
     "DID_GPX_DEV_INFO",                 // 120
     "DID_GPX_FLASH_CFG",                // 121
@@ -2514,10 +2550,13 @@ cISDataMappings::cISDataMappings()
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_TCAL);
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_MCAL);
     PopulateMapSensors(             m_data_set, DID_SENSORS_TC_BIAS);
-    // PopulateMapSensorTCalGroup(m_data_set, DID_CAL_TEMP_COMP);
-    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_SC_INFO);
-    PopulateMapSensorTCalSubsetGroup(m_data_set, DID_CAL_TEMP_COMP);
-    PopulateMapSensorMCalGroup(      m_data_set, DID_CAL_MOTION);
+    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_INFO);
+    PopulateMapSensorTCalGyrGroup(   m_data_set, DID_CAL_TEMP_COMP_GYR);
+    PopulateMapSensorTCalAccGroup(   m_data_set, DID_CAL_TEMP_COMP_ACC);
+    PopulateMapSensorTCalMagGroup(   m_data_set, DID_CAL_TEMP_COMP_MAG);
+    PopulateMapSensorMCalGyrGroup(   m_data_set, DID_CAL_MOTION_GYR);
+    PopulateMapSensorMCalAccGroup(   m_data_set, DID_CAL_MOTION_ACC);
+    PopulateMapSensorMCalMagGroup(   m_data_set, DID_CAL_MOTION_MAG);
     PopulateMapSensorCompensation(   m_data_set, DID_SCOMP);
 
     // This must come last
@@ -2658,10 +2697,13 @@ uint32_t cISDataMappings::DefaultPeriodMultiple(uint32_t did)
     case DID_NVR_USERPAGE_G0:
     case DID_NVR_USERPAGE_G1:
     case DID_FLASH_CONFIG:
-    case DID_CAL_SC_INFO:
-    case DID_CAL_SC:
-    case DID_CAL_TEMP_COMP:
-    case DID_CAL_MOTION:
+    case DID_CAL_INFO:
+    case DID_CAL_TEMP_COMP_GYR:
+    case DID_CAL_TEMP_COMP_ACC:
+    case DID_CAL_TEMP_COMP_MAG:
+    case DID_CAL_MOTION_GYR:
+    case DID_CAL_MOTION_ACC:
+    case DID_CAL_MOTION_MAG:
     case DID_RTOS_INFO:
     case DID_SYS_CMD:
     case DID_NMEA_BCAST_PERIOD:

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -15,8 +15,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <any>
 #include <cinttypes>
+#include <cstdio>
 #include <map>
 #include <string>
+#include <typeinfo>
 #include <vector>
 #include <functional>
 #include <type_traits>
@@ -233,7 +235,12 @@ public:
 
     ~DataMapper()
     {
-        assert((totalSize == structSize) && "Size of mapped fields does not match struct size");
+        if (totalSize != structSize)
+        {
+            fprintf(stderr, "DataMapper ERROR [%s]: mapped size %u != struct size %u (diff %d bytes)\n",
+                typeid(MAP_TYPE).name(), totalSize, structSize, (int)structSize - (int)totalSize);
+            assert(false && "Size of mapped fields does not match struct size");
+        }
     }
 
     template <typename MemberType>

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -312,10 +312,13 @@ bool ISDevice::queryDeviceInfoISbl(uint32_t timeout) {
                         devInfo.hardwareVer[1] = 0;
                         break;
                     case ISBootloader::IS_PROCESSOR_STM32U5:
-                        // GPX-1
-                        devInfo.hardwareType = IS_HARDWARE_TYPE_GPX; // OR IMX-6.0
-                        devInfo.hardwareVer[0] = 1;
-                        devInfo.hardwareVer[1] = 0;
+                        // STM32U5 hardware (IMX-6 and GPX-1) uses mcuBoot, not ISbl —
+                        // reaching this branch indicates an unexpected/legacy state.
+                        // Don't assign a misleading default like "GPX-1.0" or "IMX-1.0":
+                        // both type and version are ambiguous from the bootloader response
+                        // alone, and a wrong combination can mis-route firmware images.
+                        // Leave hardwareType/hardwareVer untouched so any previously-cached
+                        // identity (set by an APP-state validation upstream) survives.
                         break;
                     case ISBootloader::IS_PROCESSOR_NUM:
                         break;
@@ -349,18 +352,34 @@ bool ISDevice::validate(uint32_t timeout) {
     FnProfiler fn("ISDevice::queryDeviceInfoISbl() [" + getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO) + "]", timeout / 2 * 1000);    // this shouldn't really ever take longer than 50ms to execute
     log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::validate(%d) called.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), timeout);
 
+    // Check the discovery hint for this port (set by RelayPortFactory or similar). The
+    // hint is informative only — we still actively validate — but it lets us pick the
+    // most-efficient initial query type. This matters for bootloader devices: NMEA and
+    // DID queries can leave a bootloader in an unresponsive state for a window, so when
+    // the hint says HDW_STATE_BOOTLOADER we start with the ISBL query to land cleanly.
+    const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
+
     // check for Inertial-Sense App by making an NMEA request (which it should respond to)
     is_hardware_t oldHdwId = hdwId;
     dev_info_t oldDevInfo = devInfo;
     hdwId = IS_HARDWARE_NONE,  devInfo = {};    // force a fresh check, don't just take previous values.
 
     bool hasDevInfo = hasDeviceInfo();
-    queryType nextQueryType = QUERYTYPE_NMEA;
+    queryType nextQueryType = (hint && hint->hdwRunState == HDW_STATE_BOOTLOADER)
+                              ? QUERYTYPE_ISbootloader
+                              : QUERYTYPE_NMEA;
     unsigned int startTime = current_timeMs();
     do {
         if ((current_timeMs() - startTime) > timeout) {
-            // after we've timed out - make a last ditch effort to check for a legacy (<6j) IS bootloader, otherwise fail
-            hdwId = oldHdwId, devInfo = oldDevInfo;
+            // After we've timed out — make a last-ditch effort to check for a legacy (<6j)
+            // IS bootloader, otherwise fail. Only restore the prior identity if it came
+            // from a successful APP-state validation. A previous mis-identification (e.g.
+            // a spurious "uINS-0.0" from an earlier failed validate) would otherwise persist
+            // across the next bootloader bounce and corrupt subsequent ISBL identification.
+            if (oldDevInfo.hdwRunState == HDW_STATE_APP) {
+                hdwId = oldHdwId;
+                devInfo = oldDevInfo;
+            }
             log_more_debug(IS_LOG_ISDEVICE, "[%s] ISDevice::validate(%d) : Device failed to validate in time.", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), timeout);
             return (queryDeviceInfoISbl(250) && hasDeviceInfo());
         }
@@ -448,6 +467,15 @@ int ISDevice::validateAsync(uint32_t timeout) {
     // if this is non-zero, it means we're actively validating; this helps us know when to give up/timeout
     if (!validationStartMs) {
         validationStartMs = now;
+        // First step of a new validation cycle — pick the initial query type based on
+        // the discovery hint, if any. NMEA/DID queries to a bootloader can leave it in
+        // an unresponsive state, so when the hint says HDW_STATE_BOOTLOADER we lead
+        // with the ISBL query. Without a hint we fall through to NMEA (the default
+        // for app firmware) and round-robin from there.
+        const dev_info_t* hint = DeviceManager::getInstance().getDeviceHint(port);
+        if (hint && hint->hdwRunState == HDW_STATE_BOOTLOADER) {
+            nextValidationType = QUERYTYPE_ISbootloader;
+        }
     }
 
     // doing the timeout check first helps during debugging (since stepping through code will likely trigger the timeout.

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -125,7 +125,7 @@ bool ISDevice::step() {
     }
 
     if (m_calibration && m_calUploadState != -1) {
-        if (ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration) != ASYNC_STATE__PENDING) {
+        if (ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo) != ASYNC_STATE__PENDING) {
             m_calibration = nullptr;
             m_calUploadState = -1;
         }
@@ -1358,7 +1358,7 @@ int ISDevice::UploadImxCalibrationAsync(ISDeviceCal& cal) {
     if (!isConnected())
         return ASYNC_STATE__FAILURE;   // nothing to do, if we aren't connected
 
-    return ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, cal);
+    return ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, cal, devInfo);
 }
 
 
@@ -1371,7 +1371,7 @@ bool ISDevice::UploadImxCalibration(ISDeviceCal& cal)
     try {
         int calUploadState = 0;
         do {
-            result = ISDeviceCal::uploadSensorCalStep(port, calUploadState, cal);
+            result = ISDeviceCal::uploadSensorCalStep(port, calUploadState, cal, devInfo);
             SLEEP_MS(ISDeviceCal::CAL_UPLOAD_SLEEP_MS);
         } while (result == ASYNC_STATE__PENDING);
     } catch (const std::exception& e) {

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -33,6 +33,7 @@
 #include "com_manager.h"
 #include "ISDevice.h"
 #include "ISLogFile.h"
+#include "IS_calibration_convert.h"
 
 using namespace std;
 using json = nlohmann::json;
@@ -966,54 +967,95 @@ json ISDeviceCal::saveMcToJsonObj(const std::string& filePath, int pose, sOrthoC
     return jCal;
 }
 
-/**
- * @brief Uploads sensor calibration data to a device in steps.
- * @param port The communication port handle.
- * @param calUploadState The current state of the upload process. This is updated by the function.
- * @param cal The sensor_cal_t structure containing the calibration data to upload.
- * @return 1 if the upload is complete, 0 if it's in progress, -1 on error.
- */
-int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal)
+int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo)
 {
+    // Per-thread v1.3 staging buffer; built once on state==0 when target is IMX-5.
+    // Reused across the 8 send steps to avoid repeated conversion.
+    static thread_local sensor_cal_v1p3_t s_v1p3Buf;
+
+    const int hwMajor = devInfo.hardwareVer[0];
+    const bool sendV1p3 = (hwMajor == 5);
+    const bool sendV1p4 = (hwMajor == 6);
+
+    if (!sendV1p3 && !sendV1p4)
+    {
+        log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: unresolved hardware version (hardwareVer[0]=%d); refusing upload. Device must be in app mode.", hwMajor);
+        return -1;
+    }
+
+    if (calUploadState == 0 && sendV1p3)
+    {
+        // Build v1.3 payload from in-memory v1.4 cal. Recomputes both checksums.
+        convert_sensor_cal_v1p4_to_v1p3(&cal, &s_v1p3Buf);
+    }
+
     switch (calUploadState++)
     {
-    // Upload Calibration Info
     case 0:     // General Info
-        if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+        }
         break;
 
     case 1:     // Data Info
-        if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+        }
         break;
 
-    // Upload Temperature Cal
     case 2:     // Temp comp - Gyros
-        if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_t, gyr)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, gyr)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, gyr)) != 0) { return 0; }
+        }
         break;
 
     case 3:     // Temp comp - Accelerometers
-        if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_t, acc)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, acc)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, acc)) != 0) { return 0; }
+        }
         break;
 
     case 4:     // Temp comp - Magnetometers
-        if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_t, mag)) != 0) { return 0; }
-        break;  
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, mag)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, mag)) != 0) { return 0; }
+        }
+        break;
 
-    // Upload Motion Cal
     case 5:     // Motion cal - Gyros
-        if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_t, pqr)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, pqr)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, pqr)) != 0) { return 0; }
+        }
         break;
 
     case 6:     // Motion cal - Accelerometers
-        if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_t, acc)) != 0) { return 0; }
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, acc)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, acc)) != 0) { return 0; }
+        }
         break;
 
-    case 7:     // Motion cal - Magnetometers
-        if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_t, mag)) != 0) { return 0; }
-        // log_debug(IS_LOG_CALIBRATION, "Done uploadSensorCal() - hdl: %d, serial#: %d, devSerialNum: %d\n", port, serialNum, cal.info.devSerialNum);
+    case 7:     // Motion cal - Magnetometers (last step)
+        if (sendV1p3) {
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, mag)) != 0) { return 0; }
+        } else {
+            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, mag)) != 0) { return 0; }
+        }
         return 1;    // Done
-        
-    default:    // Error
+
+    default:
         return -1;
     }
 

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -993,65 +993,65 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     {
     case 0:     // General Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
         }
         break;
 
     case 1:     // Data Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
         }
         break;
 
     case 2:     // Temp comp - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, gyr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR) != 0) { return 0; }
         }
         break;
 
     case 3:     // Temp comp - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP, MAX_IMU_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC) != 0) { return 0; }
         }
         break;
 
     case 4:     // Temp comp - Magnetometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P3 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP, MAX_MAG_DEVICES_V1P4 * sizeof(nvm_sensor_tcal_3axis_t), offsetof(sensor_tcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG) != 0) { return 0; }
         }
         break;
 
     case 5:     // Motion cal - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, pqr)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR) != 0) { return 0; }
         }
         break;
 
     case 6:     // Motion cal - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION, MAX_IMU_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, acc)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC) != 0) { return 0; }
         }
         break;
 
     case 7:     // Motion cal - Magnetometers (last step)
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P3 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p3_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION, MAX_MAG_DEVICES_V1P4 * sizeof(sensor_motion_cal_t), offsetof(sensor_mcal_group_v1p4_t, mag)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG) != 0) { return 0; }
         }
         return 1;    // Done
 

--- a/src/ISDeviceCal.h
+++ b/src/ISDeviceCal.h
@@ -294,7 +294,21 @@ public:
                                    sOrthoCal *cal, 
                                    sensor_mcal_group_t *mcal);
 
-    static int uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal);
+    /**
+     * @brief Uploads sensor calibration to a device in steps, with version-aware conversion.
+     *
+     * Resolves the on-device cal version from devInfo.hardwareVer[0] (5 -> v1.3, 6 -> v1.4)
+     * and transmits a payload sized/laid out for that version. For IMX-5 targets, the in-memory
+     * v1.4 calibration is downgraded to v1.3 on the host before sending. Refuses upload when the
+     * hardware version is unresolved (e.g. devInfo unpopulated). (SN-7966)
+     *
+     * @param port Communication port handle
+     * @param calUploadState State machine cursor (caller-owned, init to 0)
+     * @param cal In-memory calibration (v1.4 format)
+     * @param devInfo Target device info; hardwareVer[0] selects v1.3 vs v1.4 transmission
+     * @return ASYNC_STATE__PENDING (in progress), ASYNC_STATE__SUCCESS (done), ASYNC_STATE__FAILURE (error)
+     */
+    static int uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo);
 
     static const int CAL_UPLOAD_SLEEP_MS = 150;
 

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -956,13 +956,20 @@ void ISFirmwareUpdater::cmd_WaitFor(ISFwUpdaterCmd& cmd) {
         timeoutLabel.clear();      //!< a label to jump to, when a "waitfor" times out (which is not always an error)
     } else if (pingTimeoutExpires && (current_timeMs() > pingTimeoutExpires)) {
         // TIMEOUT occurred
-        cmd.status = ISFwUpdaterCmd::CMD_ERROR;
-        cmd.resultMsg = "Timeout limit reached waiting for response from the target device.";
-        pingTimeoutExpires= pingNextRetry = 0;
+        pingTimeoutExpires = pingNextRetry = 0;
         if (!timeoutLabel.empty()) {
+            // The script provided an on-timeout label, so this is expected control flow,
+            // not a failure. The script's terminal step (typically `:ERROR` with `finish: true`)
+            // is the proper place to flag overall failure. Marking the cmd CMD_ERROR here
+            // would contaminate hasErrors for fully-successful runs that just happened to
+            // skip absent peer modules via their on-timeout fallback.
+            cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+            cmd.resultMsg = "Target not found before timeout; diverting to step " + timeoutLabel;
             LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, cmd.resultMsg.c_str());
             activeCmd = &jumpToStep(timeoutLabel.substr(1));
         } else {
+            cmd.status = ISFwUpdaterCmd::CMD_ERROR;
+            cmd.resultMsg = "Timeout limit reached waiting for response from the target device.";
             handleCommandError(cmd, -1, cmd.resultMsg.c_str());
         }
     } else if (pingInterval && (pingNextRetry < current_timeMs())) {
@@ -1084,6 +1091,27 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;
             else if (!target_devInfo)
                 flags |= fwUpdate::IMG_FLAG_useAlternateMD5;  // unknown version, use alternate MD5 for safety
+        }
+
+        // If the target is a MAIN MCU in bootloader mode, the app firmware version is
+        // unobservable (firmwareVer reflects the bootloader identifier, e.g. ISbl "v6j"
+        // → [6, 'j']). Any version comparison is wasted energy and tends to look "newer"
+        // because 'j' (106) dwarfs typical app majors. Promote the policy to FORCE so the
+        // upload proceeds. SKIP is honored — if the caller explicitly asked to skip, we
+        // still skip.
+        //
+        // Scope to non-peripheral types only: peripherals (CXD/UBX/SEP/STM) use a
+        // bootloader-like interface as their NORMAL operating mode, so HDW_STATE_BOOTLOADER
+        // on a peripheral isn't a "device wiped" signal and shouldn't trigger force-flash.
+        const bool isMainMCU = target_devInfo &&
+                               target_devInfo->hardwareType > IS_HARDWARE_TYPE_UNKNOWN &&
+                               target_devInfo->hardwareType < IS_HDW_TYPE_PERIPHERAL;
+        if (isMainMCU && target_devInfo->hdwRunState == HDW_STATE_BOOTLOADER &&
+            effectivePolicy != UPDATE_POLICY_SKIP && effectivePolicy != UPDATE_POLICY_FORCE) {
+            LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO,
+                "Target is in bootloader mode; promoting policy to FORCE (app version is unobservable).");
+            effectivePolicy = UPDATE_POLICY_FORCE;
+            forceUpdate = true;
         }
 
         // IF_NEWER: compare image version against target's current firmware version
@@ -1225,10 +1253,21 @@ void ISFirmwareUpdater::cmd_finish(ISFwUpdaterCmd& cmd) {
             cmd.status = ISFwUpdaterCmd::CMD_NOT_EXECUTED;
     bool reportErrors = (cmd.args.size() == 1 && cmd[0] == "true");
     cmd.resultMsg = utils::string_format("Firmware Update completed %s", reportErrors ? "with errors. Please review update log for specifics." : "successfully.");
-    cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
 
-    if (reportErrors)
-        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_INFO, cmd.resultMsg.c_str());
+    if (reportErrors) {
+        // Authoritative failure declaration: the script reached `finish: true`, which is
+        // the manifest's way of saying "this run is a failure outcome". Flag it via
+        // CMD_ERROR so refreshUpdateState() picks it up into hasErrors, and record the
+        // message so the dialog's error expansion shows it.
+        cmd.status = ISFwUpdaterCmd::CMD_ERROR;
+        {
+            auto lk = updateState.lock();
+            updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_ERROR, cmd.resultMsg);
+        }
+        LOG_FWUPDATE_STATUS(IS_LOG_LEVEL_ERROR, cmd.resultMsg.c_str());
+    } else {
+        cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
+    }
 }
 
 void ISFirmwareUpdater::initialize() {

--- a/src/ISMatrix.h
+++ b/src/ISMatrix.h
@@ -65,6 +65,8 @@ extern "C" {
 #define VEC3_ALL_ZERO(v)                    ( (((v)[0]) == ZERO_OF((v)[0])) && (((v)[1]) == ZERO_OF((v)[1])) && (((v)[2]) == ZERO_OF((v)[2])) )
 #define VEC3_ANY_ZERO(v)                    ( (((v)[0]) == ZERO_OF((v)[0])) || (((v)[1]) == ZERO_OF((v)[1])) || (((v)[2]) == ZERO_OF((v)[2])) )
 #define VEC3_ANY_NOT_ZERO(v)                ( (((v)[0]) != ZERO_OF((v)[0])) || (((v)[1]) != ZERO_OF((v)[1])) || (((v)[2]) != ZERO_OF((v)[2])) )
+#define VEC3_ANY_NAN(v)                     ( (is_nan_f((v)[0])) || (is_nan_f((v)[1])) || (is_nan_f((v)[2])) )  
+#define VEC3_NO_NAN(v)                      ( !VEC3_ANY_NAN(v) )
 
 #define INT3_ANY_NOT_ZERO(v)                ( ((v[0])!=(0)) || ((v[1])!=(0)) || ((v[2])!=(0)) )
 

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -113,23 +113,33 @@ typedef struct PACKED
 
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[MAX_IMU_DEVICES_V1P3];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[MAX_IMU_DEVICES_V1P3];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[MAX_MAG_DEVICES_V1P3];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P3];          // Gyro temperature calibration
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P3];          // Accel temperature calibration
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P3];          // Mag temperature calibration
 } sensor_tcal_group_v1p3_t;
 
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[MAX_IMU_DEVICES_V1P4];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[MAX_IMU_DEVICES_V1P4];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[MAX_MAG_DEVICES_V1P4];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P4];          // Gyro temperature calibration
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P4];          // Accel temperature calibration
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P4];          // Mag temperature calibration
 } sensor_tcal_group_v1p4_t;
 
 // 1/3 of sensor_tcal_group_t used for uploading calibration
 typedef struct PACKED
 {
     nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
-} sensor_tcal_group_subset_t;
+} sensor_tcal_gyr_group_t;
+
+typedef struct PACKED
+{
+    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
+} sensor_tcal_acc_group_t;
+
+typedef struct PACKED
+{
+    nvm_sensor_tcal_3axis_t sensor[MAX_MAG_DEVICES];            // temperature calibration
+} sensor_tcal_mag_group_t;
 
 ////////////////////////////////////////////////
 // MCAL v1.3
@@ -139,18 +149,34 @@ typedef struct PACKED
     float                   bias[3];        // Bias
 } sensor_motion_cal_t;
 
+// 1/3 of sensor_mcal_group_t used for uploading calibration
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[MAX_IMU_DEVICES_V1P3];          // Gyros (x3 IMUs)
-    sensor_motion_cal_t     acc[MAX_IMU_DEVICES_V1P3];          // Accelerometers (x3 IMUs)
-    sensor_motion_cal_t     mag[MAX_MAG_DEVICES_V1P3];          // Magnetometers
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // gyro motion calibration
+} sensor_mcal_gyr_group_t;
+
+typedef struct PACKED
+{
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // accel motion calibration
+} sensor_mcal_acc_group_t;
+
+typedef struct PACKED
+{
+    sensor_motion_cal_t sensor[MAX_MAG_DEVICES];                // mag motion calibration
+} sensor_mcal_mag_group_t;
+
+typedef struct PACKED
+{
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P3];          // Gyros (x3 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P3];          // Accelerometers (x3 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P3];          // Magnetometers
 } sensor_mcal_group_v1p3_t;
 
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[MAX_IMU_DEVICES_V1P4];          // Gyros (x5 IMUs)
-    sensor_motion_cal_t     acc[MAX_IMU_DEVICES_V1P4];          // Accelerometers (x5 IMUs)
-    sensor_motion_cal_t     mag[MAX_MAG_DEVICES_V1P4];          // Magnetometers
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P4];          // Gyros (x5 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P4];          // Accelerometers (x5 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P4];          // Magnetometers
 } sensor_mcal_group_v1p4_t;
 
 ////////////////////////////////////////////////
@@ -196,6 +222,36 @@ typedef sensor_tcal_group_v1p4_t    sensor_tcal_group_t;
 typedef sensor_mcal_group_v1p4_t    sensor_mcal_group_t;
 typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;
 typedef sensor_cal_v1p4_t           sensor_cal_t;
+#endif
+
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+
+#if defined(IMX_5)
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P3
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P3
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P3
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P3
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P3
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P3
+#else
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P4
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P4
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P4
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P4
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P4
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P4
 #endif
 
 #ifdef __cplusplus

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -183,11 +183,20 @@ typedef struct PACKED
     sensor_cal_v1p4_data_t      data;
 } sensor_cal_v1p4_t;
 
-// Current version of sensor calibration in use
+// Per-build-target native calibration types. SN-7966: IMX-5 hardware is permanently Cal v1.3,
+// IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) sees v1.4 so
+// ISDeviceCal etc. continue to operate on the v1.4 in-memory representation.
+#if defined(IMX_5)
+typedef sensor_tcal_group_v1p3_t    sensor_tcal_group_t;
+typedef sensor_mcal_group_v1p3_t    sensor_mcal_group_t;
+typedef sensor_cal_v1p3_data_t      sensor_cal_data_t;
+typedef sensor_cal_v1p3_t           sensor_cal_t;
+#else
 typedef sensor_tcal_group_v1p4_t    sensor_tcal_group_t;
 typedef sensor_mcal_group_v1p4_t    sensor_mcal_group_t;
 typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;
-typedef sensor_cal_v1p4_t           sensor_cal_t;               
+typedef sensor_cal_v1p4_t           sensor_cal_t;
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -12,7 +12,7 @@ void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
     if (data == NULL) { return; }
 
     memset(data, 0, sizeof(sensor_cal_v1p4_data_t));
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
         data->mcal.pqr[d].orth[4] = 1;
@@ -22,7 +22,7 @@ void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
         data->mcal.acc[d].orth[4] = 1;
         data->mcal.acc[d].orth[8] = 1;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P4; d++)
     {
         data->mcal.mag[d].orth[0] = 1;
         data->mcal.mag[d].orth[4] = 1;
@@ -38,7 +38,7 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
     if (data == NULL) { return; }
 
     memset(data, 0, sizeof(sensor_cal_v1p3_data_t));
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
         data->mcal.pqr[d].orth[4] = 1;
@@ -48,7 +48,7 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
         data->mcal.acc[d].orth[4] = 1;
         data->mcal.acc[d].orth[8] = 1;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
         data->mcal.mag[d].orth[0] = 1;
         data->mcal.mag[d].orth[4] = 1;
@@ -61,12 +61,12 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
 
 void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p4->gyr[d] = v1p3->gyr[d];
         v1p4->acc[d] = v1p3->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p4->mag[d] = v1p3->mag[d];
     }
@@ -74,12 +74,12 @@ void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal
 
 void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p4->pqr[d] = v1p3->pqr[d];
         v1p4->acc[d] = v1p3->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p4->mag[d] = v1p3->mag[d];
     }
@@ -104,12 +104,12 @@ void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v
 
 void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p3->gyr[d] = v1p4->gyr[d];
         v1p3->acc[d] = v1p4->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p3->mag[d] = v1p4->mag[d];
     }
@@ -117,12 +117,12 @@ void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal
 
 void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3)
 {
-    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
     {
         v1p3->pqr[d] = v1p4->pqr[d];
         v1p3->acc[d] = v1p4->acc[d];
     }
-    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
     {
         v1p3->mag[d] = v1p4->mag[d];
     }

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -1,0 +1,146 @@
+#include <string.h>
+
+#include "IS_calibration_convert.h"
+#include "data_sets.h"
+
+#ifndef _MIN
+#define _MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
+void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
+{
+    if (data == NULL) { return; }
+
+    memset(data, 0, sizeof(sensor_cal_v1p4_data_t));
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    {
+        data->mcal.pqr[d].orth[0] = 1;
+        data->mcal.pqr[d].orth[4] = 1;
+        data->mcal.pqr[d].orth[8] = 1;
+
+        data->mcal.acc[d].orth[0] = 1;
+        data->mcal.acc[d].orth[4] = 1;
+        data->mcal.acc[d].orth[8] = 1;
+    }
+    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    {
+        data->mcal.mag[d].orth[0] = 1;
+        data->mcal.mag[d].orth[4] = 1;
+        data->mcal.mag[d].orth[8] = 1;
+    }
+
+    data->dinfo.size = sizeof(sensor_cal_v1p4_data_t);
+    data->dinfo.checksum = flashChecksum32(data, data->dinfo.size);
+}
+
+void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
+{
+    if (data == NULL) { return; }
+
+    memset(data, 0, sizeof(sensor_cal_v1p3_data_t));
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    {
+        data->mcal.pqr[d].orth[0] = 1;
+        data->mcal.pqr[d].orth[4] = 1;
+        data->mcal.pqr[d].orth[8] = 1;
+
+        data->mcal.acc[d].orth[0] = 1;
+        data->mcal.acc[d].orth[4] = 1;
+        data->mcal.acc[d].orth[8] = 1;
+    }
+    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    {
+        data->mcal.mag[d].orth[0] = 1;
+        data->mcal.mag[d].orth[4] = 1;
+        data->mcal.mag[d].orth[8] = 1;
+    }
+
+    data->dinfo.size = sizeof(sensor_cal_v1p3_data_t);
+    data->dinfo.checksum = flashChecksum32(data, data->dinfo.size);
+}
+
+void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4)
+{
+    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    {
+        v1p4->gyr[d] = v1p3->gyr[d];
+        v1p4->acc[d] = v1p3->acc[d];
+    }
+    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    {
+        v1p4->mag[d] = v1p3->mag[d];
+    }
+}
+
+void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4)
+{
+    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    {
+        v1p4->pqr[d] = v1p3->pqr[d];
+        v1p4->acc[d] = v1p3->acc[d];
+    }
+    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    {
+        v1p4->mag[d] = v1p3->mag[d];
+    }
+}
+
+void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v1p4_t *v1p4)
+{
+    v1p4->info = v1p3->info;
+    v1p4->info.version[0] = 1;
+    v1p4->info.version[1] = 4;
+    v1p4->info.version[2] = 0;
+    v1p4->info.version[3] = 0;
+    v1p4->info.size = sizeof(sensor_cal_info_t);
+    v1p4->info.checksum = flashChecksum32(&v1p4->info, v1p4->info.size);
+
+    set_sensor_cal_data_defaults_v1p4(&v1p4->data);
+    convert_tcal_v1p3_to_v1p4(&(v1p3->data.tcal), &(v1p4->data.tcal));
+    convert_mcal_v1p3_to_v1p4(&(v1p3->data.mcal), &(v1p4->data.mcal));
+    v1p4->data.dinfo.size = sizeof(sensor_cal_v1p4_data_t);
+    v1p4->data.dinfo.checksum = flashChecksum32(&v1p4->data, v1p4->data.dinfo.size);
+}
+
+void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3)
+{
+    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    {
+        v1p3->gyr[d] = v1p4->gyr[d];
+        v1p3->acc[d] = v1p4->acc[d];
+    }
+    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    {
+        v1p3->mag[d] = v1p4->mag[d];
+    }
+}
+
+void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3)
+{
+    for (int d = 0; d < _MIN(MAX_IMU_DEVICES_V1P3, MAX_IMU_DEVICES_V1P4); d++)
+    {
+        v1p3->pqr[d] = v1p4->pqr[d];
+        v1p3->acc[d] = v1p4->acc[d];
+    }
+    for (int d = 0; d < _MIN(MAX_MAG_DEVICES_V1P3, MAX_MAG_DEVICES_V1P4); d++)
+    {
+        v1p3->mag[d] = v1p4->mag[d];
+    }
+}
+
+void convert_sensor_cal_v1p4_to_v1p3(const sensor_cal_v1p4_t *v1p4, sensor_cal_v1p3_t *v1p3)
+{
+    v1p3->info = v1p4->info;
+    v1p3->info.version[0] = 1;
+    v1p3->info.version[1] = 3;
+    v1p3->info.version[2] = 0;
+    v1p3->info.version[3] = 0;
+    v1p3->info.size = sizeof(sensor_cal_info_t);
+    v1p3->info.checksum = flashChecksum32(&v1p3->info, v1p3->info.size);
+
+    set_sensor_cal_data_defaults_v1p3(&(v1p3->data));
+    convert_tcal_v1p4_to_v1p3(&(v1p4->data.tcal), &(v1p3->data.tcal));
+    convert_mcal_v1p4_to_v1p3(&(v1p4->data.mcal), &(v1p3->data.mcal));
+    v1p3->data.dinfo.size = sizeof(sensor_cal_v1p3_data_t);
+    v1p3->data.dinfo.checksum = flashChecksum32(&v1p3->data, v1p3->data.dinfo.size);
+}

--- a/src/IS_calibration_convert.h
+++ b/src/IS_calibration_convert.h
@@ -1,0 +1,35 @@
+#ifndef IS_CALIBRATION_CONVERT_H
+#define IS_CALIBRATION_CONVERT_H
+
+#include "IS_calibration.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data);
+void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data);
+
+// Native (build-target) defaults init. Resolves to _v1p3 under IMX_5, _v1p4 elsewhere.
+static inline void set_sensor_cal_data_defaults(sensor_cal_data_t *data)
+{
+#if defined(IMX_5)
+    set_sensor_cal_data_defaults_v1p3(data);
+#else
+    set_sensor_cal_data_defaults_v1p4(data);
+#endif
+}
+
+void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4);
+void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4);
+void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v1p4_t *v1p4);
+
+void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3);
+void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3);
+void convert_sensor_cal_v1p4_to_v1p3(const sensor_cal_v1p4_t *v1p4, sensor_cal_v1p3_t *v1p3);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IS_CALIBRATION_CONVERT_H

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -433,7 +433,7 @@ bool InertialSense::Update()
     return anyOpen;
 }
 
-bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsOnClose)
+bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsOnClose, uint16_t filterHdwType)
 {
     // null com port, just use other features of the interface like ntrip
     if (port[0] == '0' && port[1] == '\0')
@@ -443,7 +443,7 @@ bool InertialSense::Open(const char* port, int baudRate, bool disableBroadcastsO
 
     m_disableBroadcastsOnClose = false;
     m_baudRate = baudRate;
-    if (OpenPorts(port, baudRate))
+    if (OpenPorts(port, baudRate, filterHdwType))
     {
         m_disableBroadcastsOnClose = disableBroadcastsOnClose;
         return true;
@@ -960,7 +960,7 @@ int InertialSense::OnPortError(port_handle_t port, int errCode, const char *errM
     return 0;
 }
 
-bool InertialSense::OpenPorts(const char* portPattern, int baudRate)
+bool InertialSense::OpenPorts(const char* portPattern, int baudRate, uint16_t filterHdwType)
 {
     m_baudRate = baudRate;
 
@@ -1017,7 +1017,7 @@ bool InertialSense::OpenPorts(const char* portPattern, int baudRate)
         for (auto port : portManager.locked_range()) portsToValidate.insert(port);
 
         // attempt to discover devices on all known ports
-        deviceManager.discoverDevices(IS_HARDWARE_ANY, m_comManagerState.discoveryTimeout, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE);  // In this case, We ABSOLUTELY want to open any closes ports (because they are all closed currently)
+        deviceManager.discoverDevices(filterHdwType, m_comManagerState.discoveryTimeout, DeviceManager::DISCOVERY__CLOSE_PORT_ON_FAILURE);  // In this case, We ABSOLUTELY want to open any closes ports (because they are all closed currently)
 
         // remove all ports from portToValidate if a device has bound to that port
         for ( auto d : deviceManager ) portsToValidate.erase(d->port);

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -666,12 +666,16 @@ bool InertialSense::UploadImxCalibrationFromFile(std::string path, port_handle_t
     });
 }
 
-void InertialSense::SetNetworkPortDiscovery(bool enable)
+// Rebuild the PortManager's factory list according to the current enable flags.
+// SerialPortFactory is included by default (m_serialPortDiscoveryEnabled defaults to true);
+// the network and relay factories are opt-in. TcpPortFactory is always present — direct
+// tcp:// URLs are a host-side capability, not a discovery surface.
+void InertialSense::rebuildPortFactories()
 {
-    m_networkPortDiscoveryEnabled = enable;
-
     portManager.clearPortFactories();
-    portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
+    if (m_serialPortDiscoveryEnabled) {
+        portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
+    }
     portManager.addPortFactory((PortFactory*)&(TcpPortFactory::getInstance()));
     if (m_networkPortDiscoveryEnabled) {
         portManager.addPortFactory((PortFactory*)&(ISmDnsPortFactory::getInstance()));
@@ -679,27 +683,26 @@ void InertialSense::SetNetworkPortDiscovery(bool enable)
     if (m_relayPortDiscoveryEnabled) {
         portManager.addPortFactory((PortFactory*)&(RelayPortFactory::getInstance()));
     }
-
-    // Removes all ports from the PortManager
+    // Removes all ports from the PortManager.
     portManager.clear();
+}
+
+void InertialSense::SetSerialPortDiscovery(bool enable)
+{
+    m_serialPortDiscoveryEnabled = enable;
+    rebuildPortFactories();
+}
+
+void InertialSense::SetNetworkPortDiscovery(bool enable)
+{
+    m_networkPortDiscoveryEnabled = enable;
+    rebuildPortFactories();
 }
 
 void InertialSense::SetRelayPortDiscovery(bool enable)
 {
     m_relayPortDiscoveryEnabled = enable;
-
-    // Rebuild the factory list preserving whatever mDNS state was set last.
-    portManager.clearPortFactories();
-    portManager.addPortFactory((PortFactory*)&(SerialPortFactory::getInstance()));
-    portManager.addPortFactory((PortFactory*)&(TcpPortFactory::getInstance()));
-    if (m_networkPortDiscoveryEnabled) {
-        portManager.addPortFactory((PortFactory*)&(ISmDnsPortFactory::getInstance()));
-    }
-    if (m_relayPortDiscoveryEnabled) {
-        portManager.addPortFactory((PortFactory*)&(RelayPortFactory::getInstance()));
-    }
-
-    portManager.clear();
+    rebuildPortFactories();
 }
 
 void InertialSense::ProcessRxData(port_handle_t port, p_data_t* data)

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -131,7 +131,7 @@ public:
     * @param disableBroadcastsOnClose whether to send a stop broadcasts command to all units on Close
     * @return true if opened, false if failure (i.e. baud rate is bad or port fails to open)
     */
-    bool Open(const char* port, int baudRate=IS_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false);
+    bool Open(const char* port, int baudRate=IS_BAUDRATE_DEFAULT, bool disableBroadcastsOnClose=false, uint16_t filterHdwType=IS_HARDWARE_ANY);
 
     /**
     * Check if the connection is open
@@ -648,7 +648,7 @@ private:
     bool EnableLogging(const std::string& path, const cISLogger::sSaveOptions& options = cISLogger::sSaveOptions());
     void DisableLogging();
     bool HasReceivedDeviceInfoFromAllDevices();
-    bool OpenPorts(const char* port, int baudRate);
+    bool OpenPorts(const char* port, int baudRate, uint16_t filterHdwType=IS_HARDWARE_ANY);
     void ClosePorts(bool drainBeforeClose = false);
     static void LoggerThread(void* info);
     static void StepLogger(void* ctx, const p_data_t* data, port_handle_t port);

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -577,6 +577,20 @@ public:
      */
     void SetRelayPortDiscovery(bool enable = false);
 
+    /**
+     * Enable or disable local-serial port discovery (SerialPortFactory) alongside the
+     * other registered factories. Defaults to enabled — most consumers want host-attached
+     * USB/UART devices visible. Disable when the host is also running a service that
+     * holds USB serial ports exclusively (e.g. the bridgeboard relay simulator on the
+     * same machine), to avoid the SDK racing the local-OS enumeration against the
+     * relay-mediated discovery for the same physical device.
+     *
+     * @param enable Set to true (default) to register SerialPortFactory, false to remove
+     *               it. Toggling clears PortManager's existing ports, matching the
+     *               SetNetworkPortDiscovery() / SetRelayPortDiscovery() contract.
+     */
+    void SetSerialPortDiscovery(bool enable = true);
+
     // Used for testing
     InertialSense::com_manager_cpp_state_t* ComManagerState() { return &m_comManagerState; }
 
@@ -635,8 +649,13 @@ private:
     int m_baudRate = IS_BAUDRATE_DEFAULT;
     bool m_enableDeviceValidation = true;
     bool m_disableBroadcastsOnClose;
+    bool m_serialPortDiscoveryEnabled  = true;   ///< last value passed to SetSerialPortDiscovery (default on)
     bool m_networkPortDiscoveryEnabled = false;  ///< last value passed to SetNetworkPortDiscovery
     bool m_relayPortDiscoveryEnabled   = false;  ///< last value passed to SetRelayPortDiscovery
+
+    /// Rebuild PortManager's factory list according to the current m_*PortDiscoveryEnabled
+    /// flags and clear its existing ports. Shared by all three Set*PortDiscovery setters.
+    void rebuildPortFactories();
 
     std::vector<std::string> m_ignoredPorts;    //!< port names which should be ignored (known bad, etc).
 

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -65,6 +65,22 @@ public:
      * @return true if the port specified was a valid port, and it was successfully released, otherwise false.
      */
     virtual bool releasePort(port_handle_t port) = 0;
+
+    /**
+     * Called by PortManager when this factory's locatePorts() emitted a port that was
+     * already bound under a *different* factory. PortManager skips this factory's bindPort()
+     * to avoid duplicate allocations, but still gives the factory a chance to perform
+     * post-bind decoration on the existing port — e.g. RelayPortFactory uses this to seed
+     * a device hint into DeviceManager even when TcpPortFactory got there first to claim
+     * the port handle. Default: no-op. The factory must NOT take ownership of the port.
+     *
+     * @param existing the port handle that was already bound under another factory
+     * @param pName the canonical port name (URL or device path)
+     * @param pType the port type bitmask
+     */
+    virtual void onPortAlias(port_handle_t existing, const std::string& pName, uint16_t pType) {
+        (void)existing; (void)pName; (void)pType;
+    }
 };
 
 class SerialPortFactory : public PortFactory {

--- a/src/PortManager.cpp
+++ b/src/PortManager.cpp
@@ -101,6 +101,11 @@ void PortManager::portHandler(PortFactory* factory, uint16_t portType, const std
     // (e.g., dual-stack mDNS producing alias URLs that resolve to the same endpoint).
     for (auto& [entry, existingPort] : knownPorts) {
         if (entry.name == portName && existingPort && portIsValid(existingPort)) {
+            // Skip duplicate port allocation, but give the new factory a chance to do
+            // post-bind decoration on the existing port (e.g. RelayPortFactory seeding
+            // a device hint into DeviceManager). Factories that don't override
+            // onPortAlias() default to a no-op.
+            factory->onPortAlias(existingPort, portName, portType);
             return; // already bound under a different factory — don't duplicate
         }
     }

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -13,6 +13,7 @@
 #include "core/msg_logger.h"
 #include "protocol/mdns.hpp"
 #include "ISComm.h"
+#include "util/util.h"
 
 #include <algorithm>
 #include <chrono>
@@ -37,29 +38,6 @@ is_hardware_t stateToHardwareId(const std::string& state) {
     if (state == "gpx")  return IS_HARDWARE_GPX_1_0;
     if (state == "isbl") return ENCODE_HDW_ID(IS_HARDWARE_TYPE_UINS, 0, 0); // bootloader — type ambiguous
     return IS_HARDWARE_NONE;
-}
-
-/// Parse a firmware version string like "fw3.0.0-snap" or "2.4.0" into a 4-byte array [major, minor, patch, build].
-void parseFirmwareVer(const std::string& verStr, uint8_t out[4]) {
-    out[0] = out[1] = out[2] = out[3] = 0;
-    // Strip leading "fw" prefix if present
-    std::string s = verStr;
-    if (s.size() > 2 && (s[0] == 'f' || s[0] == 'F') && (s[1] == 'w' || s[1] == 'W'))
-        s = s.substr(2);
-    // Parse "major.minor.patch" — ignore anything after a dash or non-numeric
-    int idx = 0;
-    size_t pos = 0;
-    while (idx < 4 && pos < s.size()) {
-        size_t dot = s.find_first_of(".-", pos);
-        if (dot == std::string::npos) dot = s.size();
-        std::string part = s.substr(pos, dot - pos);
-        if (!part.empty()) {
-            try { out[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) {}
-        }
-        idx++;
-        pos = dot + 1;
-        if (dot < s.size() && s[dot] == '-') break; // stop at -snap, -rc1, etc.
-    }
 }
 
 /// Canonicalize any relay input (bare hostname, IP, full URL, URL-with-path) into
@@ -155,23 +133,33 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     if (uri.empty()) return false;
 
     dev_info_t hint = {};
-    is_hardware_t hdwId = stateToHardwareId(state);
-    hint.hardwareType = DECODE_HDW_TYPE(hdwId);
-    hint.hardwareVer[0] = DECODE_HDW_MAJOR(hdwId);
-    hint.hardwareVer[1] = DECODE_HDW_MINOR(hdwId);
+
+    // Prefer the consolidated "hdw" string (e.g. "IMX-5.0", "GPX-1.0.2") when present — it
+    // preserves the cached pre-ISBL identity, so we can still tell IMX-5/IMX-6/GPX apart
+    // when state == "isbl". Older bridgeboards don't emit it, so fall back to state mapping.
+    std::string hdwStr = dev.value("hdw", "");
+    if (hdwStr.empty() || !utils::parseHardwareFromString(hdwStr, hint)) {
+        is_hardware_t hdwId = stateToHardwareId(state);
+        hint.hardwareType = DECODE_HDW_TYPE(hdwId);
+        hint.hardwareVer[0] = DECODE_HDW_MAJOR(hdwId);
+        hint.hardwareVer[1] = DECODE_HDW_MINOR(hdwId);
+    }
     hint.hdwRunState = (state == "isbl") ? HDW_STATE_BOOTLOADER : HDW_STATE_APP;
     hint.serialNumber = dev.value("serial_number", 0u);
 
-    // Protocol version — all four components are compile-time constants baked into the SDK.
-    // Populating only CHAR0 leaves consumers reading CHAR1..3 as zero, which can trip
-    // version-compatibility checks.
+    // Protocol version is the SDK's compile-time constant; populating all four
+    // components keeps version-compatibility checks consistent with what a real
+    // probe response would report. Auto-OPEN side effects are gated separately:
+    // hint-driven device registration (DeviceManager::seedDeviceHint) deliberately
+    // never opens the port, so DEVICE_CONNECTED only fires when the user explicitly
+    // opens the port via Find/Open.
     hint.protocolVer[0] = PROTOCOL_VERSION_CHAR0;
     hint.protocolVer[1] = PROTOCOL_VERSION_CHAR1;
     hint.protocolVer[2] = PROTOCOL_VERSION_CHAR2;
     hint.protocolVer[3] = PROTOCOL_VERSION_CHAR3;
 
     std::string fwVer = dev.value("firmware_ver", "");
-    if (!fwVer.empty()) parseFirmwareVer(fwVer, hint.firmwareVer);
+    if (!fwVer.empty()) utils::parseFirmwareFromString(fwVer, hint);
 
     std::string fwCommit = dev.value("firmware_commit", "");
     if (!fwCommit.empty()) parseRepoRevision(fwCommit, hint);
@@ -182,11 +170,6 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     // Manufacturer isn't in the SN-7804 schema — bridgeboard only relays IS devices,
     // so we hard-code a sane default. This matches what real devices report.
     std::strncpy(hint.manufacturer, "Inertial Sense", sizeof(hint.manufacturer) - 1);
-
-    // Build type — SN-7804 doesn't ship this, but 'r' (production release) is the
-    // default the SDK's display/upload paths tolerate. If it matters later, bridgeboard
-    // can expose it explicitly.
-    hint.buildType = 'r';
 
     out.portUrl = std::move(uri);
     out.hint = hint;
@@ -430,22 +413,33 @@ bool RelayPortFactory::validatePort(const std::string& pName, uint16_t pType) {
     return false;
 }
 
-port_handle_t RelayPortFactory::bindPort(const std::string& pName, uint16_t pType) {
-    auto port = TcpPortFactory::getInstance().bindPort(pName, pType);
-    if (port) {
-        std::lock_guard<std::recursive_mutex> lock(mutex_);
-        for (const auto& [url, hostPtr] : relayHosts_) {
-            const RelayHost& host = *hostPtr;
-            if (!host.enabled) continue;
-            for (const auto& device : host.devices) {
-                if (device.portUrl == pName) {
-                    DeviceManager::getInstance().seedDeviceHint(port, device.hint);
-                    return port;
-                }
+// If we know a hint for this port (it appears in any enabled relay host's device list),
+// seed it into DeviceManager. Used by both bindPort (when we win the bind race) and
+// onPortAlias (when TcpPortFactory wins for a relay-known URL — the port handle is the
+// same TCP port either way; only the hint-seeding side-effect differs).
+void RelayPortFactory::seedHintForPortIfKnown(port_handle_t port, const std::string& portUrl) {
+    if (!port) return;
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    for (const auto& [url, hostPtr] : relayHosts_) {
+        const RelayHost& host = *hostPtr;
+        if (!host.enabled) continue;
+        for (const auto& device : host.devices) {
+            if (device.portUrl == portUrl) {
+                DeviceManager::getInstance().seedDeviceHint(port, device.hint);
+                return;
             }
         }
     }
+}
+
+port_handle_t RelayPortFactory::bindPort(const std::string& pName, uint16_t pType) {
+    auto port = TcpPortFactory::getInstance().bindPort(pName, pType);
+    seedHintForPortIfKnown(port, pName);
     return port;
+}
+
+void RelayPortFactory::onPortAlias(port_handle_t existing, const std::string& pName, uint16_t /*pType*/) {
+    seedHintForPortIfKnown(existing, pName);
 }
 
 bool RelayPortFactory::releasePort(port_handle_t port) {

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -128,6 +128,20 @@ public:
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
     bool releasePort(port_handle_t port) override;
 
+    /// PortManager calls this when our locatePorts() emit was deduped against an existing
+    /// port (typically TcpPortFactory got there first for a relay-known tcp:// URL). The
+    /// existing port handle is fine; we just need to seed our device hint into
+    /// DeviceManager so beginValidation can use it. Does NOT create a new port.
+    void onPortAlias(port_handle_t existing, const std::string& pName, uint16_t pType) override;
+
+private:
+    /// Internal helper: if @p portUrl appears in any enabled relay host's device list,
+    /// seed that device's hint into DeviceManager keyed by @p port. Shared by
+    /// bindPort() and onPortAlias().
+    void seedHintForPortIfKnown(port_handle_t port, const std::string& portUrl);
+
+public:
+
     /**
      * External polling driver — same pattern as ISmDnsPortFactory::tick().
      * Drives mDNS host discovery refresh and HTTP polling for all enabled hosts.

--- a/src/core/tcpPort.c
+++ b/src/core/tcpPort.c
@@ -104,8 +104,17 @@ int tcpPortOpen(port_handle_t port) {
  */
 int tcpPortClose(port_handle_t port) {
     tcp_port_t* tcpPort = TCP_PORT(port);
-    if (tcpPort->socket < 0) { // The file descriptor is invalid, creating it errored, or we already closed it.
-        tcpPort->base.perror = -(tcpPort->socket);
+    if (tcpPort->socket < 0) {
+        // socket < 0 covers three cases, none of which are an "operation failed"
+        // for this call:
+        //   1. Never opened (socket initialized to -EBADF in tcpPortInit).
+        //   2. Open previously failed — perror was already stamped at the
+        //      original failure site (HANDLE_SOCKET_ERROR / tcpPortValidate).
+        //   3. Already closed — perror reflects whatever the prior close set.
+        // In all three, closing again is a benign no-op; stamping perror here
+        // would either invent a phantom EBADF (case 1) or overwrite a more
+        // meaningful prior error (cases 2/3) and surface "errant" status to
+        // consumers reading via portError() (e.g. UI markup).
         return tcpPort->socket;
     }
 

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <math.h>
 
 const char* g_isHardwareTypeNames[IS_HARDWARE_TYPE_COUNT] = {"UNKNOWN", "uINS", "EVB", "IMX", "GPX"};
+const char* g_isGnssHardwareNames[IS_HDW_GNSS_TYPE_COUNT] = {"UBX", "CXD", "SEP", "STM"};
 
 // Reversed bytes in a float.
 // compiler will likely inline this as it's a tiny function

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -307,9 +307,9 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetsDebugArray,      // 39: DID_DEBUG_ARRAY
         0,                      // 40: DID_SENSORS_MCAL
         offsetsGpsTimepulse,    // 41: DID_GPS1_TIMEPULSE
-        0,                      // 42: DID_CAL_SC
-        0,                      // 43: DID_CAL_SC1
-        0,                      // 44: DID_CAL_SC2
+        0,                      // 42: DID_UNUSED
+        0,                      // 43: DID_UNUSED
+        0,                      // 44: DID_UNUSED
         0,                      // 45: DID_GPS1_SIG
         offsetsOnlyTimeFirst,   // 46: DID_SENSORS_ADC_SIGMA
         offsetsOnlyTimeFirst,   // 47: DID_REFERENCE_MAGNETOMETER
@@ -365,26 +365,26 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetsOnlyTimeFirst,   // 97: DID_IMU_RAW
         0,                      // 98: DID_FIRMWARE_UPDATE
         0,                      // 99: DID_RUNTIME_PROFILER
-        0,                      // 100: 
-        0,                      // 101: 
-        0,                      // 102: 
-        0,                      // 103: 
-        0,                      // 104: 
-        0,                      // 105:
-        0,                      // 106:
-        0,                      // 107:
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
-        0,                      // 113:
-        0,                      // 114:
-        0,                      // 115:
-        0,                      // 116:
-        0,                      // 117:
-        0,                      // 118:
-        0,                      // 119:
+        0,                      // 100: DID_CAL_TEMP_COMP_GYR
+        0,                      // 101: DID_CAL_TEMP_COMP_ACC
+        0,                      // 102: DID_CAL_TEMP_COMP_MAG
+        0,                      // 103: DID_CAL_MOTION_GYR
+        0,                      // 104: DID_CAL_MOTION_ACC
+        0,                      // 105: DID_CAL_MOTION_MAG
+        0,                      // 106: 
+        0,                      // 107: 
+        0,                      // 108: 
+        0,                      // 109: 
+        0,                      // 110: 
+        0,                      // 111: 
+        0,                      // 112: 
+        0,                      // 113: 
+        0,                      // 114: 
+        0,                      // 115: 
+        0,                      // 116: 
+        0,                      // 117: 
+        0,                      // 118: 
+        0,                      // 119: 
         0,                      // 120: DID_GPX_DEV_INFO
         0,                      // 121: DID_GPX_FLASH_CFG
         0,                      // 122: DID_GPX_RTOS_INFO
@@ -496,11 +496,11 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         rtosTaskOffsets,        // 38: DID_RTOS_INFO
         0,                      // 39: DID_DEBUG_ARRAY
         0,                      // 40: DID_SENSORS_MCAL
-        0,                      // 41: 
-        0,                      // 42: DID_CAL_SC
-        0,                      // 43: DID_CAL_SC1
-        0,                      // 44: DID_CAL_SC2
-        0,                      // 45:
+        0,                      // 41: DID_GPS1_TIMEPULSE
+        0,                      // 42: DID_UNUSED
+        0,                      // 43: DID_UNUSED
+        0,                      // 44: DID_UNUSED
+        0,                      // 45: DID_GPS1_SIG
         0,                      // 46: DID_SENSORS_ADC_SIGMA
         0,                      // 47: DID_REFERENCE_MAGNETOMETER
         0,                      // 48: DID_INL2_STATES
@@ -529,7 +529,7 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 71: DID_WHEEL_ENCODER
         diagMsgOffsets,         // 72: DID_DIAGNOSTIC_MESSAGE
         0,                      // 73: DID_SURVEY_IN
-        0,                      // 74: DID_CAL_SC_INFO
+        0,                      // 74: DID_CAL_INFO
         0,                      // 75: DID_PORT_MONITOR
         0,                      // 76: DID_RTK_STATE
         0,                      // 77: DID_RTK_RESIDUAL
@@ -555,26 +555,26 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 97: DID_IMU_RAW
         0,                      // 98: DID_FIRMWARE_UPDATE
         0,                      // 99: DID_RUNTIME_PROFILER
-        0,                      // 100: 
-        0,                      // 101: 
-        0,                      // 102: 
-        0,                      // 103: 
-        0,                      // 104: 
-        0,                      // 105:
-        0,                      // 106:
-        0,                      // 107:
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
-        0,                      // 113:
-        0,                      // 114:
-        0,                      // 115:
-        0,                      // 116:
-        0,                      // 117:
-        0,                      // 118:
-        0,                      // 119:
+        0,                      // 100: DID_CAL_TEMP_COMP_GYR
+        0,                      // 101: DID_CAL_TEMP_COMP_ACC
+        0,                      // 102: DID_CAL_TEMP_COMP_MAG
+        0,                      // 103: DID_CAL_MOTION_GYR
+        0,                      // 104: DID_CAL_MOTION_ACC
+        0,                      // 105: DID_CAL_MOTION_MAG
+        0,                      // 106: 
+        0,                      // 107: 
+        0,                      // 108: 
+        0,                      // 109: 
+        0,                      // 110: 
+        0,                      // 111: 
+        0,                      // 112: 
+        0,                      // 113: 
+        0,                      // 114: 
+        0,                      // 115: 
+        0,                      // 116: 
+        0,                      // 117: 
+        0,                      // 118: 
+        0,                      // 119: 
         0,                      // 120: DID_GPX_DEV_INFO
         0,                      // 121: DID_GPX_FLASH_CFG
         0,                      // 122: DID_GPX_RTOS_INFO

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -592,7 +592,8 @@ enum eIsHardwareType
     IS_HDW_GNSS_SEPTENTRIO          = IS_HDW_TYPE_PERIPHERAL + 3,    // Septentrio
     IS_HDW_GNSS_STM_TESSIO          = IS_HDW_TYPE_PERIPHERAL + 4,    // STM Tessio
 
-    IS_HARDWARE_TYPE_COUNT          = 5     // Keep last
+    IS_HARDWARE_TYPE_COUNT          = 5,     // Keep last non-peripheral
+    IS_HDW_GNSS_TYPE_COUNT          = 4      // Number of entries in g_isGnssHardwareNames (IS_HDW_GNSS_UBLOX..STM_TESSIO)
 };
 
 typedef uint16_t is_hardware_t;
@@ -614,6 +615,8 @@ static const is_hardware_t IS_HDW_SEPTENTRIO_P3  = ENCODE_HDW_ID(IS_HDW_GNSS_SEP
 static const is_hardware_t IS_HDW_SEPTENTRIO_M3  = ENCODE_HDW_ID(IS_HDW_GNSS_SEPTENTRIO, 'M' - 'A', 3);
 
 extern const char* g_isHardwareTypeNames[IS_HARDWARE_TYPE_COUNT];
+/// Names for the peripheral GNSS hardware types, indexed by (type - IS_HDW_TYPE_PERIPHERAL - 1).
+extern const char* g_isGnssHardwareNames[IS_HDW_GNSS_TYPE_COUNT];
 
 enum eHdwRunStates {
     HDW_STATE_UNKNOWN,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -200,9 +200,15 @@ typedef uint32_t eDataIDs;
 // Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
 #define MAX_IMU_DEVICES_V1P4    5
 #define MAX_MAG_DEVICES_V1P4    1
-// Max number of devices across all hardware types: uINS-3, IMX-5, and IMX-6
-#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P4    // g_numImuDevices defines the actual number of hardware specific devices
-#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P4    // g_numMagDevices defines the actual number of hardware specific devices
+// Per-build-target native counts. SN-7966: IMX-5 hardware is permanently Cal v1.3,
+// IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) uses v1.4.
+#if defined(IMX_5)
+#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P3
+#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P3
+#else
+#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P4
+#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P4
+#endif
 
 /** INS status flags */
 enum eInsStatusFlags

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -79,9 +79,9 @@ typedef uint32_t eDataIDs;
 #define DID_DEBUG_ARRAY                 (eDataIDs)39 /** INTERNAL USE ONLY (debug_array_t) */
 #define DID_SENSORS_MCAL                (eDataIDs)40 /** INTERNAL USE ONLY (sensors_w_temp_t) Temperature compensated and motion calibrated IMU output. */
 #define DID_GPS1_TIMEPULSE              (eDataIDs)41 /** (gps_timepulse_t) GPS1 PPS time synchronization. */
-#define DID_CAL_SC                      (eDataIDs)42 /** INTERNAL USE ONLY (sensor_cal_t) */
-#define DID_CAL_TEMP_COMP               (eDataIDs)43 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
-#define DID_CAL_MOTION                  (eDataIDs)44 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_UNUSED_42                   (eDataIDs)42 /** unused */
+#define DID_UNUSED_43                   (eDataIDs)43 /** unused */
+#define DID_UNUSED_44                   (eDataIDs)44 /** unused */
 #define DID_GPS1_SIG                    (eDataIDs)45 /** (gps_sig_t) GPS 1 GNSS signal information. */
 #define DID_SENSORS_ADC_SIGMA           (eDataIDs)46 /** INTERNAL USE ONLY (sys_sensors_adc_t) */
 #define DID_REFERENCE_MAGNETOMETER      (eDataIDs)47 /** (magnetometer_t) Reference or truth magnetometer used for manufacturing calibration and testing */
@@ -111,7 +111,7 @@ typedef uint32_t eDataIDs;
 #define DID_WHEEL_ENCODER               (eDataIDs)71 /** (wheel_encoder_t) Wheel encoder data to be fused with GPS-INS measurements, set DID_GROUND_VEHICLE for configuration before sending this message */
 #define DID_DIAGNOSTIC_MESSAGE          (eDataIDs)72 /** (diag_msg_t) Diagnostic message */
 #define DID_SURVEY_IN                   (eDataIDs)73 /** (survey_in_t) Survey in, used to determine position for RTK base station. Base correction output cannot run during a survey and will be automatically disabled if a survey is started. */
-#define DID_CAL_SC_INFO                 (eDataIDs)74 /** INTERNAL USE ONLY (sensor_cal_info_t) */
+#define DID_CAL_INFO                    (eDataIDs)74 /** INTERNAL USE ONLY (sensor_cal_info_t) */
 #define DID_PORT_MONITOR                (eDataIDs)75 /** (port_monitor_t) Data rate and status monitoring for each communications port. */
 #define DID_RTK_STATE                   (eDataIDs)76 /** INTERNAL USE ONLY (rtk_state_t) */
 #define DID_RTK_PHASE_RESIDUAL          (eDataIDs)77 /** INTERNAL USE ONLY (rtk_residual_t) */
@@ -137,6 +137,12 @@ typedef uint32_t eDataIDs;
 #define DID_IMU_RAW                     (eDataIDs)97 /** (imu_t) IMU data averaged from DID_IMUS_RAW.  Use this IMU data for output data rates faster than DID_FLASH_CONFIG.startupNavDtMs.  Otherwise we recommend use of DID_IMU or DID_PIMU as they are oversampled and contain less noise. */
 #define DID_FIRMWARE_UPDATE             (eDataIDs)98 /** (firmware_payload_t) firmware update payload */
 #define DID_RUNTIME_PROFILER            (eDataIDs)99 /** INTERNAL USE ONLY (runtime_profiler_t) System runtime profiler */
+#define DID_CAL_TEMP_COMP_GYR           (eDataIDs)100 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_TEMP_COMP_ACC           (eDataIDs)101 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_TEMP_COMP_MAG           (eDataIDs)102 /** INTERNAL USE ONLY (sensor_tcal_group_t) */
+#define DID_CAL_MOTION_GYR              (eDataIDs)103 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_CAL_MOTION_ACC              (eDataIDs)104 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
+#define DID_CAL_MOTION_MAG              (eDataIDs)105 /** INTERNAL USE ONLY (sensor_mcal_group_t) */
 
 #define DID_EVENT                       (eDataIDs)119 /** INTERNAL USE ONLY (did_event_t)*/
 
@@ -162,7 +168,6 @@ typedef uint32_t eDataIDs;
 
 /** Count of data ids (including null data id 0) - MUST BE MULTPLE OF 4 and larger than last DID number! */
 #define DID_COUNT       (eDataIDs)132    // Used in SDK
-#define DID_COUNT_UINS  (eDataIDs)100    // Used in IMX
 
 /** Maximum number of data ids */
 #define DID_MAX_COUNT   256
@@ -195,20 +200,15 @@ typedef uint32_t eDataIDs;
 #define RECEIVER_INDEX_GPS2             3 // DO NOT CHANGE
 
 // Version 1.3 of sensor calibration format supports up to 3 IMUs and 2 mags, with separate orthonormalization and bias calibration for each device
-#define MAX_IMU_DEVICES_V1P3    3
-#define MAX_MAG_DEVICES_V1P3    2
+#define NUM_IMU_DEVICES_V1P3    3
+#define NUM_MAG_DEVICES_V1P3    2
 // Version 1.4 of sensor calibration format supports up to 5 IMUs and 1 mag, with separate orthonormalization and bias calibration for each device
-#define MAX_IMU_DEVICES_V1P4    5
-#define MAX_MAG_DEVICES_V1P4    1
+#define NUM_IMU_DEVICES_V1P4    5
+#define NUM_MAG_DEVICES_V1P4    1
 // Per-build-target native counts. SN-7966: IMX-5 hardware is permanently Cal v1.3,
 // IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) uses v1.4.
-#if defined(IMX_5)
-#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P3
-#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P3
-#else
-#define MAX_IMU_DEVICES         MAX_IMU_DEVICES_V1P4
-#define MAX_MAG_DEVICES         MAX_MAG_DEVICES_V1P4
-#endif
+#define MAX_IMU_DEVICES         NUM_IMU_DEVICES_V1P4
+#define MAX_MAG_DEVICES         NUM_MAG_DEVICES_V1P4
 
 /** INS status flags */
 enum eInsStatusFlags

--- a/src/protocol/FirmwareUpdate.cpp
+++ b/src/protocol/FirmwareUpdate.cpp
@@ -618,7 +618,12 @@ namespace fwUpdate {
         payload_t response;
         response.hdr.target_device = TARGET_HOST;
         response.hdr.msg_type = MSG_VERSION_INFO_RESP;
-        response.data.version_resp.resTarget = session_target;
+        // Echo back the queried target, not session_target — REQ_VERSION_INFO doesn't
+        // update session_target (only REQ_UPDATE does, around line 305), so a standalone
+        // version-info query would otherwise respond with resTarget=0/TARGET_HOST.
+        // Hosts use resTarget to confirm the response is for their requested target;
+        // a mismatched/zero resTarget causes infinite ping-loop on the host side.
+        response.data.version_resp.resTarget = payload.hdr.target_device;
         response.data.version_resp.serialNumber = devInfo.serialNumber;
         response.data.version_resp.hardwareType = devInfo.hardwareType;
         response.data.version_resp.hdwRunState = devInfo.hdwRunState;

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -540,6 +540,11 @@ static int serialPortOpenPlatform(port_handle_t port, const char* portName, int 
     {
         serialPort->errorCode = errno;
         serialPort->error = strerror(serialPort->errorCode);
+        // Stamp the generic base-port error so cross-transport consumers (e.g. UI
+        // port-status markup) can see "this port failed to open" without having to
+        // know about platform-specific errno values. The platform-specific detail
+        // (errno + strerror) remains in serialPort->errorCode/error.
+        serialPort->base.perror = PORT_ERROR__OPEN_FAILURE;
         log_error(IS_LOG_PORT, "[%s] serialPortOpenPlatform():: Error opening port: %s (%d)", portName, serialPort->error, serialPort->errorCode);
         return 0;
     }
@@ -548,6 +553,7 @@ static int serialPortOpenPlatform(port_handle_t port, const char* portName, int 
     {
         serialPort->errorCode = errno;
         serialPort->error = strerror(serialPort->errorCode);
+        serialPort->base.perror = PORT_ERROR__OPEN_FAILURE;
         log_error(IS_LOG_PORT, "[%s] serialPortOpenPlatform():: Error configuring port: %s (%d)", port, serialPort->error, serialPort->errorCode);
         return 0;
     }

--- a/src/serialPortPlatform.c
+++ b/src/serialPortPlatform.c
@@ -1184,7 +1184,9 @@ static int serialPortWritePlatform(port_handle_t port, const unsigned char* buff
  * On other platforms, it uses `poll` and `ioctl` with `FIONREAD`.
  *
  * @param port The port handle.
- * @return int The number of bytes available to read, or PORT_ERROR__INVALID on error.
+ * @return int The number of bytes available to read, PORT_ERROR__INVALID if the port
+ *         handle is invalid, or PORT_ERROR__NOT_CONNECTED if the internal handle is NULL
+ *         (i.e., the port has not been opened or has been closed).
  */
 static int serialPortGetByteCountAvailableToReadPlatform(port_handle_t port)
 {
@@ -1195,6 +1197,12 @@ static int serialPortGetByteCountAvailableToReadPlatform(port_handle_t port)
 
     serial_port_t* serialPort = (serial_port_t*)port;
     serialPortHandle* handle = (serialPortHandle*)serialPort->handle;
+    if (!handle)
+    {
+        serialPort->errorCode = ENOENT;
+        serialPort->error = "Internal port handle is NULL; Port is closed.";
+        return PORT_ERROR__NOT_CONNECTED;
+    }
 
 #if PLATFORM_IS_WINDOWS
 

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -216,17 +216,16 @@ std::string utils::did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, in
 }
 
 std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) {
-    // hardware type & version
-    const char *typeName = "\?\?\?";
-    switch (devInfo.hardwareType) {
-        case IS_HARDWARE_TYPE_UINS: typeName = "uINS"; break;
-        case IS_HARDWARE_TYPE_IMX: typeName = "IMX"; break;
-        case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
-        case IS_HDW_GNSS_SONY: typeName = "CXD"; break;
-        case IS_HDW_GNSS_UBLOX: typeName = "UBX"; break;
-        case IS_HDW_GNSS_SEPTENTRIO: typeName = "SEP"; break;
-        case IS_HDW_GNSS_STM_TESSIO: typeName = "STM"; break;
-        default: typeName = "\?\?\?"; break;
+    // hardware type & version — resolved via the canonical tables in data_sets.c.
+    const char* typeName = "\?\?\?";
+    const uint8_t t = devInfo.hardwareType;
+    if (t > 0 && t < IS_HARDWARE_TYPE_COUNT) {
+        typeName = g_isHardwareTypeNames[t];
+    } else if (t > IS_HDW_TYPE_PERIPHERAL) {
+        const int peripheralIdx = static_cast<int>(t) - IS_HDW_TYPE_PERIPHERAL - 1;
+        if (peripheralIdx >= 0 && peripheralIdx < IS_HDW_GNSS_TYPE_COUNT) {
+            typeName = g_isGnssHardwareNames[peripheralIdx];
+        }
     }
     std::string out = utils::string_format("%s-%u.%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1]);
     if (!showRev)
@@ -238,6 +237,114 @@ std::string utils::getHardwareAsString(const dev_info_t& devInfo, bool showRev) 
             out += utils::string_format(".%u", devInfo.hardwareVer[3]);
     }
     return out;
+}
+
+// Renders just the type + major + minor captured in an encoded is_hardware_t.
+// Does not include hardwareVer[2]/hardwareVer[3] — those are not part of hdwId.
+std::string utils::getHardwareAsString(is_hardware_t hdwId) {
+    const char *typeName = "\?\?\?";
+    switch (DECODE_HDW_TYPE(hdwId)) {
+        case IS_HARDWARE_TYPE_UINS:    typeName = "uINS"; break;
+        case IS_HARDWARE_TYPE_IMX:     typeName = "IMX";  break;
+        case IS_HARDWARE_TYPE_GPX:     typeName = "GPX";  break;
+        case IS_HDW_GNSS_SONY:         typeName = "CXD";  break;
+        case IS_HDW_GNSS_UBLOX:        typeName = "UBX";  break;
+        case IS_HDW_GNSS_SEPTENTRIO:   typeName = "SEP";  break;
+        case IS_HDW_GNSS_STM_TESSIO:   typeName = "STM";  break;
+        default:                       typeName = "\?\?\?"; break;
+    }
+    return utils::string_format("%s-%u.%u", typeName,
+                                DECODE_HDW_MAJOR(hdwId),
+                                DECODE_HDW_MINOR(hdwId));
+}
+
+bool utils::parseHardwareFromString(const std::string& s, dev_info_t& devInfo) {
+    auto dash = s.find('-');
+    if (dash == std::string::npos || dash == 0) return false;
+
+    const std::string typeName = s.substr(0, dash);
+    uint8_t type = 0;
+    bool matched = false;
+    // Skip index 0 ("UNKNOWN") — it's a placeholder, not a real hardware type.
+    for (int i = 1; i < IS_HARDWARE_TYPE_COUNT; ++i) {
+        if (typeName == g_isHardwareTypeNames[i]) {
+            type = static_cast<uint8_t>(i);
+            matched = true;
+            break;
+        }
+    }
+    if (!matched) {
+        for (int i = 0; i < IS_HDW_GNSS_TYPE_COUNT; ++i) {
+            if (typeName == g_isGnssHardwareNames[i]) {
+                type = static_cast<uint8_t>(IS_HDW_TYPE_PERIPHERAL + 1 + i);
+                matched = true;
+                break;
+            }
+        }
+    }
+    if (!matched) return false;
+
+    uint8_t ver[4] = {0, 0, 0, 0};
+    size_t pos = dash + 1;
+    for (int idx = 0; idx < 4 && pos < s.size(); ++idx) {
+        size_t dot = s.find('.', pos);
+        if (dot == std::string::npos) dot = s.size();
+        const std::string part = s.substr(pos, dot - pos);
+        if (!part.empty()) {
+            try { ver[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) { return false; }
+        }
+        pos = dot + 1;
+    }
+
+    devInfo.hardwareType = type;
+    for (int i = 0; i < 4; ++i) devInfo.hardwareVer[i] = ver[i];
+    return true;
+}
+
+bool utils::parseFirmwareFromString(const std::string& s, dev_info_t& devInfo) {
+    // Strip optional "fw" prefix.
+    std::string w = s;
+    if (w.size() >= 2 && (w[0] == 'f' || w[0] == 'F') && (w[1] == 'w' || w[1] == 'W'))
+        w = w.substr(2);
+    if (w.empty()) return false;
+
+    // Split at the first '-' (build-type suffix); everything before is "<M>.<m>.<p>".
+    const size_t dash = w.find('-');
+    const std::string head = (dash == std::string::npos) ? w : w.substr(0, dash);
+    const std::string tail = (dash == std::string::npos) ? ""  : w.substr(dash + 1);
+
+    uint8_t fv[4] = {0, 0, 0, 0};
+    size_t pos = 0;
+    for (int idx = 0; idx < 3 && pos < head.size(); ++idx) {
+        const size_t dot = head.find('.', pos);
+        const size_t end = (dot == std::string::npos) ? head.size() : dot;
+        const std::string part = head.substr(pos, end - pos);
+        if (!part.empty()) {
+            try { fv[idx] = static_cast<uint8_t>(std::stoi(part)); } catch (...) { return false; }
+        }
+        if (dot == std::string::npos) break;
+        pos = dot + 1;
+    }
+
+    // Decode build-type suffix and optional ".<build>" trailing number.
+    char buildType = 'r';
+    if (!tail.empty()) {
+        const size_t trailDot = tail.find('.');
+        const std::string label = (trailDot == std::string::npos) ? tail : tail.substr(0, trailDot);
+        if      (label == "alpha") buildType = 'a';
+        else if (label == "beta")  buildType = 'b';
+        else if (label == "rc")    buildType = 'c';
+        else if (label == "devel") buildType = 'd';
+        else if (label == "snap")  buildType = 's';
+        else buildType = 'r'; // unknown label — treat as release
+        if (trailDot != std::string::npos) {
+            try { fv[3] = static_cast<uint8_t>(std::stoi(tail.substr(trailDot + 1))); } catch (...) {}
+        }
+    }
+
+    for (int i = 0; i < 4; ++i) devInfo.firmwareVer[i] = fv[i];
+    devInfo.buildType = buildType;
+    return true;
 }
 
 std::string utils::getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -224,8 +224,20 @@ namespace utils {
     };
 
     std::string getHardwareAsString(const dev_info_t& devInfo, bool showRev = true);
+    std::string getHardwareAsString(is_hardware_t hdwId);
     std::string getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix = "fw");
     std::string getBuildAsString(const dev_info_t& devInfo, uint16_t flags = -1, const std::string& sep = " ");
+
+    /// Parse a hardware identity string (inverse of getHardwareAsString). Accepts "<TYPE>-<major>.<minor>[.<p2>[.<p3>]]"
+    /// e.g. "IMX-5.0", "GPX-1.0.2", "uINS-3.2". Populates devInfo.hardwareType and hardwareVer[0..3].
+    /// Returns false on unrecognized type prefix or malformed version — caller should leave devInfo unchanged.
+    bool parseHardwareFromString(const std::string& s, dev_info_t& devInfo);
+
+    /// Parse a firmware version string (inverse of getFirmwareAsString). Accepts optional "fw" prefix followed by
+    /// "<M>.<m>.<p>" and an optional build-type suffix "-alpha|-beta|-rc|-devel|-snap" with optional ".<build>".
+    /// Populates devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|'r' for release/no suffix).
+    /// Returns false on malformed input.
+    bool parseFirmwareFromString(const std::string& s, dev_info_t& devInfo);
     // semver::version<uint8_t, uint8_t, uint8_t> getSemanticVersion(const dev_info_t& devInfo, uint16_t flags = -1);
 
     std::string getCurrentTimestamp();

--- a/tests/test_ISDeviceCal.cpp
+++ b/tests/test_ISDeviceCal.cpp
@@ -319,13 +319,13 @@ static void buildV1p4Sample(sensor_cal_v1p4_t &cal, uint32_t serialNum = 60010)
     cal.info.devSerialNum = serialNum;
     cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
         cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
         cal.data.mcal.acc[d].orth[4] = 1.0f + 0.02f * d;
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P4; d++)
     {
         cal.data.mcal.mag[d].orth[0] = 2.5f;
         cal.data.mcal.mag[d].bias[1] = 0.5f;
@@ -343,12 +343,12 @@ static void buildV1p3Sample(sensor_cal_v1p3_t &cal, uint32_t serialNum = 60010)
     cal.info.devSerialNum = serialNum;
     cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
         cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
     }
-    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
         cal.data.mcal.mag[d].orth[0] = 2.5f + 0.1f * d;
     }
@@ -370,8 +370,8 @@ TEST(ISDeviceCalConvert, V1p4ToV1p3PreservesSharedFields)
     EXPECT_EQ(v1p3.info.version[1], 3);
     EXPECT_EQ(v1p3.info.devSerialNum, 60010u);
 
-    // First MAX_IMU_DEVICES_V1P3 IMUs survive the downgrade
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    // First NUM_IMU_DEVICES_V1P3 IMUs survive the downgrade
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].orth[0], v1p4.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].bias[0], v1p4.data.mcal.pqr[d].bias[0]);
@@ -396,14 +396,14 @@ TEST(ISDeviceCalConvert, V1p3ToV1p4PreservesSharedFields)
     EXPECT_EQ(v1p4.info.version[1], 4);
     EXPECT_EQ(v1p4.info.devSerialNum, 60011u);
 
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], v1p3.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].bias[0], v1p3.data.mcal.pqr[d].bias[0]);
     }
     EXPECT_FLOAT_EQ(v1p4.data.mcal.mag[0].orth[0], v1p3.data.mcal.mag[0].orth[0]);
     // v1p4 IMU slots beyond v1p3 are identity
-    for (int d = MAX_IMU_DEVICES_V1P3; d < MAX_IMU_DEVICES_V1P4; d++)
+    for (int d = NUM_IMU_DEVICES_V1P3; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], 1.0f);
         EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[4], 1.0f);
@@ -438,7 +438,7 @@ TEST(ISDeviceCalConvert, RoundTripV1p4ToV1p3ToV1p4PreservesSharedSlots)
 
     EXPECT_EQ(out.info.devSerialNum, orig.info.devSerialNum);
     // Slots that fit in v1.3 (first 3 IMUs, first mag) round-trip exactly
-    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].orth[0], orig.data.mcal.pqr[d].orth[0]);
         EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].bias[0], orig.data.mcal.pqr[d].bias[0]);

--- a/tests/test_ISDeviceCal.cpp
+++ b/tests/test_ISDeviceCal.cpp
@@ -21,6 +21,8 @@
 
 #include "ISDeviceCal.h"
 #include "ISLogFile.h"
+#include "IS_calibration_convert.h"
+#include "data_sets.h"
 #include "json.hpp"
 
 using json = nlohmann::json;
@@ -298,4 +300,181 @@ TEST_F(test_ISDeviceCal, roundTrip_saveAndLoad)
     EXPECT_NEAR(loadMcal.acc[0].orth[4], origMcal.acc[0].orth[4], 0.001f);
 
     std::remove(path.c_str());
+}
+
+
+// =====================================================================================
+// SN-7966: v1.3 <-> v1.4 conversion + version-aware upload tests
+// =====================================================================================
+
+namespace {
+
+// Populate a v1p4 cal with distinguishable per-device values, then compute info checksum.
+static void buildV1p4Sample(sensor_cal_v1p4_t &cal, uint32_t serialNum = 60010)
+{
+    memset(&cal, 0, sizeof(cal));
+    cal.info.size = sizeof(sensor_cal_info_t);
+    cal.info.version[0] = 1;
+    cal.info.version[1] = 4;
+    cal.info.devSerialNum = serialNum;
+    cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
+
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P4; d++)
+    {
+        cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
+        cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
+        cal.data.mcal.acc[d].orth[4] = 1.0f + 0.02f * d;
+    }
+    for (int d = 0; d < MAX_MAG_DEVICES_V1P4; d++)
+    {
+        cal.data.mcal.mag[d].orth[0] = 2.5f;
+        cal.data.mcal.mag[d].bias[1] = 0.5f;
+    }
+    cal.data.dinfo.size = sizeof(sensor_cal_v1p4_data_t);
+    cal.data.dinfo.checksum = flashChecksum32(&cal.data, cal.data.dinfo.size);
+}
+
+static void buildV1p3Sample(sensor_cal_v1p3_t &cal, uint32_t serialNum = 60010)
+{
+    memset(&cal, 0, sizeof(cal));
+    cal.info.size = sizeof(sensor_cal_info_t);
+    cal.info.version[0] = 1;
+    cal.info.version[1] = 3;
+    cal.info.devSerialNum = serialNum;
+    cal.info.checksum = flashChecksum32(&cal.info, cal.info.size);
+
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    {
+        cal.data.mcal.pqr[d].orth[0] = 1.0f + 0.01f * d;
+        cal.data.mcal.pqr[d].bias[0] = 0.001f * (d + 1);
+    }
+    for (int d = 0; d < MAX_MAG_DEVICES_V1P3; d++)
+    {
+        cal.data.mcal.mag[d].orth[0] = 2.5f + 0.1f * d;
+    }
+    cal.data.dinfo.size = sizeof(sensor_cal_v1p3_data_t);
+    cal.data.dinfo.checksum = flashChecksum32(&cal.data, cal.data.dinfo.size);
+}
+
+} // namespace
+
+TEST(ISDeviceCalConvert, V1p4ToV1p3PreservesSharedFields)
+{
+    sensor_cal_v1p4_t v1p4;
+    buildV1p4Sample(v1p4, 60010);
+
+    sensor_cal_v1p3_t v1p3;
+    convert_sensor_cal_v1p4_to_v1p3(&v1p4, &v1p3);
+
+    EXPECT_EQ(v1p3.info.version[0], 1);
+    EXPECT_EQ(v1p3.info.version[1], 3);
+    EXPECT_EQ(v1p3.info.devSerialNum, 60010u);
+
+    // First MAX_IMU_DEVICES_V1P3 IMUs survive the downgrade
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    {
+        EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].orth[0], v1p4.data.mcal.pqr[d].orth[0]);
+        EXPECT_FLOAT_EQ(v1p3.data.mcal.pqr[d].bias[0], v1p4.data.mcal.pqr[d].bias[0]);
+    }
+    // First mag survives
+    EXPECT_FLOAT_EQ(v1p3.data.mcal.mag[0].orth[0], v1p4.data.mcal.mag[0].orth[0]);
+    // v1p3.mag[1] (no v1.4 source) is set to identity defaults by set_sensor_cal_data_defaults_v1p3
+    EXPECT_FLOAT_EQ(v1p3.data.mcal.mag[1].orth[0], 1.0f);
+    EXPECT_FLOAT_EQ(v1p3.data.mcal.mag[1].orth[4], 1.0f);
+    EXPECT_FLOAT_EQ(v1p3.data.mcal.mag[1].orth[8], 1.0f);
+}
+
+TEST(ISDeviceCalConvert, V1p3ToV1p4PreservesSharedFields)
+{
+    sensor_cal_v1p3_t v1p3;
+    buildV1p3Sample(v1p3, 60011);
+
+    sensor_cal_v1p4_t v1p4;
+    convert_sensor_cal_v1p3_to_v1p4(&v1p3, &v1p4);
+
+    EXPECT_EQ(v1p4.info.version[0], 1);
+    EXPECT_EQ(v1p4.info.version[1], 4);
+    EXPECT_EQ(v1p4.info.devSerialNum, 60011u);
+
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    {
+        EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], v1p3.data.mcal.pqr[d].orth[0]);
+        EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].bias[0], v1p3.data.mcal.pqr[d].bias[0]);
+    }
+    EXPECT_FLOAT_EQ(v1p4.data.mcal.mag[0].orth[0], v1p3.data.mcal.mag[0].orth[0]);
+    // v1p4 IMU slots beyond v1p3 are identity
+    for (int d = MAX_IMU_DEVICES_V1P3; d < MAX_IMU_DEVICES_V1P4; d++)
+    {
+        EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[0], 1.0f);
+        EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[4], 1.0f);
+        EXPECT_FLOAT_EQ(v1p4.data.mcal.pqr[d].orth[8], 1.0f);
+    }
+}
+
+TEST(ISDeviceCalConvert, V1p4ToV1p3RecomputesChecksums)
+{
+    sensor_cal_v1p4_t v1p4;
+    buildV1p4Sample(v1p4);
+
+    sensor_cal_v1p3_t v1p3;
+    convert_sensor_cal_v1p4_to_v1p3(&v1p4, &v1p3);
+
+    EXPECT_EQ(v1p3.info.checksum, flashChecksum32(&v1p3.info, v1p3.info.size));
+    EXPECT_EQ(v1p3.data.dinfo.checksum, flashChecksum32(&v1p3.data, v1p3.data.dinfo.size));
+    EXPECT_EQ(v1p3.info.size, sizeof(sensor_cal_info_t));
+    EXPECT_EQ(v1p3.data.dinfo.size, sizeof(sensor_cal_v1p3_data_t));
+}
+
+TEST(ISDeviceCalConvert, RoundTripV1p4ToV1p3ToV1p4PreservesSharedSlots)
+{
+    sensor_cal_v1p4_t orig;
+    buildV1p4Sample(orig, 60012);
+
+    sensor_cal_v1p3_t intermediate;
+    convert_sensor_cal_v1p4_to_v1p3(&orig, &intermediate);
+
+    sensor_cal_v1p4_t out;
+    convert_sensor_cal_v1p3_to_v1p4(&intermediate, &out);
+
+    EXPECT_EQ(out.info.devSerialNum, orig.info.devSerialNum);
+    // Slots that fit in v1.3 (first 3 IMUs, first mag) round-trip exactly
+    for (int d = 0; d < MAX_IMU_DEVICES_V1P3; d++)
+    {
+        EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].orth[0], orig.data.mcal.pqr[d].orth[0]);
+        EXPECT_FLOAT_EQ(out.data.mcal.pqr[d].bias[0], orig.data.mcal.pqr[d].bias[0]);
+    }
+    EXPECT_FLOAT_EQ(out.data.mcal.mag[0].orth[0], orig.data.mcal.mag[0].orth[0]);
+}
+
+TEST(ISDeviceCalUpload, RefusesUnknownHardwareVersion)
+{
+    sensor_cal_v1p4_t cal;
+    buildV1p4Sample(cal);
+
+    dev_info_t devInfo = {};
+    devInfo.hardwareVer[0] = 0; // unresolved (e.g. bootloader / unconnected)
+
+    int state = 0;
+    int result = ISDeviceCal::uploadSensorCalStep(/*port=*/nullptr, state, cal, devInfo);
+    EXPECT_EQ(result, -1) << "Upload must refuse when hardware version is unresolved";
+}
+
+TEST(ISDeviceCalUpload, AcceptsImx5AndImx6HardwareVersions)
+{
+    sensor_cal_v1p4_t cal;
+    buildV1p4Sample(cal);
+
+    // Note: full upload would call comManagerSendData on a port, which will fail
+    // without a registered port and return non-zero from comManagerSendData. That
+    // surfaces as state machine returning 0 (still "in progress"), not -1. So we
+    // assert "not the refusal code" rather than "success".
+    dev_info_t imx5 = {};
+    imx5.hardwareVer[0] = 5;
+    int state5 = 0;
+    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state5, cal, imx5));
+
+    dev_info_t imx6 = {};
+    imx6.hardwareVer[0] = 6;
+    int state6 = 0;
+    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state6, cal, imx6));
 }

--- a/tests/test_RelayPortFactory.cpp
+++ b/tests/test_RelayPortFactory.cpp
@@ -31,8 +31,12 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// Compose one device entry in the SN-7804 schema.
-json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0, const std::string& state = "imx6") {
+/// Compose one device entry in the SN-7804 schema. The optional `hdw` parameter mirrors
+/// bridgeboard's consolidated hardware identity string (the cached pre-ISBL identity). When
+/// empty, it is derived from `state` for convenience; pass it explicitly for `state == "isbl"`
+/// to exercise the identity-preservation path.
+json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0,
+                const std::string& state = "imx6", const std::string& hdw = "") {
     json d = {
         {"testbed", testbed},
         {"slot", slot},
@@ -42,6 +46,13 @@ json makeDevice(int testbed, int slot, const std::string& uri, uint32_t sn = 0, 
         {"device_path", std::string("/dev/ttyACM") + std::to_string(slot)},
         {"has_tcp_client", false},
     };
+    std::string hdwOut = hdw;
+    if (hdwOut.empty()) {
+        if      (state == "imx5") hdwOut = "IMX-5.0";
+        else if (state == "imx6") hdwOut = "IMX-6.0";
+        else if (state == "gpx")  hdwOut = "GPX-1.0";
+    }
+    if (!hdwOut.empty()) d["hdw"] = hdwOut;
     if (sn) {
         d["serial_number"] = sn;
         d["firmware_ver"] = "fw3.0.0-test";

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -128,3 +128,86 @@ TEST(test_utils, parse_devInfo_from_filename) {
     // EXPECT_EQ(devInfoStr, "GPX-1.0 fw2.3.0-snap.153 2024-12-17 00:28:37");
 
 }
+
+TEST(test_utils, parseHardwareFromString_roundtrip) {
+    dev_info_t devInfo = {};
+
+    ASSERT_TRUE(utils::parseHardwareFromString("IMX-5.0", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_IMX);
+    EXPECT_EQ(devInfo.hardwareVer[0], 5);
+    EXPECT_EQ(devInfo.hardwareVer[1], 0);
+    EXPECT_EQ(devInfo.hardwareVer[2], 0);
+    EXPECT_EQ(devInfo.hardwareVer[3], 0);
+
+    ASSERT_TRUE(utils::parseHardwareFromString("GPX-1.0.2", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_GPX);
+    EXPECT_EQ(devInfo.hardwareVer[0], 1);
+    EXPECT_EQ(devInfo.hardwareVer[1], 0);
+    EXPECT_EQ(devInfo.hardwareVer[2], 2);
+
+    ASSERT_TRUE(utils::parseHardwareFromString("uINS-3.2.1.4", devInfo));
+    EXPECT_EQ(devInfo.hardwareType, IS_HARDWARE_TYPE_UINS);
+    EXPECT_EQ(devInfo.hardwareVer[0], 3);
+    EXPECT_EQ(devInfo.hardwareVer[1], 2);
+    EXPECT_EQ(devInfo.hardwareVer[2], 1);
+    EXPECT_EQ(devInfo.hardwareVer[3], 4);
+
+    // Round-trip: emit then parse.
+    devInfo = {};
+    devInfo.hardwareType = IS_HARDWARE_TYPE_IMX;
+    devInfo.hardwareVer[0] = 5; devInfo.hardwareVer[1] = 1;
+    std::string s = utils::getHardwareAsString(devInfo);
+    dev_info_t parsed = {};
+    ASSERT_TRUE(utils::parseHardwareFromString(s, parsed));
+    EXPECT_EQ(parsed.hardwareType, devInfo.hardwareType);
+    EXPECT_EQ(parsed.hardwareVer[0], devInfo.hardwareVer[0]);
+    EXPECT_EQ(parsed.hardwareVer[1], devInfo.hardwareVer[1]);
+
+    // Malformed input is rejected without mutating devInfo.
+    dev_info_t before = parsed;
+    EXPECT_FALSE(utils::parseHardwareFromString("", parsed));
+    EXPECT_FALSE(utils::parseHardwareFromString("IMX", parsed));
+    EXPECT_FALSE(utils::parseHardwareFromString("BOGUS-1.0", parsed));
+    EXPECT_EQ(parsed.hardwareType, before.hardwareType);
+    EXPECT_EQ(parsed.hardwareVer[0], before.hardwareVer[0]);
+}
+
+TEST(test_utils, parseFirmwareFromString_roundtrip) {
+    dev_info_t devInfo = {};
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0", devInfo));
+    EXPECT_EQ(devInfo.firmwareVer[0], 3);
+    EXPECT_EQ(devInfo.firmwareVer[1], 0);
+    EXPECT_EQ(devInfo.firmwareVer[2], 0);
+    EXPECT_EQ(devInfo.firmwareVer[3], 0);
+    EXPECT_EQ(devInfo.buildType, 'r');
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0-devel.175", devInfo));
+    EXPECT_EQ(devInfo.firmwareVer[0], 3);
+    EXPECT_EQ(devInfo.firmwareVer[3], 175);
+    EXPECT_EQ(devInfo.buildType, 'd');
+
+    ASSERT_TRUE(utils::parseFirmwareFromString("2.1.7-rc.83", devInfo)); // no 'fw' prefix
+    EXPECT_EQ(devInfo.firmwareVer[0], 2);
+    EXPECT_EQ(devInfo.firmwareVer[1], 1);
+    EXPECT_EQ(devInfo.firmwareVer[2], 7);
+    EXPECT_EQ(devInfo.firmwareVer[3], 83);
+    EXPECT_EQ(devInfo.buildType, 'c');
+
+    // Round-trip: emit then parse.
+    dev_info_t src = {};
+    src.firmwareVer[0] = 2; src.firmwareVer[1] = 4; src.firmwareVer[2] = 0; src.firmwareVer[3] = 12;
+    src.buildType = 's';
+    std::string s = utils::getFirmwareAsString(src);
+    dev_info_t parsed = {};
+    ASSERT_TRUE(utils::parseFirmwareFromString(s, parsed));
+    EXPECT_EQ(parsed.firmwareVer[0], src.firmwareVer[0]);
+    EXPECT_EQ(parsed.firmwareVer[1], src.firmwareVer[1]);
+    EXPECT_EQ(parsed.firmwareVer[2], src.firmwareVer[2]);
+    EXPECT_EQ(parsed.firmwareVer[3], src.firmwareVer[3]);
+    EXPECT_EQ(parsed.buildType, src.buildType);
+
+    // ISBL "firmware_ver" like "ISbl.v6j **BOOTLOADER**" is not parseable — helper returns false,
+    // caller leaves fields at whatever they were.
+    EXPECT_FALSE(utils::parseFirmwareFromString("ISbl.v6j **BOOTLOADER**", parsed));
+}


### PR DESCRIPTION
## Summary

Sync `develop` into `logalyzer-develop` to pick up the six commits accumulated since the last sync (calibration version conversion, NaN check, version-regression fix, network firmware update durability, IMX-5/IMX-6 bootloader work, IMX-6 cal debug). Two conflicts surfaced and were resolved deliberately rather than mechanically.

## Conflicts + resolution

### `src/util/util.cpp` — `getHardwareAsString` / `hdwIdToString`

Both branches refactored the same family of functions in different directions:

- **`logalyzer-develop`** (chore #1136): Added a private `hardwareTypeName(unsigned)` switch helper used by new `hdwIdToString` / `deviceIdString` exposed in the header.
- **`develop`** (rolled in via SN-7891 / SN-7966 work): Rewrote `getHardwareAsString(const dev_info_t&)` to use the canonical `g_isHardwareTypeNames[]` / `g_isGnssHardwareNames[]` tables from `data_sets.c`, and added a new `getHardwareAsString(is_hardware_t hdwId)` overload using a hand-coded switch.

**Resolution:** drop the private switch entirely and route everything through a unified `hardwareTypeName(uint8_t)` helper that consults the canonical tables. `hdwIdToString` calls it via `DECODE_HDW_TYPE`; `getHardwareAsString(dev_info_t&)` calls it via `devInfo.hardwareType`. Develop's new `getHardwareAsString(is_hardware_t)` overload is preserved as a one-line alias for `hdwIdToString` so external callers that picked up the develop API don't break. Type 0 (UNKNOWN) still renders as `"???"` rather than the table's `"UNKNOWN"` to preserve the legacy display string the chore tests pin.

Why this resolution and not "keep both": the chore's switch was missing `IS_HARDWARE_TYPE_EVB` (type 2) — `hdwIdToString` would have rendered EVB hardware as `"???-x.y"` instead of `"EVB-x.y"`. The canonical-table approach fixes that automatically. It's also strictly less code: one helper, four exported functions, no duplication.

### `tests/test_utils.cpp`

Both branches appended distinct `TEST` blocks after the existing `parse_devInfo_from_filename` test. Mechanical concatenation — kept both sets verbatim:

- chore #1136's 12 tests (`hdwIdToString_*`, `deviceIdString_*`, `getHardwareAsString_still_renders_subrev_when_present`)
- develop's 2 tests (`parseHardwareFromString_roundtrip`, `parseFirmwareFromString_roundtrip`)

## What auto-merged cleanly

The other 41 modified files merged without conflict. Notable additions from develop:

- `src/IS_calibration_convert.{c,h}` — new cal version-conversion (SN-7966)
- `src/ISDeviceCal.{cpp,h}` — version-aware upload path
- `src/ISMatrix.h` — NaN check
- `src/InertialSense.{cpp,h}`, `src/DeviceManager.{cpp,h}`, bootloader files — SN-7891 firmware-update durability + SN-7863 IMX5 bootloader stress
- `src/util/util.h` — declarations for `parseHardwareFromString` / `parseFirmwareFromString`

## Test plan

- [x] `cmake --build build && cmake --build tests/build` clean (after `cmake -B` re-glob to pick up `IS_calibration_convert.c`).
- [x] `IS-SDK_unit-tests --gtest_filter='test_utils.*'` — **18/18 PASS** (12 chore tests + 2 develop parse-roundtrip tests + 4 pre-existing).
- [x] Full suite `IS-SDK_unit-tests` — **256/257 PASS** (1 pre-existing skip in `protocol_nmea.zda_gps_time_skip`, identical to the chore #1136 baseline).
- [ ] CI on push.

## Followup for whoever merges this

- Logalyzer-side submodule pointer needs a bump after this lands (separate small Logalyzer PR per the SDK PR workflow). Not in scope here.
- The IS_HARDWARE_TYPE_EVB (type 2) display string change from `"???-x.y"` → `"EVB-x.y"` is an unintentional behavior fix from this merge. If that's user-visible anywhere, worth a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
