### PR TITLE
SN-8024 Fix a bug in the SDK device software reset

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -1436,7 +1436,7 @@ int ISDevice::UploadIMXCalibrationFromURL(const std::string& restBaseUrl)
 bool ISDevice::softwareReset() {
     std::lock_guard<std::recursive_mutex> lock(portMutex);
 
-    if (!isConnected() || (nextResetTime && (nextResetTime - current_timeMs() > 0)))
+    if (!isConnected() || isResetPending())
         return false;
 
     log_info(IS_LOG_ISDEVICE, "[%s] Requesting Software Reset", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
@@ -1446,7 +1446,7 @@ bool ISDevice::softwareReset() {
         SLEEP_MS(5)
     }
     disconnect();
-    nextResetTime = current_timeMs() + resetRequestThreshold;
+    lastResetTime = current_timeMs();
     return true;
 }
 

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -372,7 +372,7 @@ public:
     /**
      * @returns true if reset() was called recently, and we are waiting for the device to return.
      */
-    bool isResetPending() { return current_timeMs() < nextResetTime; }
+    bool isResetPending() { return (current_timeMs() - lastResetTime) < resetRequestThreshold; }
 
     /**
      * Fetches (if not previously fetched), the devices manufacturing info and populates it into the passed reference.
@@ -660,7 +660,7 @@ public:
 
     uint32_t                    lastResetRequest = 0;                //!< system time when the last reset requests was sent
     uint32_t                    resetRequestThreshold = 5000;        //!< Don't allow to send reset requests more frequently than this...
-    uint32_t                    nextResetTime = 0;                   //!< used to throttle reset requests
+    uint32_t                    lastResetTime = 0;                   //!< used to throttle reset requests
 
     is_operation_result updateFirmware(fwUpdate::target_t targetDevice, std::vector<std::string> cmds, fwUpdate::pfnStatusCb infoProgress, void (*waitAction)());
     bool fwUpdateInProgress();


### PR DESCRIPTION
After any software reset is successfully issued, the Reset button in the EvalTool Settings Device Ports tab stops working for the remainder of the process lifetime. No dialog or error is shown; pressing the button produces no effect. Restarting the EvalTool restores the button until the next reset is attempted.

Root cause

ISDevice::softwareReset() contained a rate-limit guard intended to prevent resets more frequently than 5 seconds apart. The guard stored a future expiry timestamp (nextResetTime = current_timeMs() + 5000) and checked it as:


if (!isConnected() || (nextResetTime && (nextResetTime - current_timeMs() > 0)))
    return false;
nextResetTime and current_timeMs() are both uint32_t. Once current_timeMs() advances past nextResetTime (i.e., 5 seconds after the first reset), the subtraction nextResetTime - current_timeMs() wraps to approximately UINT32_MAX - 4999, which is always > 0. The guard never clears, and every subsequent call to softwareReset() silently returns false for the rest of the session.

On EvalTool restart, nextResetTime is re-initialized to 0, the nextResetTime && short-circuit suppresses the check, and the button works again — until the next reset.

Fix

Replaced the "future expiry" pattern with the correct elapsed-time pattern. The member was renamed from nextResetTime to lastResetTime (stores the timestamp of the last reset rather than when the cooldown expires), and isResetPending() was updated accordingly:


// ISDevice.h — member variable
uint32_t lastResetTime = 0;

// ISDevice.h — isResetPending()
bool isResetPending() { return (current_timeMs() - lastResetTime) < resetRequestThreshold; }

// ISDevice.cpp — softwareReset()
if (!isConnected() || isResetPending())
    return false;
// ...
lastResetTime = current_timeMs();
current_timeMs() - lastResetTime gives correct elapsed time even across a uint32_t rollover (~49-day uptime), and the guard naturally expires after resetRequestThreshold (5 s).

Files changed: is-common/SDK/src/ISDevice.h, is-common/SDK/src/ISDevice.cpp

Steps to reproduce

Connect an IMX-6 (or any IS device) in EvalTool.
Open Settings → Device Ports tab.
Press Reset, confirm the dialog → device resets successfully.
Wait for device to reconnect and data to resume.
Press Reset again → nothing happens.
Expected: Reset dialog appears and device resets each time the button is pressed (subject to the 5-second throttle).
Actual: After the first successful reset, all subsequent presses silently do nothing until EvalTool is restarted.

Severity: Medium — workaround is to restart EvalTool; no data loss or crash.