### PR TITLE
SN-8061_imx6_hang_w_imu_cal_upload

### DIFF
--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -134,6 +134,7 @@ bool ISDevice::step() {
 
     if (m_calibration && m_calUploadState != -1) {
         const int stepResult = ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo, m_calibration->uploadCtx);
+        SLEEP_MS(50);   // Keep it snappy, but give the device a break between steps, important for uploads over UART.
         if (stepResult != ASYNC_STATE__PENDING) {
             if (stepResult == ASYNC_STATE__SUCCESS) {
                 m_calUploadResult = IS_OP_OK;

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -133,10 +133,11 @@ bool ISDevice::step() {
     }
 
     if (m_calibration && m_calUploadState != -1) {
-        const int stepResult = ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo, m_calibration->uploadCtx);
-        SLEEP_MS(50);   // Keep it snappy, but give the device a break between steps, important for uploads over UART.
-        if (stepResult != ASYNC_STATE__PENDING) {
-            if (stepResult == ASYNC_STATE__SUCCESS) {
+        const ISDeviceCal::AsyncState stepResult = ISDeviceCal::uploadSensorCalStep(port, m_calUploadState, *m_calibration, devInfo, m_calibration->uploadCtx);
+         if (stepResult == ISDeviceCal::ASYNC_STATE__PENDING) {
+             SLEEP_MS(ISDeviceCal::CAL_UPLOAD_SLEEP_MS);   // Give the device a break between upload steps, important for uploads over UART.
+         } else {
+            if (stepResult == ISDeviceCal::ASYNC_STATE__SUCCESS) {
                 m_calUploadResult = IS_OP_OK;
                 log_info(IS_LOG_ISDEVICE, "[%s] Async calibration upload complete.", getIdAsString().c_str());
             } else {

--- a/src/ISDeviceCal.cpp
+++ b/src/ISDeviceCal.cpp
@@ -970,7 +970,7 @@ json ISDeviceCal::saveMcToJsonObj(const std::string& filePath, int pose, sOrthoC
     return jCal;
 }
 
-int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx)
+ISDeviceCal::AsyncState ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx)
 {
     const int hwMajor = devInfo.hardwareVer[0];
     const bool sendV1p3 = (hwMajor == 5);
@@ -979,7 +979,7 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     if (!sendV1p3 && !sendV1p4)
     {
         log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: unresolved hardware version (hardwareVer[0]=%d); refusing upload. Device must be in app mode.", hwMajor);
-        return -1;
+        return ASYNC_STATE__FAILURE;
     }
 
     if (calUploadState == 0)
@@ -993,12 +993,12 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
     }
 
     // Returns 0 (pending) on send failure; aborts with -1 after MAX_UPLOAD_SEND_RETRIES consecutive failures on the current step.
-    auto sendFail = [&]() -> int {
+    auto sendFail = [&]() -> AsyncState {
         if (++ctx.retryCount > MAX_UPLOAD_SEND_RETRIES) {
             log_error(IS_LOG_CALIBRATION, "uploadSensorCalStep: send failed %d times on step %d; aborting upload.", ctx.retryCount, calUploadState);
-            return -1;
+            return ASYNC_STATE__FAILURE;
         }
-        return 0;
+        return ASYNC_STATE__PENDING;
     };
 
     switch (calUploadState)
@@ -1059,15 +1059,15 @@ int ISDeviceCal::uploadSensorCalStep(port_handle_t port, int &calUploadState, se
         }
         ctx.retryCount = 0;
         calUploadState++;   // Increment state to mark completion here in case any upload fails and we need to retry the last step.  We don't want to resend all previous steps if only the last one fails.
-        return 1;    // Done
+        return ASYNC_STATE__SUCCESS;    // Done
 
     default:
-        return -1;
+        return ASYNC_STATE__FAILURE;
     }
 
     ctx.retryCount = 0;
     calUploadState++;
-    return 0;
+    return ASYNC_STATE__PENDING;
 }
 
 

--- a/src/ISDeviceCal.h
+++ b/src/ISDeviceCal.h
@@ -162,6 +162,12 @@ struct sOrthoCal
 class ISDeviceCal : public sensor_cal_t
 {
 public:
+    enum AsyncState {
+        ASYNC_STATE__FAILURE     = -1,          //!< general failure state indicating an error condition, but otherwise a completed async cycle
+        ASYNC_STATE__PENDING     = 0,           //!< indicates that the async operation is still in progress, and should be called again soon
+        ASYNC_STATE__SUCCESS     = 1,           //!< indicates that the async operation was successful, and no further actions are necessary
+    };
+
     /**
      * Creates an empty calibration object - this will need to be populated
      */
@@ -324,7 +330,7 @@ public:
      * @param ctx Per-upload context (caller-owned; one per concurrent upload)
      * @return ASYNC_STATE__PENDING (in progress), ASYNC_STATE__SUCCESS (done), ASYNC_STATE__FAILURE (error)
      */
-    static int uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx);
+    static AsyncState uploadSensorCalStep(port_handle_t port, int &calUploadState, sensor_cal_t &cal, const dev_info_t &devInfo, cal_upload_ctx_t &ctx);
 
     static const int CAL_UPLOAD_SLEEP_MS = 150;
 


### PR DESCRIPTION
This pull request introduces a minor update to the `ISDevice::step()` method to improve device communication timing during sensor calibration uploads. A short sleep interval has been added between calibration upload steps to avoid overwhelming the device, especially when communicating over UART.

- Device communication improvement:
  * Added a `SLEEP_MS(50)` delay after each calibration upload step in `ISDevice::step()` to give the device time to process and prevent issues during UART uploads.