### PR TITLE
RTOS info refinement

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -563,7 +563,7 @@ std::string ISDevice::getIdAsString(const dev_info_t& devInfo) {
         case IS_HARDWARE_TYPE_GPX: typeName = "GPX"; break;
         default: typeName = "\?\?\?"; break;
     }
-    return utils::string_format("%s-%d.%d::SN%ld", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1], devInfo.serialNumber);
+    return utils::string_format("%s-%d.%d::SN%u", typeName, devInfo.hardwareVer[0], devInfo.hardwareVer[1], devInfo.serialNumber);
 }
 
 std::string ISDevice::getIdAsString() const {


### PR DESCRIPTION
This pull request makes a minor change to the `ISDevice::getIdAsString(const dev_info_t& devInfo)` function to improve how the device serial number is formatted in the returned string.

- Changed the format specifier for the serial number from `%ld` (signed long) to `%u` (unsigned int) in `utils::string_format` to match the expected type for `devInfo.serialNumber` and prevent potential formatting issues.