### PR TITLE
Bugfix/imx imu calibration validation

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2365,7 +2365,7 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_WHEEL_ENCODER",                // 71
     "DID_DIAGNOSTIC_MESSAGE",           // 72
     "DID_SURVEY_IN",                    // 73
-    "DID_CAL_INFO",                  // 74
+    "DID_CAL_SC",                  // 74
     "DID_PORT_MONITOR",                 // 75
     "DID_RTK_STATE",                    // 76
     "DID_RTK_PHASE_RESIDUAL",           // 77
@@ -2550,7 +2550,7 @@ cISDataMappings::cISDataMappings()
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_TCAL);
     PopulateMapSensorsWTemp(        m_data_set, DID_SENSORS_MCAL);
     PopulateMapSensors(             m_data_set, DID_SENSORS_TC_BIAS);
-    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_INFO);
+    PopulateMapSensorSCalInfo(       m_data_set, DID_CAL_SC);
     PopulateMapSensorTCalGyrGroup(   m_data_set, DID_CAL_TEMP_COMP_GYR);
     PopulateMapSensorTCalAccGroup(   m_data_set, DID_CAL_TEMP_COMP_ACC);
     PopulateMapSensorTCalMagGroup(   m_data_set, DID_CAL_TEMP_COMP_MAG);
@@ -2697,7 +2697,7 @@ uint32_t cISDataMappings::DefaultPeriodMultiple(uint32_t did)
     case DID_NVR_USERPAGE_G0:
     case DID_NVR_USERPAGE_G1:
     case DID_FLASH_CONFIG:
-    case DID_CAL_INFO:
+    case DID_CAL_SC:
     case DID_CAL_TEMP_COMP_GYR:
     case DID_CAL_TEMP_COMP_ACC:
     case DID_CAL_TEMP_COMP_MAG:

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -993,17 +993,17 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     {
     case 0:     // General Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.info), DID_CAL_INFO, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
         }
         break;
 
     case 1:     // Data Info
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
         } else {
-            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_INFO, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
         }
         break;
 

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -41,6 +41,9 @@ using json = nlohmann::json;
 // Macro for checking if a 3-element vector is all zeros
 #define VEC3_ALL_ZERO(v) ((v)[0] == 0.0f && (v)[1] == 0.0f && (v)[2] == 0.0f)
 
+// Maximum number of consecutive send failures per step before aborting the upload.
+#define MAX_UPLOAD_SEND_RETRIES 50
+
 // Helper function prototypes
 static std::vector<std::string> split(const std::string& s, char delimiter);
 static std::string getFilename(const std::string& path);
@@ -972,6 +975,8 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     // Per-thread v1.3 staging buffer; built once on state==0 when target is IMX-5.
     // Reused across the 8 send steps to avoid repeated conversion.
     static thread_local sensor_cal_v1p3_t s_v1p3Buf;
+    // Per-thread retry counter; reset at the start of each new upload and after each successful step.
+    static thread_local int s_retryCount = 0;
 
     const int hwMajor = devInfo.hardwareVer[0];
     const bool sendV1p3 = (hwMajor == 5);
@@ -983,76 +988,82 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
         return -1;
     }
 
-    if (calUploadState == 0 && sendV1p3)
+    if (calUploadState == 0)
     {
-        // Build v1.3 payload from in-memory v1.4 cal. Recomputes both checksums.
-        convert_sensor_cal_v1p4_to_v1p3(&cal, &s_v1p3Buf);
+        s_retryCount = 0;   // Reset retry counter at the start of each new upload.
+        if (sendV1p3)
+        {
+            // Build v1.3 payload from in-memory v1.4 cal. Recomputes both checksums.
+            convert_sensor_cal_v1p4_to_v1p3(&cal, &s_v1p3Buf);
+        }
     }
+
+    // Returns 0 (pending) on send failure; aborts with -1 after MAX_UPLOAD_SEND_RETRIES consecutive failures on the current step.
+    auto sendFail = [&]() -> int {
+        if (++s_retryCount > MAX_UPLOAD_SEND_RETRIES) {
+            log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: send failed %d times on step %d; aborting upload.", s_retryCount, calUploadState);
+            return -1;
+        }
+        return 0;
+    };
 
     switch (calUploadState)
     {
-    case 0:     // General Info
+    case 0:     // General Info + Data Info (sent together since both are small and adjacent)
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t) + sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t), offsetof(sensor_cal_t, info)) != 0) { return 0; }
+            if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t) + sizeof(sensor_data_info_t), offsetof(sensor_cal_t, info)) != 0) { return sendFail(); }
         }
         break;
 
-    case 1:     // Data Info
+    case 1:     // Temp comp - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, &(cal.data.dinfo), DID_CAL_SC, sizeof(sensor_data_info_t), offsetof(sensor_cal_t, data.dinfo)) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR) != 0) { return sendFail(); }
         }
         break;
 
-    case 2:     // Temp comp - Gyros
+    case 2:     // Temp comp - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC) != 0) { return sendFail(); }
         }
         break;
 
-    case 3:     // Temp comp - Accelerometers
+    case 3:     // Temp comp - Magnetometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG) != 0) { return sendFail(); }
         }
         break;
 
-    case 4:     // Temp comp - Magnetometers
+    case 4:     // Motion cal - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR) != 0) { return sendFail(); }
         }
         break;
 
-    case 5:     // Motion cal - Gyros
+    case 5:     // Motion cal - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC) != 0) { return sendFail(); }
         }
         break;
 
-    case 6:     // Motion cal - Accelerometers
+    case 6:     // Motion cal - Magnetometers (last step)
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return 0; }
+            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return sendFail(); }
         } else {
-            if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC) != 0) { return 0; }
+            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG) != 0) { return sendFail(); }
         }
-        break;
-
-    case 7:     // Motion cal - Magnetometers (last step)
-        if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return 0; }
-        } else {
-            if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG) != 0) { return 0; }
-        }
+        s_retryCount = 0;
         calUploadState++;   // Increment state to mark completion here in case any upload fails and we need to retry the last step.  We don't want to resend all previous steps if only the last one fails.
         return 1;    // Done
 
@@ -1060,6 +1071,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
         return -1;
     }
 
+    s_retryCount = 0;
     calUploadState++;
     return 0;
 }

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -19,7 +19,7 @@ extern "C" {
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     3
 #define SENSOR_CAL_VER2     0
-#elif defined(IMX_6)
+#elif // IMX_6 and host SDK
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     4
 #define SENSOR_CAL_VER2     0

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -19,7 +19,7 @@ extern "C" {
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     3
 #define SENSOR_CAL_VER2     0
-#elif // IMX_6 and host SDK
+#else // IMX-6 and host SDK
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     4
 #define SENSOR_CAL_VER2     0

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -19,7 +19,7 @@ extern "C" {
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     3
 #define SENSOR_CAL_VER2     0
-#elif defined(IMX_6)
+#else // IMX-6 and host SDK
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     4
 #define SENSOR_CAL_VER2     0

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -15,9 +15,15 @@ extern "C" {
 #define TCAL_MAX_TEMPERATURE    85      // Maximum temperature for temperature calibration
 
 // 1.2.0 = 2x IMU, 1.3.0 = 3x IMU + 2x Mag, 1.4.0 = 5x IMU + 1x Mag
+#if defined(IMX_5)
+#define SENSOR_CAL_VER0     1
+#define SENSOR_CAL_VER1     3
+#define SENSOR_CAL_VER2     0
+#elif defined(IMX_6)
 #define SENSOR_CAL_VER0     1
 #define SENSOR_CAL_VER1     4
 #define SENSOR_CAL_VER2     0
+#endif
 
 enum eScompCalState
 {

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -59,9 +59,9 @@ void set_sensor_mcal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
     }
     for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
-        data->mcal.mag[d].orth[0] = 2.593418189666583;  // Golden mag calibration only for IMX-5.  Do not use with IMX-6.
-        data->mcal.mag[d].orth[4] = 2.593418189666583;
-        data->mcal.mag[d].orth[8] = 2.593418189666583;
+        data->mcal.mag[d].orth[0] = 1;
+        data->mcal.mag[d].orth[4] = 1;
+        data->mcal.mag[d].orth[8] = 1;
     }
 
     // Set data info (size and checksum)

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -11,7 +11,7 @@ void set_sensor_mcal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
 {
     if (data == NULL) { return; }
 
-    memset(data, 0, sizeof(sensor_mcal_group_v1p4_t));
+    memset(&data->mcal, 0, sizeof(sensor_mcal_group_v1p4_t));
     for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
@@ -59,7 +59,7 @@ void set_sensor_mcal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
     }
     for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
-        data->mcal.mag[d].orth[0] = 2.593418189666583;  // Golden mag calibration only for IMX-5.  Do not use wth IMX-6.
+        data->mcal.mag[d].orth[0] = 2.593418189666583;  // Golden mag calibration only for IMX-5.  Do not use with IMX-6.
         data->mcal.mag[d].orth[4] = 2.593418189666583;
         data->mcal.mag[d].orth[8] = 2.593418189666583;
     }

--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -7,11 +7,11 @@
 #define _MIN(a,b) (((a)<(b))?(a):(b))
 #endif
 
-void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
+void set_sensor_mcal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
 {
     if (data == NULL) { return; }
 
-    memset(data, 0, sizeof(sensor_cal_v1p4_data_t));
+    memset(data, 0, sizeof(sensor_mcal_group_v1p4_t));
     for (int d = 0; d < NUM_IMU_DEVICES_V1P4; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
@@ -29,15 +29,24 @@ void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
         data->mcal.mag[d].orth[8] = 1;
     }
 
+    // Set data info (size and checksum)
     data->dinfo.size = sizeof(sensor_cal_v1p4_data_t);
     data->dinfo.checksum = flashChecksum32(data, data->dinfo.size);
 }
 
-void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
+void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data)
 {
     if (data == NULL) { return; }
 
-    memset(data, 0, sizeof(sensor_cal_v1p3_data_t));
+    memset(data, 0, sizeof(sensor_cal_v1p4_data_t));    // Default tcal
+    set_sensor_mcal_data_defaults_v1p4(data);           // Default mcal and set size and checksum for data struct
+}
+
+void set_sensor_mcal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
+{
+    if (data == NULL) { return; }
+
+    memset(&data->mcal, 0, sizeof(sensor_mcal_group_v1p3_t));    // Default mcal
     for (int d = 0; d < NUM_IMU_DEVICES_V1P3; d++)
     {
         data->mcal.pqr[d].orth[0] = 1;
@@ -50,13 +59,22 @@ void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
     }
     for (int d = 0; d < NUM_MAG_DEVICES_V1P3; d++)
     {
-        data->mcal.mag[d].orth[0] = 1;
-        data->mcal.mag[d].orth[4] = 1;
-        data->mcal.mag[d].orth[8] = 1;
+        data->mcal.mag[d].orth[0] = 2.593418189666583;  // Golden mag calibration only for IMX-5.  Do not use wth IMX-6.
+        data->mcal.mag[d].orth[4] = 2.593418189666583;
+        data->mcal.mag[d].orth[8] = 2.593418189666583;
     }
 
+    // Set data info (size and checksum)
     data->dinfo.size = sizeof(sensor_cal_v1p3_data_t);
     data->dinfo.checksum = flashChecksum32(data, data->dinfo.size);
+}
+
+void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data)
+{
+    if (data == NULL) { return; }
+
+    memset(data, 0, sizeof(sensor_cal_v1p3_data_t));    // Default tcal
+    set_sensor_mcal_data_defaults_v1p3(data);           // Default mcal and set size and checksum for data struct
 }
 
 void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4)

--- a/src/IS_calibration_convert.h
+++ b/src/IS_calibration_convert.h
@@ -9,6 +9,8 @@ extern "C" {
 
 void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data);
 void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data);
+void set_sensor_mcal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data);
+void set_sensor_mcal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data);
 
 // Native (build-target) defaults init. Resolves to _v1p3 under IMX_5, _v1p4 elsewhere.
 static inline void set_sensor_cal_data_defaults(sensor_cal_data_t *data)
@@ -17,6 +19,16 @@ static inline void set_sensor_cal_data_defaults(sensor_cal_data_t *data)
     set_sensor_cal_data_defaults_v1p3(data);
 #else
     set_sensor_cal_data_defaults_v1p4(data);
+#endif
+}
+
+// Native (build-target) defaults init. Resolves to _v1p3 under IMX_5, _v1p4 elsewhere.
+static inline void set_sensor_motion_cal_data_defaults(sensor_cal_data_t *data)
+{
+#if defined(IMX_5)
+    set_sensor_mcal_data_defaults_v1p3(data);
+#else
+    set_sensor_mcal_data_defaults_v1p4(data);
 #endif
 }
 

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -529,7 +529,7 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 71: DID_WHEEL_ENCODER
         diagMsgOffsets,         // 72: DID_DIAGNOSTIC_MESSAGE
         0,                      // 73: DID_SURVEY_IN
-        0,                      // 74: DID_CAL_INFO
+        0,                      // 74: DID_CAL_SC
         0,                      // 75: DID_PORT_MONITOR
         0,                      // 76: DID_RTK_STATE
         0,                      // 77: DID_RTK_RESIDUAL

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -79,7 +79,7 @@ typedef uint32_t eDataIDs;
 #define DID_DEBUG_ARRAY                 (eDataIDs)39 /** INTERNAL USE ONLY (debug_array_t) */
 #define DID_SENSORS_MCAL                (eDataIDs)40 /** INTERNAL USE ONLY (sensors_w_temp_t) Temperature compensated and motion calibrated IMU output. */
 #define DID_GPS1_TIMEPULSE              (eDataIDs)41 /** (gps_timepulse_t) GPS1 PPS time synchronization. */
-#define DID_UNUSED_42                   (eDataIDs)42 /** unused */
+#define DID_CAL_SC                      (eDataIDs)42 /** INTERNAL USE ONLY (sensor_cal_info_t) */
 #define DID_UNUSED_43                   (eDataIDs)43 /** unused */
 #define DID_UNUSED_44                   (eDataIDs)44 /** unused */
 #define DID_GPS1_SIG                    (eDataIDs)45 /** (gps_sig_t) GPS 1 GNSS signal information. */
@@ -111,7 +111,7 @@ typedef uint32_t eDataIDs;
 #define DID_WHEEL_ENCODER               (eDataIDs)71 /** (wheel_encoder_t) Wheel encoder data to be fused with GPS-INS measurements, set DID_GROUND_VEHICLE for configuration before sending this message */
 #define DID_DIAGNOSTIC_MESSAGE          (eDataIDs)72 /** (diag_msg_t) Diagnostic message */
 #define DID_SURVEY_IN                   (eDataIDs)73 /** (survey_in_t) Survey in, used to determine position for RTK base station. Base correction output cannot run during a survey and will be automatically disabled if a survey is started. */
-#define DID_CAL_INFO                    (eDataIDs)74 /** INTERNAL USE ONLY (sensor_cal_info_t) */
+#define DID_UNUSED_74                   (eDataIDs)74 /** unused */
 #define DID_PORT_MONITOR                (eDataIDs)75 /** (port_monitor_t) Data rate and status monitoring for each communications port. */
 #define DID_RTK_STATE                   (eDataIDs)76 /** INTERNAL USE ONLY (rtk_state_t) */
 #define DID_RTK_PHASE_RESIDUAL          (eDataIDs)77 /** INTERNAL USE ONLY (rtk_residual_t) */

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1674,12 +1674,12 @@ enum eSystemCommand
     SYS_CMD_SAVE_GPS_ASSIST_TO_FLASH_RESET              = 98,           // (uint32 inv: 4294967197)
     SYS_CMD_SOFTWARE_RESET                              = 99,           // (uint32 inv: 4294967196)
     SYS_CMD_MANF_UNLOCK                                 = 1122334455,   // (uint32 inv: 3172632840)
-    SYS_CMD_MANF_ERASE_CALIBRATION_MOTION               = 1357924678,   // (uint32 inv: 2937042617) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_ERASE_CALIBRATION                      = 1357924679,   // (uint32 inv: 2937042616) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
-    SYS_CMD_MANF_DOWNGRADE_CALIBRATION                  = 1357924682,   // (uint32 inv: 2937042613) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
-    SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER                  = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
+    SYS_CMD_MANF_ERASE_CALIBRATION_MOTION               = 1357924678,   // (uint32 inv: 2937042617) SYS_CMD_MANF_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_ERASE_CALIBRATION                      = 1357924679,   // (uint32 inv: 2937042616) SYS_CMD_MANF_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
+    SYS_CMD_MANF_DOWNGRADE_CALIBRATION                  = 1357924682,   // (uint32 inv: 2937042613) SYS_CMD_MANF_UNLOCK must be sent prior to this command.
+    SYS_CMD_MANF_ENABLE_ROM_BOOTLOADER                  = 1357924683,   // (uint32 inv: 2937042612) SYS_CMD_MANF_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.
 
     SYS_CMD_FAULT_TEST_TRIG_MALLOC                      = 57005,
     SYS_CMD_FAULT_TEST_TRIG_HARD_FAULT                  = 57006,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1674,6 +1674,7 @@ enum eSystemCommand
     SYS_CMD_SAVE_GPS_ASSIST_TO_FLASH_RESET              = 98,           // (uint32 inv: 4294967197)
     SYS_CMD_SOFTWARE_RESET                              = 99,           // (uint32 inv: 4294967196)
     SYS_CMD_MANF_UNLOCK                                 = 1122334455,   // (uint32 inv: 3172632840)
+    SYS_CMD_MANF_ERASE_CALIBRATION_MOTION               = 1357924678,   // (uint32 inv: 2937042617) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_ERASE_CALIBRATION                      = 1357924679,   // (uint32 inv: 2937042616) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_FACTORY_RESET                          = 1357924680,   // (uint32 inv: 2937042615) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.
     SYS_CMD_MANF_CHIP_ERASE                             = 1357924681,   // (uint32 inv: 2937042614) SYS_CMD_MANF_RESET_UNLOCK must be sent prior to this command.  A device power cycle may be necessary to complete this command.

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -79,7 +79,7 @@ typedef uint32_t eDataIDs;
 #define DID_DEBUG_ARRAY                 (eDataIDs)39 /** INTERNAL USE ONLY (debug_array_t) */
 #define DID_SENSORS_MCAL                (eDataIDs)40 /** INTERNAL USE ONLY (sensors_w_temp_t) Temperature compensated and motion calibrated IMU output. */
 #define DID_GPS1_TIMEPULSE              (eDataIDs)41 /** (gps_timepulse_t) GPS1 PPS time synchronization. */
-#define DID_CAL_SC                      (eDataIDs)42 /** INTERNAL USE ONLY (sensor_cal_info_t) */
+#define DID_CAL_SC                      (eDataIDs)42 /** INTERNAL USE ONLY (sensor_cal_t) */
 #define DID_UNUSED_43                   (eDataIDs)43 /** unused */
 #define DID_UNUSED_44                   (eDataIDs)44 /** unused */
 #define DID_GPS1_SIG                    (eDataIDs)45 /** (gps_sig_t) GPS 1 GNSS signal information. */


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the sensor calibration code, focusing on clearer separation between overall and motion calibration defaults, better support for different hardware versions (IMX-5 and IMX-6), and the addition of a new system command for erasing only motion calibration data. The changes also improve maintainability by making the initialization routines more modular.

**Calibration Data Initialization Refactoring:**

* Split calibration defaults initialization into separate functions for overall calibration (`set_sensor_cal_data_defaults_*`) and motion calibration (`set_sensor_mcal_data_defaults_*`), allowing more granular control and clearer code organization. (`[[1]](diffhunk://#diff-4bf43ae1bcf40825c8b28c87d4fd29d05ed4302e2fb1b44610bedb3faeebc964L10-R14)`, `[[2]](diffhunk://#diff-4bf43ae1bcf40825c8b28c87d4fd29d05ed4302e2fb1b44610bedb3faeebc964R32-R49)`, `[[3]](diffhunk://#diff-4bf43ae1bcf40825c8b28c87d4fd29d05ed4302e2fb1b44610bedb3faeebc964L53-R79)`, `[[4]](diffhunk://#diff-df4535d379fce9406fa98506a87ef2387334d101687c07c086cbdf16d3b2fe64R12-R13)`)
* Added new inline function `set_sensor_motion_cal_data_defaults` to initialize only motion calibration data, with logic to select the appropriate version based on hardware target (IMX-5 or IMX-6). (`[src/IS_calibration_convert.hR25-R34](diffhunk://#diff-df4535d379fce9406fa98506a87ef2387334d101687c07c086cbdf16d3b2fe64R25-R34)`)

**Hardware Version Support:**

* Updated calibration version macros in `IS_calibration.h` to explicitly handle IMX-5 and IMX-6 hardware, ensuring correct calibration data structures are used for each. (`[src/IS_calibration.hR18-R26](diffhunk://#diff-074a7615a8aae9964ec6aa6b40163c8ac12043e2a16ee38f4473a0ca739934faR18-R26)`)

**Calibration Data Defaults:**

* For IMX-5, set "golden" default values for magnetometer calibration in `set_sensor_mcal_data_defaults_v1p3`, improving out-of-the-box accuracy for this hardware. (`[src/IS_calibration_convert.cL53-R79](diffhunk://#diff-4bf43ae1bcf40825c8b28c87d4fd29d05ed4302e2fb1b44610bedb3faeebc964L53-R79)`)

**System Command Additions:**

* Added a new system command `SYS_CMD_MANF_ERASE_CALIBRATION_MOTION` to allow erasing only the motion calibration data, providing more flexibility for device management and manufacturing workflows. (`[src/data_sets.hR1677](diffhunk://#diff-a58fce04e6c6d3ce510e53e485a7dec47f3f8542be0cd23f2527a2254e87813aR1677)`)