### PR TITLE
Fix IMX imu calibration upload

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2333,7 +2333,7 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_DEBUG_ARRAY",                  // 39
     "DID_SENSORS_MCAL",                 // 40
     "DID_GPS1_TIMEPULSE",               // 41
-    "DID_UNUSED_42",                    // 42
+    "DID_CAL_SC",                       // 42
     "DID_UNUSED_43",                    // 43
     "DID_UNUSED_44",                    // 44
     "DID_GPS1_SIG",                     // 45
@@ -2365,7 +2365,7 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_WHEEL_ENCODER",                // 71
     "DID_DIAGNOSTIC_MESSAGE",           // 72
     "DID_SURVEY_IN",                    // 73
-    "DID_CAL_SC",                  // 74
+    "DID_UNUSED_74",                  // 74
     "DID_PORT_MONITOR",                 // 75
     "DID_RTK_STATE",                    // 76
     "DID_RTK_PHASE_RESIDUAL",           // 77

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -580,7 +580,7 @@ bool ISDeviceCal::loadCalibrationFromJsonObj(const json& jObj, sOrthoCal *ocal, 
     }
     if (dinfo)
     {   // Recompute data info size and checksum
-        dinfo->size = sizeof(sensor_cal_v1p3_data_t);
+        dinfo->size = sizeof(sensor_cal_data_t);
         dinfo->checksum = flashChecksum32(dinfo, dinfo->size);
     }
 


### PR DESCRIPTION
This PR fixes the issue where uploaded IMX IMU calibration does not persist across reboots.

This pull request updates data ID mappings and corrects a structure size used in calibration data handling. The main changes are the reassignment of data ID names in the `cISDataMappings` array and a fix to the size calculation for calibration data structures.

**Data ID mapping updates:**

* Changed the name for data ID 42 from `"DID_UNUSED_42"` to `"DID_CAL_SC"` in `m_dataIdNames[]`.
* Changed the name for data ID 74 from `"DID_CAL_SC"` to `"DID_UNUSED_74"` in `m_dataIdNames[]`.

**Calibration data handling fix:**

* Updated the size calculation for `dinfo->size` from `sizeof(sensor_cal_v1p3_data_t)` to `sizeof(sensor_cal_data_t)` when loading calibration from JSON, ensuring the correct structure size is used for checksum computation.