### PR TITLE
SN-8005: sibling-aware truncation warning — quiet routine mid-rotation tails

### DIFF
--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <sstream>
 #include <system_error>
 
@@ -43,6 +44,44 @@ namespace inertial_sense {
 namespace fs = std::filesystem;
 
 const std::vector<std::size_t> ISLogReader::kEmptyIndices_ = {};
+
+namespace {
+
+/**
+ * @brief Whether a sibling segment (next sequence number) exists alongside this .raw.
+ *
+ * The cISLogger convention is `<prefix>_NNNN.raw` where NNNN is a zero-padded sequence counter (typically 4 digits but
+ * the width is taken from whatever is on disk). This helper detects whether the next-sequence file exists in the same
+ * directory. Used to discriminate normal mid-rotation truncation (a sibling exists; the trailing partial packet
+ * continues into the successor segment) from a genuinely-truncated terminal segment (no successor; logger crashed,
+ * disk full, file copied mid-write, etc.).
+ *
+ * @param rawPath Path to a `.raw` segment file.
+ * @return `true` if a sibling at `<prefix>_(NNNN+1).raw` exists in the same directory; `false` otherwise (no trailing
+ *         segment number, parse failure, or file simply not present).
+ * @note SN-8005.
+ */
+bool hasSiblingSuccessor(const fs::path& rawPath) noexcept {
+    std::error_code ec;
+    const std::string stem = rawPath.stem().string();
+    const auto und = stem.find_last_of('_');
+    if (und == std::string::npos) return false;
+    const std::string seqStr = stem.substr(und + 1);
+    if (seqStr.empty()) return false;
+    if (seqStr.find_first_not_of("0123456789") != std::string::npos) return false;
+
+    int seq = 0;
+    try { seq = std::stoi(seqStr); } catch (...) { return false; }
+
+    // Preserve the original zero-padding width — `_0001` -> `_0002`, not `_2`.
+    std::ostringstream nextSeq;
+    nextSeq << std::setw(static_cast<int>(seqStr.size())) << std::setfill('0') << (seq + 1);
+    const fs::path sibling =
+        rawPath.parent_path() / (stem.substr(0, und + 1) + nextSeq.str() + rawPath.extension().string());
+    return fs::exists(sibling, ec);
+}
+
+} // namespace
 
 // ============================================================
 // ISFileSource — mmap with buffered fallback.
@@ -465,12 +504,29 @@ void ISLogReader::buildIndexFromScan() {
 
     // After the scan, any bytes the parser consumed-but-didn't-emit since lastEmitEnd are an incomplete trailing packet
     // — the truncation signal.
+    //
+    // SN-8005: discriminate normal mid-rotation truncation (segment N ends mid-packet, segment N+1 begins with the
+    // continuation) from genuine truncation (last segment cut by logger crash / disk full). Sibling-exists path emits
+    // log_info because the data is intact in the next segment; no-sibling path keeps log_warn because the tail loss
+    // is real.
     if (lastEmitEnd < total) {
         isTruncated_      = true;
         truncationOffset_ = static_cast<uint64_t>(lastEmitEnd);
-        warnings_.push_back("truncation: stopped at offset " + std::to_string(lastEmitEnd) + " (file size " + std::to_string(total) + ")");
-        log_warn(IS_LOG_ISLOG, "%s: truncated, stopped at offset %zu (file size %zu)",
-                 rawPath_.filename().c_str(), static_cast<std::size_t>(lastEmitEnd), static_cast<std::size_t>(total));
+        const std::size_t trailingBytes = total - lastEmitEnd;
+        if (hasSiblingSuccessor(rawPath_)) {
+            warnings_.push_back("trailing partial packet at end of segment (" + std::to_string(trailingBytes)
+                                + " bytes); continues in next segment");
+            log_info(IS_LOG_ISLOG,
+                     "%s: trailing partial packet (%zu bytes) at offset %zu (file size %zu); data continues in successor segment",
+                     rawPath_.filename().c_str(), trailingBytes,
+                     static_cast<std::size_t>(lastEmitEnd), static_cast<std::size_t>(total));
+        } else {
+            warnings_.push_back("truncation: stopped at offset " + std::to_string(lastEmitEnd)
+                                + " (file size " + std::to_string(total) + ")");
+            log_warn(IS_LOG_ISLOG, "%s: truncated, stopped at offset %zu (file size %zu)",
+                     rawPath_.filename().c_str(), static_cast<std::size_t>(lastEmitEnd),
+                     static_cast<std::size_t>(total));
+        }
     } else {
         truncationOffset_ = total;
     }

--- a/tests/test_log_reader.cpp
+++ b/tests/test_log_reader.cpp
@@ -36,9 +36,11 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iterator>
 #include <list>
 #include <set>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -438,6 +440,84 @@ TEST_F(LogReaderTest, GpsRawTimestampDoesNotTriggerPoisonRebuild) {
     EXPECT_TRUE(reader->hadOnDiskIndex())
         << "Poison sweep falsely flagged the .idx as stale despite the >1e12 timestamp belonging to a GPS_RAW record "
            "(Unix-epoch-ms via gtime_t is the documented behavior of cISDataMappings::Timestamp for those DIDs).";
+}
+
+// ============================================================
+// SN-8005 — sibling-aware truncation: mid-rotation tails (next-segment file
+// exists alongside) get demoted to log_info because the data is intact in
+// the successor segment. Terminal-segment truncation (no successor) stays
+// log_warn because the tail loss is real.
+// ============================================================
+
+TEST_F(LogReaderTest, TruncationWithSiblingEmitsTrailingPartialMessage) {
+    // Append 64 bytes of garbage to the .raw so the parser detects an incomplete trailing packet.
+    {
+        std::ofstream out(f_.rawFile, std::ios::binary | std::ios::app);
+        std::vector<char> garbage(64, '\xAA');
+        out.write(garbage.data(), garbage.size());
+    }
+    // Wipe the persisted .idx so openSegment hits the rebuild path that emits the truncation log line.
+    std::error_code ec;
+    fs::remove(f_.idxFile, ec);
+
+    // Create a sibling _0002.raw next to the _0001.raw the fixture produced. We don't need it to be a valid log — we
+    // just need its filesystem presence for the sibling check.
+    const std::string stem = f_.rawFile.stem().string();
+    const auto und = stem.find_last_of('_');
+    ASSERT_NE(und, std::string::npos);
+    const std::string seqStr = stem.substr(und + 1);
+    int seq = std::stoi(seqStr);
+    std::ostringstream nextSeq;
+    nextSeq << std::setw(static_cast<int>(seqStr.size())) << std::setfill('0') << (seq + 1);
+    const fs::path siblingRaw =
+        f_.rawFile.parent_path() / (stem.substr(0, und + 1) + nextSeq.str() + f_.rawFile.extension().string());
+    {
+        std::ofstream siblingOut(siblingRaw, std::ios::binary | std::ios::trunc);
+        siblingOut << "placeholder";   // any content; only existence matters
+    }
+
+    auto r = ISLogReader::openSegment(f_.rawFile);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    EXPECT_TRUE(r->isTruncated());
+
+    bool sawTrailingPartial = false;
+    bool sawTruncatedStopped = false;
+    for (const auto& w : r->warnings()) {
+        if (w.find("trailing partial packet") != std::string::npos) sawTrailingPartial = true;
+        if (w.find("truncation: stopped") != std::string::npos)     sawTruncatedStopped = true;
+    }
+    EXPECT_TRUE(sawTrailingPartial)
+        << "Expected 'trailing partial packet' (mid-rotation, info-level) warning when a sibling segment exists.";
+    EXPECT_FALSE(sawTruncatedStopped)
+        << "Did NOT expect the warn-level 'truncation: stopped' message when a sibling segment exists.";
+
+    fs::remove(siblingRaw, ec);
+}
+
+TEST_F(LogReaderTest, TruncationWithoutSiblingEmitsWarnMessage) {
+    // Same setup as above but without the sibling — this segment is terminal; truncation here means real tail loss.
+    {
+        std::ofstream out(f_.rawFile, std::ios::binary | std::ios::app);
+        std::vector<char> garbage(64, '\xAA');
+        out.write(garbage.data(), garbage.size());
+    }
+    std::error_code ec;
+    fs::remove(f_.idxFile, ec);
+
+    auto r = ISLogReader::openSegment(f_.rawFile);
+    ASSERT_TRUE(r.has_value()) << r.error().message;
+    EXPECT_TRUE(r->isTruncated());
+
+    bool sawTrailingPartial = false;
+    bool sawTruncatedStopped = false;
+    for (const auto& w : r->warnings()) {
+        if (w.find("trailing partial packet") != std::string::npos) sawTrailingPartial = true;
+        if (w.find("truncation: stopped") != std::string::npos)     sawTruncatedStopped = true;
+    }
+    EXPECT_TRUE(sawTruncatedStopped)
+        << "Expected the warn-level 'truncation: stopped' message for a terminal segment with no successor.";
+    EXPECT_FALSE(sawTrailingPartial)
+        << "Did NOT expect the info-level 'trailing partial packet' message when no sibling segment exists.";
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem
Multi-segment continuous logging routinely splits the final packet of segment N across the N → N+1 rotation boundary. The pre-fix \`buildIndexFromScan\` emitted \`log_warn\` on every such tail, producing 5+ scary-looking warnings per routine multi-segment load (Kyle's 9-segment \`rtk-slow-fix\` reload was one such trigger). That dilutes the signal when truncation is actually meaningful — e.g. logger crashed, disk full, file copied mid-write.

## Fix
Detect whether \`<prefix>_(NNNN+1).raw\` exists alongside the current \`<prefix>_NNNN.raw\` segment. Sibling exists → demote to \`log_info\` (data is intact in the next segment); no sibling → keep \`log_warn\` (terminal segment, tail loss is real).

The sibling detector preserves the original zero-padding width (\`_0001\` → \`_0002\`) and rejects non-numeric suffixes / parse failures cleanly so non-rotating-logger naming patterns don't get false sibling hits.

## Tests
Two new cases in \`test_log_reader.cpp\`:
- \`TruncationWithSiblingEmitsTrailingPartialMessage\` — append 64 bytes to the fixture .raw, drop the .idx (so the scan path runs), create an empty \`_0002.raw\` next to \`_0001.raw\`, assert warnings contain "trailing partial packet" and NOT "truncation: stopped".
- \`TruncationWithoutSiblingEmitsWarnMessage\` — same setup minus the sibling, assert the reverse.

## Companion PR coming up
This is SN-8005 standalone. The Logalyzer-side submodule bump that picks up this fix will land folded into the **D-111 / SN-7996** Logalyzer PR (background log loading + FD limit fix) per the no-stacking convention — not as its own dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)