### PR TITLE
SN-8052: v1.3/v1.4 SCOMP wire-format types + convert helpers

### DIFF
--- a/src/IS_calibration_convert.c
+++ b/src/IS_calibration_convert.c
@@ -120,6 +120,48 @@ void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v
     v1p4->data.dinfo.checksum = flashChecksum32(&v1p4->data, v1p4->data.dinfo.size);
 }
 
+void convert_scomp_v1p3_to_v1p4(const sensor_compensation_v1p3_t *v1p3, sensor_compensation_v1p4_t *v1p4)
+{
+    memset(v1p4, 0, sizeof(*v1p4));
+    v1p4->timeMs = v1p3->timeMs;
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
+    {
+        v1p4->pqr[d] = v1p3->pqr[d];
+        v1p4->acc[d] = v1p3->acc[d];
+    }
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
+    {
+        v1p4->mag[d] = v1p3->mag[d];
+    }
+    v1p4->referenceImu = v1p3->referenceImu;
+    memcpy(v1p4->referenceMag, v1p3->referenceMag, sizeof(v1p4->referenceMag));
+    v1p4->sampleCount = v1p3->sampleCount;
+    v1p4->calState = v1p3->calState;
+    v1p4->status = v1p3->status;
+    memcpy(v1p4->alignAccel, v1p3->alignAccel, sizeof(v1p4->alignAccel));
+}
+
+void convert_scomp_v1p4_to_v1p3(const sensor_compensation_v1p4_t *v1p4, sensor_compensation_v1p3_t *v1p3)
+{
+    memset(v1p3, 0, sizeof(*v1p3));
+    v1p3->timeMs = v1p4->timeMs;
+    for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)
+    {
+        v1p3->pqr[d] = v1p4->pqr[d];
+        v1p3->acc[d] = v1p4->acc[d];
+    }
+    for (int d = 0; d < _MIN(NUM_MAG_DEVICES_V1P3, NUM_MAG_DEVICES_V1P4); d++)
+    {
+        v1p3->mag[d] = v1p4->mag[d];
+    }
+    v1p3->referenceImu = v1p4->referenceImu;
+    memcpy(v1p3->referenceMag, v1p4->referenceMag, sizeof(v1p3->referenceMag));
+    v1p3->sampleCount = v1p4->sampleCount;
+    v1p3->calState = v1p4->calState;
+    v1p3->status = v1p4->status;
+    memcpy(v1p3->alignAccel, v1p4->alignAccel, sizeof(v1p3->alignAccel));
+}
+
 void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3)
 {
     for (int d = 0; d < _MIN(NUM_IMU_DEVICES_V1P3, NUM_IMU_DEVICES_V1P4); d++)

--- a/src/IS_calibration_convert.h
+++ b/src/IS_calibration_convert.h
@@ -35,10 +35,12 @@ static inline void set_sensor_motion_cal_data_defaults(sensor_cal_data_t *data)
 void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4);
 void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4);
 void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v1p4_t *v1p4);
+void convert_scomp_v1p3_to_v1p4(const sensor_compensation_v1p3_t *v1p3, sensor_compensation_v1p4_t *v1p4);
 
 void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3);
 void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3);
 void convert_sensor_cal_v1p4_to_v1p3(const sensor_cal_v1p4_t *v1p4, sensor_cal_v1p3_t *v1p3);
+void convert_scomp_v1p4_to_v1p3(const sensor_compensation_v1p4_t *v1p4, sensor_compensation_v1p3_t *v1p3);
 
 #ifdef __cplusplus
 }

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -1820,20 +1820,42 @@ typedef struct PACKED
     float                   dtTemp;                 // (°C) Temperature from last calibration point
 } sensor_comp_unit_t;
 
-/** (DID_SCOMP) INTERNAL USE ONLY */
+// Explicit wire-format variants of the DID_SCOMP payload. IMX-5 firmware sends v1.3
+// (3 IMU + 2 mag), IMX-6 firmware sends v1.4 (5 IMU + 1 mag). Host SDK keeps
+// sensor_compensation_t at the v1.4 shape (MAX_IMU_DEVICES / MAX_MAG_DEVICES) and
+// converts v1.3 payloads on receive via convert_scomp_v1p3_to_v1p4() in
+// IS_calibration_convert.h.
 typedef struct PACKED
-{                                                   // Sensor temperature compensation
-    uint32_t                timeMs;                 // (ms) Time since boot up.
-    sensor_comp_unit_t      pqr[MAX_IMU_DEVICES];
-    sensor_comp_unit_t      acc[MAX_IMU_DEVICES];
-    sensor_comp_unit_t      mag[MAX_MAG_DEVICES];
-    imui_t                  referenceImu;           // External reference IMU
-    float                   referenceMag[3];        // External reference magnetometer (heading reference)
-    uint32_t                sampleCount;            // Number of samples collected
-    uint32_t                calState;               // state machine (see eScompCalState)
-    uint32_t                status;                 // Status used to control LED and indicate valid sensor samples (see eScompStatus)
-    float                   alignAccel[3];          // Alignment acceleration
-} sensor_compensation_t;
+{
+    uint32_t                timeMs;
+    sensor_comp_unit_t      pqr[NUM_IMU_DEVICES_V1P3];
+    sensor_comp_unit_t      acc[NUM_IMU_DEVICES_V1P3];
+    sensor_comp_unit_t      mag[NUM_MAG_DEVICES_V1P3];
+    imui_t                  referenceImu;
+    float                   referenceMag[3];
+    uint32_t                sampleCount;
+    uint32_t                calState;
+    uint32_t                status;
+    float                   alignAccel[3];
+} sensor_compensation_v1p3_t;
+
+typedef struct PACKED
+{
+    uint32_t                timeMs;
+    sensor_comp_unit_t      pqr[NUM_IMU_DEVICES_V1P4];
+    sensor_comp_unit_t      acc[NUM_IMU_DEVICES_V1P4];
+    sensor_comp_unit_t      mag[NUM_MAG_DEVICES_V1P4];
+    imui_t                  referenceImu;
+    float                   referenceMag[3];
+    uint32_t                sampleCount;
+    uint32_t                calState;
+    uint32_t                status;
+    float                   alignAccel[3];
+} sensor_compensation_v1p4_t;
+
+/** (DID_SCOMP) INTERNAL USE ONLY - aliased to sensor_compensation_v1p4_t since
+ * MAX_IMU_DEVICES / MAX_MAG_DEVICES are unconditionally v1.4 on every build target. */
+typedef sensor_compensation_v1p4_t  sensor_compensation_t;
 
 #define NUM_ANA_CHANNELS    4
 


### PR DESCRIPTION
## Summary

- Adds `sensor_compensation_v1p3_t` (3 IMU + 2 mag) and `sensor_compensation_v1p4_t` (5 IMU + 1 mag) explicit wire-format typedefs in `data_sets.h`. Collapses `sensor_compensation_t` to `typedef sensor_compensation_v1p4_t` (byte-identical, since `MAX_IMU_DEVICES` / `MAX_MAG_DEVICES` are unconditionally v1.4 on every build target).
- Adds `convert_scomp_v1p3_to_v1p4()` and `convert_scomp_v1p4_to_v1p3()` to `IS_calibration_convert.{h,c}` mirroring the existing `convert_*cal_*` helpers from SN-7966 (uses `_MIN(NUM_X_V1P3, NUM_X_V1P4)` for shared array regions, preserves header/footer fields verbatim).

No build-target #ifdef switching is introduced. The discriminator on host is runtime-per-device, consumed by the EvalTool side of [SN-8052](https://inertialsense.atlassian.net/browse/SN-8052) (PR forthcoming on `inertialsense/imx`).

## Context

[SN-7677](https://inertialsense.atlassian.net/browse/SN-7677) / [SN-7966](https://inertialsense.atlassian.net/browse/SN-7966) widened the SDK cal structures from v1.3 (3 IMU + 2 mag) to v1.4 (5 IMU + 1 mag) and added `convert_*cal_*` helpers + a hardware-version-aware **upload** path. The receive path was left without equivalent v1.3 decode, which is what this change unblocks for the host EvalTool.

## Test plan

- [ ] Verify SDK builds clean on host
- [ ] Verify the existing `tests/test_ISDeviceCal.cpp` round-trip tests still pass
- [ ] Companion EvalTool PR (inertialsense/imx#TBD) verified against:
  - [ ] 14 IMX-5 / fw 2.4.1 (v1.3) devices: TC Pts shows `20,20,20,0,0`, MC=3, Cal Ver=1.3.0, Cal Date/Time populate after Load-from-DB
  - [ ] 16 IMX-6 / fw 3.0.0 (v1.4) devices: TC Pts shows `0,0,0,0,0`, Cal Ver=1.4.0, all from the same EvalTool binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8052]: https://inertialsense.atlassian.net/browse/SN-8052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SN-7677]: https://inertialsense.atlassian.net/browse/SN-7677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SN-7966]: https://inertialsense.atlassian.net/browse/SN-7966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ