### PR TITLE
SN-8032 debug mode support

### DIFF
--- a/scripts/lib/version_tools.py
+++ b/scripts/lib/version_tools.py
@@ -139,7 +139,7 @@ class RepositoryInfo:
             f.write(f"#define {prefix}REPO_GIT_COMMIT 0x{self.commit[:8]}\n")
             f.write(f"#define {prefix}REPO_VERSION_NO_META \"{str(self.version).split('+')[0]}\"\n")
             f.write(f"#define {prefix}REPO_VERSION \"{str(self.version)}\"\n")
-            f.write(f"#define {prefix}REPO_VERSION_RELEASE_TYPE {str(self.release_type)}\n")
+            f.write(f"#define {prefix}REPO_VERSION_RELEASE_TYPE {str(self.release_type)}  // 'd'=developer, 'c'=release candidate, 'b'=beta, 'a'=alpha, 0=production, 's'=snapshot, '^'=dirty\n")
             f.write(f"#define {prefix}REPO_VERSION_MAJOR {str(self.version.major)}\n")
             f.write(f"#define {prefix}REPO_VERSION_MINOR {str(self.version.minor)}\n")
             f.write(f"#define {prefix}REPO_VERSION_REVIS {str(self.version.patch)}\n")
@@ -331,7 +331,8 @@ class RepositoryInfo:
         """
 
         self.version = self.get_latest_version()
-        if self.branch == "develop":                                    # Develop
+        # release_type: 0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, 's'=snapshot, '^'=dirty
+        if self.branch == "develop":                                    # Developer
             self.release_type = "'d'"
         elif re.match(r"\d.\d.\d-rc", self.branch) is not None:         # Release Candidate
             self.release_type = "'c'"
@@ -339,7 +340,7 @@ class RepositoryInfo:
             self.release_type = "'b'"
         elif re.match(r"\d.\d.\d-a", self.branch) is not None:          # Alpha
             self.release_type = "'a'"
-        elif self.version.prerelease is None:                           # Production Release
+        elif self.version.prerelease is None:                           # Production
             self.release_type = "0"
         else:                                                           # Snapshot
             self.release_type = "'s'"

--- a/scripts/lib/version_tools.py
+++ b/scripts/lib/version_tools.py
@@ -139,7 +139,7 @@ class RepositoryInfo:
             f.write(f"#define {prefix}REPO_GIT_COMMIT 0x{self.commit[:8]}\n")
             f.write(f"#define {prefix}REPO_VERSION_NO_META \"{str(self.version).split('+')[0]}\"\n")
             f.write(f"#define {prefix}REPO_VERSION \"{str(self.version)}\"\n")
-            f.write(f"#define {prefix}REPO_VERSION_RELEASE_TYPE {str(self.release_type)}  // 'd'=developer, 'c'=release candidate, 'b'=beta, 'a'=alpha, 0=production, 's'=snapshot, '^'=dirty\n")
+            f.write(f"#define {prefix}REPO_VERSION_RELEASE_TYPE {str(self.release_type)}  // 'd'=developer, 'c'=release candidate, 'b'=beta, 'a'=alpha, 0=production, 's'=snapshot\n")
             f.write(f"#define {prefix}REPO_VERSION_MAJOR {str(self.version.major)}\n")
             f.write(f"#define {prefix}REPO_VERSION_MINOR {str(self.version.minor)}\n")
             f.write(f"#define {prefix}REPO_VERSION_REVIS {str(self.version.patch)}\n")

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -884,9 +884,9 @@ static void PopulateMapTimestampField(data_set_t data_set[DID_COUNT], uint32_t d
 static void PopulateMapDeviceInfo(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<dev_info_t> mapper(data_set, did);
-    mapper.AddMember("reserved", &dev_info_t::reserved, DATA_TYPE_UINT8);
-    mapper.AddMember("buildFlags", &dev_info_t::buildFlags, DATA_TYPE_UINT8, "", "Build flags: 0x1=debug mode, 0x2=dirty");
-    mapper.AddMember("hardwareState", &dev_info_t::hdwRunState, DATA_TYPE_UINT8, "", "Hardware state: APP, BOOTLOADER, ");
+    mapper.AddMember("reserved", &dev_info_t::reserved, DATA_TYPE_UINT8, "", "", DATA_FLAGS_READ_ONLY);
+    mapper.AddMember("buildFlags", &dev_info_t::buildFlags, DATA_TYPE_UINT8, "", "Build flags: 0x1=debug mode, 0x2=dirty", DATA_FLAGS_READ_ONLY);
+    mapper.AddMember("hardwareState", &dev_info_t::hdwRunState, DATA_TYPE_UINT8, "", "Hardware state: APP, BOOTLOADER, ", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("hardwareType", &dev_info_t::hardwareType, DATA_TYPE_UINT8,  "", "Hardware type: 1=uINS, 2=EVB, 3=IMX, 4=GPX", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("serialNumber", &dev_info_t::serialNumber, DATA_TYPE_UINT32, "", "Serial number", DATA_FLAGS_READ_ONLY);
     mapper.AddArray("hardwareVer", &dev_info_t::hardwareVer, DATA_TYPE_UINT8, 4, {""}, {"Hardware version"}, DATA_FLAGS_READ_ONLY);

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -884,7 +884,8 @@ static void PopulateMapTimestampField(data_set_t data_set[DID_COUNT], uint32_t d
 static void PopulateMapDeviceInfo(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<dev_info_t> mapper(data_set, did);
-    mapper.AddMember("reserved", &dev_info_t::reserved, DATA_TYPE_UINT16);
+    mapper.AddMember("reserved", &dev_info_t::reserved, DATA_TYPE_UINT8);
+    mapper.AddMember("buildFlags", &dev_info_t::buildFlags, DATA_TYPE_UINT8, "", "Build flags: 0x1=debug mode, 0x2=dirty");
     mapper.AddMember("hardwareState", &dev_info_t::hdwRunState, DATA_TYPE_UINT8, "", "Hardware state: APP, BOOTLOADER, ");
     mapper.AddMember("hardwareType", &dev_info_t::hardwareType, DATA_TYPE_UINT8,  "", "Hardware type: 1=uINS, 2=EVB, 3=IMX, 4=GPX", DATA_FLAGS_READ_ONLY);
     mapper.AddMember("serialNumber", &dev_info_t::serialNumber, DATA_TYPE_UINT32, "", "Serial number", DATA_FLAGS_READ_ONLY);

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -243,6 +243,7 @@ bool ISFirmwareUpdater::fwUpdate_handleVersionResponse(const fwUpdate::payload_t
     memcpy(remoteDevInfo.hardwareVer, msg.data.version_resp.hardwareVer, 4);
     memcpy(remoteDevInfo.firmwareVer, msg.data.version_resp.firmwareVer, 4);
     remoteDevInfo.buildType = (msg.data.version_resp.buildType == 'r') ? 0 : msg.data.version_resp.buildType;
+    remoteDevInfo.buildFlags = msg.data.version_resp.buildFlags;
     remoteDevInfo.buildNumber = msg.data.version_resp.buildNumber;
     remoteDevInfo.buildYear = msg.data.version_resp.buildYear;
     remoteDevInfo.buildMonth = msg.data.version_resp.buildMonth;

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -242,7 +242,7 @@ bool ISFirmwareUpdater::fwUpdate_handleVersionResponse(const fwUpdate::payload_t
     remoteDevInfo.hdwRunState = msg.data.version_resp.hdwRunState;
     memcpy(remoteDevInfo.hardwareVer, msg.data.version_resp.hardwareVer, 4);
     memcpy(remoteDevInfo.firmwareVer, msg.data.version_resp.firmwareVer, 4);
-    remoteDevInfo.buildType = msg.data.version_resp.buildType;
+    remoteDevInfo.buildType = (msg.data.version_resp.buildType == 'r') ? 0 : msg.data.version_resp.buildType;
     remoteDevInfo.buildNumber = msg.data.version_resp.buildNumber;
     remoteDevInfo.buildYear = msg.data.version_resp.buildYear;
     remoteDevInfo.buildMonth = msg.data.version_resp.buildMonth;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -671,7 +671,7 @@ typedef struct PACKED
     /** Manufacturer name */
     char            manufacturer[DEVINFO_MANUFACTURER_STRLEN];
 
-    /** Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty) */
+    /** Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, 's'=snapshot, '^'=dirty) */
     uint8_t         buildType;
     
     /** Build date year - 2000 */

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -630,11 +630,19 @@ enum eHdwRunStates {
     HDW_STATE_APP,
 };
 
+enum eBuildFlags {
+    BUILD_FLAG_DEBUG = 0x1,
+    BUILD_FLAG_DIRTY = 0x2,
+};
+
 /** (DID_DEV_INFO) Device information */
 typedef struct PACKED
 {
     /** Reserved bits */
-    uint16_t        reserved;
+    uint8_t         reserved;
+
+    /** Build flags: 0x1=debug mode, 0x2=dirty (see eBuildFlags) */
+    uint8_t         buildFlags;
 
     /** Hardware Type: 1=uINS, 2=EVB, 3=IMX, 4=GPX (see eIsHardwareType) */
     uint8_t         hardwareType;
@@ -663,7 +671,7 @@ typedef struct PACKED
     /** Manufacturer name */
     char            manufacturer[DEVINFO_MANUFACTURER_STRLEN];
 
-    /** Build type (Release: 'a'=ALPHA, 'b'=BETA, 'c'=RELEASE CANDIDATE, 'r'=PRODUCTION RELEASE, 'd'=developer/debug) */
+    /** Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty) */
     uint8_t         buildType;
     
     /** Build date year - 2000 */

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -284,7 +284,7 @@ namespace fwUpdate {
             uint8_t buildHash[4];   //!< Git hash
             uint32_t buildNumber;   //!< Build number
 
-            uint8_t buildType;      //!< Build type (Release: 'a'=ALPHA, 'b'=BETA, 'c'=RELEASE CANDIDATE, 'r'=PRODUCTION RELEASE, 'd'=debug)
+            uint8_t buildType;      //!< Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty)
             uint8_t buildYear;      //!< Build date year - 2000
             uint8_t buildMonth;     //!< Build date month
             uint8_t buildDay;       //!< Build date day

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -283,6 +283,7 @@ namespace fwUpdate {
 
             uint8_t buildHash[4];   //!< Git hash
             uint32_t buildNumber;   //!< Build number
+            uint8_t buildFlags;     //!< Build flags (preserves debug/dirty and related build-state flags)
 
             uint8_t buildType;      //!< Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty)
             uint8_t buildYear;      //!< Build date year - 2000

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -283,7 +283,6 @@ namespace fwUpdate {
 
             uint8_t buildHash[4];   //!< Git hash
             uint32_t buildNumber;   //!< Build number
-            uint8_t buildFlags;     //!< Build flags (preserves debug/dirty and related build-state flags)
 
             uint8_t buildType;      //!< Build type (0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty)
             uint8_t buildYear;      //!< Build date year - 2000
@@ -294,6 +293,8 @@ namespace fwUpdate {
             uint8_t buildMinute;    //!< Build time minute
             uint8_t buildSecond;    //!< Build time second
             uint8_t buildMillis;    //!< Build time millisecond
+
+            uint8_t buildFlags;     //!< Build flags (preserves debug/dirty and related build-state flags)
         } version_resp;
 
     } msg_data_t;

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -491,22 +491,22 @@ int nmea_dev_info(char a[], const int aSize, dev_info_t &info)
         ",%d"                   // 11
         ",%d"                   // 12
         ",%c"                   // 13
-        // TODO: dev_info_t.firmwareMD5Hash support
-        // ",%08x%08x%08x%08x"     // 14
-        , (int)info.serialNumber // 1
-        , info.hardwareVer[0], info.hardwareVer[1], info.hardwareVer[2], info.hardwareVer[3] // 2
-        , info.firmwareVer[0], info.firmwareVer[1], info.firmwareVer[2], info.firmwareVer[3] // 3
-        , (int)info.buildNumber  // 4
-        , info.protocolVer[0], info.protocolVer[1], info.protocolVer[2], info.protocolVer[3] // 5
-        , (int)info.repoRevision // 6
-        , info.manufacturer      // 7
-        , info.buildYear+2000, info.buildMonth, info.buildDay // 8
-        , info.buildHour, info.buildMinute, info.buildSecond, info.buildMillisecond // 9
-        , info.addInfo           // 10
-        , info.hardwareType      // 11
-        , info.hdwRunState       // 12
-        , (info.buildType ? info.buildType : ' ') // 13
-        // , info.firmwareMD5Hash[0], info.firmwareMD5Hash[1], info.firmwareMD5Hash[2], info.firmwareMD5Hash[3]    // 14
+        ",%d"                   // 14
+
+        , (int)info.serialNumber                                                                // 1
+        , info.hardwareVer[0], info.hardwareVer[1], info.hardwareVer[2], info.hardwareVer[3]    // 2
+        , info.firmwareVer[0], info.firmwareVer[1], info.firmwareVer[2], info.firmwareVer[3]    // 3
+        , (int)info.buildNumber                                                                 // 4
+        , info.protocolVer[0], info.protocolVer[1], info.protocolVer[2], info.protocolVer[3]    // 5
+        , (int)info.repoRevision                                                                // 6
+        , info.manufacturer                                                                     // 7
+        , info.buildYear+2000, info.buildMonth, info.buildDay                                   // 8
+        , info.buildHour, info.buildMinute, info.buildSecond, info.buildMillisecond             // 9
+        , info.addInfo                                                                          // 10
+        , info.hardwareType                                                                     // 11
+        , info.hdwRunState                                                                      // 12
+        , (info.buildType ? info.buildType : ' ')                                               // 13
+        , info.buildFlags                                                                       // 14
     );
 
     return nmea_sprint_footer(a, aSize, n);
@@ -1957,15 +1957,16 @@ int nmea_parse_info(dev_info_t &info, const char a[], const int aSize)
     }
 
     // uint8_t         build type;
-    if (ptr < a + aSize)
+    if (ptr < a + aSize) {
         info.buildType = (uint8_t)*ptr;
+        ptr = ASCII_find_next_field(ptr);
+    }
     if (info.buildType==0) { info.buildType = ' '; }
 
-    // ptr = ASCII_find_next_field(ptr);
-
-    // TODO: dev_info_t.firmwareMD5Hash support
-    // uint32_t         firmwareMD5Hash[4];
-    // ptr = ASCII_to_MD5(info.firmwareMD5Hash, ptr);
+    // uint8_t         buildFlags;
+    if (ptr < a + aSize) {
+        ptr = ASCII_to_u8(&info.buildFlags, ptr);
+    }
 
     // Populate missing hardware descriptor
     devInfoPopulateMissingHardware(&info);

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1958,10 +1958,14 @@ int nmea_parse_info(dev_info_t &info, const char a[], const int aSize)
 
     // uint8_t         build type;
     if (ptr < a + aSize) {
-        info.buildType = (uint8_t)*ptr;
-        ptr = ASCII_find_next_field(ptr);
+        if (std::isdigit((unsigned char)*ptr)) {
+            ptr = ASCII_to_u8(&info.buildType, ptr);
+        }
+        else {
+            info.buildType = (uint8_t)*ptr;
+            ptr = ASCII_find_next_field(ptr);
+        }
     }
-    if (info.buildType==0) { info.buildType = ' '; }
 
     // uint8_t         buildFlags;
     if (ptr < a + aSize) {

--- a/src/protocol_nmea.cpp
+++ b/src/protocol_nmea.cpp
@@ -1966,6 +1966,7 @@ int nmea_parse_info(dev_info_t &info, const char a[], const int aSize)
             ptr = ASCII_find_next_field(ptr);
         }
     }
+    if (info.buildType == ' ' || info.buildType == 'r') { info.buildType = 0; }  // normalize legacy/encoded production values
 
     // uint8_t         buildFlags;
     if (ptr < a + aSize) {

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -20,7 +20,7 @@ PYBIND11_NUMPY_DTYPE(evb_luna_velocity_control_t, timeMs, dt, current_mode, stat
 PYBIND11_NUMPY_DTYPE(nmeaBroadcastMsgPair_t, msgID, msgPeriod);
 
 // Public Types
-PYBIND11_NUMPY_DTYPE(dev_info_t, reserved, serialNumber, hardwareVer, firmwareVer, buildNumber, protocolVer, repoRevision, manufacturer, buildType, buildYear, buildMonth, buildDay, buildHour, buildMinute, buildSecond, buildMillisecond, addInfo);
+PYBIND11_NUMPY_DTYPE(dev_info_t, reserved, buildFlags, serialNumber, hardwareVer, firmwareVer, buildNumber, protocolVer, repoRevision, manufacturer, buildType, buildYear, buildMonth, buildDay, buildHour, buildMinute, buildSecond, buildMillisecond, addInfo);
 PYBIND11_NUMPY_DTYPE(system_fault_t, upTime, status, fileNum, lineNum, haltReason, lr, pc, psr, taskALastFeed, taskBLastFeed, wdtLastFeed, var0, var1, var2, var3);
 PYBIND11_NUMPY_DTYPE(pimu_t, time, dt, status, theta, vel);
 PYBIND11_NUMPY_DTYPE(ins_1_t, week, timeOfWeek, insStatus, hdwStatus, theta, uvw, lla, ned);

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -327,7 +327,7 @@ bool utils::parseFirmwareFromString(const std::string& s, dev_info_t& devInfo) {
     }
 
     // Decode build-type suffix and optional ".<build>" trailing number.
-    char buildType = 'r';
+    char buildType = 0;
     if (!tail.empty()) {
         const size_t trailDot = tail.find('.');
         const std::string label = (trailDot == std::string::npos) ? tail : tail.substr(0, trailDot);
@@ -336,7 +336,8 @@ bool utils::parseFirmwareFromString(const std::string& s, dev_info_t& devInfo) {
         else if (label == "rc")    buildType = 'c';
         else if (label == "devel") buildType = 'd';
         else if (label == "snap")  buildType = 's';
-        else buildType = 'r'; // unknown label — treat as release
+        else if (label == "r")     buildType = 0;  // legacy production suffix
+        else buildType = 0; // unknown label — treat as production
         if (trailDot != std::string::npos) {
             try { fv[3] = static_cast<uint8_t>(std::stoi(tail.substr(trailDot + 1))); } catch (...) {}
         }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -235,8 +235,8 @@ namespace utils {
 
     /// Parse a firmware version string (inverse of getFirmwareAsString). Accepts optional "fw" prefix followed by
     /// "<M>.<m>.<p>" and an optional build-type suffix "-alpha|-beta|-rc|-devel|-snap" with optional ".<build>".
-    /// Populates devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|'r' for release/no suffix).
-    /// Returns false on malformed input.
+    /// Populates devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|0 for production/no suffix).
+    /// The legacy "-r" suffix and unknown suffixes are normalized to 0 (production). Returns false on malformed input.
     bool parseFirmwareFromString(const std::string& s, dev_info_t& devInfo);
     // semver::version<uint8_t, uint8_t, uint8_t> getSemanticVersion(const dev_info_t& devInfo, uint16_t flags = -1);
 

--- a/tests/test_protocol_nmea.cpp
+++ b/tests/test_protocol_nmea.cpp
@@ -269,6 +269,7 @@ TEST(protocol_nmea, INFO)
     info.repoRevision = 789;
     snprintf(info.manufacturer, DEVINFO_MANUFACTURER_STRLEN, "manufacturer string 123");
     info.buildType = 0;
+    info.buildFlags = 1;
     info.buildYear = 23;
     info.buildMonth = 6;
     info.buildDay = 9;

--- a/tests/test_protocol_nmea.cpp
+++ b/tests/test_protocol_nmea.cpp
@@ -268,7 +268,7 @@ TEST(protocol_nmea, INFO)
     }
     info.repoRevision = 789;
     snprintf(info.manufacturer, DEVINFO_MANUFACTURER_STRLEN, "manufacturer string 123");
-    info.buildType = 'r';
+    info.buildType = 0;
     info.buildYear = 23;
     info.buildMonth = 6;
     info.buildDay = 9;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -207,6 +207,14 @@ TEST(test_utils, parseFirmwareFromString_roundtrip) {
     EXPECT_EQ(parsed.firmwareVer[3], src.firmwareVer[3]);
     EXPECT_EQ(parsed.buildType, src.buildType);
 
+    // Legacy '-r' production suffix: must normalise to buildType == 0 (same as no suffix).
+    ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0-r", devInfo));
+    EXPECT_EQ(devInfo.firmwareVer[0], 3);
+    EXPECT_EQ(devInfo.firmwareVer[1], 0);
+    EXPECT_EQ(devInfo.firmwareVer[2], 0);
+    EXPECT_EQ(devInfo.firmwareVer[3], 0);
+    EXPECT_EQ(devInfo.buildType, 0);
+
     // ISBL "firmware_ver" like "ISbl.v6j **BOOTLOADER**" is not parseable — helper returns false,
     // caller leaves fields at whatever they were.
     EXPECT_FALSE(utils::parseFirmwareFromString("ISbl.v6j **BOOTLOADER**", parsed));

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -180,7 +180,7 @@ TEST(test_utils, parseFirmwareFromString_roundtrip) {
     EXPECT_EQ(devInfo.firmwareVer[1], 0);
     EXPECT_EQ(devInfo.firmwareVer[2], 0);
     EXPECT_EQ(devInfo.firmwareVer[3], 0);
-    EXPECT_EQ(devInfo.buildType, 'r');
+    EXPECT_EQ(devInfo.buildType, 0);
 
     ASSERT_TRUE(utils::parseFirmwareFromString("fw3.0.0-devel.175", devInfo));
     EXPECT_EQ(devInfo.firmwareVer[0], 3);


### PR DESCRIPTION
This pull request updates the handling and documentation of build types and build flags throughout the codebase to improve clarity and add support for new build flag fields. The changes standardize the meaning of build type codes, introduce a new `buildFlags` field, and update serialization/deserialization logic accordingly.

**Build Type and Build Flags Standardization:**

* Updated the documentation and comments for the `buildType` field in multiple files to clarify the meaning of each code (e.g., 0=production, 'c'=release candidate, 'b'=beta, 'a'=alpha, 'd'=developer, '^'=dirty), and removed the previous 'r'=production release code. (`src/data_sets.h`, `src/protocol/FirmwareUpdate.h`, `scripts/lib/version_tools.py`) [[1]](diffhunk://#diff-a58fce04e6c6d3ce510e53e485a7dec47f3f8542be0cd23f2527a2254e87813aL666-R674) [[2]](diffhunk://#diff-3dfd92dad620e38243892d4a6964a85f149bc68badfe8077052296d5da6641a9L287-R287) [[3]](diffhunk://#diff-ff2c93a8d43e5be454cdb12b445f4476d86956f11805ac415bc7341ee0bda6ffL334-R343)
* Added a new `buildFlags` field (with an accompanying `eBuildFlags` enum) to the `dev_info_t` struct, representing debug and dirty build states, and updated the reserved field accordingly. (`src/data_sets.h`)

**Serialization/Deserialization Updates:**

* Updated the NMEA device info serialization and deserialization to include the new `buildFlags` field and ensure correct parsing and formatting of both `buildType` and `buildFlags`. (`src/protocol_nmea.cpp`) [[1]](diffhunk://#diff-69d079866a13d685eb9b1c3a0488bfbd20059720bf0a678e1294fed1bd8ffb85L494-R495) [[2]](diffhunk://#diff-69d079866a13d685eb9b1c3a0488bfbd20059720bf0a678e1294fed1bd8ffb85L509-R509) [[3]](diffhunk://#diff-69d079866a13d685eb9b1c3a0488bfbd20059720bf0a678e1294fed1bd8ffb85L1960-R1969)

**Build Metadata Generation:**

* Enhanced the version metadata generation script to include detailed comments explaining the meaning of each build type code in the generated output. (`scripts/lib/version_tools.py`)