### PR TITLE
SN-8065: allow gnss2 pps to trigger off g8

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3401,22 +3401,22 @@ enum ePlatformConfig
     PLATFORM_CFG_TYPE_MASK                      = (int)0x0000003F,
     PLATFORM_CFG_TYPE_FROM_MANF_OTP             = (int)0x00000080,  // Type is overwritten from manufacturing OTP memory.  Write protection, prevents direct change of platformType in flashConfig.
     PLATFORM_CFG_TYPE_NONE                      = (int)0,           // IMX-5 default
-    PLATFORM_CFG_TYPE_RUG3_G0                   = (int)8,           // PCB RUG-3.x.  PPS disabled (no GNSS1 PPS timepulse configured)
-    PLATFORM_CFG_TYPE_RUG3_G1                   = (int)9,           // "
-    PLATFORM_CFG_TYPE_RUG3_G2                   = (int)10,          // "
+    PLATFORM_CFG_TYPE_RUG3_G0                   = (int)8,           // PCB RUG-3.x.         PPS disabled
+    PLATFORM_CFG_TYPE_RUG3_G1                   = (int)9,           // "                    PPS1 on G15 (pin 20)
+    PLATFORM_CFG_TYPE_RUG3_G2                   = (int)10,          // "                    PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_EVB2_G2                   = (int)11,          
-    PLATFORM_CFG_TYPE_TBED3                     = (int)12,          // Testbed-3 (excluding TBED-3.0) PPS1 on G5 (pin 9)
-    PLATFORM_CFG_TYPE_IG1_0_G2                  = (int)13,          // PCB IG-1.0.  PPS1 on G8
-    PLATFORM_CFG_TYPE_IG1_G1                    = (int)14,          // PCB IG-1.1 and later.  PPS1 on G15 (pin 20)
-    PLATFORM_CFG_TYPE_IG1_G2                    = (int)15,  
-    PLATFORM_CFG_TYPE_IG2                       = (int)16,          // IG-2 and IS-IMX-GPX-DEV-1 (w/ IMX-5 and GPX-1)
+    PLATFORM_CFG_TYPE_TBED3                     = (int)12,          // Testbed-3:           PPS1 on  G5 (pin  9), PPS2 on G8 (pin 8)
+    PLATFORM_CFG_TYPE_IG1_0_G2                  = (int)13,          // IG-1.0:              PPS1 on  G8 (pin  8)
+    PLATFORM_CFG_TYPE_IG1_G1                    = (int)14,          // IG-1.1 and later:    PPS1 on G15 (pin 20)
+    PLATFORM_CFG_TYPE_IG1_G2                    = (int)15,          // IG-1.1 and later:    PPS1 on G15 (pin 20)
+    PLATFORM_CFG_TYPE_IG2                       = (int)16,          // IG-2:                PPS1 on G15 (pin 20)
     PLATFORM_CFG_TYPE_LAMBDA_G1                 = (int)17,          // Enable UBX output on Lambda for testbed
     PLATFORM_CFG_TYPE_LAMBDA_G2                 = (int)18,          // "
     PLATFORM_CFG_TYPE_TBED2_G1_W_LAMBDA         = (int)19,          // Enable UBX input from Lambda
     PLATFORM_CFG_TYPE_TBED2_G2_W_LAMBDA         = (int)20,          // "
-    PLATFORM_CFG_TYPE_TBED3_3                   = (int)21,          // Testbed-3.3 and later.  PPS1 on G5 (pin 9), PPS2 on G13 (pin 14)
-    PLATFORM_CFG_TYPE_RUG4_G2                   = (int)22,          // PCB RUG-4.x.  PPS1 on G15 (default), PPS2 on G11 (pin 16)
-    PLATFORM_CFG_TYPE_IG2_1                     = (int)23,          // IG-2.1 and later.  PPS1 on G15 (pin 20), PPS2 on G13 (pin 14)
+    PLATFORM_CFG_TYPE_IMX_BRK_1                 = (int)21,          // IS-IMX-GPX-DEV-1:    PPS1 on G15 (pin 20), PPS2 on G13 (pin 14)
+    PLATFORM_CFG_TYPE_RUG4_G2                   = (int)22,          // PCB RUG-4.x:         PPS1 on G15 (pin 20), PPS2 on G11 (pin 16)
+    PLATFORM_CFG_TYPE_IG2_1                     = (int)23,          // IG-2.1 and later:    PPS1 on G15 (pin 20), PPS2 on G13 (pin 14)
     PLATFORM_CFG_TYPE_COUNT                     = (int)24,
 
     // Presets

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3388,7 +3388,7 @@ enum eIoConfig2
     IO_CFG2_GNSS2_PPS_SOURCE_G11            = (int)2,
     IO_CFG2_GNSS2_PPS_SOURCE_G13            = (int)3,    
     IO_CFG2_GNSS2_PPS_SOURCE_DISABLED_val   = (int)0x00,
-    IO_CFG2_GNSS2_PPS_SOURCE_G8_val         = (int)0x04,
+    IO_CFG2_GNSS2_PPS_SOURCE_G8_val         = (int)0x40,
     IO_CFG2_GNSS2_PPS_SOURCE_G11_val        = (int)0x80,
     IO_CFG2_GNSS2_PPS_SOURCE_G13_val        = (int)0xC0,
 };

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3267,7 +3267,7 @@ enum eIoConfig
     IO_CFG_GNSS1_PPS_SOURCE_G15                 = (int)1,
     IO_CFG_GNSS1_PPS_SOURCE_G2                  = (int)3,
     IO_CFG_GNSS1_PPS_SOURCE_G5                  = (int)4,
-    IO_CFG_GNSS1_PPS_SOURCE_G8                  = (int)5,
+    IO_CFG_GNSS1_PPS_SOURCE_G12                 = (int)5,
     IO_CFG_GNSS1_PPS_SOURCE_G9                  = (int)6,
 
  #define SET_STATUS_OFFSET_MASK(result,val,offset,mask)    { (result) &= ~((mask)<<(offset)); (result) |= ((val)<<(offset)); }    
@@ -3384,12 +3384,12 @@ enum eIoConfig2
     IO_CFG2_GNSS2_PPS_SOURCE_MASK           = (int)0x03,
     IO_CFG2_GNSS2_PPS_SOURCE_BITMASK        = (int)(IO_CFG2_GNSS2_PPS_SOURCE_MASK<<IO_CFG2_GNSS2_PPS_SOURCE_OFFSET),    
     IO_CFG2_GNSS2_PPS_SOURCE_DISABLED       = (int)0,
-    IO_CFG2_GNSS2_PPS_SOURCE_G11            = (int)1,
-    IO_CFG2_GNSS2_PPS_SOURCE_G12            = (int)2,
+    IO_CFG2_GNSS2_PPS_SOURCE_G8             = (int)1,
+    IO_CFG2_GNSS2_PPS_SOURCE_G11            = (int)2,
     IO_CFG2_GNSS2_PPS_SOURCE_G13            = (int)3,    
     IO_CFG2_GNSS2_PPS_SOURCE_DISABLED_val   = (int)0x00,
-    IO_CFG2_GNSS2_PPS_SOURCE_G11_val        = (int)0x04,
-    IO_CFG2_GNSS2_PPS_SOURCE_G12_val        = (int)0x80,
+    IO_CFG2_GNSS2_PPS_SOURCE_G8_val         = (int)0x04,
+    IO_CFG2_GNSS2_PPS_SOURCE_G11_val        = (int)0x80,
     IO_CFG2_GNSS2_PPS_SOURCE_G13_val        = (int)0xC0,
 };
 

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -155,8 +155,8 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
 
     case PLATFORM_CFG_TYPE_IG2:
     case PLATFORM_CFG_TYPE_IG2_1:
+    case PLATFORM_CFG_TYPE_IMX_BRK_1:
     case PLATFORM_CFG_TYPE_TBED3:
-    case PLATFORM_CFG_TYPE_TBED3_3:
         SET_IO_CFG_GNSS1_SOURCE(*ioConfig, IO_CONFIG_GNSS_SOURCE_SER0);
         SET_IO_CFG_GNSS2_SOURCE(*ioConfig, IO_CONFIG_GNSS_SOURCE_SER0);
         SET_IO_CFG_GNSS1_TYPE(*ioConfig, IO_CONFIG_GNSS_TYPE_GPX);
@@ -198,7 +198,6 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
         break;
         // G5
     case PLATFORM_CFG_TYPE_TBED3:
-    case PLATFORM_CFG_TYPE_TBED3_3:
         *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G5<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
         break;
         // G12
@@ -225,7 +224,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
         break;
         // G13
     case PLATFORM_CFG_TYPE_IG2_1:
-    case PLATFORM_CFG_TYPE_TBED3_3:
+    case PLATFORM_CFG_TYPE_IMX_BRK_1:
         *ioConfig2 |= IO_CFG2_GNSS2_PPS_SOURCE_G13<<IO_CFG2_GNSS2_PPS_SOURCE_OFFSET;
         break;
     }

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -201,10 +201,10 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     case PLATFORM_CFG_TYPE_TBED3_3:
         *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G5<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
         break;
-        // G8
-    case PLATFORM_CFG_TYPE_EVB2_G2:
-        *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G12<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
-        break;
+        // G12
+    // case PLATFORM_CFG_TYPE_EVB2_G2:
+    //     *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G12<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
+    //     break;
         // G15
     default:
         *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G15<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
@@ -215,7 +215,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     *ioConfig2 = 0;
     switch (type)
     {
-        
+        // G8
     case PLATFORM_CFG_TYPE_TBED3:
         *ioConfig2 |= IO_CFG2_GNSS2_PPS_SOURCE_G8<<IO_CFG2_GNSS2_PPS_SOURCE_OFFSET;
         break;

--- a/src/imx_defaults.c
+++ b/src/imx_defaults.c
@@ -203,8 +203,7 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
         break;
         // G8
     case PLATFORM_CFG_TYPE_EVB2_G2:
-    case PLATFORM_CFG_TYPE_IG1_0_G2:
-        *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G8<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
+        *ioConfig |= IO_CFG_GNSS1_PPS_SOURCE_G12<<IO_CFG_GNSS1_PPS_SOURCE_OFFSET;
         break;
         // G15
     default:
@@ -216,6 +215,10 @@ void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2,
     *ioConfig2 = 0;
     switch (type)
     {
+        
+    case PLATFORM_CFG_TYPE_TBED3:
+        *ioConfig2 |= IO_CFG2_GNSS2_PPS_SOURCE_G8<<IO_CFG2_GNSS2_PPS_SOURCE_OFFSET;
+        break;
         // G11
     case PLATFORM_CFG_TYPE_RUG4_G2:
         *ioConfig2 |= IO_CFG2_GNSS2_PPS_SOURCE_G11<<IO_CFG2_GNSS2_PPS_SOURCE_OFFSET;


### PR DESCRIPTION
This pull request updates GNSS PPS source assignments and platform configuration mappings to improve clarity and consistency across the codebase. The main changes include reassigning GNSS source values in enums, updating platform configuration types and their documentation, and refining the mapping logic in `imxPlatformConfigToFlashCfgIoConfig` to match these changes.

**GNSS PPS Source Assignment Updates:**

* In `enum eIoConfig` (`src/data_sets.h`), replaced `IO_CFG_GNSS1_PPS_SOURCE_G8` with `IO_CFG_GNSS1_PPS_SOURCE_G12` for value 5, reflecting a change in GNSS1 PPS source assignments.
* In `enum eIoConfig2` (`src/data_sets.h`), reassigned values so `G8` and `G11` now occupy positions 1 and 2, and updated the corresponding `_val` constants to match.

**Platform Configuration Type and Documentation Improvements:**

* In `enum ePlatformConfig` (`src/data_sets.h`), clarified and updated platform type documentation, added `PLATFORM_CFG_TYPE_IMX_BRK_1`, and redefined several platform types to better reflect their PPS pin assignments.

**Platform-to-IO Mapping Logic Adjustments:**

* Updated `imxPlatformConfigToFlashCfgIoConfig` (`src/imx_defaults.c`) to:
  - Include `PLATFORM_CFG_TYPE_IMX_BRK_1` in relevant switch cases for consistent handling.
  - Remove handling for `PLATFORM_CFG_TYPE_TBED3_3` and `G8` as a GNSS1 PPS source, and comment out the `G12` case for `PLATFORM_CFG_TYPE_EVB2_G2`.
  - Add logic to assign GNSS2 PPS source `G8` for `PLATFORM_CFG_TYPE_TBED3`, and assign GNSS2 PPS source `G13` for `PLATFORM_CFG_TYPE_IMX_BRK_1`.