### PR TITLE
SN-7965: Wire IOManager-driven async calibration upload

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -913,6 +913,7 @@ typedef f_t         ixMatrix5[25];
 typedef double      ixMatrix3d[9];
 
 typedef enum {
+    IS_OP_NONE = 2,             //!< no operation has been initiated; sentinel for "never started" — distinct from IS_OP_OK ("succeeded")
     IS_OP_IN_PROGRESS = 1,      //!< operation not started; a prior operation is still running
     IS_OP_OK = 0,
     IS_OP_ERROR = -1,

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -107,6 +107,14 @@ bool ISDevice::step() {
 
     if (was_connected != (bool)portIsOpened(port)) {
         was_connected = isConnected();
+        if (!isConnected() && m_calibration) {
+            // Port went away mid-upload. Drop the cal data and surface IS_OP_CLOSED so the
+            // caller can distinguish this from a protocol-layer failure.
+            log_warn(IS_LOG_ISDEVICE, "[%s] Async calibration upload aborted: port closed mid-upload at step %d.", getIdAsString().c_str(), m_calUploadState);
+            m_calibration.reset();
+            m_calUploadState = -1;
+            m_calUploadResult = IS_OP_CLOSED;
+        }
         DeviceManager::getInstance().notifyListeners(shared_from_this(), isConnected() ? DeviceManager::DEVICE_CONNECTED : DeviceManager::DEVICE_DISCONNECTED);
     }
 
@@ -125,10 +133,19 @@ bool ISDevice::step() {
     }
 
     if (m_calibration && m_calUploadState != -1) {
-        if (ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo) != ASYNC_STATE__PENDING) {
-            m_calibration = nullptr;
+        const int stepResult = ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo, m_calibration->uploadCtx);
+        if (stepResult != ASYNC_STATE__PENDING) {
+            if (stepResult == ASYNC_STATE__SUCCESS) {
+                m_calUploadResult = IS_OP_OK;
+                log_info(IS_LOG_ISDEVICE, "[%s] Async calibration upload complete.", getIdAsString().c_str());
+            } else {
+                m_calUploadResult = IS_OP_ERROR;
+                log_error(IS_LOG_ISDEVICE, "[%s] Async calibration upload failed at step %d.", getIdAsString().c_str(), m_calUploadState);
+            }
+            m_calibration.reset();
             m_calUploadState = -1;
         }
+        didStuff = true;
     }
 
     if (fwUpdater) {  // the fwUpdate MUST happen after is_comm_port_parse_messages
@@ -1355,17 +1372,22 @@ bool ISDevice::LoadGpxFlashConfigFromFile(std::string path)
 }
 
 /**
- * @brief Uploads sensor calibration data to a device in steps.
- * @param port The communication port handle.
- * @param calUploadState The current state of the upload process. This is updated by the function.
- * @param cal The sensor_cal_t structure containing the calibration data to upload.
- * @return 1 if the upload is complete, 0 if it's in progress, -1 on error.
+ * @brief Initiates an asynchronous calibration upload. Ownership of the supplied
+ * calibration object transfers to the device on accept; subsequent step() ticks drive
+ * the per-step protocol until completion. See header for full result vocabulary.
  */
-int ISDevice::UploadImxCalibrationAsync(ISDeviceCal& cal) {
+is_operation_result ISDevice::UploadImxCalibrationAsync(std::unique_ptr<ISDeviceCal> cal) {
     if (!isConnected())
-        return ASYNC_STATE__FAILURE;   // nothing to do, if we aren't connected
+        return IS_OP_CLOSED;
 
-    return ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, cal, devInfo);
+    if (m_calUploadResult == IS_OP_IN_PROGRESS || m_calibration)
+        return IS_OP_IN_PROGRESS;
+
+    m_calibration = std::move(cal);
+    m_calUploadState = 0;
+    m_calUploadResult = IS_OP_IN_PROGRESS;
+    log_info(IS_LOG_ISDEVICE, "[%s] Async calibration upload initiated.", getIdAsString().c_str());
+    return IS_OP_OK;
 }
 
 
@@ -1377,8 +1399,9 @@ bool ISDevice::UploadImxCalibration(ISDeviceCal& cal)
     int result = 0;
     try {
         int calUploadState = 0;
+        ISDeviceCal::cal_upload_ctx_t ctx;
         do {
-            result = ISDeviceCal::uploadSensorCalStep(port, calUploadState, cal, devInfo);
+            result = ISDeviceCal::uploadSensorCalStep(port, calUploadState, cal, devInfo, ctx);
             SLEEP_MS(ISDeviceCal::CAL_UPLOAD_SLEEP_MS);
         } while (result == ASYNC_STATE__PENDING);
     } catch (const std::exception& e) {

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -128,6 +128,12 @@ public:
     }
 
     virtual ~ISDevice() {
+        if (m_calibration) {
+            // Log silent failures on shutdown; unique_ptr frees the cal data.
+            log_warn(IS_LOG_ISDEVICE, "[%s] ISDevice destroyed with async calibration upload still in flight at step %d.", getIdAsString().c_str(), m_calUploadState);
+            m_calUploadResult = IS_OP_CLOSED;
+        }
+
         devInfo = {};
 
         if (port) {
@@ -580,17 +586,30 @@ public:
     bool LoadGpxFlashConfigFromFile(std::string path);
 
     /**
-     * Asynchronously loads the referenced Device calibration.
-     * It is expected that this function will be called periodically from the step()
-     * function, if a calibration upload is in progress.
-     * @param cal a reference to the calibration data to load on the device
-     * @return one of ASYNC_STATE__* indicating if an upload is in progress or not.
-     *      ASYNC_STATE__TIMEOUT if the calibration failed to upload or an issue occurred.
-     *      ASYNC_STATE__PENDING if the calibration upload is still being performed. step()
-     *      should continue to call this function as long as this value is being returned.
-     *      ASYNC_STATE__SUCCESS if the calibration was successfully uploaded.
+     * Initiates an asynchronous calibration upload. The device takes ownership of the
+     * supplied calibration object; subsequent step() ticks drive the per-step protocol
+     * until completion. Poll getCalibrationUploadResult() (or isCalibrationUploadInProgress())
+     * for status.
+     * @param cal heap-allocated calibration data; ownership transfers to the device on IS_OP_OK.
+     *            On any other return value the caller retains ownership.
+     * @return IS_OP_OK on accept (upload kicked off);
+     *         IS_OP_IN_PROGRESS if a prior upload is still in flight on this device (caller retains ownership);
+     *         IS_OP_CLOSED if the device is not connected (caller retains ownership).
      */
-    int UploadImxCalibrationAsync(ISDeviceCal& cal);
+    is_operation_result UploadImxCalibrationAsync(std::unique_ptr<ISDeviceCal> cal);
+
+    /**
+     * @return result of the most recent (or currently in-flight) async calibration upload.
+     *         IS_OP_NONE if no upload has ever been initiated on this device.
+     *         IS_OP_IN_PROGRESS if an upload is in flight.
+     *         IS_OP_OK if the last upload completed successfully.
+     *         IS_OP_ERROR if the last upload failed at the protocol layer.
+     *         IS_OP_CLOSED if the last upload was aborted because the port closed mid-upload.
+     */
+    is_operation_result getCalibrationUploadResult() const { return m_calUploadResult; }
+
+    /** @return true if an async calibration upload is currently in flight on this device. */
+    bool isCalibrationUploadInProgress() const { return m_calUploadResult == IS_OP_IN_PROGRESS; }
 
     bool UploadImxCalibration(ISDeviceCal& cal);
 
@@ -708,8 +727,9 @@ private:
     pfnIsCommHandler            externalAllHandler = nullptr;        //!< A user-implemented handler for all packet/message types
     pfnIsCommIsbDataHandler     defaultISBHandler = nullptr;
 
-    int                         m_calUploadState = -1;               //!< step indicator for calibration uploads
-    ISDeviceCal*                m_calibration = nullptr;             //!< pointer to a calibration object that is currently being uploaded
+    int                         m_calUploadState = -1;               //!< step indicator for calibration uploads (-1 = idle, 0..7 = active step)
+    std::unique_ptr<ISDeviceCal> m_calibration;                       //!< calibration object owned by the device while an async upload is in flight (nullptr otherwise)
+    is_operation_result         m_calUploadResult = IS_OP_NONE;      //!< result of the most recent (or currently in-flight) async calibration upload
 
     static int processPacket(void* ctx, protocol_type_t ptype, packet_t *pkt, port_handle_t port);
     static int processIsbMsgs(void* ctx, p_data_t* data, port_handle_t port);

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -970,14 +970,8 @@ json ISDeviceCal::saveMcToJsonObj(const std::string& filePath, int pose, sOrthoC
     return jCal;
 }
 
-int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo)
+int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx)
 {
-    // Per-thread v1.3 staging buffer; built once on state==0 when target is IMX-5.
-    // Reused across the 8 send steps to avoid repeated conversion.
-    static thread_local sensor_cal_v1p3_t s_v1p3Buf;
-    // Per-thread retry counter; reset at the start of each new upload and after each successful step.
-    static thread_local int s_retryCount = 0;
-
     const int hwMajor = devInfo.hardwareVer[0];
     const bool sendV1p3 = (hwMajor == 5);
     const bool sendV1p4 = (hwMajor == 6);
@@ -990,18 +984,18 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     if (calUploadState == 0)
     {
-        s_retryCount = 0;   // Reset retry counter at the start of each new upload.
+        ctx.retryCount = 0;   // Reset retry counter at the start of each new upload.
         if (sendV1p3)
         {
             // Build v1.3 payload from in-memory v1.4 cal. Recomputes both checksums.
-            convert_sensor_cal_v1p4_to_v1p3(&cal, &s_v1p3Buf);
+            convert_sensor_cal_v1p4_to_v1p3(&cal, &ctx.v1p3StagingBuf);
         }
     }
 
     // Returns 0 (pending) on send failure; aborts with -1 after MAX_UPLOAD_SEND_RETRIES consecutive failures on the current step.
     auto sendFail = [&]() -> int {
-        if (++s_retryCount > MAX_UPLOAD_SEND_RETRIES) {
-            log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: send failed %d times on step %d; aborting upload.", s_retryCount, calUploadState);
+        if (++ctx.retryCount > MAX_UPLOAD_SEND_RETRIES) {
+            log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: send failed %d times on step %d; aborting upload.", ctx.retryCount, calUploadState);
             return -1;
         }
         return 0;
@@ -1011,7 +1005,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     {
     case 0:     // General Info + Data Info (sent together since both are small and adjacent)
         if (sendV1p3) {
-            if (comManagerSendData(port, &(s_v1p3Buf.info), DID_CAL_SC, sizeof(sensor_cal_info_t) + sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return sendFail(); }
+            if (comManagerSendData(port, &(ctx.v1p3StagingBuf.info), DID_CAL_SC, sizeof(sensor_cal_info_t) + sizeof(sensor_data_info_t), offsetof(sensor_cal_v1p3_t, info)) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, &(cal.info), DID_CAL_SC, sizeof(sensor_cal_info_t) + sizeof(sensor_data_info_t), offsetof(sensor_cal_t, info)) != 0) { return sendFail(); }
         }
@@ -1019,7 +1013,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 1:     // Temp comp - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.tcal.gyr, DID_CAL_TEMP_COMP_GYR, SIZE_OF_SENSOR_TCAL_GYR) != 0) { return sendFail(); }
         }
@@ -1027,7 +1021,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 2:     // Temp comp - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.tcal.acc, DID_CAL_TEMP_COMP_ACC, SIZE_OF_SENSOR_TCAL_ACC) != 0) { return sendFail(); }
         }
@@ -1035,7 +1029,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 3:     // Temp comp - Magnetometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.tcal.mag, DID_CAL_TEMP_COMP_MAG, SIZE_OF_SENSOR_TCAL_MAG) != 0) { return sendFail(); }
         }
@@ -1043,7 +1037,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 4:     // Motion cal - Gyros
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.mcal.pqr, DID_CAL_MOTION_GYR, SIZE_OF_SENSOR_MCAL_GYR) != 0) { return sendFail(); }
         }
@@ -1051,7 +1045,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 5:     // Motion cal - Accelerometers
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.mcal.acc, DID_CAL_MOTION_ACC, SIZE_OF_SENSOR_MCAL_ACC) != 0) { return sendFail(); }
         }
@@ -1059,11 +1053,11 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
 
     case 6:     // Motion cal - Magnetometers (last step)
         if (sendV1p3) {
-            if (comManagerSendData(port, s_v1p3Buf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return sendFail(); }
+            if (comManagerSendData(port, ctx.v1p3StagingBuf.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG_V1P3) != 0) { return sendFail(); }
         } else {
             if (comManagerSendData(port, cal.data.mcal.mag, DID_CAL_MOTION_MAG, SIZE_OF_SENSOR_MCAL_MAG) != 0) { return sendFail(); }
         }
-        s_retryCount = 0;
+        ctx.retryCount = 0;
         calUploadState++;   // Increment state to mark completion here in case any upload fails and we need to retry the last step.  We don't want to resend all previous steps if only the last one fails.
         return 1;    // Done
 
@@ -1071,7 +1065,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
         return -1;
     }
 
-    s_retryCount = 0;
+    ctx.retryCount = 0;
     calUploadState++;
     return 0;
 }

--- a/src/ISDeviceCal.h
+++ b/src/ISDeviceCal.h
@@ -295,6 +295,21 @@ public:
                                    sensor_mcal_group_t *mcal);
 
     /**
+     * @brief Per-upload context for the step machine.
+     *
+     * Holds state that must persist across step() invocations for a single device's upload,
+     * but must NOT be shared across concurrent uploads to different devices. Previously held
+     * in thread_local storage, which was correct under a one-task-per-worker-thread model but
+     * unsafe under main-thread-driven concurrent uploads. Callers either store one of these
+     * per in-flight upload (async path: ISDevice::m_calibration owns this via ISDeviceCal),
+     * or stack-allocate one for the duration of a synchronous upload.
+     */
+    struct cal_upload_ctx_t {
+        sensor_cal_v1p3_t v1p3StagingBuf = {};  //!< downgrade staging buffer for IMX-5 (v1.3) targets
+        int retryCount = 0;                      //!< consecutive send failures on the current step
+    };
+
+    /**
      * @brief Uploads sensor calibration to a device in steps, with version-aware conversion.
      *
      * Resolves the on-device cal version from devInfo.hardwareVer[0] (5 -> v1.3, 6 -> v1.4)
@@ -306,11 +321,14 @@ public:
      * @param calUploadState State machine cursor (caller-owned, init to 0)
      * @param cal In-memory calibration (v1.4 format)
      * @param devInfo Target device info; hardwareVer[0] selects v1.3 vs v1.4 transmission
+     * @param ctx Per-upload context (caller-owned; one per concurrent upload)
      * @return ASYNC_STATE__PENDING (in progress), ASYNC_STATE__SUCCESS (done), ASYNC_STATE__FAILURE (error)
      */
-    static int uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo);
+    static int uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx);
 
     static const int CAL_UPLOAD_SLEEP_MS = 150;
+
+    cal_upload_ctx_t uploadCtx = {};    //!< per-upload state; owned by ISDeviceCal so async owners (ISDevice::m_calibration) have stable storage
 
 protected:
     sOrthoCal ocal = {};                //!< orthonormalization calibration data

--- a/tests/test_ISDeviceCal.cpp
+++ b/tests/test_ISDeviceCal.cpp
@@ -455,7 +455,8 @@ TEST(ISDeviceCalUpload, RefusesUnknownHardwareVersion)
     devInfo.hardwareVer[0] = 0; // unresolved (e.g. bootloader / unconnected)
 
     int state = 0;
-    int result = ISDeviceCal::uploadSensorCalStep(/*port=*/nullptr, state, cal, devInfo);
+    ISDeviceCal::cal_upload_ctx_t ctx;
+    int result = ISDeviceCal::uploadSensorCalStep(/*port=*/nullptr, state, cal, devInfo, ctx);
     EXPECT_EQ(result, -1) << "Upload must refuse when hardware version is unresolved";
 }
 
@@ -471,10 +472,12 @@ TEST(ISDeviceCalUpload, AcceptsImx5AndImx6HardwareVersions)
     dev_info_t imx5 = {};
     imx5.hardwareVer[0] = 5;
     int state5 = 0;
-    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state5, cal, imx5));
+    ISDeviceCal::cal_upload_ctx_t ctx5;
+    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state5, cal, imx5, ctx5));
 
     dev_info_t imx6 = {};
     imx6.hardwareVer[0] = 6;
     int state6 = 0;
-    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state6, cal, imx6));
+    ISDeviceCal::cal_upload_ctx_t ctx6;
+    EXPECT_NE(-1, ISDeviceCal::uploadSensorCalStep(nullptr, state6, cal, imx6, ctx6));
 }


### PR DESCRIPTION
## Summary

- Properly wires `ISDevice::UploadImxCalibrationAsync` (previously plumbed but never invoked) as a true async initializer that transfers ownership of the cal data to the device and seeds `m_calUploadState = 0`.
- Maps step-machine results into `m_calUploadResult` (`is_operation_result`): `IS_OP_IN_PROGRESS` while running, `IS_OP_OK` on success, `IS_OP_ERROR` on protocol failure, `IS_OP_CLOSED` if the port closes mid-upload.
- Removes `thread_local` from `ISDeviceCal::uploadSensorCalStep` (would clobber across concurrent main-thread-driven uploads). Per-upload state moves into a new `cal_upload_ctx_t` — synchronous wrapper stack-allocates one; async path uses `ISDeviceCal::uploadCtx` member.
- Adds `getCalibrationUploadResult()` + `isCalibrationUploadInProgress()` so callers can observe per-device state.
- Adds `IS_OP_NONE = 2` to `is_operation_result` — sentinel for "never initiated", generally useful beyond cal upload (fwUpdate, flash sync, etc.).
- Disconnect + destructor cleanup: in-flight upload state is released and surfaced as `IS_OP_CLOSED` (port lost) so callers don't see stale `IS_OP_IN_PROGRESS` after a teardown.

This SDK change pairs with the EvalTool fix at inertialsense/imx#TBD (Calibration::uploadSensorCal rewrite) to resolve SN-7965, where 13 of 14 devices had their COM ports closed during multi-device "Load All" cal upload. Full root-cause analysis: https://inertialsense.atlassian.net/browse/SN-7965

## Test plan

- [x] SDK unit tests — 173 passed, 1 skipped (`protocol_nmea.zda_gps_time_skip`, pre-existing) locally on Ubuntu 22.04.
- [x] Test signature updates: existing `ISDeviceCalUpload.RefusesUnknownHardwareVersion` and `ISDeviceCalUpload.AcceptsImx5AndImx6HardwareVersions` updated for the new `cal_upload_ctx_t` parameter and still pass.
- [ ] Hardware-loop validation against a multi-device bench (cannot reproduce a 14-device setup locally — requesting reviewer validation, particularly on the Manufacturing tab "Load All" flow).
- [ ] Regression check: single-device "Load From DB" path (uses the synchronous `UploadImxCalibration` wrapper, signature change is internal).
- [ ] Regression check: firmware update flow (this PR touches `is_operation_result` and `ISDevice::step()` — both used by fwUpdate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)