### PR TITLE
SN-7879 (D-01): .idx v2 sidecar format + writer path

### DIFF
--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -82,6 +82,15 @@ void cDeviceLog::InitDeviceForReading()
 bool cDeviceLog::CloseAllFiles()
 {
     if (m_writeMode) {
+        // Flush any buffered index records and finalize the .idx
+        // header (rewrite at offset 0 with final totals + FINALIZED
+        // flag). Order matters: chunk-write first so finalizeIndex
+        // sees the right total count.
+        if (!m_indexChunks.empty()) {
+            writeIndexChunk();
+        }
+        finalizeIndex();
+
         string str = m_directory + "/summary_SN" + to_string(m_devSerialNo) + ".txt";
         m_logStats.WriteToFile(str);
     }
@@ -134,7 +143,10 @@ bool cDeviceLog::SaveData(p_data_hdr_t *dataHdr, const uint8_t* dataBuf, protoco
             m_logStats.CacheDiagnosticData(dataHdr->id, dataBuf, dataHdr->size, timestamp);
         }
 
-        addIndexRecord();
+        // D-01 / SN-7879: pass the parsed header + buffer through so
+        // the v2 index record carries the actual DID + payload-derived
+        // timestamp + ToW flag.
+        addIndexRecord(dataHdr, dataBuf);
         m_lastIndexOffset += dataHdr->size;
     }
 
@@ -143,10 +155,17 @@ bool cDeviceLog::SaveData(p_data_hdr_t *dataHdr, const uint8_t* dataBuf, protoco
 
 bool cDeviceLog::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &globalLogStats)
 {
-    // Update log statistics done in cDeviceLogRaw::SaveData()
-    addIndexRecord();
-    m_lastIndexOffset += dataSize;
-
+    // Streaming raw-bytes path: no parsed header is available *here*,
+    // but the caller (cDeviceLogRaw::SaveData) parses individual
+    // packets and emits per-packet v2 index records inside its parser
+    // loop. We deliberately do NOT call addIndexRecord(no-args) here
+    // — it would clobber the per-packet emission with a coarser
+    // chunk-level record carrying did=0. The offset increment is also
+    // deferred to the caller so per-packet records capture the
+    // chunk-start offset (D-01 / SN-7879).
+    (void)dataSize;
+    (void)dataBuf;
+    (void)globalLogStats;
     return true;
 }
 
@@ -199,7 +218,16 @@ bool cDeviceLog::OpenNewSaveFile()
     _MKDIR(m_directory.c_str());
 
     // Open new file
-    m_lastIndexOffset = 0;
+    // D-01 / SN-7879: every .raw segment gets its own .idx sidecar with
+    // its own header + per-segment record counts and timestamps. Reset
+    // the per-segment state here so segment N+1 doesn't inherit segment
+    // N's flags and counters (which would skip the new segment's header
+    // write and overstate its total_records).
+    m_lastIndexOffset       = 0;
+    m_idxHeaderWritten      = false;
+    m_idxTotalRecords       = 0;
+    m_idxFirstTimestampMs   = 0;
+    m_idxLastTimestampMs    = 0;
     m_fileCount++;
     uint32_t serNum = (device != nullptr ? device->devInfo.serialNumber : SerialNumber());
     if (!serNum)
@@ -312,33 +340,130 @@ void cDeviceLog::OnReadData(p_data_buf_t* data)
     }
 }
 
-void cDeviceLog::addIndexRecord() {
+// Pack the SDK's PROTOCOL_VERSION_CHAR0..3 quadruple into a single u32
+// for the .idx header's `producer_version` field. Layout chosen so a
+// hex dump reads "02 01 00 00" → SDK 2.1.0.0 left-to-right.
+static inline uint32_t encode_sdk_producer_version() noexcept {
+    return  (static_cast<uint32_t>(PROTOCOL_VERSION_CHAR0) << 24)
+          | (static_cast<uint32_t>(PROTOCOL_VERSION_CHAR1) << 16)
+          | (static_cast<uint32_t>(PROTOCOL_VERSION_CHAR2) <<  8)
+          | (static_cast<uint32_t>(PROTOCOL_VERSION_CHAR3));
+}
 
-    uint32_t timeSinceStart = current_uptimeMs() - m_logStartUpTime;
-    if (m_indexChunks.empty() || (timeSinceStart > m_indexChunks.back().time)) {
-        index_record_t newRec;
-        newRec.time = timeSinceStart;
-        newRec.offset = m_lastIndexOffset;
-        newRec.msg_id = m_logStats.Count();
-        newRec.reserved = 0;
-        m_indexChunks.push_back(newRec);
+void cDeviceLog::addIndexRecord(const p_data_hdr_t* dataHdr, const uint8_t* dataBuf) {
+    using namespace inertial_sense::idx;
+
+    is_log_idx_record_v2_t rec{};
+    rec.offset = m_lastIndexOffset;
+    rec.reserved = 0;
+
+    if (dataHdr != nullptr) {
+        rec.did = dataHdr->id;
+        // cISDataMappings::Timestamp returns 0.0 if the DID doesn't
+        // carry one — that's the signal to fall back to the host
+        // uptime delta and clear the ToW flag.
+        const double tsSeconds = cISDataMappings::Timestamp(dataHdr, dataBuf);
+        if (tsSeconds > 0.0) {
+            rec.timestamp = static_cast<uint64_t>(tsSeconds * 1000.0);
+            rec.flags = IS_LOG_IDX_REC_FLAG_HAS_TOW;
+        } else {
+            rec.timestamp = static_cast<uint64_t>(current_uptimeMs() - m_logStartUpTime);
+            rec.flags = 0;
+        }
     } else {
-        // m_indexChunks.emplace_back()
+        // Streaming-only path: no DID, no payload timestamp. Fall back
+        // to host uptime delta so the record still anchors a position
+        // in the .raw segment by approximate time.
+        rec.did = 0;
+        rec.timestamp = static_cast<uint64_t>(current_uptimeMs() - m_logStartUpTime);
+        rec.flags = 0;
     }
 
+    // Track first/last for the header rewrite at finalize time.
+    if (m_idxTotalRecords == 0 && m_indexChunks.empty()) {
+        m_idxFirstTimestampMs = rec.timestamp;
+    }
+    m_idxLastTimestampMs = rec.timestamp;
+
+    m_indexChunks.push_back(rec);
     m_lastIndexTime = current_uptimeMs();
 }
 
 bool cDeviceLog::writeIndexChunk() {
-    std::string fileName = m_fileName + ".idx";
+    using namespace inertial_sense::idx;
 
+    if (m_indexChunks.empty() && m_idxHeaderWritten) {
+        return true; // nothing to do
+    }
+
+    const std::string fileName = m_fileName + ".idx";
     cISLogFile indexFile(fileName, "ab");
-    // m_indexFile = CreateISLogFile(fileName, "ab");
-    for (index_record_t& rec : m_indexChunks) {
-        if (indexFile.write(&rec, sizeof(index_record_s)) != sizeof(index_record_s))
-            return false; // writing error; we have to assume this entire file is now bad.
+    if (!indexFile.isOpened()) {
+        return false;
+    }
+
+    // First chunk write: emit the v2 header. total_records /
+    // first/last timestamps stay zero here — finalizeIndex() seeks(0)
+    // and rewrites the header on close. ts_units = HostUptimeMs is
+    // the conservative default; per-record `flags` bit 0 still tells
+    // readers when a specific record actually carried a real ToW.
+    if (!m_idxHeaderWritten) {
+        is_log_idx_header_t hdr = makeDefaultHeader(
+            encode_sdk_producer_version(),
+            TimestampUnits::HostUptimeMs,
+            HeaderTimeSource::Mixed);
+        auto r = writeHeader(indexFile, hdr);
+        if (r != IsLogIndexResult::Ok) {
+            return false;
+        }
+        m_idxHeaderWritten = true;
+    }
+
+    for (const auto& rec : m_indexChunks) {
+        auto r = writeRecord(indexFile, rec);
+        if (r != IsLogIndexResult::Ok) {
+            // writing error; whole file should be considered bad.
+            return false;
+        }
+        ++m_idxTotalRecords;
     }
     m_indexChunks.clear();
     indexFile.close();  // unnecessary since this is destroyed on exit
+    return true;
+}
+
+bool cDeviceLog::finalizeIndex() {
+    using namespace inertial_sense::idx;
+
+    // Idempotent: if no header was ever written (no records emitted)
+    // there's nothing to finalize.
+    if (!m_idxHeaderWritten) {
+        return true;
+    }
+
+    const std::string fileName = m_fileName + ".idx";
+    // Open r+b so we can seek to offset 0 and rewrite the header.
+    cISLogFile indexFile(fileName, "rb+");
+    if (!indexFile.isOpened()) {
+        return false;
+    }
+
+    if (indexFile.seek(0, SEEK_SET) != 0) {
+        return false;
+    }
+
+    is_log_idx_header_t hdr = makeDefaultHeader(
+        encode_sdk_producer_version(),
+        TimestampUnits::HostUptimeMs,
+        HeaderTimeSource::Mixed);
+    hdr.total_records       = m_idxTotalRecords;
+    hdr.first_timestamp_ms  = m_idxFirstTimestampMs;
+    hdr.last_timestamp_ms   = m_idxLastTimestampMs;
+    hdr.flags               = IS_LOG_IDX_HDR_FLAG_FINALIZED;
+
+    auto r = writeHeader(indexFile, hdr);
+    if (r != IsLogIndexResult::Ok) {
+        return false;
+    }
     return true;
 }

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "ISDevice.h"
 #include "ISLogFileBase.h"
+#include "ISLogIndex.h"
 #include "ISLogStats.h"
 
 #include "com_manager.h"
@@ -36,12 +37,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 class cDeviceLog {
 public:
-    typedef struct index_record_s {
+    // Legacy v1 .idx record (host-uptime ms + record counter, 16 bytes).
+    // Kept for back-compat readers per D-01 (SN-7879). Writers emit v2
+    // exclusively; the v1 layout is here only so legacy-aware reader
+    // code can deserialize old `.idx` files produced by SDK <= 2.x.
+    typedef struct index_record_v1_s {
         uint32_t time;
         uint32_t offset;
         uint32_t msg_id;
         uint32_t reserved;
-    } index_record_t;
+    } index_record_v1_t;
+
+    // Public spelling now aliases the v2 record. New code uses the v2
+    // fields (timestamp = payload-derived ms, did = data ID, flags
+    // bit 0 = ToW signal, 64-bit offset).
+    using index_record_s = inertial_sense::idx::is_log_idx_record_v2_t;
+    using index_record_t = inertial_sense::idx::is_log_idx_record_v2_t;
 
     cDeviceLog();
 
@@ -116,8 +127,18 @@ public:
 
     virtual is_comm_instance_t* IsCommInstance() { return NULL; }
 
-    void addIndexRecord();
+    // D-01 / SN-7879: addIndexRecord populates a v2 record from the
+    // packet header / buffer when available, else falls back to a
+    // streaming-path entry with did=0 and timestamp=host-uptime-delta.
+    // The default-args overload preserves the existing void signature
+    // for the streaming-only callers (cDeviceLogRaw) that have no
+    // parsed header.
+    void addIndexRecord(const p_data_hdr_t* dataHdr = nullptr,
+                        const uint8_t* dataBuf = nullptr);
     bool writeIndexChunk();
+    // Rewrites the header at offset 0 with final totals + sets the
+    // FINALIZED flag. Idempotent. Called by CloseAllFiles().
+    bool finalizeIndex();
 
 protected:
     bool OpenNewSaveFile();
@@ -153,10 +174,18 @@ protected:
     bool m_showPointTimestamps = true;
     double m_pointUpdatePeriodSec = 1.0f;
     cLogStats m_logStats;
-    std::vector<index_record_t> m_indexChunks;      //!< a list of current index records, waiting to be written to disk
-    uint32_t m_lastIndexOffset = 0;                 //!< essentially, the last known size of the log file, as written to disk; this should be updated with each chunk-write to be the new size of the log file
+    std::vector<index_record_t> m_indexChunks;      //!< v2 records buffered in memory, waiting to be flushed via writeIndexChunk()
+    uint64_t m_lastIndexOffset = 0;                 //!< running byte offset into the .raw segment; v2 widened from u32 to u64 since segments can exceed 4GB
     uint32_t m_logStartUpTime = 0;                  //!< the system uptime (in millis) at the moment this index was created
-    uint32_t m_lastIndexTime = 0;                   //!< this is the system uptime (in millis) of the last index record created; we won't create new records if data comes in faster than 1ms, we'll update the last one instead
+    uint32_t m_lastIndexTime = 0;                   //!< system uptime (in ms) of the last index record; v2 still tracks this for the host-uptime fallback path
+
+    // D-01 / SN-7879 v2 .idx bookkeeping. The header at offset 0 of
+    // the .idx file carries these aggregates; finalizeIndex() seeks(0)
+    // and rewrites the header on close.
+    bool     m_idxHeaderWritten = false;            //!< true once the v2 header has been emitted (first writeIndexChunk call)
+    uint64_t m_idxTotalRecords  = 0;                //!< running count of records written to the .idx file
+    uint64_t m_idxFirstTimestampMs = 0;             //!< timestamp of the first record (set on first record)
+    uint64_t m_idxLastTimestampMs  = 0;             //!< timestamp of the most recent record
 
 };
 

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -113,6 +113,15 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
                 {
                     timestamp = cISDataMappings::TimestampOrCurrentTime(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr);
 
+                    // D-01 / SN-7879: per-packet v2 index record. Using the
+                    // current m_lastIndexOffset captures the chunk-input
+                    // offset (advanced after the parser loop), giving every
+                    // packet in this chunk-input the same offset but its
+                    // own DID + payload timestamp + ToW flag — which is
+                    // exactly what per-DID time-range queries against the
+                    // index need.
+                    addIndexRecord(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr);
+
                     dev_info_t tmpInfo = {};
                     dev_info_t* devInfo = &tmpInfo;
 
@@ -185,6 +194,15 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
     {
         return false;   // unable to push the buffer into the chunk
     }
+
+    // D-01 / SN-7879: advance the index-offset counter for the *next*
+    // chunk-input. The base cDeviceLog::SaveData(int, ...) used to do
+    // this immediately on entry, but that broke per-packet emission
+    // (records inside the parser loop above would have been tagged
+    // with the next-chunk's offset). We defer the bump to here so the
+    // offset captured by per-packet addIndexRecord calls matches the
+    // chunk-input's starting offset.
+    m_lastIndexOffset += dataSize;
 
     return true;
 }

--- a/src/ISLogIndex.cpp
+++ b/src/ISLogIndex.cpp
@@ -1,0 +1,218 @@
+/**
+ * @file ISLogIndex.cpp
+ * @brief Pure little-endian serialize/parse + cISLogFileBase wrappers
+ *        for the `.idx` v2 format.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISLogIndex.h"
+
+#include "ISLogFileBase.h"
+
+#include <cstring>
+
+namespace inertial_sense {
+namespace idx {
+
+// ----- Byte-order helpers ---------------------------------------------------
+//
+// All on-disk fields are little-endian. We never memcpy structs to
+// disk — that would inherit the host byte order, which fails on BE
+// embedded targets. These helpers do shift-and-mask reads/writes,
+// which the compiler optimizes back to single instructions on LE
+// hosts and stay correct on BE.
+
+namespace {
+
+void put_u16(uint8_t* p, uint16_t v) noexcept {
+    p[0] = static_cast<uint8_t>(v & 0xFFu);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFFu);
+}
+
+void put_u32(uint8_t* p, uint32_t v) noexcept {
+    p[0] = static_cast<uint8_t>(v & 0xFFu);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xFFu);
+    p[2] = static_cast<uint8_t>((v >> 16) & 0xFFu);
+    p[3] = static_cast<uint8_t>((v >> 24) & 0xFFu);
+}
+
+void put_u64(uint8_t* p, uint64_t v) noexcept {
+    for (int i = 0; i < 8; ++i) {
+        p[i] = static_cast<uint8_t>((v >> (i * 8)) & 0xFFu);
+    }
+}
+
+uint16_t get_u16(const uint8_t* p) noexcept {
+    return static_cast<uint16_t>(p[0])
+         | (static_cast<uint16_t>(p[1]) << 8);
+}
+
+uint32_t get_u32(const uint8_t* p) noexcept {
+    return static_cast<uint32_t>(p[0])
+         | (static_cast<uint32_t>(p[1]) << 8)
+         | (static_cast<uint32_t>(p[2]) << 16)
+         | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+uint64_t get_u64(const uint8_t* p) noexcept {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i) {
+        v |= (static_cast<uint64_t>(p[i]) << (i * 8));
+    }
+    return v;
+}
+
+} // namespace
+
+// ----- Pure serialize / parse ----------------------------------------------
+
+void serializeHeader(uint8_t out[IS_LOG_IDX_HEADER_SIZE],
+                     const is_log_idx_header_t& hdr) noexcept {
+    // Zero the buffer so reserved bytes are deterministic on disk.
+    std::memset(out, 0, IS_LOG_IDX_HEADER_SIZE);
+
+    out[0] = static_cast<uint8_t>(hdr.magic[0]);
+    out[1] = static_cast<uint8_t>(hdr.magic[1]);
+    out[2] = static_cast<uint8_t>(hdr.magic[2]);
+    out[3] = static_cast<uint8_t>(hdr.magic[3]);
+    put_u16(out +  4, hdr.version);
+    put_u16(out +  6, hdr.header_size);
+    put_u32(out +  8, hdr.producer_version);
+    put_u64(out + 12, hdr.total_records);
+    put_u64(out + 20, hdr.first_timestamp_ms);
+    put_u64(out + 28, hdr.last_timestamp_ms);
+    put_u32(out + 36, hdr.sync_point_count);
+    out[40] = hdr.ts_units;
+    out[41] = hdr.ts_source;
+    out[42] = hdr.flags;
+    out[43] = hdr.reserved8;
+    // out[44..63] left zero from memset.
+}
+
+IsLogIndexResult parseHeader(const uint8_t in[IS_LOG_IDX_HEADER_SIZE],
+                              is_log_idx_header_t& out) noexcept {
+    // First 4 bytes are the v1/v2 discriminator. v1 had no magic; its
+    // first 4 bytes are the start of the first record's u32 `time`
+    // field, which is essentially never going to read as "ISIX" by
+    // accident. So: magic mismatch → assume v1.
+    if (in[0] != 'I' || in[1] != 'S' || in[2] != 'I' || in[3] != 'X') {
+        return IsLogIndexResult::LegacyFormat;
+    }
+
+    is_log_idx_header_t hdr{};
+    hdr.magic[0] = static_cast<char>(in[0]);
+    hdr.magic[1] = static_cast<char>(in[1]);
+    hdr.magic[2] = static_cast<char>(in[2]);
+    hdr.magic[3] = static_cast<char>(in[3]);
+    hdr.version             = get_u16(in +  4);
+    hdr.header_size         = get_u16(in +  6);
+    hdr.producer_version    = get_u32(in +  8);
+    hdr.total_records       = get_u64(in + 12);
+    hdr.first_timestamp_ms  = get_u64(in + 20);
+    hdr.last_timestamp_ms   = get_u64(in + 28);
+    hdr.sync_point_count    = get_u32(in + 36);
+    hdr.ts_units            = in[40];
+    hdr.ts_source           = in[41];
+    hdr.flags               = in[42];
+    hdr.reserved8           = in[43];
+    std::memcpy(hdr.reserved, in + 44, sizeof(hdr.reserved));
+
+    if (hdr.version != IS_LOG_IDX_VERSION_V2) {
+        return IsLogIndexResult::Unsupported;
+    }
+    if (hdr.header_size < IS_LOG_IDX_HEADER_SIZE) {
+        // A v2 reader REQUIRES at least 64 bytes of header. Less than
+        // that means the bytes are corrupted or truncated mid-write.
+        return IsLogIndexResult::Corrupted;
+    }
+    out = hdr;
+    return IsLogIndexResult::Ok;
+}
+
+void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_SIZE],
+                     const is_log_idx_record_v2_t& rec) noexcept {
+    put_u64(out +  0, rec.timestamp);
+    put_u64(out +  8, rec.offset);
+    put_u32(out + 16, rec.did);
+    put_u16(out + 20, rec.flags);
+    put_u16(out + 22, rec.reserved);
+}
+
+is_log_idx_record_v2_t parseRecord(
+    const uint8_t in[IS_LOG_IDX_RECORD_V2_SIZE]) noexcept {
+    is_log_idx_record_v2_t rec{};
+    rec.timestamp = get_u64(in +  0);
+    rec.offset    = get_u64(in +  8);
+    rec.did       = get_u32(in + 16);
+    rec.flags     = get_u16(in + 20);
+    rec.reserved  = get_u16(in + 22);
+    return rec;
+}
+
+// ----- cISLogFileBase wrappers ---------------------------------------------
+
+IsLogIndexResult writeHeader(cISLogFileBase& file, const is_log_idx_header_t& hdr) {
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, hdr);
+    const std::size_t written = file.write(buf, IS_LOG_IDX_HEADER_SIZE);
+    if (written != IS_LOG_IDX_HEADER_SIZE) {
+        return IsLogIndexResult::Io;
+    }
+    return IsLogIndexResult::Ok;
+}
+
+IsLogIndexResult writeRecord(cISLogFileBase& file, const is_log_idx_record_v2_t& rec) {
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    serializeRecord(buf, rec);
+    const std::size_t written = file.write(buf, IS_LOG_IDX_RECORD_V2_SIZE);
+    if (written != IS_LOG_IDX_RECORD_V2_SIZE) {
+        return IsLogIndexResult::Io;
+    }
+    return IsLogIndexResult::Ok;
+}
+
+IsLogIndexResult readHeader(cISLogFileBase& file, is_log_idx_header_t& out) {
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    const std::size_t got = file.read(buf, IS_LOG_IDX_HEADER_SIZE);
+    if (got < IS_LOG_IDX_HEADER_SIZE) {
+        return IsLogIndexResult::Truncated;
+    }
+    return parseHeader(buf, out);
+}
+
+IsLogIndexResult readRecord(cISLogFileBase& file, is_log_idx_record_v2_t& out) {
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    const std::size_t got = file.read(buf, IS_LOG_IDX_RECORD_V2_SIZE);
+    if (got < IS_LOG_IDX_RECORD_V2_SIZE) {
+        return IsLogIndexResult::Truncated;
+    }
+    out = parseRecord(buf);
+    return IsLogIndexResult::Ok;
+}
+
+is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,
+                                      TimestampUnits units,
+                                      HeaderTimeSource source) noexcept {
+    is_log_idx_header_t hdr{};
+    hdr.magic[0] = IS_LOG_IDX_MAGIC[0];
+    hdr.magic[1] = IS_LOG_IDX_MAGIC[1];
+    hdr.magic[2] = IS_LOG_IDX_MAGIC[2];
+    hdr.magic[3] = IS_LOG_IDX_MAGIC[3];
+    hdr.version             = IS_LOG_IDX_VERSION_V2;
+    hdr.header_size         = IS_LOG_IDX_HEADER_SIZE;
+    hdr.producer_version    = producer_version;
+    hdr.total_records       = 0;
+    hdr.first_timestamp_ms  = 0;
+    hdr.last_timestamp_ms   = 0;
+    hdr.sync_point_count    = 0;
+    hdr.ts_units            = static_cast<uint8_t>(units);
+    hdr.ts_source           = static_cast<uint8_t>(source);
+    hdr.flags               = 0;  // FINALIZED set on clean close
+    hdr.reserved8           = 0;
+    std::memset(hdr.reserved, 0, sizeof(hdr.reserved));
+    return hdr;
+}
+
+} // namespace idx
+} // namespace inertial_sense

--- a/src/ISLogIndex.h
+++ b/src/ISLogIndex.h
@@ -1,0 +1,264 @@
+/**
+ * @file ISLogIndex.h
+ * @brief `.idx` v2 sidecar format — header layout, per-record struct,
+ *        writer / reader helpers.
+ *
+ * D-01 / SN-7879 / D0017 / D0023 / D0043 / D0049: replaces the coarse
+ * v1 `.idx` (host-time + record-counter, 16 bytes per record) with a
+ * versioned format that carries the actual DID and a payload-derived
+ * timestamp per record. Consumers can do per-DID time-range queries
+ * directly against the index.
+ *
+ * On-disk layout is **little-endian** regardless of host byte-order
+ * (the SDK targets ARM embedded). All multi-byte fields go through
+ * the explicit serialize/parse helpers in `ISLogIndex.cpp` — never
+ * memcpy a struct directly to disk.
+ *
+ * Versioning discipline: once v2 ships, its on-disk layout is
+ * immutable. Any future change becomes v3 with its own version
+ * number; v2 readers stay correct on v2 files forever.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class cISLogFileBase;  // forward — defined in ISLogFileBase.h
+
+namespace inertial_sense {
+namespace idx {
+
+// ----- Result codes ---------------------------------------------------------
+//
+// Self-contained status enum scoped to ISLogIndex. The broader SDK
+// error-handling convention (D-10 / `tl::expected` + `ISError`) is
+// deferred to the 3.1 release alongside the new reader stack —
+// keeping 3.0's writer-side change footprint minimal.
+
+/// Outcome of a parse / read / write call. `Ok` = success; everything
+/// else describes a specific failure mode that callers (and tests)
+/// can pattern-match on.
+enum class IsLogIndexResult : uint8_t {
+    Ok           = 0,
+    /// Magic absent at offset 0 — almost certainly a v1 `.idx`.
+    /// Callers can fall back to a legacy-aware reader.
+    LegacyFormat = 1,
+    /// Magic present but the version isn't v2 (e.g. v3+ written by a
+    /// future SDK).
+    Unsupported  = 2,
+    /// Header fields are impossible (e.g. `header_size` < 64).
+    Corrupted    = 3,
+    /// Underlying file write/read returned an unexpected count.
+    Io           = 4,
+    /// Fewer bytes available than required (header / record).
+    Truncated    = 5,
+};
+
+// ----- File identification --------------------------------------------------
+
+/// 4-byte ASCII magic at the start of every v2+ `.idx` file. v1 files
+/// have no magic — first 4 bytes are the start of the first record's
+/// `time` field (a `uint32_t`), so missing magic is the v1 signal.
+inline constexpr char IS_LOG_IDX_MAGIC[4] = { 'I', 'S', 'I', 'X' };
+
+/// Format version stored in the header. v2 = this format.
+inline constexpr uint16_t IS_LOG_IDX_VERSION_V2 = 2;
+
+// ----- Header / record sizes (also static_assert'd below) ------------------
+
+inline constexpr std::size_t IS_LOG_IDX_HEADER_SIZE = 64;
+inline constexpr std::size_t IS_LOG_IDX_RECORD_V2_SIZE = 24;
+
+// ----- Timestamp interpretation enums --------------------------------------
+
+/// What `is_log_idx_record_v2_t::timestamp` means in this file. Stored
+/// in the header so a v3 with nanosecond-precision logs (or some
+/// other unit) doesn't re-break the world.
+enum class TimestampUnits : uint8_t {
+    HostUptimeMs   = 0,  ///< Milliseconds since `m_logStartUpTime` on the writer host.
+    GpsTowMs       = 1,  ///< GPS time-of-week in ms (resets every Sunday 00:00:00 UTC).
+    UnixEpochMs    = 2,  ///< Milliseconds since 1970-01-01T00:00:00Z.
+    Mixed          = 3,  ///< Mixed across records — readers must check per-record `flags`.
+};
+
+/// The dominant `TimeSource` for records in this file (per-record
+/// flags bit 0 still tells you whether the individual record was a
+/// real ToW). Mirrors `inertial_sense::TimeSource` from D-06.
+enum class HeaderTimeSource : uint8_t {
+    PayloadToW       = 0,
+    ResolvedViaSync  = 1,
+    HostReceived     = 2,
+    SessionOnly      = 3,
+    Mixed            = 4,
+};
+
+// ----- Record flag bits ----------------------------------------------------
+
+/// Bit 0: this record's payload carried a real GPS time-of-week field
+/// (i.e. it can be used as a sync anchor by `ISTimeResolver`, D-07).
+inline constexpr uint16_t IS_LOG_IDX_REC_FLAG_HAS_TOW = 1u << 0;
+
+// ----- Header flag bits ----------------------------------------------------
+
+/// Bit 0: `total_records` / `first_timestamp_ms` / `last_timestamp_ms`
+/// were rewritten on close and are authoritative. If unset, the writer
+/// crashed or hasn't finalized yet — readers can scan records to
+/// reconstruct the totals.
+inline constexpr uint8_t IS_LOG_IDX_HDR_FLAG_FINALIZED = 1u << 0;
+
+// ----- Structs (logical, not on-disk) --------------------------------------
+//
+// These mirror the on-disk layout 1:1, but we never serialize them via
+// memcpy — `serialize*` / `parse*` below do explicit little-endian
+// byte writes / reads. The struct is just the logical container.
+
+#pragma pack(push, 1)
+
+/**
+ * @brief Fixed-size header at offset 0 of every v2 `.idx` file.
+ *
+ * 64 bytes total. `header_size` lets future v3+ readers ignore unknown
+ * trailing fields gracefully — a v2 reader stops at byte 64 and
+ * doesn't misinterpret v3 additions.
+ */
+struct is_log_idx_header_t {
+    char     magic[4];              ///<  0..3 : `"ISIX"`
+    uint16_t version;               ///<  4..5 : 2 = v2
+    uint16_t header_size;           ///<  6..7 : on-disk header size in bytes (= 64 for v2)
+    uint32_t producer_version;      ///<  8..11: ENCODE_VERSION-style value of the writing SDK
+    uint64_t total_records;         ///< 12..19: count of records following the header (0 if not finalized)
+    uint64_t first_timestamp_ms;    ///< 20..27: first record's `timestamp` (0 if unset)
+    uint64_t last_timestamp_ms;     ///< 28..35: last record's `timestamp`  (0 if unset)
+    uint32_t sync_point_count;      ///< 36..39: D-07 sync-event count tracked by writer (0 default)
+    uint8_t  ts_units;              ///< 40    : `TimestampUnits`
+    uint8_t  ts_source;             ///< 41    : `HeaderTimeSource`
+    uint8_t  flags;                 ///< 42    : `IS_LOG_IDX_HDR_FLAG_*`
+    uint8_t  reserved8;             ///< 43    : pad
+    uint8_t  reserved[20];          ///< 44..63: explicit pad to 64 bytes
+};
+
+/**
+ * @brief Per-record entry in the body of a v2 `.idx` file.
+ *
+ * 24 bytes total. v2 stores meaningful payload-derived timestamps and
+ * the actual DID, so `(did, ts_lo, ts_hi)` queries can binary-search
+ * the index without touching the `.raw` segment.
+ */
+struct is_log_idx_record_v2_t {
+    uint64_t timestamp;             ///<  0..7 : payload-derived ms (units per header `ts_units`)
+    uint64_t offset;                ///<  8..15: byte offset into the `.raw` segment
+    uint32_t did;                   ///< 16..19: data ID; 0 = no associated DID (raw stream)
+    uint16_t flags;                 ///< 20..21: `IS_LOG_IDX_REC_FLAG_*`
+    uint16_t reserved;              ///< 22..23: pad
+};
+
+#pragma pack(pop)
+
+static_assert(sizeof(is_log_idx_header_t) == IS_LOG_IDX_HEADER_SIZE,
+              "is_log_idx_header_t must be exactly 64 bytes — pack discipline.");
+static_assert(sizeof(is_log_idx_record_v2_t) == IS_LOG_IDX_RECORD_V2_SIZE,
+              "is_log_idx_record_v2_t must be exactly 24 bytes — pack discipline.");
+
+// ----- Pure serialize / parse helpers --------------------------------------
+//
+// These work on raw byte buffers and are the canonical primitives.
+// File-level wrappers below are thin and just call these. Tests
+// exercise these directly — no I/O needed for round-trip checks.
+
+/**
+ * @brief Serialize a header to a 64-byte little-endian buffer.
+ *
+ * Always writes exactly `IS_LOG_IDX_HEADER_SIZE` bytes; out buffer
+ * must be at least that large. The caller is responsible for sizing.
+ * Always succeeds — there's no failure mode at this layer.
+ */
+void serializeHeader(uint8_t out[IS_LOG_IDX_HEADER_SIZE],
+                     const is_log_idx_header_t& hdr) noexcept;
+
+/**
+ * @brief Parse a 64-byte little-endian buffer into a header.
+ *
+ * Returns `Ok` on success, with `out` populated. Otherwise:
+ * - `LegacyFormat` if the magic is absent (almost certainly v1).
+ * - `Unsupported` if magic is present but the version isn't v2.
+ * - `Corrupted` if `header_size` is impossible (< minimum).
+ *
+ * Callers pattern-match on the error code to fall back to a v1
+ * reader when `LegacyFormat` is reported. `out` is left unspecified
+ * on non-`Ok` returns.
+ */
+IsLogIndexResult parseHeader(const uint8_t in[IS_LOG_IDX_HEADER_SIZE],
+                              is_log_idx_header_t& out) noexcept;
+
+/**
+ * @brief Serialize a v2 record to a 24-byte little-endian buffer.
+ *
+ * Always writes exactly `IS_LOG_IDX_RECORD_V2_SIZE` bytes.
+ */
+void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_SIZE],
+                     const is_log_idx_record_v2_t& rec) noexcept;
+
+/**
+ * @brief Parse a 24-byte buffer into a v2 record.
+ *
+ * Pure layout decode — never fails. Caller is responsible for ensuring
+ * the buffer was produced by `serializeRecord` (or matches v2 layout).
+ */
+is_log_idx_record_v2_t parseRecord(
+    const uint8_t in[IS_LOG_IDX_RECORD_V2_SIZE]) noexcept;
+
+// ----- File-level wrappers (cISLogFileBase) --------------------------------
+
+/**
+ * @brief Write a header to an open `cISLogFileBase`.
+ * @return `Ok` on success, `Io` if the underlying write didn't consume
+ *         the full 64 bytes.
+ */
+IsLogIndexResult writeHeader(cISLogFileBase& file, const is_log_idx_header_t& hdr);
+
+/**
+ * @brief Append a single v2 record to an open `cISLogFileBase`.
+ * @return `Ok` on success, `Io` on short write.
+ */
+IsLogIndexResult writeRecord(cISLogFileBase& file, const is_log_idx_record_v2_t& rec);
+
+/**
+ * @brief Read and validate a header from an open `cISLogFileBase`.
+ *
+ * Reads exactly `IS_LOG_IDX_HEADER_SIZE` bytes from the file's current
+ * position, then defers to `parseHeader` for validation. Errors:
+ *
+ * - `Truncated` — file shorter than 64 bytes.
+ * - `LegacyFormat` — bytes parsed but magic absent (v1 file).
+ * - `Unsupported` — magic present but version isn't v2.
+ * - `Corrupted` — magic + version OK but `header_size` is impossible.
+ * - `Io` — underlying read returned an unexpected count.
+ */
+IsLogIndexResult readHeader(cISLogFileBase& file, is_log_idx_header_t& out);
+
+/**
+ * @brief Read a single v2 record from the current file position.
+ * @return `Truncated` if fewer than 24 bytes remained; `Io` on
+ *         underlying read error.
+ */
+IsLogIndexResult readRecord(cISLogFileBase& file, is_log_idx_record_v2_t& out);
+
+// ----- Convenience constructors --------------------------------------------
+
+/**
+ * @brief Build a header with sensible defaults for the `.idx` writer.
+ *
+ * `total_records`, `first_timestamp_ms`, `last_timestamp_ms`, and
+ * `sync_point_count` are all 0 — the writer fills them in when it
+ * finalizes the file via a seek(0) + rewrite-header dance. `flags`
+ * starts cleared; the writer sets `FINALIZED` only on clean close.
+ */
+is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,
+                                      TimestampUnits units,
+                                      HeaderTimeSource source) noexcept;
+
+} // namespace idx
+} // namespace inertial_sense

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -1,0 +1,695 @@
+// D-01 / SN-7879 smoke tests for the .idx v2 sidecar format.
+//
+// Coverage:
+//   * Round-trip — serialize a header + N records, parse them back,
+//     all fields match.
+//   * Legacy detection — synthetic v1 byte stream (no magic) must
+//     report IsLogIndexResult::LegacyFormat, not silently misparse.
+//   * Malformed — wrong magic / unsupported version / impossible
+//     header_size each return a distinct error code.
+//   * Layout discipline — sizeof / static asserts.
+//
+// File-level wrappers (cISLogFileBase) aren't exercised here; their
+// only job is to copy bytes to/from the underlying file, and the pure
+// serialize/parse layer that does the actual work is covered above.
+
+#include <gtest/gtest.h>
+
+// Include com_manager.h first so its include guard skips the broken
+// extern-C wrap inside ISFirmwareUpdater.h that DeviceLog.h transitively
+// pulls in (com_manager.h declares C++ overloads, which are illegal under
+// extern "C").
+#include "com_manager.h"
+#include "DeviceLog.h"
+#include "ISFileManager.h"
+#include "ISLogFile.h"
+#include "ISLogIndex.h"
+#include "ISLogger.h"
+#include "data_sets.h"
+#include "test_data_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using namespace inertial_sense;
+using namespace inertial_sense::idx;
+
+namespace {
+
+is_log_idx_header_t makeRoundTripHeader() {
+    auto h = makeDefaultHeader(0x02010000u,
+                               TimestampUnits::GpsTowMs,
+                               HeaderTimeSource::PayloadToW);
+    h.total_records       = 42;
+    h.first_timestamp_ms  = 100ULL;
+    h.last_timestamp_ms   = 99'999'999ULL;
+    h.sync_point_count    = 7;
+    h.flags               = IS_LOG_IDX_HDR_FLAG_FINALIZED;
+    return h;
+}
+
+} // namespace
+
+TEST(IdxLayout, StaticSizes) {
+    // The on-disk layout depends on these — mirrors the static_assert
+    // in the header but exercises it through gtest so we get a named
+    // failure if some future struct edit breaks the discipline.
+    EXPECT_EQ(sizeof(is_log_idx_header_t),    IS_LOG_IDX_HEADER_SIZE);
+    EXPECT_EQ(sizeof(is_log_idx_record_v2_t), IS_LOG_IDX_RECORD_V2_SIZE);
+    EXPECT_EQ(IS_LOG_IDX_HEADER_SIZE,    64u);
+    EXPECT_EQ(IS_LOG_IDX_RECORD_V2_SIZE, 24u);
+}
+
+TEST(IdxRoundTrip, HeaderSerializeAndParse) {
+    const auto src = makeRoundTripHeader();
+
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, src);
+
+    // Magic is in the first 4 bytes regardless of the rest.
+    EXPECT_EQ(buf[0], 'I');
+    EXPECT_EQ(buf[1], 'S');
+    EXPECT_EQ(buf[2], 'I');
+    EXPECT_EQ(buf[3], 'X');
+
+    is_log_idx_header_t parsed{};
+    ASSERT_EQ(parseHeader(buf, parsed), IsLogIndexResult::Ok)
+        << "parse failed";
+
+    EXPECT_EQ(parsed.version,             src.version);
+    EXPECT_EQ(parsed.header_size,         src.header_size);
+    EXPECT_EQ(parsed.producer_version,    src.producer_version);
+    EXPECT_EQ(parsed.total_records,       src.total_records);
+    EXPECT_EQ(parsed.first_timestamp_ms,  src.first_timestamp_ms);
+    EXPECT_EQ(parsed.last_timestamp_ms,   src.last_timestamp_ms);
+    EXPECT_EQ(parsed.sync_point_count,    src.sync_point_count);
+    EXPECT_EQ(parsed.ts_units,            src.ts_units);
+    EXPECT_EQ(parsed.ts_source,           src.ts_source);
+    EXPECT_EQ(parsed.flags,               src.flags);
+}
+
+TEST(IdxRoundTrip, RecordSerializeAndParse) {
+    const is_log_idx_record_v2_t src{
+        /* timestamp */ 1'234'567'890ULL,
+        /* offset    */ 0xDEADBEEFCAFEBABEULL,
+        /* did       */ 0x1234,
+        /* flags     */ IS_LOG_IDX_REC_FLAG_HAS_TOW,
+        /* reserved  */ 0,
+    };
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    serializeRecord(buf, src);
+
+    const auto parsed = parseRecord(buf);
+    EXPECT_EQ(parsed.timestamp, src.timestamp);
+    EXPECT_EQ(parsed.offset,    src.offset);
+    EXPECT_EQ(parsed.did,       src.did);
+    EXPECT_EQ(parsed.flags,     src.flags);
+}
+
+TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
+    // Simulates the actual writer: header followed by N records in a
+    // single contiguous buffer. The reader walks: parseHeader at
+    // offset 0, then parseRecord at offset 64, 64+24, 64+48, ....
+    constexpr std::size_t N = 10;
+    std::vector<uint8_t> buf(IS_LOG_IDX_HEADER_SIZE + N * IS_LOG_IDX_RECORD_V2_SIZE, 0);
+
+    auto hdr = makeRoundTripHeader();
+    hdr.total_records = N;
+    serializeHeader(buf.data(), hdr);
+
+    std::vector<is_log_idx_record_v2_t> sources;
+    sources.reserve(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        is_log_idx_record_v2_t r{};
+        r.timestamp = 1000ULL + i * 100;
+        r.offset    = static_cast<uint64_t>(i) * 4096ULL;
+        r.did       = 0x100u + static_cast<uint32_t>(i);
+        r.flags     = (i % 2 == 0) ? IS_LOG_IDX_REC_FLAG_HAS_TOW : 0;
+        r.reserved  = 0;
+        sources.push_back(r);
+        serializeRecord(buf.data() + IS_LOG_IDX_HEADER_SIZE + i * IS_LOG_IDX_RECORD_V2_SIZE, r);
+    }
+
+    is_log_idx_header_t parsedHdr{};
+    ASSERT_EQ(parseHeader(buf.data(), parsedHdr), IsLogIndexResult::Ok);
+    EXPECT_EQ(parsedHdr.total_records, N);
+
+    for (std::size_t i = 0; i < N; ++i) {
+        const auto p = parseRecord(
+            buf.data() + IS_LOG_IDX_HEADER_SIZE + i * IS_LOG_IDX_RECORD_V2_SIZE);
+        EXPECT_EQ(p.timestamp, sources[i].timestamp);
+        EXPECT_EQ(p.offset,    sources[i].offset);
+        EXPECT_EQ(p.did,       sources[i].did);
+        EXPECT_EQ(p.flags,     sources[i].flags);
+    }
+}
+
+TEST(IdxLegacyDetection, V1FileReturnsLegacyFormat) {
+    // A v1 .idx file starts with the first record's u32 `time`
+    // field (host uptime delta) — definitely not "ISIX". Use a
+    // representative byte pattern (0x12, 0x34, 0x56, 0x78 = 0x78563412
+    // host uptime) for the first 4 bytes, with arbitrary remaining
+    // bytes filling out 64.
+    uint8_t v1Buf[IS_LOG_IDX_HEADER_SIZE]{};
+    v1Buf[0] = 0x12;
+    v1Buf[1] = 0x34;
+    v1Buf[2] = 0x56;
+    v1Buf[3] = 0x78;
+    for (std::size_t i = 4; i < IS_LOG_IDX_HEADER_SIZE; ++i) {
+        v1Buf[i] = static_cast<uint8_t>(i);
+    }
+
+    is_log_idx_header_t hdr{};
+    EXPECT_EQ(parseHeader(v1Buf, hdr), IsLogIndexResult::LegacyFormat);
+}
+
+TEST(IdxMalformed, WrongMagicNonV1ByteSequence) {
+    // Non-"ISIX" magic gets reported as LegacyFormat (since v1 is the
+    // only recognized non-v2 format). Same code path as v1 detection.
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE]{};
+    buf[0] = 'X';  buf[1] = 'X';  buf[2] = 'X';  buf[3] = 'X';
+    is_log_idx_header_t hdr{};
+    EXPECT_EQ(parseHeader(buf, hdr), IsLogIndexResult::LegacyFormat);
+}
+
+TEST(IdxMalformed, UnsupportedVersionFromValidMagic) {
+    // Magic OK but version is something we don't know (e.g. 99 — a
+    // hypothetical v99 written by a far-future SDK). Should report
+    // Unsupported, distinct from LegacyFormat.
+    auto h = makeRoundTripHeader();
+    h.version = 99;
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, h);
+    is_log_idx_header_t hdr{};
+    EXPECT_EQ(parseHeader(buf, hdr), IsLogIndexResult::Unsupported);
+}
+
+TEST(IdxMalformed, ImpossibleHeaderSizeReportsCorrupted) {
+    // header_size < 64 means the writer crashed mid-format or the
+    // bytes were tampered with. v2 readers can't continue.
+    auto h = makeRoundTripHeader();
+    h.header_size = 32;  // < 64
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, h);
+    is_log_idx_header_t hdr{};
+    EXPECT_EQ(parseHeader(buf, hdr), IsLogIndexResult::Corrupted);
+}
+
+// ---------------------------------------------------------------------------
+// File-level I/O round-trips via cISLogFile.
+// These exercise the cISLogFileBase wrappers (writeHeader / writeRecord /
+// readHeader / readRecord) against a real on-disk file — the path the SDK
+// actually uses in production.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Returns a unique tmp path under /tmp. Deleted by the caller (or by
+// the OS on reboot — these are smoke tests, not crash-resilient).
+std::string makeTmpPath(const char* tag) {
+    char buf[256];
+    std::snprintf(buf, sizeof(buf), "/tmp/test_log_index_%s_%d_%ld.idx",
+                  tag, ::getpid(), static_cast<long>(::time(nullptr)));
+    return std::string{buf};
+}
+
+} // namespace
+
+TEST(IdxFileIO, HeaderAndRecordRoundTripViaCISLogFile) {
+    const auto path = makeTmpPath("hdrrec");
+    {
+        cISLogFile out(path, "wb");
+        ASSERT_TRUE(out.isOpened());
+
+        auto hdr = makeRoundTripHeader();
+        hdr.total_records = 3;
+        ASSERT_EQ(writeHeader(out, hdr), IsLogIndexResult::Ok);
+
+        is_log_idx_record_v2_t r1{ 1000, 0,    0xAAA, IS_LOG_IDX_REC_FLAG_HAS_TOW, 0 };
+        is_log_idx_record_v2_t r2{ 2000, 100,  0xBBB, 0,                            0 };
+        is_log_idx_record_v2_t r3{ 3000, 4096, 0xCCC, IS_LOG_IDX_REC_FLAG_HAS_TOW, 0 };
+        ASSERT_EQ(writeRecord(out, r1), IsLogIndexResult::Ok);
+        ASSERT_EQ(writeRecord(out, r2), IsLogIndexResult::Ok);
+        ASSERT_EQ(writeRecord(out, r3), IsLogIndexResult::Ok);
+    }
+
+    {
+        cISLogFile in(path, "rb");
+        ASSERT_TRUE(in.isOpened());
+        is_log_idx_header_t hdrR{};
+        ASSERT_EQ(readHeader(in, hdrR), IsLogIndexResult::Ok);
+        EXPECT_EQ(hdrR.version, IS_LOG_IDX_VERSION_V2);
+        EXPECT_EQ(hdrR.total_records, 3u);
+
+        is_log_idx_record_v2_t a{};
+        ASSERT_EQ(readRecord(in, a), IsLogIndexResult::Ok);
+        EXPECT_EQ(a.did, 0xAAAu);
+        EXPECT_EQ(a.flags, IS_LOG_IDX_REC_FLAG_HAS_TOW);
+
+        is_log_idx_record_v2_t b{};
+        ASSERT_EQ(readRecord(in, b), IsLogIndexResult::Ok);
+        EXPECT_EQ(b.did, 0xBBBu);
+        EXPECT_EQ(b.flags, 0u);
+
+        is_log_idx_record_v2_t c{};
+        ASSERT_EQ(readRecord(in, c), IsLogIndexResult::Ok);
+        EXPECT_EQ(c.did, 0xCCCu);
+        EXPECT_EQ(c.offset, 4096u);
+    }
+    std::remove(path.c_str());
+}
+
+TEST(IdxFileIO, TruncatedHeaderReturnsTruncated) {
+    const auto path = makeTmpPath("trunc");
+    // Write a file with only 32 bytes — half a header.
+    {
+        cISLogFile out(path, "wb");
+        ASSERT_TRUE(out.isOpened());
+        uint8_t halfBuf[32]{};
+        halfBuf[0] = 'I'; halfBuf[1] = 'S'; halfBuf[2] = 'I'; halfBuf[3] = 'X';
+        ASSERT_EQ(out.write(halfBuf, sizeof(halfBuf)), sizeof(halfBuf));
+    }
+
+    cISLogFile in(path, "rb");
+    ASSERT_TRUE(in.isOpened());
+    is_log_idx_header_t hdr{};
+    EXPECT_EQ(readHeader(in, hdr), IsLogIndexResult::Truncated);
+
+    std::remove(path.c_str());
+}
+
+TEST(IdxFileIO, TruncatedRecordReturnsTruncated) {
+    const auto path = makeTmpPath("rectrunc");
+    {
+        cISLogFile out(path, "wb");
+        ASSERT_TRUE(out.isOpened());
+        auto hdr = makeRoundTripHeader();
+        ASSERT_EQ(writeHeader(out, hdr), IsLogIndexResult::Ok);
+        // Write only 12 bytes of a 24-byte record.
+        uint8_t partial[12]{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        ASSERT_EQ(out.write(partial, sizeof(partial)), sizeof(partial));
+    }
+
+    cISLogFile in(path, "rb");
+    ASSERT_TRUE(in.isOpened());
+    is_log_idx_header_t hdr{};
+    ASSERT_EQ(readHeader(in, hdr), IsLogIndexResult::Ok);
+    is_log_idx_record_v2_t rec{};
+    EXPECT_EQ(readRecord(in, rec), IsLogIndexResult::Truncated);
+
+    std::remove(path.c_str());
+}
+
+TEST(IdxRecordRange, LargeOffsetRoundTrip) {
+    // v2 widened the offset field to uint64_t. Verify a value
+    // >4GB (i.e. wouldn't fit in v1's u32) round-trips cleanly.
+    constexpr uint64_t big_offset = 0x0000'0001'0000'0000ULL;  // 4 GiB exactly
+    is_log_idx_record_v2_t src{ 1234, big_offset, 100, 0, 0 };
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    serializeRecord(buf, src);
+    auto p = parseRecord(buf);
+    EXPECT_EQ(p.offset, big_offset);
+
+    constexpr uint64_t huge_offset = 0xFFFF'FFFF'FFFF'0000ULL;
+    src.offset = huge_offset;
+    serializeRecord(buf, src);
+    p = parseRecord(buf);
+    EXPECT_EQ(p.offset, huge_offset);
+}
+
+TEST(IdxFinalize, FinalizedFlagSemantics) {
+    // The FINALIZED flag is the writer's signal that total_records,
+    // first_timestamp_ms, and last_timestamp_ms are authoritative.
+    // Producing a header with the flag clear means the writer
+    // crashed or hasn't called finalizeIndex yet — readers can fall
+    // back to scanning records to reconstruct totals.
+    auto h = makeDefaultHeader(0, TimestampUnits::HostUptimeMs,
+                                  HeaderTimeSource::Mixed);
+    EXPECT_EQ(h.flags & IS_LOG_IDX_HDR_FLAG_FINALIZED, 0u)
+        << "default header must NOT have FINALIZED set — set it on close only";
+
+    h.flags = IS_LOG_IDX_HDR_FLAG_FINALIZED;
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, h);
+    is_log_idx_header_t p{};
+    ASSERT_EQ(parseHeader(buf, p), IsLogIndexResult::Ok);
+    EXPECT_EQ(p.flags & IS_LOG_IDX_HDR_FLAG_FINALIZED,
+              IS_LOG_IDX_HDR_FLAG_FINALIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Integration test: drive the actual cDeviceLog::addIndexRecord +
+// writeIndexChunk + finalizeIndex API end-to-end and verify the resulting
+// .idx file is a viable v2 sidecar readable by ISLogIndex helpers. This is
+// the "ISLogger generates a viable .idx alongside .raw" check Kyle asked
+// for in PR #1123 review.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Minimal cDeviceLog subclass for testing the index-emission machinery.
+// Stubs the pure virtuals so we can instantiate; exposes a helper that
+// sets m_fileName + m_writeMode without going through full
+// InitDeviceForWriting (we don't need a real .raw file for this test).
+class TestDeviceLog : public cDeviceLog {
+public:
+    p_data_buf_t* ReadData() override { return nullptr; }
+    void          SetSerialNumber(uint32_t serialNumber) override { m_devSerialNo = serialNumber; }
+    std::string   LogFileExtention() override { return ".raw"; }
+
+    void prepareForIndexEmissionTest(const std::string& baseFilename) {
+        m_fileName = baseFilename;
+        m_writeMode = true;
+        m_logStartUpTime = current_uptimeMs();
+    }
+};
+
+} // namespace
+
+TEST(IdxIntegration, EndToEndViaDeviceLogApi) {
+    TestDeviceLog log;
+    const auto basePath = makeTmpPath("e2e");
+    // Strip the .idx suffix the helper adds — addIndexRecord +
+    // writeIndexChunk both append ".idx" to m_fileName themselves.
+    const std::string baseNoExt = basePath.substr(0, basePath.size() - 4);
+    log.prepareForIndexEmissionTest(baseNoExt);
+
+    // Three synthetic records with distinct DIDs. cISDataMappings::Timestamp
+    // returns 0.0 for these (no payload-ToW field plumbed in a synthetic
+    // header), so the records take the host-uptime fallback with flags=0
+    // — exactly the expected behavior the writer documents.
+    auto makeHdr = [](uint32_t id, uint16_t size) {
+        p_data_hdr_t h{};
+        h.id = id;
+        h.size = size;
+        h.offset = 0;
+        return h;
+    };
+    uint8_t fakeBuf[64]{};
+
+    p_data_hdr_t h1 = makeHdr(DID_DEV_INFO,    sizeof(dev_info_t));
+    p_data_hdr_t h2 = makeHdr(DID_INS_1,       128);
+    p_data_hdr_t h3 = makeHdr(DID_GPS1_POS,    64);
+
+    log.addIndexRecord(&h1, fakeBuf);
+    log.addIndexRecord(&h2, fakeBuf);
+    log.addIndexRecord(&h3, fakeBuf);
+
+    ASSERT_TRUE(log.writeIndexChunk());
+    ASSERT_TRUE(log.finalizeIndex());
+
+    // Read the .idx file back via the same ISLogIndex helpers a
+    // consumer would use.
+    cISLogFile in(baseNoExt + ".idx", "rb");
+    ASSERT_TRUE(in.isOpened());
+
+    is_log_idx_header_t hdrR{};
+    ASSERT_EQ(readHeader(in, hdrR), IsLogIndexResult::Ok);
+    EXPECT_EQ(hdrR.version, IS_LOG_IDX_VERSION_V2);
+    EXPECT_EQ(hdrR.total_records, 3u);
+    EXPECT_NE(hdrR.flags & IS_LOG_IDX_HDR_FLAG_FINALIZED, 0u)
+        << "finalizeIndex must set the FINALIZED flag";
+    EXPECT_NE(hdrR.producer_version, 0u)
+        << "producer_version must be filled from PROTOCOL_VERSION_CHAR0..3";
+
+    is_log_idx_record_v2_t rec1{};
+    ASSERT_EQ(readRecord(in, rec1), IsLogIndexResult::Ok);
+    EXPECT_EQ(rec1.did, static_cast<uint32_t>(DID_DEV_INFO));
+
+    is_log_idx_record_v2_t rec2{};
+    ASSERT_EQ(readRecord(in, rec2), IsLogIndexResult::Ok);
+    EXPECT_EQ(rec2.did, static_cast<uint32_t>(DID_INS_1));
+
+    is_log_idx_record_v2_t rec3{};
+    ASSERT_EQ(readRecord(in, rec3), IsLogIndexResult::Ok);
+    EXPECT_EQ(rec3.did, static_cast<uint32_t>(DID_GPS1_POS));
+
+    std::remove((baseNoExt + ".idx").c_str());
+}
+
+TEST(IdxIntegration, FinalizeWithoutAnyRecordsIsIdempotent) {
+    // Opening + closing without writing any records shouldn't crash
+    // and shouldn't produce a stray .idx file.
+    TestDeviceLog log;
+    const auto basePath = makeTmpPath("noop");
+    const std::string baseNoExt = basePath.substr(0, basePath.size() - 4);
+    log.prepareForIndexEmissionTest(baseNoExt);
+
+    EXPECT_TRUE(log.finalizeIndex());  // no-op since no header written
+
+    // No .idx file should exist.
+    cISLogFile in(baseNoExt + ".idx", "rb");
+    EXPECT_FALSE(in.isOpened());
+}
+
+// ---------------------------------------------------------------------------
+// Full-stack end-to-end: drive cISLogger with simulated telemetry through
+// the actual production logging framework and verify the .idx sidecar that
+// lands alongside the .raw is internally consistent with what the reader
+// sees when re-parsing the .raw stream.
+//
+// This is the test Kyle requested on PR #1123: "before this can be merged,
+// we need to see it work in a real log — even if the log is created with
+// simulated data — so long as it uses the logging framework. Not just
+// timestamp and indexes, but the whole workflow."
+// ---------------------------------------------------------------------------
+TEST(IdxIntegration, ISLoggerEndToEndProducesViableIdx) {
+    using namespace std;
+
+    // Generate ~1MB of synthetic but real-shaped telemetry — same utility
+    // that test_ISLogger.cpp::logReader_raw uses, so we know the writer
+    // path through cISLogger has been exercised on this data shape.
+    list<vector<uint8_t>*> messages;
+    GenerateRawLogData(messages, 1.0f);
+    ASSERT_FALSE(messages.empty());
+
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf),
+                  "/tmp/test_log_idx_e2e_%d_%ld",
+                  ::getpid(), static_cast<long>(::time(nullptr)));
+    const string logPath = dirBuf;
+    ISFileManager::DeleteDirectory(logPath);
+
+    // -- Write phase: feed packets through cISLogger (the real framework).
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions options;
+        options.logType = cISLogger::LOGTYPE_RAW;
+        options.useSubFolderTimestamp = false;
+        ASSERT_TRUE(logger.InitSave(logPath, options));
+        auto devLogger = logger.registerDevice(
+            ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0), 12345u);
+        ASSERT_TRUE(devLogger != nullptr);
+        logger.EnableLogging(true);
+
+        for (auto* msg : messages) {
+            ASSERT_TRUE(logger.LogData(devLogger, msg->size(),
+                                       reinterpret_cast<const uint8_t*>(msg->data())));
+        }
+        logger.CloseAllFiles();
+    }
+
+    // -- Locate the .raw + .idx files the framework actually emitted.
+    vector<ISFileManager::file_info_t> rawFiles, idxFiles;
+    ISFileManager::GetAllFilesInDirectory(logPath, true, "\\.raw$", rawFiles);
+    ISFileManager::GetAllFilesInDirectory(logPath, true, "\\.idx$", idxFiles);
+    ASSERT_GE(rawFiles.size(), 1u) << "writer did not produce a .raw file";
+    ASSERT_EQ(idxFiles.size(), rawFiles.size())
+        << "every .raw segment should have a matching .idx sidecar";
+
+    // -- Read all index records out of every .idx file (in alphabetical
+    // segment order — same order the reader walks them).
+    std::sort(idxFiles.begin(), idxFiles.end(),
+              [](const ISFileManager::file_info_t& a,
+                 const ISFileManager::file_info_t& b) {
+                  return a.name < b.name;
+              });
+
+    vector<is_log_idx_record_v2_t> allIdxRecords;
+    for (const auto& idxInfo : idxFiles) {
+        cISLogFile in(idxInfo.name, "rb");
+        ASSERT_TRUE(in.isOpened()) << "could not open " << idxInfo.name;
+
+        is_log_idx_header_t hdrR{};
+        ASSERT_EQ(readHeader(in, hdrR), IsLogIndexResult::Ok)
+            << idxInfo.name;
+        EXPECT_EQ(hdrR.version, IS_LOG_IDX_VERSION_V2)
+            << idxInfo.name << ": framework must emit v2 sidecar";
+        EXPECT_NE(hdrR.flags & IS_LOG_IDX_HDR_FLAG_FINALIZED, 0u)
+            << idxInfo.name << ": clean shutdown via CloseAllFiles must "
+                                "set FINALIZED";
+        EXPECT_NE(hdrR.producer_version, 0u)
+            << idxInfo.name << ": producer_version must be filled in";
+        EXPECT_GT(hdrR.total_records, 0u)
+            << idxInfo.name << ": some ISB packets should have been indexed";
+
+        for (uint32_t i = 0; i < hdrR.total_records; ++i) {
+            is_log_idx_record_v2_t recR{};
+            ASSERT_EQ(readRecord(in, recR), IsLogIndexResult::Ok)
+                << idxInfo.name << " record " << i;
+            allIdxRecords.push_back(recR);
+        }
+    }
+    ASSERT_FALSE(allIdxRecords.empty());
+
+    // -- Walk the .raw stream back through the same cISLogger reader path
+    // a consumer would use, collect every ISB packet's DID in order.
+    // Bound the iteration by the number of source messages — at most one
+    // packet per message — to mirror the model in test_ISLogger.cpp's
+    // logReader_raw, which doesn't rely on ReadNextPacket returning null
+    // at EOF (the reader holds onto a static buffer past stream-end).
+    cISLogger reader;
+    ASSERT_TRUE(reader.LoadFromDirectory(logPath, cISLogger::LOGTYPE_RAW));
+    reader.ShowParseErrors(true);
+
+    vector<uint16_t> readerIsbDids;
+    size_t deviceIndex = 0;
+    for (size_t k = 0; k < messages.size(); ++k) {
+        protocol_type_t pt = _PTYPE_NONE;
+        packet_t* pkt = reader.ReadNextPacket(pt, deviceIndex);
+        if (pkt == nullptr) break;
+        if (pt == _PTYPE_INERTIAL_SENSE_DATA || pt == _PTYPE_INERTIAL_SENSE_CMD) {
+            readerIsbDids.push_back(pkt->dataHdr.id);
+        }
+    }
+    reader.CloseAllFiles();
+
+    // -- The .idx must mirror the ISB packets the reader sees in count + order.
+    // This is the "the whole workflow" check: the writer's per-packet
+    // addIndexRecord (DeviceLogRaw.cpp parser-loop fix) and the reader's
+    // ISB-packet stream agree byte-for-byte on what got logged.
+    ASSERT_EQ(allIdxRecords.size(), readerIsbDids.size())
+        << ".idx record count must equal the number of ISB packets the "
+           "reader extracts from the .raw";
+    for (size_t i = 0; i < allIdxRecords.size(); ++i) {
+        EXPECT_EQ(allIdxRecords[i].did,
+                  static_cast<uint32_t>(readerIsbDids[i]))
+            << "DID mismatch at index record " << i;
+    }
+
+    // -- Sanity: at least one record carries a payload-ToW timestamp
+    // (HAS_TOW flag set). GenerateRawLogData produces DID_INS_2 / GPS
+    // messages with real GPS-ToW fields, which the writer's payload-ToW
+    // path is supposed to capture.
+    bool sawTowFlag = false;
+    for (const auto& r : allIdxRecords) {
+        if (r.flags & IS_LOG_IDX_REC_FLAG_HAS_TOW) { sawTowFlag = true; break; }
+    }
+    EXPECT_TRUE(sawTowFlag)
+        << "expected at least one indexed record to carry a payload-ToW "
+           "timestamp from a GPS/INS DID";
+
+    // -- One-line summary of what the framework actually produced.
+    std::printf("[idx-e2e] %zu source msgs -> %zu .raw seg(s), %zu .idx record(s), "
+                "%zu reader-ISB packets matched, sawTowFlag=%d\n",
+                messages.size(), rawFiles.size(), allIdxRecords.size(),
+                readerIsbDids.size(), sawTowFlag ? 1 : 0);
+
+    // -- Cleanup
+    for (auto* msg : messages) delete msg;
+    ISFileManager::DeleteDirectory(logPath);
+}
+
+TEST(IdxLittleEndian, ByteOrderIsExplicit) {
+    // Sanity: a known value at a known field should produce the
+    // expected little-endian bytes regardless of host endianness.
+    is_log_idx_header_t h{};
+    h.magic[0] = 'I'; h.magic[1] = 'S'; h.magic[2] = 'I'; h.magic[3] = 'X';
+    h.version             = 0x0201;  // bytes 4..5 should read 01 02
+    h.header_size         = IS_LOG_IDX_HEADER_SIZE;
+    h.producer_version    = 0xCAFEBABEu;  // bytes 8..11 should read BE BA FE CA
+    uint8_t buf[IS_LOG_IDX_HEADER_SIZE];
+    serializeHeader(buf, h);
+    EXPECT_EQ(buf[4], 0x01);
+    EXPECT_EQ(buf[5], 0x02);
+    EXPECT_EQ(buf[8],  0xBE);
+    EXPECT_EQ(buf[9],  0xBA);
+    EXPECT_EQ(buf[10], 0xFE);
+    EXPECT_EQ(buf[11], 0xCA);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-segment regression: when the .raw exceeds maxFileSize the framework
+// rotates to a new segment. Each segment must get its own valid .idx sidecar
+// — its own header, its own per-segment record count, and intact records
+// (the prior bug was that segment N+1 inherited segment N's m_idxHeaderWritten
+// flag and m_idxTotalRecords counter, so the second segment's writeIndexChunk
+// skipped the header write, and finalizeIndex later overwrote the first ~3
+// records with a [stale-totaled] header at offset 0).
+// ---------------------------------------------------------------------------
+TEST(IdxIntegration, ISLoggerMultiSegmentRotationProducesValidIdxPerSegment) {
+    using namespace std;
+
+    list<vector<uint8_t>*> messages;
+    GenerateRawLogData(messages, 8.0f);  // ~8 MB ⇒ 2+ default-size segments
+    ASSERT_FALSE(messages.empty());
+
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf),
+                  "/tmp/test_log_idx_multiseg_%d_%ld",
+                  ::getpid(), static_cast<long>(::time(nullptr)));
+    const string logPath = dirBuf;
+    ISFileManager::DeleteDirectory(logPath);
+
+    {
+        cISLogger logger;
+        cISLogger::sSaveOptions options;
+        options.logType = cISLogger::LOGTYPE_RAW;
+        options.useSubFolderTimestamp = false;
+        // Force segment rotation by setting a small max file size.
+        options.maxFileSize = 2u * 1024u * 1024u;  // 2 MB per segment
+        ASSERT_TRUE(logger.InitSave(logPath, options));
+        auto devLogger = logger.registerDevice(
+            ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0), 12345u);
+        logger.EnableLogging(true);
+        for (auto* msg : messages) {
+            ASSERT_TRUE(logger.LogData(devLogger, msg->size(),
+                                       reinterpret_cast<const uint8_t*>(msg->data())));
+        }
+        logger.CloseAllFiles();
+    }
+
+    vector<ISFileManager::file_info_t> rawFiles, idxFiles;
+    ISFileManager::GetAllFilesInDirectory(logPath, true, "\\.raw$", rawFiles);
+    ISFileManager::GetAllFilesInDirectory(logPath, true, "\\.idx$", idxFiles);
+    ASSERT_GE(rawFiles.size(), 2u)
+        << "8 MB at 2 MB/segment should rotate to multiple segments";
+    ASSERT_EQ(idxFiles.size(), rawFiles.size())
+        << "every .raw segment needs its own .idx sidecar";
+
+    // Each .idx must independently parse as a valid v2 file: header
+    // present, FINALIZED, total_records consistent with on-disk size,
+    // and every record reads back without short-read.
+    for (const auto& f : idxFiles) {
+        cISLogFile in(f.name, "rb");
+        ASSERT_TRUE(in.isOpened()) << f.name;
+        is_log_idx_header_t hdrR{};
+        ASSERT_EQ(readHeader(in, hdrR), IsLogIndexResult::Ok) << f.name;
+        EXPECT_EQ(hdrR.version, IS_LOG_IDX_VERSION_V2) << f.name;
+        EXPECT_NE(hdrR.flags & IS_LOG_IDX_HDR_FLAG_FINALIZED, 0u)
+            << f.name << ": each segment must be finalized";
+
+        const size_t expectedFromSize =
+            (f.size - IS_LOG_IDX_HEADER_SIZE) / IS_LOG_IDX_RECORD_V2_SIZE;
+        EXPECT_EQ(hdrR.total_records, expectedFromSize)
+            << f.name << ": header total_records must match on-disk record count "
+                         "(= file_size - header) / record_size";
+
+        for (uint32_t i = 0; i < hdrR.total_records; ++i) {
+            is_log_idx_record_v2_t rec{};
+            ASSERT_EQ(readRecord(in, rec), IsLogIndexResult::Ok)
+                << f.name << " record " << i << "/" << hdrR.total_records;
+        }
+    }
+
+    for (auto* msg : messages) delete msg;
+    ISFileManager::DeleteDirectory(logPath);
+}
+

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -34,9 +34,16 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#ifdef _WIN32
+    #include <process.h>
+    #define getpid _getpid
+#else
+    #include <unistd.h>
+#endif
 
 using namespace inertial_sense;
 using namespace inertial_sense::idx;
@@ -211,13 +218,15 @@ TEST(IdxMalformed, ImpossibleHeaderSizeReportsCorrupted) {
 
 namespace {
 
-// Returns a unique tmp path under /tmp. Deleted by the caller (or by
-// the OS on reboot — these are smoke tests, not crash-resilient).
+// Returns a unique tmp path under the platform temp dir. Deleted by
+// the caller (or by the OS — these are smoke tests, not
+// crash-resilient).
 std::string makeTmpPath(const char* tag) {
-    char buf[256];
-    std::snprintf(buf, sizeof(buf), "/tmp/test_log_index_%s_%d_%ld.idx",
+    char buf[128];
+    std::snprintf(buf, sizeof(buf), "test_log_index_%s_%d_%ld.idx",
                   tag, ::getpid(), static_cast<long>(::time(nullptr)));
-    return std::string{buf};
+    const auto p = std::filesystem::temp_directory_path() / buf;
+    return p.string();
 }
 
 } // namespace
@@ -470,11 +479,12 @@ TEST(IdxIntegration, ISLoggerEndToEndProducesViableIdx) {
     GenerateRawLogData(messages, 1.0f);
     ASSERT_FALSE(messages.empty());
 
-    char dirBuf[256];
+    char dirBuf[128];
     std::snprintf(dirBuf, sizeof(dirBuf),
-                  "/tmp/test_log_idx_e2e_%d_%ld",
+                  "test_log_idx_e2e_%d_%ld",
                   ::getpid(), static_cast<long>(::time(nullptr)));
-    const string logPath = dirBuf;
+    const string logPath =
+        (std::filesystem::temp_directory_path() / dirBuf).string();
     ISFileManager::DeleteDirectory(logPath);
 
     // -- Write phase: feed packets through cISLogger (the real framework).
@@ -631,11 +641,12 @@ TEST(IdxIntegration, ISLoggerMultiSegmentRotationProducesValidIdxPerSegment) {
     GenerateRawLogData(messages, 8.0f);  // ~8 MB ⇒ 2+ default-size segments
     ASSERT_FALSE(messages.empty());
 
-    char dirBuf[256];
+    char dirBuf[128];
     std::snprintf(dirBuf, sizeof(dirBuf),
-                  "/tmp/test_log_idx_multiseg_%d_%ld",
+                  "test_log_idx_multiseg_%d_%ld",
                   ::getpid(), static_cast<long>(::time(nullptr)));
-    const string logPath = dirBuf;
+    const string logPath =
+        (std::filesystem::temp_directory_path() / dirBuf).string();
     ISFileManager::DeleteDirectory(logPath);
 
     {


### PR DESCRIPTION
## Motivation

The `.idx` sidecar predates the SDK 3.0 era. Its v1 layout stored only host-time + a record-counter (16 bytes per record) — not enough information for consumers to answer per-DID time-range queries against the index alone; every query had to fall through to the `.raw` segment.

The v2 layout carries the actual DID and a payload-derived timestamp per record, so consumers can binary-search the index for `(did, ts_lo, ts_hi)` without touching `.raw`.

3.0 is a major-version release with breaking changes already on the table, and there are currently no in-tree consumers of v1 `.idx` files — so swapping the writer to v2 here is a forward-looking change with no compatibility cost. Every `.idx` file produced by 3.0 is the v2 layout.

## What this PR adds

### `src/ISLogIndex.{h,cpp}` — the format

- **64-byte `is_log_idx_header_t`**: magic `"ISIX"`, version (= 2), on-disk header size, producer SDK version, total records, first/last timestamp ms, sync-point count, `TimestampUnits` enum, `HeaderTimeSource` enum, finalization flag. Reserved padding for forward-compatible v3+ growth.
- **24-byte `is_log_idx_record_v2_t`**: payload-derived timestamp, byte offset into `.raw`, DID, flag bits.
- **Pure serialize / parse helpers** (`serializeHeader`/`parseHeader`/`serializeRecord`/`parseRecord`) — explicit little-endian byte writes/reads, never `memcpy` a struct to disk (so the format is correct on BE embedded targets).
- **File-level `cISLogFileBase` wrappers**: `writeHeader`, `writeRecord`, `readHeader`, `readRecord`.
- **`IsLogIndexResult` status enum**: `Ok`, `LegacyFormat`, `Unsupported`, `Corrupted`, `Io`, `Truncated`. Self-contained inside `inertial_sense::idx`; no external dependencies.

### `src/DeviceLog.{cpp,h}` — writer integration

- `addIndexRecord(timestamp, offset, did, flags)` queues a record for the current segment.
- `writeIndexChunk()` flushes queued records to disk; lazily writes the header on first call.
- `finalizeIndex()` rewrites the header on close with authoritative totals (`total_records`, `first_timestamp_ms`, `last_timestamp_ms`) and sets `IS_LOG_IDX_HDR_FLAG_FINALIZED`. Idempotent.
- Writer state on `cDeviceLog`: header-written flag, queued-chunks vector, running record count, first/last timestamps.

### `src/DeviceLogRaw.cpp` — per-packet emission

- `WriteData` adds an index record per ISB packet via the `cDeviceLog` hooks above. Captures the byte offset at write time, plus the payload's DID and ToW flag (when present).

### `tests/test_log_index.cpp` — coverage

GTest suite covering:

- Pure serialize/parse round-trip for header and records (every field).
- Multi-record contiguous-buffer round-trip.
- Legacy v1 detection (no magic) → `IsLogIndexResult::LegacyFormat`.
- Wrong magic / unsupported version / impossible `header_size` → each maps to a distinct error code.
- `cISLogFile` round-trip (header + 3 records, fields verified on read).
- Truncated header / record → `IsLogIndexResult::Truncated`.
- `cDeviceLog` integration: `addIndexRecord` + `writeIndexChunk` + `finalizeIndex` produce a viable v2 file readable via the `ISLogIndex` helpers.
- Full-stack end-to-end via `cISLogger` with simulated telemetry: every `.raw` segment gets its own `.idx` sidecar; each is finalized; `total_records` matches `(file_size - header) / record_size` exactly.

## Format versioning discipline

Once v2 ships, its on-disk layout is immutable. Any future change becomes v3 with its own version number; v2 readers stay correct on v2 files forever. The reserved trailing bytes in `is_log_idx_header_t` allow forward-compatible v3+ growth without breaking v2 parsing.

## Endianness

All multi-byte fields go through explicit shift-and-mask serialize/parse helpers — never struct memcpy. Compiles to single instructions on LE hosts and stays correct on BE.