### PR TITLE
SN-8057: narrow DeviceManager::discoverDevice lock scope (deadlock fix)

### DIFF
--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -95,26 +95,36 @@ public:
      * @return true if a device was discovered on the specified port, otherwise false
      */
     bool discoverDevice(port_handle_t port, uint16_t hdwId = IS_HARDWARE_ANY, uint32_t timeoutMs = 0, uint32_t options = OPTIONS_USE_DEFAULTS) {
-        std::lock_guard<std::recursive_mutex> lock(mutex);
         options = (options != OPTIONS_USE_DEFAULTS) ? options : managementOptions;
         options = (options == OPTIONS_USE_DEFAULTS) ? DISCOVERY__DEFAULTS : options;
 
         if (!portIsValid(port))
             return false;
 
-        // first check if this port is already associated with another device
-        for (auto d: *this) {
-            if (d && d->hasDeviceInfo() && (d->port == port)) {
-                if ((options & DISCOVERY__FORCE_REVALIDATION)) {
-                    // Invalidate the device, which will force a rediscovery, without losing the identity of the device itself.
-                    d->devInfo.hdwRunState = HDW_STATE_UNKNOWN;
-                    memset(d->devInfo.firmwareVer, 0, sizeof(d->devInfo.firmwareVer));
-                } else {
-                    if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)
-                        portClose(port);
-                    return true;    // this is a success (rediscovered an existing device), without a FORCE_VALIDATION
+        // Narrow the manager lock to only the parts that touch knownDevices/factories.
+        // factory->locateDevice() below can block up to timeoutMs doing port I/O and
+        // invokes user packet callbacks; holding the manager mutex across it causes
+        // AB-BA deadlock with locks taken by those callbacks (SN-8057).
+        std::vector<DeviceFactory*> factoriesSnapshot;
+        {
+            std::lock_guard<std::recursive_mutex> lock(mutex);
+
+            // first check if this port is already associated with another device
+            for (auto d: *this) {
+                if (d && d->hasDeviceInfo() && (d->port == port)) {
+                    if ((options & DISCOVERY__FORCE_REVALIDATION)) {
+                        // Invalidate the device, which will force a rediscovery, without losing the identity of the device itself.
+                        d->devInfo.hdwRunState = HDW_STATE_UNKNOWN;
+                        memset(d->devInfo.firmwareVer, 0, sizeof(d->devInfo.firmwareVer));
+                    } else {
+                        if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)
+                            portClose(port);
+                        return true;    // this is a success (rediscovered an existing device), without a FORCE_VALIDATION
+                    }
                 }
             }
+
+            factoriesSnapshot = factories;
         }
 
         // open the port, if needed - if we can't open it, fail.
@@ -123,7 +133,7 @@ public:
             return false;
 
 
-        for (auto l : factories) {
+        for (auto l : factoriesSnapshot) {
             std::function<bool(DeviceFactory *, const dev_info_t &, port_handle_t)> cb = std::bind(&DeviceManager::deviceHandler, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, options);
             if (l->locateDevice(cb, port, hdwId, timeoutMs)) {
                 if (options & DISCOVERY__CLOSE_PORT_ON_COMPLETION)  // locateDevice should already handle this, but just in case.


### PR DESCRIPTION
## Summary
- Narrow the `DeviceManager` recursive_mutex in `discoverDevice()` so it no longer covers `factory->locateDevice()`.
- Take the lock briefly for the knownDevices walk + a `factories` snapshot; release before the port I/O and validation loop.
- `deviceHandler` (the factory callback) re-takes the lock itself — recursive_mutex makes that safe.

## Why
`factory->locateDevice()` can block up to `timeoutMs` doing port I/O and dispatches user packet callbacks (e.g. EvalTool's `Devices::processMsgAll`). Holding the manager mutex across those callbacks causes AB-BA inversion against the caller's own locks. Reproducible during multi-device firmware update with ≥8 IMX-5s; probability scales with device count.

Full analysis, stack traces, and lock-cycle diagram in [SN-8057](https://inertialsense.atlassian.net/browse/SN-8057).

## Pairs with
- imx PR for the EvalTool half (gate `updateDevicesInStatusBar` during fwupdate)

## Out of scope (follow-up)
- `DeviceManager::discoverDevices()` (plural) has the same broad-lock pattern. Different call path, not implicated in this stack — worth a follow-up audit.

## Test plan
- [ ] Build clean (verified locally)
- [ ] Repro: ≥8 IMX-5s on bridgeboard fixture, kick off firmware update, confirm no deadlock
- [ ] ci_hdw regression run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8057]: https://inertialsense.atlassian.net/browse/SN-8057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ