### PR TITLE
Fix static destruction order segfault in cISDataMappings::s_map

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -2286,7 +2286,7 @@ static void PopulateMapRosCovariancePoseTwist(data_set_t data_set[DID_COUNT], ui
 #if PLATFORM_IS_EMBEDDED
 cISDataMappings* cISDataMappings::s_map;
 #else
-cISDataMappings cISDataMappings::s_map;
+cISDataMappings* cISDataMappings::s_map = nullptr;
 #endif
 
 const char* const cISDataMappings::m_dataIdNames[] =
@@ -2578,11 +2578,14 @@ data_set_t* cISDataMappings::DataSet(uint32_t did)
     {
         s_map = new cISDataMappings();
     }
+#else
+    if (s_map == nullptr)
+    {
+        s_map = new cISDataMappings();
+    }
+#endif
 
     return &(s_map->m_data_set[did]);
-#else
-    return &(s_map.m_data_set[did]);
-#endif
 }
 
 const char* cISDataMappings::DataName(uint32_t did)

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -789,7 +789,10 @@ protected:
     // on embedded we cannot new up C++ runtime until after free rtos has started
     static cISDataMappings* s_map;
 #else
-    static cISDataMappings s_map;
+    // Heap-allocated pointer (never deleted) to avoid static destruction order fiasco:
+    // other static objects (e.g. cDeviceLog containers) may call NameToInfoMap() during
+    // their own destructors, after a value-typed s_map would have already been destroyed.
+    static cISDataMappings* s_map;
 #endif
 
 private:


### PR DESCRIPTION
On non-embedded platforms, cISDataMappings::s_map was defined as a static value (static cISDataMappings s_map). Its destructor runs at program exit, which destroys the std::string name fields inside every data_info_t entry in the mapping tables.

Other static objects (e.g. shared_ptr<cDeviceLog> entries in a std::map) are destroyed in an unspecified order relative to s_map. When they happen to be destroyed after s_map, their destructors call cLogStats::WriteToFile() → DiagnosticSummary() → FormatFlashConfigDiffSection() → NameToInfoMap(), which then iterates over already-freed std::string objects in the nameToInfo map — resulting in a segfault inside std::string::compare() → __memcmp_avx2_movbe.

Fix: Change the non-embedded s_map from a static value to a heap-allocated pointer (lazy-initialized, intentionally never deleted), matching the existing PLATFORM_IS_EMBEDDED pattern. Because the object is never destroyed, all data_info_t::name strings remain valid for the entire program lifetime regardless of static destructor ordering.

Files changed:

SDK/src/ISDataMappings.h — change non-embedded s_map declaration from value to pointer
SDK/src/ISDataMappings.cpp — change definition to nullptr init; add lazy new in DataSet() for non-embedded path
