### PR TITLE
SN-8031: lazy-init plotWindow Qt to avoid per-script QApplication

### DIFF
--- a/python/inertialsense/plotWindow/plotWindow.py
+++ b/python/inertialsense/plotWindow/plotWindow.py
@@ -9,34 +9,26 @@ from PyQt6.QtCore import pyqtSlot, QTimer
 import sys, os
 
 class plotWindow():
+    # Lazy Qt instantiation: QApplication / MainWindow / per-tab widgets are
+    # not constructed in __init__. They are deferred to show() so that scripts
+    # which only generate and save figures (no on-screen display) never pay
+    # the cost of a Qt6 + X11 client per child process. See SN-8031.
     def __init__(self, title="Plot Window", parent=None):
-        self.app = QApplication(sys.argv)
-        self.MainWindow = QMainWindow()
-        self.MainWindow.__init__()
-        self.MainWindow.setWindowTitle(title)
+        self._title = title
+        self._pending_plots = []   # list of (title, figure, threeD)
+        # Realized Qt objects are created in show(); kept as attributes for
+        # _poll_close_request() to reach them after materialization.
+        self.app = None
+        self.MainWindow = None
+        self.tabs = None
         self.canvases = []
         self.figure_handles = []
         self.toolbar_handles = []
         self.tab_handles = []
         self.current_window = -1
-        self.tabs = QTabWidget()
-        self.MainWindow.setCentralWidget(self.tabs)
-        # self.MainWindow.resize(1920, 1080)
-        self.MainWindow.resize(1200, 980)
-
         self._close_marker_path = os.environ.get('IMX_CLOSE_PLOTS_MARKER', '')
         self._close_marker_mtime = 0.0
-        if self._close_marker_path:
-            try:
-                self._close_marker_mtime = os.path.getmtime(self._close_marker_path)
-            except OSError:
-                self._close_marker_mtime = 0.0
-
-            self._close_timer = QTimer(self.MainWindow)
-            self._close_timer.timeout.connect(self._poll_close_request)
-            self._close_timer.start(250)
-
-        self.MainWindow.show()
+        self._close_timer = None
 
     def _poll_close_request(self):
         if not self._close_marker_path:
@@ -49,31 +41,52 @@ class plotWindow():
         if marker_mtime > self._close_marker_mtime:
             self._close_marker_mtime = marker_mtime
             plt.close('all')
-            self.MainWindow.close()
-            self.app.quit()
+            if self.MainWindow is not None:
+                self.MainWindow.close()
+            if self.app is not None:
+                self.app.quit()
 
     def addPlot(self, title, figure, threeD=False):
-        new_tab = QWidget()
-        layout = QVBoxLayout()
-        new_tab.setLayout(layout)
-
+        # subplots_adjust must run eagerly so subsequent saveFig() output has
+        # the right margins regardless of whether show() is ever called.
         figure.subplots_adjust(left=0.07, right=0.95, bottom=0.05, top=0.91, wspace=0.25, hspace=0.25)
-        new_canvas = FigureCanvas(figure)
-
-        new_toolbar = NavigationToolbar(new_canvas, new_tab)
-
-        layout.addWidget(new_canvas)
-        layout.addWidget(new_toolbar)
-        self.tabs.addTab(new_tab, title)
-
-        self.toolbar_handles.append(new_toolbar)
-        self.canvases.append(new_canvas)
-        self.figure_handles.append(figure)
         if threeD:
             figure.axes[0].mouse_init()
-        self.tab_handles.append(new_tab)
+        self._pending_plots.append((title, figure, threeD))
+        self.figure_handles.append(figure)
 
-    def show(self):        
+    def show(self):
+        # Build the Qt UI now -- first time we actually need a display.
+        self.app = QApplication.instance() or QApplication(sys.argv)
+        self.MainWindow = QMainWindow()
+        self.MainWindow.setWindowTitle(self._title)
+        self.tabs = QTabWidget()
+        self.MainWindow.setCentralWidget(self.tabs)
+        self.MainWindow.resize(1200, 980)
+
+        if self._close_marker_path:
+            try:
+                self._close_marker_mtime = os.path.getmtime(self._close_marker_path)
+            except OSError:
+                self._close_marker_mtime = 0.0
+            self._close_timer = QTimer(self.MainWindow)
+            self._close_timer.timeout.connect(self._poll_close_request)
+            self._close_timer.start(250)
+
+        for title, figure, _threeD in self._pending_plots:
+            new_tab = QWidget()
+            layout = QVBoxLayout()
+            new_tab.setLayout(layout)
+            new_canvas = FigureCanvas(figure)
+            new_toolbar = NavigationToolbar(new_canvas, new_tab)
+            layout.addWidget(new_canvas)
+            layout.addWidget(new_toolbar)
+            self.tabs.addTab(new_tab, title)
+            self.toolbar_handles.append(new_toolbar)
+            self.canvases.append(new_canvas)
+            self.tab_handles.append(new_tab)
+
+        self.MainWindow.show()
         return self.app.exec()
 
     def saveFig(self, fig, filepath, format='svg', sizeInches=[]):
@@ -117,9 +130,3 @@ if __name__ == '__main__':
     pw.show()
 
     # sys.exit(app.exec_())
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

- Defers `QApplication` / `QMainWindow` / per-tab widget construction in `plotWindow.py` until `show()` is actually called.
- `addPlot()` stores `(title, figure, threeD)` tuples; eager `figure.subplots_adjust(...)` and 3D `mouse_init` calls preserve `saveFig()` output byte-for-byte.
- `saveFig()` was already Qt-free and is unchanged.

Background in [SN-8031](https://inertialsense.atlassian.net/browse/SN-8031) — at end of TC calibration on a 128-device rig, EvalTool launches ~120 simultaneous python children; each unconditionally instantiated a PyQt6 `QApplication` and `show()`ed a 1200×980 main window regardless of the `enable_plots` argument. The kernel OOM log for the May 14 incident shows 116 concurrent python3 children summing to ~11.6 GB RSS. This change eliminates the Qt/X11 cost from any run where plots are not displayed.

Paired with [imx#SN-8031](https://github.com/inertialsense/imx/pulls?q=is%3Apr+head%3ASN-8031_tc_cal_python_crash) which adds a C++-side concurrency throttle in `ScriptRunner` and bumps this SDK.

## Test plan

- [ ] Build the SDK venv as usual (`SDK/scripts/build_log_inspector.sh`).
- [ ] Run `temperature_calibration.py <SN> <SN> 0 1 <calpath> 2.1.0.0 0.018 0.05 0.15 0.5 0.5 1.5 0` on a known-good calibration directory; confirm PNGs in `figures/` are byte-identical (or visually indistinguishable) to a pre-change run.
- [ ] Run the same script with plots enabled (`enable_plots=1`); confirm the Qt window still appears and remains interactive.
- [ ] Verify `validate_temperature_calibration.py`, `motion_calibration.py`, `validate_motion_calibration.py` all still work in both `enable_plots=0` (no window) and `=1` (window appears) modes.
- [ ] `pmap -x <python3-pid>` on a no-plots run should not show `libQt6*.so` resident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8031]: https://inertialsense.atlassian.net/browse/SN-8031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ