### PR TITLE
chore: add ISLog::takeDevices() for ownership transfer

### DIFF
--- a/src/ISLog.cpp
+++ b/src/ISLog.cpp
@@ -180,4 +180,17 @@ std::size_t ISLog::recordCount() const noexcept {
     return n;
 }
 
+std::vector<ISDeviceLog> ISLog::takeDevices() {
+    std::vector<ISDeviceLog> out;
+    out.reserve(orderedIds_.size());
+    for (const uint64_t id : orderedIds_) {
+        auto it = devicesById_.find(id);
+        if (it == devicesById_.end()) continue;
+        out.push_back(std::move(it->second));
+    }
+    devicesById_.clear();
+    orderedIds_.clear();
+    return out;
+}
+
 } // namespace inertial_sense

--- a/src/ISLog.h
+++ b/src/ISLog.h
@@ -90,6 +90,18 @@ public:
     /** @return  Total record count summed across every device-log. */
     std::size_t recordCount() const noexcept;
 
+    /**
+     * Move every composed `ISDeviceLog` out of this `ISLog`, in
+     * `deviceIds()` order. After the call, the `ISLog` is in a
+     * moved-from state — `deviceIds()`, `device(...)`, etc. all
+     * return empty results. Intended for callers that want to take
+     * direct ownership of each per-device log (e.g. an application
+     * holding a flat `vector<ISDeviceLog>` keyed by row).
+     *
+     * @return  Owned device-logs in the same order as `deviceIds()`.
+     */
+    std::vector<ISDeviceLog> takeDevices();
+
 private:
     ISLog() = default;
 


### PR DESCRIPTION
## Summary

Tiny follow-up to #1139 (merged as `fcf921a1`). I had two commits on the chore branch — the instrumentation (which landed) and this one — but I pushed this commit AFTER opening the PR and didn't verify the GitHub API had picked it up before #1139 was merged. Result: only the instrumentation went in, this addition didn't. Apologies for the noise.

This commit adds an rvalue-style move-out so callers can take direct ownership of every composed `ISDeviceLog` after `openDirectory` succeeds. Logalyzer's loader (the companion logalyzer#26 PR) needs this — without it, the only public path to a per-device log is `ISLog::device(uint64_t) const&` which can't transfer ownership, and callers have to re-open every segment via `ISDeviceLog::fromSegments`, duplicating the parse work this class was built to avoid.

## What's in the PR

`src/ISLog.h` + `src/ISLog.cpp` — adds:

```cpp
/**
 * Move every composed `ISDeviceLog` out of this `ISLog`, in
 * `deviceIds()` order. After the call, the `ISLog` is in a
 * moved-from state — `deviceIds()`, `device(...)`, etc. all
 * return empty results.
 */
std::vector<ISDeviceLog> takeDevices();
```

Implementation drains `devicesById_` into a `vector<ISDeviceLog>` in `deviceIds()` order, then clears the internal maps. Documented in the header so callers know to discard the `ISLog` after.

## Test plan

- [x] SDK unit tests still PASS (existing ISLog tests don't call `takeDevices`; behavior is unchanged for them).
- [x] Logalyzer PR #26 builds cleanly against this branch tip locally and exercises `IsLog::takeDevices` through the multi-device loader path; ctest 14/14 PASS.

## Why a separate PR rather than amend / direct push

Per the SDK CLAUDE.md convention, "direct commits to `logalyzer-develop` are OK only for trivial one-line fixes." A 25-line additive method with a docstring is mechanically simple and fully additive but more than a one-liner — opening the PR is the right default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)