### PR TITLE
SN-7988: Refactor find-library helper to expose InertialSenseSDK target

### DIFF
--- a/ExampleProjects/Ascii/CMakeLists.txt
+++ b/ExampleProjects/Ascii/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISAsciiExample.cpp)
 

--- a/ExampleProjects/Bootloader/CMakeLists.txt
+++ b/ExampleProjects/Bootloader/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISBootloaderExample.cpp)
 

--- a/ExampleProjects/ISComm/CMakeLists.txt
+++ b/ExampleProjects/ISComm/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME}
     ISCommExample.cpp

--- a/ExampleProjects/ISComm_callback/CMakeLists.txt
+++ b/ExampleProjects/ISComm_callback/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISCommCallbackExample.cpp)
 

--- a/ExampleProjects/ISLogger_read/CMakeLists.txt
+++ b/ExampleProjects/ISLogger_read/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISLoggerReadExample.cpp)
 

--- a/ExampleProjects/ISLogger_write/CMakeLists.txt
+++ b/ExampleProjects/ISLogger_write/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISLoggerWriteExample.cpp)
 

--- a/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
+++ b/ExampleProjects/IS_NMEAProtocolCheckSum/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} IS_NMEAProtocolCheckSum.cpp)
 

--- a/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
+++ b/ExampleProjects/IS_firmwareUpdate_v2/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISFirmwareUpdateExample_v2.cpp)
 

--- a/ExampleProjects/InertialSense_log_reader/CMakeLists.txt
+++ b/ExampleProjects/InertialSense_log_reader/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISLogReaderExample.cpp)
 

--- a/ExampleProjects/InertialSense_log_reader_RegCmp/CMakeLists.txt
+++ b/ExampleProjects/InertialSense_log_reader_RegCmp/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} "LogReader_RegCmp.cpp")
 

--- a/ExampleProjects/InertialSense_logger/CMakeLists.txt
+++ b/ExampleProjects/InertialSense_logger/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISLoggerExample.cpp)
 

--- a/ExampleProjects/Minimal_ISDevice/CMakeLists.txt
+++ b/ExampleProjects/Minimal_ISDevice/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISDeviceExample1.cpp)
 

--- a/ExampleProjects/NTRIP_rover/CMakeLists.txt
+++ b/ExampleProjects/NTRIP_rover/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} ISNtripRoverExampleV3.cpp)
 

--- a/ExampleProjects/Simple_Discovery/CMakeLists.txt
+++ b/ExampleProjects/Simple_Discovery/CMakeLists.txt
@@ -11,9 +11,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 # Define the executable
 add_executable(${PROJECT_NAME} Example-2_Device-Discovery.cpp)
 

--- a/cltool/CMakeLists.txt
+++ b/cltool/CMakeLists.txt
@@ -15,9 +15,6 @@ include_directories(
     ${IS_SDK_DIR}/src/libusb/libusb
 )
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 add_definitions(-DIS_LOG_LEVEL=IS_LOG_LEVEL_MORE_INFO)
 
 if(WIN32)

--- a/include_is_sdk_find_library.cmake
+++ b/include_is_sdk_find_library.cmake
@@ -1,21 +1,77 @@
-if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(IS_SDK_BUILD_DIR "${IS_SDK_DIR}/build-debug")
-    else()
-        set(IS_SDK_BUILD_DIR "${IS_SDK_DIR}/build-release")
-    endif()
-else()
-    set(IS_SDK_BUILD_DIR "${IS_SDK_DIR}/build")
+# Locate a prebuilt InertialSenseSDK static library, or fall back to building
+# it from source as a sub-project. Either way, downstream consumers can link
+# the SDK simply by referencing the target name `InertialSenseSDK`.
+#
+# Strategy: mirror the consumer's build-directory NAME under ${IS_SDK_DIR}.
+# So if EvalTool is being configured at `cpp/EvalTool/cmake-build-debug/`, we
+# look for (and, if absent, build into) `SDK/cmake-build-debug/`. This is
+# platform- and IDE-agnostic, and it lets a previous source-build be picked
+# up as a "prebuilt" on subsequent configures.
+#
+# Convention summary:
+#   manual scripts (Linux):    cpp/<proj>/build         -> SDK/build
+#   manual scripts (Windows):  cpp/<proj>/build-debug   -> SDK/build-debug
+#   CLion / IDE:               cpp/<proj>/cmake-build-* -> SDK/cmake-build-*
+#
+# Note on dependency tracking: when a prebuilt static library is found, it is
+# wrapped in an IMPORTED target — CMake treats it as opaque and will NOT
+# rebuild the SDK if its source changes. This is intentional for fast CI /
+# automated builds. Set IS_SDK_BUILD_FROM_SOURCE=ON to force the SDK to be
+# built from source as a sub-project (with full dependency tracking) — useful
+# when actively iterating on SDK source.
+#
+# - Default (no flag set): Prebuilt library is used as IMPORTED target. Fast, suitable for CI.
+# - -DIS_SDK_BUILD_FROM_SOURCE=ON: Forces add_subdirectory, full dependency tracking, SDK rebuilds when its source changes.
+#
+# Usage
+#
+# # CI / fast builds (default — uses prebuilt if available)
+# cmake -S cpp/EvalTool -B cpp/EvalTool/cmake-build-debug
+#
+# # Active SDK development (always rebuilds SDK on source change)
+# cmake -S cpp/EvalTool -B cpp/EvalTool/cmake-build-debug -DIS_SDK_BUILD_FROM_SOURCE=ON
+#
+# In CLion, add -DIS_SDK_BUILD_FROM_SOURCE=ON to Settings → Build, Execution, Deployment → CMake → CMake options for the relevant profile when iterating on SDK code.
+#
+# A note worth flagging: because IS_SDK_BUILD_FROM_SOURCE uses CMake option(), its value is cached on first configure. To toggle it later, either pass -DIS_SDK_BUILD_FROM_SOURCE=OFF explicitly or clear CMakeCache.txt.
+
+
+if(TARGET InertialSenseSDK)
+    # Already set up by an earlier include of this file in the same project.
+    return()
+endif()
+
+option(IS_SDK_BUILD_FROM_SOURCE
+    "Always build InertialSenseSDK from source (skip prebuilt detection)" OFF)
+
+get_filename_component(_consumer_build_name "${CMAKE_BINARY_DIR}" NAME)
+set(_IS_SDK_BUILD_DIR "${IS_SDK_DIR}/${_consumer_build_name}")
+
+if(IS_SDK_BUILD_FROM_SOURCE)
+    add_subdirectory(${IS_SDK_DIR} ${_IS_SDK_BUILD_DIR})
+    message(STATUS "IS_SDK_BUILD_FROM_SOURCE=ON. Building SDK source into: ${_IS_SDK_BUILD_DIR}")
+    return()
 endif()
 
 unset(SDK_LIBRARY_PATH CACHE)
-find_library(SDK_LIBRARY_PATH InertialSenseSDK PATHS ${IS_SDK_BUILD_DIR})
+find_library(SDK_LIBRARY_PATH InertialSenseSDK
+    PATHS ${_IS_SDK_BUILD_DIR}
+    NO_DEFAULT_PATH
+)
 
-if(NOT SDK_LIBRARY_PATH AND NOT TARGET InertialSenseSDK)
-    # InertialSenseSDK library not prebuilt and not already included in project.  Include it in this project.
-    add_subdirectory(${IS_SDK_DIR} InertialSenseSDK)
-    message("InertialSenseSDK library NOT FOUND.  Including SDK source in project.")
+if(SDK_LIBRARY_PATH)
+    # Wrap the prebuilt static library in an IMPORTED target so consumers can
+    # link via `InertialSenseSDK` regardless of whether it was prebuilt or
+    # built from source.
+    add_library(InertialSenseSDK STATIC IMPORTED GLOBAL)
+    set_target_properties(InertialSenseSDK PROPERTIES
+        IMPORTED_LOCATION "${SDK_LIBRARY_PATH}"
+    )
+    message(STATUS "Using prebuilt InertialSenseSDK at: ${SDK_LIBRARY_PATH}")
 else()
-    link_directories(${IS_SDK_BUILD_DIR})
-    message("Using InertialSenseSDK library prebuilt at: ${SDK_LIBRARY_PATH}")
+    # No prebuilt library — build the SDK from source as a sub-project.
+    # Place artifacts under SDK/<consumer-build-name>/ so the result is
+    # discoverable as a prebuilt on subsequent configures.
+    add_subdirectory(${IS_SDK_DIR} ${_IS_SDK_BUILD_DIR})
+    message(STATUS "InertialSenseSDK library NOT FOUND. Building SDK source into: ${_IS_SDK_BUILD_DIR}")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,9 +22,6 @@ include_directories(
 
 find_package(GTest REQUIRED)
 
-# Link the InertialSenseSDK static library 
-link_directories(${IS_SDK_DIR})
-
 file(GLOB TESTS_SOURCES "${CMAKE_CURRENT_LIST_DIR}/test_*.cpp")
 list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_com_manager_2.cpp")
 if(WIN32)   # These do not run in Windows


### PR DESCRIPTION
## Summary
- Rewrite `include_is_sdk_find_library.cmake` so consumers always link via the `InertialSenseSDK` CMake target — IMPORTED when a prebuilt static library is found, `add_subdirectory` otherwise. `${SDK_LIBRARY_PATH}` and `${IS_SDK_BUILD_DIR}` are no longer set by the helper.
- Add `IS_SDK_BUILD_FROM_SOURCE` option to force source builds (full dependency tracking) when actively iterating on SDK code.
- Mirror the consumer's build-dir name under `SDK/` (so `cmake-build-debug/` ↔ `SDK/cmake-build-debug/`) — IDE- and platform-agnostic; a previous source build is automatically reused as a "prebuilt" on subsequent configures.
- Drop now-vestigial `link_directories(${IS_SDK_DIR})` from 16 helper-using `CMakeLists.txt` (cltool, tests, 14 ExampleProjects).

## Why
Today the helper exposes `${SDK_LIBRARY_PATH}` (set only when a prebuilt is found) and consumers have to either reference that variable, copy/paste a 10-line `find_library` block, or fall through to `add_subdirectory`. That's brittle: a stale-pointing variable, a Windows-only `build-debug`/`build-release` split, and no canonical CMake target. After this PR, every consumer just writes `target_link_libraries(... InertialSenseSDK ...)` and the helper figures out the rest.

Pairs with consumer migrations in `inertialsense/imx` and `inertialsense/is-gpx` (separate PRs that bump this submodule).

Tracking: SN-7988

## Test plan
- [ ] `cltool` builds and links cleanly with a previously-built SDK (prebuilt path) — existing CLion `cmake-build-debug` configure
- [ ] `cltool` builds cleanly after deleting `SDK/cmake-build-debug/` (source-build path)
- [ ] At least one ExampleProject (e.g., `Simple_Discovery`) builds with the new helper
- [ ] `IS_SDK_BUILD_FROM_SOURCE=ON` forces source build even when a prebuilt exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)