### PR TITLE
SN-7659 RTOS cleanup

### DIFF
--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -3981,8 +3981,8 @@ class logPlot:
             else:
                 towOffset = 0
 
-            deltaTimestamp = 0
-            timeImu  = 0
+            deltaTimestamp = np.array([])
+            timeImu  = np.array([])
             timePimu = self.getData(d, DID_PIMU, 'time')
             timeIMU  = self.getData(d, DID_IMU, 'time')
             timeImus = self.getData(d, DID_IMUS_RAW, 'time')

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -534,6 +534,8 @@ std::string renderGpxStatus_status(const data_info_t& info, std::any value, int 
 
     /** GNSS receiver time fault **/
         BIT_MSG(status, GPX_STATUS_FAULT_GNSS_RCVR_TIME          , "0x00100000 - GNSS receiver time fault");
+    /** RTOS task period overrun **/
+        BIT_MSG(status, GPX_STATUS_FAULT_RTOS_TASK_PERIOD_OVERRUN, "0x00200000 - RTOS task period overrun");
     /** DMA Fault detected **/
         BIT_MSG(status, GPX_STATUS_FAULT_DMA                     , "0x00800000 - DMA fault");
 

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -710,6 +710,8 @@ std::string ISDevice::getFirmwareInfo(const dev_info_t &devInfo, int flags) {
         }
         if (devInfo.firmwareVer[3] != 0)
             out += utils::string_format(".%u", devInfo.firmwareVer[3]);
+        if (devInfo.buildFlags & BUILD_FLAGS_DEBUG) 
+            out += "-debug";
 
         if (devInfo.repoRevision && !(flags & OMIT_COMMIT_HASH)) {
             out += utils::string_format(" %08x", devInfo.repoRevision);

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1609,6 +1609,8 @@ enum eGenFaultCodes
     GFC_GNSS_GENERAL_FAULT                  = 0x08000000,
     /** Fault: Invalid IMU input rejected by EKF */
     GFC_EKF_INPUT_INVALID_IMU               = 0x10000000,
+    /** Fault: GPS RTOS error */
+    GFC_GNSS_RTOS_ERROR                     = 0x20000000,
 
     /** IMX GFC flags that relate to GPX status flags */
     GFC_GPX_STATUS_COMMON_MASK = GFC_GNSS1_INIT | GFC_GNSS2_INIT | GFC_GNSS_TX_LIMITED | GFC_GNSS_RX_OVERRUN | GFC_GNSS_CRITICAL_FAULT | GFC_GNSS_RECEIVER_TIME | GFC_GNSS_GENERAL_FAULT,
@@ -4826,6 +4828,8 @@ enum eGpxStatus
 
     /** GNSS receiver time fault **/
     GPX_STATUS_FAULT_GNSS_RCVR_TIME                     = (int)0x00100000,
+    /** RTOS task period overrun **/
+    GPX_STATUS_FAULT_RTOS_TASK_PERIOD_OVERRUN           = (int)0x00200000,
     /** DMA Fault detected **/
     GPX_STATUS_FAULT_DMA                                = (int)0x00800000,
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -188,7 +188,7 @@ typedef uint32_t eDataIDs;
 
 // Increment w/ breaking changes (in ISComm.cpp) that prevent backwards compatibility with older protocols. 
 // #define PROTOCOL_VERSION_CHAR0   .   // Breaking changes (Packet)        (defined in ISComm.h) 
-#define PROTOCOL_VERSION_CHAR1      1   // Breaking changes (Payload)
+#define PROTOCOL_VERSION_CHAR1      2   // Breaking changes (Payload)
 
 // Increment w/ non-breaking changes (in data_sets.h) that would still backward compatibility with older protocols
 // #define PROTOCOL_VERSION_CHAR2   .   // Non-breaking changes (Packet):   (defined in ISComm.h)
@@ -631,8 +631,8 @@ enum eHdwRunStates {
 };
 
 enum eBuildFlags {
-    BUILD_FLAG_DEBUG = 0x1,
-    BUILD_FLAG_DIRTY = 0x2,
+    BUILD_FLAGS_DEBUG = 0x1,
+    BUILD_FLAGS_DIRTY = 0x2,
 };
 
 /** (DID_DEV_INFO) Device information */

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -261,16 +261,16 @@ uint32_t imxMinNavOutputMs(nvm_flash_cfg_t *cfg)
     else if (!(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_GNSS1_FUSION) ||
              !(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_GNSS2_FUSION))
     {   // Nav: GPS enabled
-        return tNAV_MIN_PERIOD_MS_NAV_MODE;
+        return tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE;
     }
     else if (!(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_MAGNETOMETER_FUSION) ||
              !(cfg->sysCfgBits & SYS_CFG_BITS_DISABLE_AUTO_ZERO_ANGULAR_RATE_UPDATES))
     {   // AHRS: no GPS, magnetometer enabled
-        return tNAV_MIN_PERIOD_MS_AHRS_MODE;
+        return tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE;
     }
     else
     {   // VRS: no GPS or magnetometer
-        return tNAV_MIN_PERIOD_MS_VRS_MODE;
+        return tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE;
     }
 }
 

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -9,26 +9,26 @@ extern "C" {
 
 #include "data_sets.h"
 
-#define tNAV_MIN_PERIOD_IMX5_MS_NAV_MODE    7       // W/ GPS
-#define tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
-#define tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE    7       // W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
 
-#define tNAV_MIN_PERIOD_IMX6_MS_NAV_MODE    5       // W/ GPS
-#define tNAV_MIN_PERIOD_IMX6_MS_AHRS_MODE   4       // No GPS
-#define tNAV_MIN_PERIOD_IMX6_MS_VRS_MODE    3       // No GPS or magnetometer
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE    4       // W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE   3       // No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE    2       // No GPS or magnetometer
 
 #if defined(IMX_5)
-#define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_IMX5_MS_NAV_MODE        // W/ GPS
-#define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE       // No GPS
-#define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE        // No GPS or magnetometer
+#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE     // W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE    // No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE     // No GPS or magnetometer
 #else   // IMX_6
-#define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_IMX6_MS_NAV_MODE        // W/ GPS
-#define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_IMX6_MS_AHRS_MODE       // No GPS
-#define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_IMX6_MS_VRS_MODE        // No GPS or magnetometer
+#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE     // W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE    // No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE     // No GPS or magnetometer
 #endif
 
-#define tNAV_DEFAULT_PERIOD_MS              tNAV_MIN_PERIOD_MS_NAV_MODE             // Reliable / safe period for operation
-#define tMAINT_MAX_RUN_TIME_US              100000                                  // Used to increment gap count and indicate error
+#define tNAV_DEFAULT_PERIOD_MS                  tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE          // Reliable / safe period for operation
+#define tMAINT_MAX_RUN_TIME_US                  100000                                      // Used to increment gap count and indicate error
 
 
 int imxPlatformConfigTypeValid(uint32_t platformConfig);

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -13,8 +13,8 @@ extern "C" {
 #define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
 #define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
 
-#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE    4       // W/ GPS
-#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE   3       // No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE    2       // W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE   2       // No GPS
 #define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE    2       // No GPS or magnetometer
 
 #if defined(IMX_5)

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -21,13 +21,14 @@ extern "C" {
 #define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE     // W/ GPS
 #define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE    // No GPS
 #define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE     // No GPS or magnetometer
+#define tNAV_DEFAULT_PERIOD_MS                  tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE          // Reliable / safe period for operation
 #else   // IMX_6
 #define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE     // W/ GPS
 #define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE    // No GPS
 #define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE     // No GPS or magnetometer
+#define tNAV_DEFAULT_PERIOD_MS                  5                                           // Reliable / safe period for operation
 #endif
 
-#define tNAV_DEFAULT_PERIOD_MS                  tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE          // Reliable / safe period for operation
 #define tMAINT_MAX_RUN_TIME_US                  100000                                      // Used to increment gap count and indicate error
 
 

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -13,11 +13,22 @@ extern "C" {
 #define tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
 #define tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
 
+#define tNAV_MIN_PERIOD_IMX6_MS_NAV_MODE    5       // W/ GPS
+#define tNAV_MIN_PERIOD_IMX6_MS_AHRS_MODE   4       // No GPS
+#define tNAV_MIN_PERIOD_IMX6_MS_VRS_MODE    3       // No GPS or magnetometer
+
+#if defined(IMX_5)
 #define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_IMX5_MS_NAV_MODE        // W/ GPS
 #define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_IMX5_MS_AHRS_MODE       // No GPS
 #define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_IMX5_MS_VRS_MODE        // No GPS or magnetometer
-#define tMAINT_MAX_RUN_TIME_US              100000  // Used to increment gap count and indicate error
-#define tNAV_DEFAULT_PERIOD_MS              tNAV_MIN_PERIOD_MS_NAV_MODE      // Reliable / safe period for operation
+#else   // IMX_6
+#define tNAV_MIN_PERIOD_MS_NAV_MODE         tNAV_MIN_PERIOD_IMX6_MS_NAV_MODE        // W/ GPS
+#define tNAV_MIN_PERIOD_MS_AHRS_MODE        tNAV_MIN_PERIOD_IMX6_MS_AHRS_MODE       // No GPS
+#define tNAV_MIN_PERIOD_MS_VRS_MODE         tNAV_MIN_PERIOD_IMX6_MS_VRS_MODE        // No GPS or magnetometer
+#endif
+
+#define tNAV_DEFAULT_PERIOD_MS              tNAV_MIN_PERIOD_MS_NAV_MODE             // Reliable / safe period for operation
+#define tMAINT_MAX_RUN_TIME_US              100000                                  // Used to increment gap count and indicate error
 
 
 int imxPlatformConfigTypeValid(uint32_t platformConfig);


### PR DESCRIPTION
This pull request introduces several improvements and updates related to device firmware information reporting, protocol versioning, and platform-specific timing defaults. The main changes include adding a debug flag indicator to firmware version strings, updating protocol version macros, clarifying build flag naming, and refining navigation period definitions for different hardware platforms.

**Firmware information and build flags:**

* Appends a "-debug" suffix to the firmware version string when the device is built with debug flags, improving visibility of debug builds in firmware info (`ISDevice::getFirmwareInfo`, `BUILD_FLAGS_DEBUG` rename). [[1]](diffhunk://#diff-ebc1babca6ae696cf06797e0953cd073c03f5d637fbc74a09b23d9f67ab25d3fR713-R714) [[2]](diffhunk://#diff-a58fce04e6c6d3ce510e53e485a7dec47f3f8542be0cd23f2527a2254e87813aL634-R635)
* Renames `BUILD_FLAG_DEBUG` and `BUILD_FLAG_DIRTY` to `BUILD_FLAGS_DEBUG` and `BUILD_FLAGS_DIRTY` for consistency.

**Protocol versioning:**

* Increments the `PROTOCOL_VERSION_CHAR1` macro from 1 to 2 to indicate a breaking change in payload structure, ensuring proper version tracking.

**Platform-specific timing defaults:**

* Adds minimum navigation period macros for IMX6 hardware and updates the logic to select the correct timing defaults based on platform (`imx_defaults.h`). This improves clarity and maintainability for platform-dependent timing.