### PR TITLE
SN-8038 mag recal not sticking imx5

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3974,11 +3974,8 @@ typedef struct
     /** base position for relative mode */
     int32_t refpos;
 
-    /** code/phase error ratio */
-    float eratio[NFREQ];
-
     /** measurement error factor */
-    float err[7];
+    float err[12];
 
     /** initial-state std [0]bias,[1]iono [2]trop */
     float std[3];
@@ -4045,8 +4042,14 @@ typedef struct
     /** output single by dgps/float/fix/ppp outage */
     int32_t outsingle;
 
-    /** velocity constraint in compassing mode {var before fix, var after fix} (m^2/s^2) **/
+    /** velocity constraint in compassing mode {var before fix, var after fix} (m^2/s^2) */
     float velcon[2];
+
+    /** LPF alpha for multipath bias estimation. Smaller value means heavier filtering. */
+    float mp_bias_lpf_alpha;
+
+    /** LPF alpha for multipath variance estimation. Smaller value means heavier filtering. */
+    float mp_var_lpf_alpha;
 } prcopt_t;
 typedef prcopt_t gnss_rtk_opt_t;
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -914,7 +914,7 @@ typedef struct PACKED
     /** Time since boot up in seconds.  Convert to GPS time of week by adding gps.towOffset */
     double                  time;
     
-    /** Magnetometers (uT) */
+    /** Magnetometers in microtesla (uT) */
     float                   mag[3];
 } magnetometer_t;
 


### PR DESCRIPTION
Fix the issue where mag infield recalibration would not persist on an IMX-5 following reboot. This was introduced as a result of switching the mag output to uT on the IMX-6 and NOT on the IMX-5. We decided to unify the systems and output uT on the IMX-5 as well as IMX-6.

This pull request makes several updates to the `prcopt_t` and `magnetometer_t` structures in `src/data_sets.h`, primarily to expand configuration options for multipath filtering and measurement error modeling, as well as to clarify documentation.

**Configuration and Filtering Enhancements:**

* Added two new fields to `prcopt_t` for multipath filtering: `mp_bias_lpf_alpha` and `mp_var_lpf_alpha`, which control the low-pass filter alpha values for multipath bias and variance estimation, respectively. Smaller values mean heavier filtering.
* Increased the size of the `err` array in `prcopt_t` from 7 to 12 elements, allowing for more detailed measurement error modeling.

**Documentation Improvements:**

* Clarified the comment for the `mag` field in `magnetometer_t` to specify that the units are in microtesla (uT).
* Minor edit to the comment for the `velcon` field in `prcopt_t` for consistency in formatting.