### PR TITLE
SN-7996 (D-111) Phase B: close .raw/.idx FDs after mmap

### DIFF
--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -207,22 +207,27 @@ ISExpected<std::unique_ptr<ISFileSource>> ISFileSource::open(const fs::path& pat
         }
         return fail(ISErrorCode::Io, "ISFileSource::open: CreateFileW failed: " + path.string());
     }
-    out->fileHandle_ = h;
 
     HANDLE mapping = CreateFileMappingW(h, nullptr, PAGE_READONLY, 0, 0, nullptr);
     if (mapping) {
         void* base = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
         if (base) {
-            out->mappingHandle_ = mapping;
             out->mmapBase_      = base;
             out->mmapLen_       = out->size_;
             out->mmapped_       = true;
             out->data_          = static_cast<const uint8_t*>(base);
+            // SN-7996 Phase B: the view persists until UnmapViewOfFile regardless of the mapping + file
+            // handles' lifetimes (per Win32 docs). Close both immediately so a 100-segment log doesn't hold
+            // 200 handles open in parallel. fileHandle_ / mappingHandle_ stay null; releaseMapping no-ops
+            // the CloseHandle steps.
+            CloseHandle(mapping);
+            CloseHandle(h);
             return out;
         }
         CloseHandle(mapping);
     }
-    // mmap failed — fall through to buffered read.
+    // mmap failed — keep the file handle for the buffered-read fallback, then close after read completes.
+    out->fileHandle_ = h;
 #else
     int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
     if (fd < 0) {
@@ -231,7 +236,6 @@ ISExpected<std::unique_ptr<ISFileSource>> ISFileSource::open(const fs::path& pat
         }
         return fail(ISErrorCode::Io, "ISFileSource::open: open() failed: " + path.string() + " (" + std::strerror(errno) + ")");
     }
-    out->fd_ = fd;
 
     void* base = ::mmap(nullptr, out->size_, PROT_READ, MAP_PRIVATE, fd, 0);
     if (base != MAP_FAILED) {
@@ -239,14 +243,33 @@ ISExpected<std::unique_ptr<ISFileSource>> ISFileSource::open(const fs::path& pat
         out->mmapLen_  = out->size_;
         out->mmapped_  = true;
         out->data_     = static_cast<const uint8_t*>(base);
+        // SN-7996 Phase B: POSIX explicitly permits closing the fd immediately after mmap (man mmap: "After
+        // the mmap() call has returned, the file descriptor, fd, can be closed immediately without
+        // invalidating the mapping."). Close it now so a 100-segment log doesn't hold 200 FDs open in parallel
+        // and trip the default 1024 ulimit. fd_ stays -1; releaseMapping no-ops the ::close step.
+        ::close(fd);
         return out;
     }
-    // mmap failed (e.g. tmpfs-on-some-kernels, network FS) — fall through.
+    // mmap failed (e.g. tmpfs-on-some-kernels, network FS) — keep the FD only long enough for the buffered
+    // fallback below.
+    out->fd_ = fd;
 #endif
 
     // Buffered fallback: read the whole file into a heap-allocated buffer. v1 segments are < 16 MB by D-01's writer cap
     // so this is fine; if 32-bit machines hit large-segment cases later, that's a future story (per D-02 spec note on
-    // 2 GB).
+    // 2 GB). The OS-level FD/handle from the failed mmap attempt is closed before the std::ifstream open so we don't
+    // briefly hold two FDs against the same file (SN-7996 Phase B).
+#if defined(_WIN32)
+    if (out->fileHandle_) {
+        CloseHandle(static_cast<HANDLE>(out->fileHandle_));
+        out->fileHandle_ = nullptr;
+    }
+#else
+    if (out->fd_ >= 0) {
+        ::close(out->fd_);
+        out->fd_ = -1;
+    }
+#endif
     auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[out->size_]);
     std::ifstream in(path, std::ios::binary);
     if (!in) {

--- a/tests/test_log_reader.cpp
+++ b/tests/test_log_reader.cpp
@@ -521,6 +521,63 @@ TEST_F(LogReaderTest, TruncationWithoutSiblingEmitsWarnMessage) {
 }
 
 // ============================================================
+// SN-7996 Phase B — close-after-mmap leaves the process FD-budget alone
+// ============================================================
+
+#if !defined(_WIN32)
+TEST_F(LogReaderTest, OpeningManySegmentsDoesNotAccumulateFds) {
+    // Open the fixture's .raw 64 times. With the pre-Phase-B behavior we'd hold ~128 FDs (one .raw + one .idx
+    // per reader); with the close-after-mmap fix, the mmap'd pages keep `bytes()` valid while the FDs are
+    // released back to the OS immediately. The test asserts the post-open FD count grows by a small constant
+    // (allowing noise from the test harness — gtest output streams, /tmp temp files from concurrent tests on
+    // CI runners, etc.) rather than ~2 per segment.
+    //
+    // POSIX-only (counts /proc/self/fd entries). Windows uses a different handle accounting model; the same
+    // bug class is closed by the matching CloseHandle in ISFileSource::open's WIN32 branch but isn't exercised
+    // by this test directly.
+
+    auto countOpenFds = []() -> int {
+        std::error_code ec;
+        int n = 0;
+        for (const auto& entry : fs::directory_iterator("/proc/self/fd", ec)) {
+            (void)entry;
+            ++n;
+        }
+        if (ec) return -1;  // skip silently
+        return n;
+    };
+
+    const int before = countOpenFds();
+    if (before < 0) GTEST_SKIP() << "/proc/self/fd not enumerable on this kernel";
+
+    constexpr int kSegmentCount = 64;
+    std::vector<ISLogReader> readers;
+    readers.reserve(kSegmentCount);
+    for (int i = 0; i < kSegmentCount; ++i) {
+        auto r = ISLogReader::openSegment(f_.rawFile);
+        ASSERT_TRUE(r.has_value()) << "openSegment #" << i << " failed: " << r.error().message;
+        readers.push_back(std::move(*r));
+    }
+
+    const int after = countOpenFds();
+    ASSERT_GE(after, 0);
+
+    // Headroom: 8 FDs of slack for harness-side noise. Pre-fix this would be ~128 (2 per segment).
+    EXPECT_LT(after - before, 16)
+        << "FD count grew by " << (after - before) << " after opening " << kSegmentCount
+        << " segments — close-after-mmap regression suspected. before=" << before << " after=" << after;
+
+    // Sanity: payload reads still work without the FD open. Walk the first reader's records via
+    // bytes()-aliasing — proves the mmap stays valid.
+    ASSERT_GT(readers.size(), 0u);
+    ASSERT_GT(readers[0].recordCount(), 0u);
+    auto bytes = readers[0].rawBytes();
+    EXPECT_NE(bytes.first, nullptr);
+    EXPECT_GT(bytes.second, 0u);
+}
+#endif
+
+// ============================================================
 // Layout-discipline sanity
 // ============================================================
 


### PR DESCRIPTION
**Companion to** [logalyzer#48](https://github.com/inertialsense/logalyzer/pull/48) (D-111 Phase A).  Together they close out [SN-7996 / D-111](https://inertialsense.atlassian.net/browse/SN-7996).

## What's wrong today

`ISFileSource::open` (in `src/ISLogReader.cpp`) acquires a `.raw` FD via `::open()` (POSIX) or `CreateFileW()` (Win32), then mmap's the file, and **keeps both alive** for the lifetime of the `ISLogReader`.  Same on the `.idx` sidecar via the same code path.  A 100-segment log opened via `ISLog::openDirectory` therefore holds ~200 FDs / handles in parallel, which trips the default `ulimit -n 1024` on Linux and the corresponding handle limit on Windows.

## Fix

POSIX `man mmap`: *"After the `mmap()` call has returned, the file descriptor, `fd`, can be closed immediately without invalidating the mapping."*  Win32 `MapViewOfFile`: the view persists until `UnmapViewOfFile` regardless of the mapping object's or file handle's lifetime.

So: in both branches of `ISFileSource::open`, close the FD / handles **immediately after the mmap succeeds**.  The mapping itself is still torn down by `munmap` / `UnmapViewOfFile` during `releaseMapping`, exactly as before; the `::close()` / `CloseHandle()` steps in `releaseMapping` become no-ops on the close-after-mmap path.  The buffered-fallback path (mmap failure) also closes the failed-mmap FD before re-opening through `std::ifstream` so we don't briefly hold two FDs for the same file.

**Impact:** 100 segments goes from ~200 open FDs to ~0 (the mmap regions count as virtual mappings, not FDs).  No iteration path breakage — `rawBytes()` and all payload-read paths already dereference through the stable `data_` pointer set up at mmap time.

## Test

`LogReaderTest.OpeningManySegmentsDoesNotAccumulateFds` (Linux-only — counts `/proc/self/fd` entries; the matching Win32 handle audit isn't exercised by this test directly but the same `CloseHandle` pair seals the equivalent leak):

- Open 64 copies of the fixture `.raw` via `openSegment`, store them in a vector so they remain alive.
- Count `/proc/self/fd` before + after.
- Assert delta `< 16` (allows test-harness noise like gtest output streams and CI temp files).
- Sanity: walk the first reader's `rawBytes()` to prove the mmap stays valid with the FD gone.

Pre-fix this delta would be ~128 (2 FDs per reader × 64).

## Verification on the Logalyzer side

- 35 / 35 ctest green including `test_log_load_worker` (exercises `openSegment` under a real `QThread`).
- Xvfb load of `multi_segment_128mb` (26 segments): pre-fix would hold ~52 FDs through the entire Logalyzer session; with the fix it's ~0 FDs after open.  Load completes cleanly, scrub bar populates, no errors.

## Related

- `logalyzer#48` (D-111 Phase A) — the Logalyzer-side async dispatch + QProgressDialog.  Submodule bump for this PR folds into that one before its merge per the no-stacking convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)