### PR TITLE
SN-8107 / D0066: ISTimeResolver bridges session-uptime <-> ToW for v2 .idx logs

### DIFF
--- a/src/ISSyncPoint.h
+++ b/src/ISSyncPoint.h
@@ -67,6 +67,26 @@ struct ISSyncPoint {
     /// degenerate case the resolver falls back to the legacy
     /// classify-only behavior.
     uint64_t actualHostTimeMs = 0;
+
+    /// **SN-8107 / D0066.** GPS week number from the payload (e.g.
+    /// `ins_2_t::week`, `gnss_pos_t::week`). Used together with
+    /// `payloadToWMs` to compute an absolute Unix-epoch wall-clock ms:
+    /// `unix_ms = (gpsWeek × 604,800,000) + GPS_EPOCH_UNIX_MS + payloadToWMs`,
+    /// where `GPS_EPOCH_UNIX_MS = 315,964,800,000` (1980-01-06 UTC).
+    ///
+    /// When ANY sync point in the resolver's vector has `gpsWeek != 0`,
+    /// `ISTimeResolver::resolve()` anchors all output values to Unix
+    /// epoch so they're directly suitable for
+    /// `QDateTime::fromMSecsSinceEpoch` / wall-clock display. When all
+    /// sync points have `gpsWeek == 0` (logs from devices without a
+    /// usable week field), the resolver returns ToW-domain values
+    /// (pre-D0066 behavior).
+    ///
+    /// All ToW-bearing DID payload structs (`ins_1_t`, `ins_2_t`,
+    /// `ins_3_t`, `ins_4_t`, `gnss_pos_t`) start with a `uint32_t week`
+    /// field, so the scanner reads it from the first 4 bytes of the
+    /// payload.
+    uint32_t gpsWeek = 0;
 };
 
 } // namespace inertial_sense

--- a/src/ISSyncPoint.h
+++ b/src/ISSyncPoint.h
@@ -30,61 +30,65 @@ namespace inertial_sense {
  * bridge session-uptime queries into the ToW frame.
  */
 struct ISSyncPoint {
-    /// Host-side timestamp of the record, in ms. For HAS_TOW records
-    /// this equals `payloadToWMs` (the .idx-stored value); the
-    /// `.raw`-recovered host-time at sync is on `actualHostTimeMs`.
+    //! Host-side timestamp of the record, in ms. For HAS_TOW records
+    //! this equals `payloadToWMs` (the .idx-stored value); the
+    //! `.raw`-recovered host-time at sync is on `actualHostTimeMs`.
     uint64_t hostTimeMs;
 
-    /// Payload's GPS time-of-week, in ms.
+    //! Payload's GPS time-of-week, in ms.
     uint64_t payloadToWMs;
 
-    /// Source device's serial number.
+    //! Source device's serial number.
     uint64_t deviceId;
 
-    /// DID that supplied the sync (e.g. `DID_INS_2`, `DID_GNSS1_POS`).
+    //! DID that supplied the sync (e.g. `DID_INS_2`, `DID_GNSS1_POS`).
     uint32_t sourceDid;
 
-    /// **SN-8107 / D0066.** Recovered host-uptime at which this sync
-    /// record was written, captured from the most recent non-sync
-    /// record observed before this sync during the segment byte scan.
-    /// On v2 `.idx`, sync records' own `.idx` timestamp field is
-    /// overwritten with the payload ToW, so the "real" host clock at
-    /// sync time isn't stored — but the adjacent non-sync record's
-    /// host-uptime is an excellent approximation (the writer emits
-    /// records in arrival order on one host thread, so consecutive
-    /// records are millisecond-adjacent in host time).
-    ///
-    /// `ISTimeResolver::resolve` uses this to bridge session-uptime
-    /// queries into the ToW frame: any non-sync record's stored
-    /// host-uptime `H` resolves to `payloadToWMs + (H - actualHostTimeMs)`
-    /// where the sync point used is the nearest one (typically the
-    /// first sync, since pre-fix records dominate the session-uptime
-    /// query population).
-    ///
-    /// `0` means "no pre-sync non-sync record observed" — e.g. the
-    /// very first record in the segment is the sync point. In that
-    /// degenerate case the resolver falls back to the legacy
-    /// classify-only behavior.
+    //! Recovered host-uptime at which this sync record was written,
+    //! captured from the most recent non-sync record observed before
+    //! this sync during the segment byte scan. On v2 `.idx`, sync
+    //! records' own `.idx` timestamp field is overwritten with the
+    //! payload ToW, so the "real" host clock at sync time isn't
+    //! stored — but the adjacent non-sync record's host-uptime is an
+    //! excellent approximation (the writer emits records in arrival
+    //! order on one host thread, so consecutive records are
+    //! millisecond-adjacent in host time).
+    //!
+    //! `ISTimeResolver::resolve` uses this to bridge session-uptime
+    //! queries into the ToW frame: any non-sync record's stored
+    //! host-uptime `H` resolves to `payloadToWMs + (H - actualHostTimeMs)`
+    //! where the sync point used is the nearest one (typically the
+    //! first sync, since pre-fix records dominate the session-uptime
+    //! query population).
+    //!
+    //! `0` means "no pre-sync non-sync record observed" — e.g. the
+    //! very first record in the segment is the sync point. In that
+    //! degenerate case the resolver falls back to the legacy
+    //! classify-only behavior.
+    //!
+    //! @note SN-8107 / D0066.
     uint64_t actualHostTimeMs = 0;
 
-    /// **SN-8107 / D0066.** GPS week number from the payload (e.g.
-    /// `ins_2_t::week`, `gnss_pos_t::week`). Used together with
-    /// `payloadToWMs` to compute an absolute Unix-epoch wall-clock ms:
-    /// `unix_ms = (gpsWeek × 604,800,000) + GPS_EPOCH_UNIX_MS + payloadToWMs`,
-    /// where `GPS_EPOCH_UNIX_MS = 315,964,800,000` (1980-01-06 UTC).
-    ///
-    /// When ANY sync point in the resolver's vector has `gpsWeek != 0`,
-    /// `ISTimeResolver::resolve()` anchors all output values to Unix
-    /// epoch so they're directly suitable for
-    /// `QDateTime::fromMSecsSinceEpoch` / wall-clock display. When all
-    /// sync points have `gpsWeek == 0` (logs from devices without a
-    /// usable week field), the resolver returns ToW-domain values
-    /// (pre-D0066 behavior).
-    ///
-    /// All ToW-bearing DID payload structs (`ins_1_t`, `ins_2_t`,
-    /// `ins_3_t`, `ins_4_t`, `gnss_pos_t`) start with a `uint32_t week`
-    /// field, so the scanner reads it from the first 4 bytes of the
-    /// payload.
+    //! GPS week number from the payload (e.g. `ins_2_t::week`,
+    //! `gnss_pos_t::week`). Used together with `payloadToWMs` to
+    //! compute an absolute Unix-epoch wall-clock ms:
+    //! `unix_ms = (gpsWeek × 604,800,000) + GPS_EPOCH_UNIX_MS + payloadToWMs`,
+    //! where `GPS_EPOCH_UNIX_MS = 315,964,800,000` (1980-01-06 UTC).
+    //!
+    //! When ANY sync point in the resolver's vector has `gpsWeek != 0`,
+    //! `ISTimeResolver::resolve()` anchors all output values to Unix
+    //! epoch so they're directly suitable for
+    //! `QDateTime::fromMSecsSinceEpoch` / wall-clock display. When all
+    //! sync points have `gpsWeek == 0` (logs from devices without a
+    //! usable week field), the resolver returns ToW-domain values
+    //! (pre-D0066 behavior).
+    //!
+    //! All ToW-bearing DID payload structs (`ins_1_t`, `ins_2_t`,
+    //! `ins_3_t`, `ins_4_t`, `gnss_pos_t`) start with a `uint32_t week`
+    //! field, so the scanner reads it from the first 4 bytes of the
+    //! payload.
+    //!
+    //! @note SN-8107 / D0066.
     uint32_t gpsWeek = 0;
 };
 

--- a/src/ISSyncPoint.h
+++ b/src/ISSyncPoint.h
@@ -20,20 +20,19 @@ namespace inertial_sense {
  * @brief One sync anchor — a record carrying both a host-side timestamp
  *        and a payload-derived GPS time-of-week.
  *
- * **v2 `.idx` schema note.** In the current writer (`cDeviceLog`), a
- * record with the `IS_LOG_IDX_REC_FLAG_HAS_TOW` bit set has its `.idx`
+ * **v2 `.idx` schema note.** In the writer (`cDeviceLog`), a record
+ * with the `IS_LOG_IDX_REC_FLAG_HAS_TOW` bit set has its `.idx`
  * `timestamp` field overwritten with the payload ToW (in ms) — the
- * host-side capture time isn't stored separately. So for v2-produced
- * sync points, `hostTimeMs == payloadToWMs`. This is documented in
- * the resolver's header (`ISTimeResolver.h`) since it constrains
- * what the slope-fit / discontinuity-detection algorithms can do
- * meaningfully on v2 logs. A future `.idx` v3 may add an explicit
- * host-time field; sync points adopt it transparently when it lands.
+ * host-side capture time isn't stored separately in the .idx. So for
+ * .idx-only readers, `hostTimeMs == payloadToWMs`. The host-time at
+ * sync is recovered from the .raw byte stream during scan and carried
+ * on `actualHostTimeMs` (SN-8107 / D0066); the resolver uses that to
+ * bridge session-uptime queries into the ToW frame.
  */
 struct ISSyncPoint {
-    /// Host-side timestamp of the record, in ms. For v2 `.idx` HAS_TOW
-    /// records this equals `payloadToWMs`; for hypothetical v3 schemas
-    /// with a separate host field it carries the distinct host clock.
+    /// Host-side timestamp of the record, in ms. For HAS_TOW records
+    /// this equals `payloadToWMs` (the .idx-stored value); the
+    /// `.raw`-recovered host-time at sync is on `actualHostTimeMs`.
     uint64_t hostTimeMs;
 
     /// Payload's GPS time-of-week, in ms.

--- a/src/ISSyncPoint.h
+++ b/src/ISSyncPoint.h
@@ -44,6 +44,29 @@ struct ISSyncPoint {
 
     /// DID that supplied the sync (e.g. `DID_INS_2`, `DID_GNSS1_POS`).
     uint32_t sourceDid;
+
+    /// **SN-8107 / D0066.** Recovered host-uptime at which this sync
+    /// record was written, captured from the most recent non-sync
+    /// record observed before this sync during the segment byte scan.
+    /// On v2 `.idx`, sync records' own `.idx` timestamp field is
+    /// overwritten with the payload ToW, so the "real" host clock at
+    /// sync time isn't stored — but the adjacent non-sync record's
+    /// host-uptime is an excellent approximation (the writer emits
+    /// records in arrival order on one host thread, so consecutive
+    /// records are millisecond-adjacent in host time).
+    ///
+    /// `ISTimeResolver::resolve` uses this to bridge session-uptime
+    /// queries into the ToW frame: any non-sync record's stored
+    /// host-uptime `H` resolves to `payloadToWMs + (H - actualHostTimeMs)`
+    /// where the sync point used is the nearest one (typically the
+    /// first sync, since pre-fix records dominate the session-uptime
+    /// query population).
+    ///
+    /// `0` means "no pre-sync non-sync record observed" — e.g. the
+    /// very first record in the segment is the sync point. In that
+    /// degenerate case the resolver falls back to the legacy
+    /// classify-only behavior.
+    uint64_t actualHostTimeMs = 0;
 };
 
 } // namespace inertial_sense

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -24,11 +24,11 @@ namespace inertial_sense {
 
 namespace {
 
-/// DIDs whose payloads carry a usable GPS time-of-week field. Used by
-/// `detectSyncPoints` as the candidate set when scanning a segment.
-/// `cISDataMappings::Timestamp(...)` is consulted on each candidate to
-/// extract the actual ToW (returns 0 if the field is absent / zero,
-/// which the detection loop treats as "not a sync anchor").
+//! DIDs whose payloads carry a usable GPS time-of-week field. Used by
+//! `detectSyncPoints` as the candidate set when scanning a segment.
+//! `cISDataMappings::Timestamp(...)` is consulted on each candidate to
+//! extract the actual ToW (returns 0 if the field is absent / zero,
+//! which the detection loop treats as "not a sync anchor").
 constexpr std::array<uint32_t, 6> kToWBearingDids = {
     DID_INS_1, DID_INS_2, DID_INS_3, DID_INS_4,
     DID_GNSS1_POS, DID_GNSS2_POS,
@@ -61,9 +61,15 @@ inline bool isToWBearing(uint32_t did) noexcept {
     return false;
 }
 
-/// Slope between two sync points in ToW-ms per host-ms. Returns 1.0
-/// when the host distance is zero (degenerate / colocated points) so
-/// downstream comparisons don't divide-by-zero.
+/**
+ * @brief Slope between two sync points in ToW-ms per host-ms.
+ *
+ * @param a Earlier sync point.
+ * @param b Later sync point.
+ * @return  ToW-delta divided by host-delta; returns 1.0 when the host
+ *          distance is zero (degenerate / colocated points) so
+ *          downstream comparisons don't divide by zero.
+ */
 double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
     if (b.hostTimeMs == a.hostTimeMs) return 1.0;
     const double hostDelta = static_cast<double>(b.hostTimeMs) - static_cast<double>(a.hostTimeMs);

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -121,10 +121,10 @@ void scanSegmentForSyncs(const ISLogReader& reader,
     is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
     is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
 
-    //! SN-8107 / D0066: most recent non-sync host-uptime observed during
-    //! the scan. Updated on every non-ToW-bearing record whose payload
-    //! exposes a timestamp; carried onto each subsequent sync point until
-    //! a newer non-sync time arrives.
+    // SN-8107 / D0066: most recent non-sync host-uptime observed during
+    // the scan. Updated on every non-ToW-bearing record whose payload
+    // exposes a timestamp; carried onto each subsequent sync point until
+    // a newer non-sync time arrives.
     uint64_t lastNonSyncHostTimeMs = 0;
 
     for (std::size_t i = 0; i < bytes.second; ++i) {
@@ -134,44 +134,43 @@ void scanSegmentForSyncs(const ISLogReader& reader,
         }
         const auto& hdr = comm.rxPkt.dataHdr;
 
-        //! Probe every record for a payload-side timestamp. ToW-bearing
-        //! records use this for the sync's payloadToW; non-ToW-bearing
-        //! records' values feed `lastNonSyncHostTimeMs`.
+        // Probe every record for a payload-side timestamp. ToW-bearing
+        // records use this for the sync's payloadToW; non-ToW-bearing
+        // records' values feed lastNonSyncHostTimeMs.
         const double tsSec = cISDataMappings::Timestamp(&hdr, comm.rxPkt.data.ptr);
 
         if (!isToWBearing(hdr.id)) {
-            //! Non-sync candidate: if the payload carries a usable time
-            //! field, snapshot it. The vast majority of non-sync DIDs
-            //! (`DID_PIMU`, `DID_IMU`, etc.) carry a host-uptime time
-            //! field in seconds; cISDataMappings::Timestamp converts.
+            // Non-sync candidate: if the payload carries a usable time
+            // field, snapshot it. Most non-sync DIDs (DID_PIMU, DID_IMU,
+            // etc.) carry a host-uptime time field in seconds;
+            // cISDataMappings::Timestamp converts.
             if (tsSec > 0.0) {
                 lastNonSyncHostTimeMs = static_cast<uint64_t>(tsSec * 1000.0);
             }
             continue;
         }
 
-        if (tsSec <= 0.0) continue;  //!< payload's ToW field is zero / absent.
+        if (tsSec <= 0.0) continue;  // payload's ToW field is zero / absent.
 
         const uint64_t towMs = static_cast<uint64_t>(tsSec * 1000.0);
         ISSyncPoint sp{};
-        //! v2 `.idx` schema collapse: the writer's `rec.timestamp` for
-        //! HAS_TOW records is also the ToW (no separate host-time
-        //! stored in the .idx). Carry the same value in both fields;
-        //! the .raw-recovered host-time at sync rides on
-        //! `actualHostTimeMs` (set below from the byte scan's
-        //! `lastNonSyncHostTimeMs` tracker).
+        // v2 .idx schema collapse: the writer's rec.timestamp for
+        // HAS_TOW records is also the ToW (no separate host-time stored
+        // in the .idx). Carry the same value in both fields; the
+        // .raw-recovered host-time at sync rides on actualHostTimeMs
+        // (set below from the byte scan's lastNonSyncHostTimeMs tracker).
         sp.hostTimeMs        = towMs;
         sp.payloadToWMs      = towMs;
         sp.deviceId          = deviceId;
         sp.sourceDid         = hdr.id;
-        //! SN-8107 / D0066: recovered host-uptime at sync time.
+        // SN-8107 / D0066: recovered host-uptime at sync time.
         sp.actualHostTimeMs  = lastNonSyncHostTimeMs;
-        //! SN-8107 / D0066: GPS week from payload. All ToW-bearing DIDs
-        //! (`ins_1_t`, `ins_2_t`, `ins_3_t`, `ins_4_t`, `gnss_pos_t`)
-        //! start with `uint32_t week` — read it from the first 4 bytes
-        //! of the payload. Zero means the device hasn't established a
-        //! GPS week yet (still searching); we keep the sync point but
-        //! the resolver won't epoch-anchor against it.
+        // SN-8107 / D0066: GPS week from payload. All ToW-bearing DIDs
+        // (ins_1_t, ins_2_t, ins_3_t, ins_4_t, gnss_pos_t) start with a
+        // uint32_t week — read it from the first 4 bytes of the payload.
+        // Zero means the device hasn't established a GPS week yet (still
+        // searching); we keep the sync point but the resolver won't
+        // epoch-anchor against it.
         if (comm.rxPkt.data.ptr && comm.rxPkt.dataHdr.size >= sizeof(uint32_t)) {
             uint32_t weekRaw = 0;
             std::memcpy(&weekRaw, comm.rxPkt.data.ptr, sizeof(weekRaw));
@@ -263,12 +262,12 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
     }
 
-    //! SN-8107 / D0066: select a representative GPS week for the epoch
-    //! anchor. We use the first sync point's week; for the common
-    //! single-week log this is correct. A log spans < 1 hour typically,
-    //! well inside one GPS week. If `gpsWeek == 0` (week field invalid
-    //! or not yet established), we don't epoch-anchor — resolved
-    //! values stay in ToW domain (pre-D0066 behavior).
+    // SN-8107 / D0066: select a representative GPS week for the epoch
+    // anchor. We use the first sync point's week; for the common
+    // single-week log this is correct. A log spans < 1 hour typically,
+    // well inside one GPS week. If gpsWeek == 0 (week field invalid or
+    // not yet established), we don't epoch-anchor — resolved values stay
+    // in ToW domain (pre-D0066 behavior).
     const ISSyncPoint& firstSync = syncPoints_.front();
     const uint32_t anchorWeek = firstSync.gpsWeek;
     const bool     epochAnchor = (anchorWeek != 0);
@@ -276,14 +275,14 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         return epochAnchor ? gpsToUnixMs(anchorWeek, towMs) : towMs;
     };
 
-    //! SN-8107 / D0066: cross-domain bridge. v2 .idx puts sync records'
-    //! `timestamp` field in the GPS-ToW domain (hundreds of millions of
-    //! ms into the GPS week) while non-sync records' `timestamp` field
-    //! is host uptime (small ms since session start). An input
-    //! `hostTimeMs` that's dramatically smaller than the first sync's
-    //! ToW is a session-uptime query — translate it into the ToW frame
-    //! using the recovered `actualHostTimeMs` of the first sync, then
-    //! epoch-anchor the result if GPS week is known.
+    // SN-8107 / D0066: cross-domain bridge. v2 .idx puts sync records'
+    // timestamp field in the GPS-ToW domain (hundreds of millions of ms
+    // into the GPS week) while non-sync records' timestamp field is host
+    // uptime (small ms since session start). An input hostTimeMs that's
+    // dramatically smaller than the first sync's ToW is a session-uptime
+    // query — translate it into the ToW frame using the recovered
+    // actualHostTimeMs of the first sync, then epoch-anchor the result
+    // if GPS week is known.
     if (firstSync.actualHostTimeMs > 0 &&
         hostTimeMs < firstSync.payloadToWMs / 2) {
         const int64_t offset =

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -34,14 +34,24 @@ constexpr std::array<uint32_t, 6> kToWBearingDids = {
     DID_GNSS1_POS, DID_GNSS2_POS,
 };
 
-/// SN-8107 / D0066: GPS epoch (1980-01-06 00:00:00 UTC) expressed as
-/// milliseconds-since-Unix-epoch. Used together with `gpsWeek` and
-/// `payloadToWMs` to anchor resolver output to Unix epoch so QDateTime
-/// can render wall-clock dates directly.
+//! GPS epoch (1980-01-06 00:00:00 UTC) expressed as
+//! milliseconds-since-Unix-epoch. Used together with `gpsWeek` and
+//! `payloadToWMs` to anchor resolver output to Unix epoch so QDateTime
+//! can render wall-clock dates directly.
+//!
+//! @note SN-8107 / D0066.
 constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
 constexpr uint64_t kGpsWeekMs      = 604'800'000ULL;  //!< 7 days in ms
 
-/// Convert (gpsWeek, towMs) into a Unix-epoch ms timestamp.
+/**
+ * @brief Convert `(gpsWeek, towMs)` into a Unix-epoch ms timestamp.
+ *
+ * @param gpsWeek GPS week number (weeks since 1980-01-06).
+ * @param towMs   Time-of-week in milliseconds.
+ * @return        Milliseconds since Unix epoch (1970-01-01 UTC).
+ *
+ * @note SN-8107 / D0066.
+ */
 inline uint64_t gpsToUnixMs(uint32_t gpsWeek, uint64_t towMs) noexcept {
     return static_cast<uint64_t>(gpsWeek) * kGpsWeekMs + kGpsEpochUnixMs + towMs;
 }
@@ -61,33 +71,39 @@ double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
     return towDelta / hostDelta;
 }
 
-/// Walk one segment's `.raw` bytes via `is_comm_parse_byte`, emitting
-/// a sync point for every ToW-bearing-DID packet whose payload carries
-/// a non-zero ToW. The walk per segment matches the writer's per-
-/// packet emission pattern (`cDeviceLogRaw::SaveData`), so we recover
-/// the same anchors the writer would have flagged with `HAS_TOW`.
-///
-/// **SN-8107 / D0066:** the walker also tracks the most recent
-/// non-sync record's payload-side timestamp (when the payload happens
-/// to carry a `tsSec` value but the record is NOT ToW-bearing) so each
-/// emitted sync point can carry an `actualHostTimeMs` approximation
-/// (see `ISSyncPoint::actualHostTimeMs` doc). For records whose
-/// payload doesn't expose a timestamp field at all we just leave
-/// `actualHostTimeMs == 0` for those syncs that don't see a non-sync
-/// predecessor.
-///
-/// NOTE on the host-time recovery heuristic: the writer (`cDeviceLog`)
-/// emits records in arrival order on one host thread, so the
-/// host-uptime of a sync record is millisecond-adjacent to the
-/// host-uptime of the most recently emitted non-sync record. The
-/// `.idx` writer stores non-sync records' raw host uptime in the
-/// `timestamp` field — we don't have direct .idx access in this scan
-/// (the byte walk only sees payload bytes), so we approximate via
-/// `cISDataMappings::Timestamp` which reads the payload's own time
-/// field. For DIDs like `DID_PIMU` the payload's `time` field IS the
-/// host uptime; that's the value we capture. For DIDs whose payload
-/// timestamp is in a different domain (rare in v2) the approximation
-/// degrades but the bridge stays usable.
+/**
+ * @brief Walk one segment's `.raw` bytes via `is_comm_parse_byte`,
+ *        emitting a sync point for every ToW-bearing-DID packet whose
+ *        payload carries a non-zero ToW.
+ *
+ * The walk per segment matches the writer's per-packet emission
+ * pattern (`cDeviceLogRaw::SaveData`), so we recover the same anchors
+ * the writer would have flagged with `HAS_TOW`.
+ *
+ * The walker also tracks the most recent non-sync record's payload-side
+ * timestamp (when the payload happens to carry a `tsSec` value but the
+ * record is NOT ToW-bearing) so each emitted sync point can carry an
+ * `actualHostTimeMs` approximation (see `ISSyncPoint::actualHostTimeMs`
+ * doc). For records whose payload doesn't expose a timestamp field at
+ * all we leave `actualHostTimeMs == 0` for syncs that don't see a
+ * non-sync predecessor.
+ *
+ * @param reader   Segment reader yielding `.raw` bytes.
+ * @param deviceId Source device ID baked into each emitted sync point.
+ * @param out      Sync points appended to (caller's vector).
+ *
+ * @note Host-time recovery heuristic: the writer (`cDeviceLog`) emits
+ *       records in arrival order on one host thread, so the host-uptime
+ *       of a sync record is millisecond-adjacent to the host-uptime of
+ *       the most recently emitted non-sync record. The byte walk only
+ *       sees payload bytes (no direct .idx access here), so we
+ *       approximate via `cISDataMappings::Timestamp` which reads the
+ *       payload's own time field. For DIDs like `DID_PIMU` the
+ *       payload's `time` field IS the host uptime — that's the value
+ *       we capture.
+ *
+ * @note SN-8107 / D0066.
+ */
 void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t deviceId,
                          std::vector<ISSyncPoint>& out) {

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -53,6 +53,28 @@ double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
 /// a non-zero ToW. The walk per segment matches the writer's per-
 /// packet emission pattern (`cDeviceLogRaw::SaveData`), so we recover
 /// the same anchors the writer would have flagged with `HAS_TOW`.
+///
+/// **SN-8107 / D0066:** the walker also tracks the most recent
+/// non-sync record's payload-side timestamp (when the payload happens
+/// to carry a `tsSec` value but the record is NOT ToW-bearing) so each
+/// emitted sync point can carry an `actualHostTimeMs` approximation
+/// (see `ISSyncPoint::actualHostTimeMs` doc). For records whose
+/// payload doesn't expose a timestamp field at all we just leave
+/// `actualHostTimeMs == 0` for those syncs that don't see a non-sync
+/// predecessor.
+///
+/// NOTE on the host-time recovery heuristic: the writer (`cDeviceLog`)
+/// emits records in arrival order on one host thread, so the
+/// host-uptime of a sync record is millisecond-adjacent to the
+/// host-uptime of the most recently emitted non-sync record. The
+/// `.idx` writer stores non-sync records' raw host uptime in the
+/// `timestamp` field — we don't have direct .idx access in this scan
+/// (the byte walk only sees payload bytes), so we approximate via
+/// `cISDataMappings::Timestamp` which reads the payload's own time
+/// field. For DIDs like `DID_PIMU` the payload's `time` field IS the
+/// host uptime; that's the value we capture. For DIDs whose payload
+/// timestamp is in a different domain (rare in v2) the approximation
+/// degrades but the bridge stays usable.
 void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t deviceId,
                          std::vector<ISSyncPoint>& out) {
@@ -64,28 +86,50 @@ void scanSegmentForSyncs(const ISLogReader& reader,
     is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
     is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
 
+    //! SN-8107 / D0066: most recent non-sync host-uptime observed during
+    //! the scan. Updated on every non-ToW-bearing record whose payload
+    //! exposes a timestamp; carried onto each subsequent sync point until
+    //! a newer non-sync time arrives.
+    uint64_t lastNonSyncHostTimeMs = 0;
+
     for (std::size_t i = 0; i < bytes.second; ++i) {
         protocol_type_t p = is_comm_parse_byte(&comm, bytes.first[i]);
         if (p != _PTYPE_INERTIAL_SENSE_DATA && p != _PTYPE_INERTIAL_SENSE_CMD) {
             continue;
         }
         const auto& hdr = comm.rxPkt.dataHdr;
-        if (!isToWBearing(hdr.id)) continue;
 
+        //! Probe every record for a payload-side timestamp. ToW-bearing
+        //! records use this for the sync's payloadToW; non-ToW-bearing
+        //! records' values feed `lastNonSyncHostTimeMs`.
         const double tsSec = cISDataMappings::Timestamp(&hdr, comm.rxPkt.data.ptr);
-        if (tsSec <= 0.0) continue;  // payload's ToW field is zero / absent.
+
+        if (!isToWBearing(hdr.id)) {
+            //! Non-sync candidate: if the payload carries a usable time
+            //! field, snapshot it. The vast majority of non-sync DIDs
+            //! (`DID_PIMU`, `DID_IMU`, etc.) carry a host-uptime time
+            //! field in seconds; cISDataMappings::Timestamp converts.
+            if (tsSec > 0.0) {
+                lastNonSyncHostTimeMs = static_cast<uint64_t>(tsSec * 1000.0);
+            }
+            continue;
+        }
+
+        if (tsSec <= 0.0) continue;  //!< payload's ToW field is zero / absent.
 
         const uint64_t towMs = static_cast<uint64_t>(tsSec * 1000.0);
         ISSyncPoint sp{};
-        // v2 `.idx` schema collapse: the writer's `rec.timestamp` for
-        // HAS_TOW records is also the ToW (no separate host-time
-        // recorded). Carry the same value in both fields so a future
-        // v3 schema with a distinct host-time can populate `hostTimeMs`
-        // independently without touching the resolver's API.
-        sp.hostTimeMs   = towMs;
-        sp.payloadToWMs = towMs;
-        sp.deviceId     = deviceId;
-        sp.sourceDid    = hdr.id;
+        //! v2 `.idx` schema collapse: the writer's `rec.timestamp` for
+        //! HAS_TOW records is also the ToW (no separate host-time
+        //! recorded). Carry the same value in both fields so a future
+        //! v3 schema with a distinct host-time can populate `hostTimeMs`
+        //! independently without touching the resolver's API.
+        sp.hostTimeMs        = towMs;
+        sp.payloadToWMs      = towMs;
+        sp.deviceId          = deviceId;
+        sp.sourceDid         = hdr.id;
+        //! SN-8107 / D0066: recovered host-uptime at sync time.
+        sp.actualHostTimeMs  = lastNonSyncHostTimeMs;
         out.push_back(sp);
     }
 }
@@ -170,6 +214,33 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         // No anchors. Best we can do is a SessionOnly tag with the
         // input value passed through.
         return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
+    }
+
+    //! SN-8107 / D0066: cross-domain bridge. v2 .idx puts sync records'
+    //! `timestamp` field in the GPS-ToW domain (hundreds of millions of
+    //! ms into the GPS week) while non-sync records' `timestamp` field
+    //! is host uptime (small ms since session start). An input
+    //! `hostTimeMs` that's dramatically smaller than the first sync's
+    //! ToW is a session-uptime query — translate it into the ToW frame
+    //! using the recovered `actualHostTimeMs` of the first sync.
+    //!
+    //! The threshold: any non-sync query whose value is less than half
+    //! the first sync's ToW. In practice this means anything under tens
+    //! of millions of ms (a single session is at most a few hours).
+    //! ToW values are hundreds of millions of ms (GPS week scale).
+    const ISSyncPoint& firstSync = syncPoints_.front();
+    if (firstSync.actualHostTimeMs > 0 &&
+        hostTimeMs < firstSync.payloadToWMs / 2) {
+        //! Session-uptime input. Bridge to ToW using the offset
+        //! between the first sync's payload-ToW and the host-uptime we
+        //! captured at sync time.
+        const int64_t offset =
+            static_cast<int64_t>(firstSync.payloadToWMs) -
+            static_cast<int64_t>(firstSync.actualHostTimeMs);
+        const int64_t bridged = static_cast<int64_t>(hostTimeMs) + offset;
+        const uint64_t value = (bridged < 0) ? 0u : static_cast<uint64_t>(bridged);
+        return TimeStamp::fromResolvedViaSync(value, deviceId,
+                                              TimeConfidence::ExtrapolatedBackward);
     }
 
     // Binary search for the first sync point whose hostTimeMs >= input.

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstring>
 
 namespace inertial_sense {
 
@@ -32,6 +33,18 @@ constexpr std::array<uint32_t, 6> kToWBearingDids = {
     DID_INS_1, DID_INS_2, DID_INS_3, DID_INS_4,
     DID_GNSS1_POS, DID_GNSS2_POS,
 };
+
+/// SN-8107 / D0066: GPS epoch (1980-01-06 00:00:00 UTC) expressed as
+/// milliseconds-since-Unix-epoch. Used together with `gpsWeek` and
+/// `payloadToWMs` to anchor resolver output to Unix epoch so QDateTime
+/// can render wall-clock dates directly.
+constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
+constexpr uint64_t kGpsWeekMs      = 604'800'000ULL;  //!< 7 days in ms
+
+/// Convert (gpsWeek, towMs) into a Unix-epoch ms timestamp.
+inline uint64_t gpsToUnixMs(uint32_t gpsWeek, uint64_t towMs) noexcept {
+    return static_cast<uint64_t>(gpsWeek) * kGpsWeekMs + kGpsEpochUnixMs + towMs;
+}
 
 inline bool isToWBearing(uint32_t did) noexcept {
     for (auto d : kToWBearingDids) if (d == did) return true;
@@ -130,6 +143,17 @@ void scanSegmentForSyncs(const ISLogReader& reader,
         sp.sourceDid         = hdr.id;
         //! SN-8107 / D0066: recovered host-uptime at sync time.
         sp.actualHostTimeMs  = lastNonSyncHostTimeMs;
+        //! SN-8107 / D0066: GPS week from payload. All ToW-bearing DIDs
+        //! (`ins_1_t`, `ins_2_t`, `ins_3_t`, `ins_4_t`, `gnss_pos_t`)
+        //! start with `uint32_t week` — read it from the first 4 bytes
+        //! of the payload. Zero means the device hasn't established a
+        //! GPS week yet (still searching); we keep the sync point but
+        //! the resolver won't epoch-anchor against it.
+        if (comm.rxPkt.data.ptr && comm.rxPkt.dataHdr.size >= sizeof(uint32_t)) {
+            uint32_t weekRaw = 0;
+            std::memcpy(&weekRaw, comm.rxPkt.data.ptr, sizeof(weekRaw));
+            sp.gpsWeek = weekRaw;
+        }
         out.push_back(sp);
     }
 }
@@ -216,30 +240,35 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
     }
 
+    //! SN-8107 / D0066: select a representative GPS week for the epoch
+    //! anchor. We use the first sync point's week; for the common
+    //! single-week log this is correct. A log spans < 1 hour typically,
+    //! well inside one GPS week. If `gpsWeek == 0` (week field invalid
+    //! or not yet established), we don't epoch-anchor — resolved
+    //! values stay in ToW domain (pre-D0066 behavior).
+    const ISSyncPoint& firstSync = syncPoints_.front();
+    const uint32_t anchorWeek = firstSync.gpsWeek;
+    const bool     epochAnchor = (anchorWeek != 0);
+    auto unixOrToW = [&](uint64_t towMs) -> uint64_t {
+        return epochAnchor ? gpsToUnixMs(anchorWeek, towMs) : towMs;
+    };
+
     //! SN-8107 / D0066: cross-domain bridge. v2 .idx puts sync records'
     //! `timestamp` field in the GPS-ToW domain (hundreds of millions of
     //! ms into the GPS week) while non-sync records' `timestamp` field
     //! is host uptime (small ms since session start). An input
     //! `hostTimeMs` that's dramatically smaller than the first sync's
     //! ToW is a session-uptime query — translate it into the ToW frame
-    //! using the recovered `actualHostTimeMs` of the first sync.
-    //!
-    //! The threshold: any non-sync query whose value is less than half
-    //! the first sync's ToW. In practice this means anything under tens
-    //! of millions of ms (a single session is at most a few hours).
-    //! ToW values are hundreds of millions of ms (GPS week scale).
-    const ISSyncPoint& firstSync = syncPoints_.front();
+    //! using the recovered `actualHostTimeMs` of the first sync, then
+    //! epoch-anchor the result if GPS week is known.
     if (firstSync.actualHostTimeMs > 0 &&
         hostTimeMs < firstSync.payloadToWMs / 2) {
-        //! Session-uptime input. Bridge to ToW using the offset
-        //! between the first sync's payload-ToW and the host-uptime we
-        //! captured at sync time.
         const int64_t offset =
             static_cast<int64_t>(firstSync.payloadToWMs) -
             static_cast<int64_t>(firstSync.actualHostTimeMs);
         const int64_t bridged = static_cast<int64_t>(hostTimeMs) + offset;
-        const uint64_t value = (bridged < 0) ? 0u : static_cast<uint64_t>(bridged);
-        return TimeStamp::fromResolvedViaSync(value, deviceId,
+        const uint64_t towMs = (bridged < 0) ? 0u : static_cast<uint64_t>(bridged);
+        return TimeStamp::fromResolvedViaSync(unixOrToW(towMs), deviceId,
                                               TimeConfidence::ExtrapolatedBackward);
     }
 
@@ -250,7 +279,7 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
 
     if (it != syncPoints_.end() && it->hostTimeMs == hostTimeMs) {
         // Exact match against a sync point.
-        return TimeStamp::fromPayloadToW(it->payloadToWMs, deviceId);
+        return TimeStamp::fromPayloadToW(unixOrToW(it->payloadToWMs), deviceId);
     }
 
     if (it == syncPoints_.begin()) {
@@ -263,8 +292,8 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         }
         const double delta = static_cast<double>(hostTimeMs) - static_cast<double>(s0.hostTimeMs);
         const double tow   = static_cast<double>(s0.payloadToWMs) + slope * delta;
-        const uint64_t value = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
-        return TimeStamp::fromResolvedViaSync(value, deviceId,
+        const uint64_t towMs = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
+        return TimeStamp::fromResolvedViaSync(unixOrToW(towMs), deviceId,
                                               TimeConfidence::ExtrapolatedBackward);
     }
 
@@ -279,8 +308,8 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         }
         const double delta = static_cast<double>(hostTimeMs) - static_cast<double>(sLast.hostTimeMs);
         const double tow   = static_cast<double>(sLast.payloadToWMs) + slope * delta;
-        const uint64_t value = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
-        return TimeStamp::fromResolvedViaSync(value, deviceId,
+        const uint64_t towMs = (tow < 0.0) ? 0u : static_cast<uint64_t>(tow);
+        return TimeStamp::fromResolvedViaSync(unixOrToW(towMs), deviceId,
                                               TimeConfidence::ExtrapolatedForward);
     }
 
@@ -293,7 +322,7 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
                       ? 0.0
                       : (static_cast<double>(hostTimeMs) - static_cast<double>(prev.hostTimeMs)) / hostSpan;
     const double tow  = static_cast<double>(prev.payloadToWMs) + frac * towSpan;
-    return TimeStamp::fromResolvedViaSync(static_cast<uint64_t>(tow),
+    return TimeStamp::fromResolvedViaSync(unixOrToW(static_cast<uint64_t>(tow)),
                                           deviceId,
                                           TimeConfidence::Interpolated);
 }

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -134,9 +134,10 @@ void scanSegmentForSyncs(const ISLogReader& reader,
         ISSyncPoint sp{};
         //! v2 `.idx` schema collapse: the writer's `rec.timestamp` for
         //! HAS_TOW records is also the ToW (no separate host-time
-        //! recorded). Carry the same value in both fields so a future
-        //! v3 schema with a distinct host-time can populate `hostTimeMs`
-        //! independently without touching the resolver's API.
+        //! stored in the .idx). Carry the same value in both fields;
+        //! the .raw-recovered host-time at sync rides on
+        //! `actualHostTimeMs` (set below from the byte scan's
+        //! `lastNonSyncHostTimeMs` tracker).
         sp.hostTimeMs        = towMs;
         sp.payloadToWMs      = towMs;
         sp.deviceId          = deviceId;

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -47,10 +47,12 @@ namespace inertial_sense {
 
 class ISTimeResolver {
 public:
-    /// Default discontinuity threshold: 1000 ppm clock-drift equivalent
-    /// (per D0024). If the slope between two adjacent sync-point pairs
-    /// differs by more than this fraction, the boundary is reported via
-    /// `discontinuities()`.
+    //! Default discontinuity threshold: 1000 ppm clock-drift equivalent.
+    //! If the slope between two adjacent sync-point pairs differs by
+    //! more than this fraction, the boundary is reported via
+    //! `discontinuities()`.
+    //!
+    //! @note D0024.
     static constexpr double kDefaultDiscontinuityThreshold = 1.0e-3;
 
     /**
@@ -61,13 +63,13 @@ public:
      * honestly rather than smoothing over a real jump.
      */
     struct Discontinuity {
-        /// Host-time of the boundary (the second sync point's host).
+        //! Host-time of the boundary (the second sync point's host).
         uint64_t hostTimeMs;
-        /// Slope (ToW-ms per host-ms) over the segment ending at
-        /// `hostTimeMs`. Identity (1.0) for v2 .idx HAS_TOW-only logs.
+        //! Slope (ToW-ms per host-ms) over the segment ending at
+        //! `hostTimeMs`. Identity (1.0) for .idx HAS_TOW-only logs.
         double   slopeBefore;
-        /// Slope (ToW-ms per host-ms) over the segment starting at
-        /// `hostTimeMs`.
+        //! Slope (ToW-ms per host-ms) over the segment starting at
+        //! `hostTimeMs`.
         double   slopeAfter;
     };
 
@@ -79,11 +81,11 @@ public:
      * log's total record count.
      */
     struct Stats {
-        std::size_t exact          = 0;  ///< Confidence::Exact (PayloadToW).
-        std::size_t interpolated   = 0;  ///< Between sync points.
-        std::size_t extrapFwd      = 0;  ///< Past last sync.
-        std::size_t extrapBack     = 0;  ///< Before first sync.
-        std::size_t unknown        = 0;  ///< No sync points at all.
+        std::size_t exact          = 0;  //!< Confidence::Exact (PayloadToW).
+        std::size_t interpolated   = 0;  //!< Between sync points.
+        std::size_t extrapFwd      = 0;  //!< Past last sync.
+        std::size_t extrapBack     = 0;  //!< Before first sync.
+        std::size_t unknown        = 0;  //!< No sync points at all.
     };
 
     // -----------------------------------------------------------------

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -7,10 +7,10 @@
  * payload ToW. Sync points are records that carry HAS_TOW; queries
  * outside the sync-anchored region are extrapolated forward / backward.
  *
- * **v2 `.idx` constraint.** The current writer overwrites a record's
- * stored `.idx` timestamp with the payload ToW when the HAS_TOW flag
- * is set — host-side capture time isn't preserved alongside ToW for
- * sync points. The resolver therefore models a single time axis (the
+ * **v2 `.idx` constraint.** The writer overwrites a record's stored
+ * `.idx` timestamp with the payload ToW when the HAS_TOW flag is set —
+ * host-side capture time isn't preserved alongside ToW for sync points
+ * in the .idx itself. The resolver models a single time axis (the
  * `.idx` `timestamp` field) where:
  *   - **Sync records** (HAS_TOW=1): stored timestamp = payload ToW
  *     (ms). These are the anchor points.
@@ -18,14 +18,13 @@
  *     uptime delta (ms since logger session start).
  * These two clusters typically don't overlap on the same numeric
  * axis (host uptime is a few seconds; ToW is ~hundreds of millions
- * of ms into the GPS week). The resolver classifies a query by which
- * cluster it falls into and applies the appropriate confidence tier.
- * A v3 `.idx` with explicit host-time would let the model fit a real
- * slope between sync points; until then the slope between sync
- * points in v2 is identity (host==ToW for them) and pre-fix records
- * resolve with `ExtrapolatedBackward` — their numeric value is best-
- * effort and consumers (UI per D-58) treat that confidence tier with
- * dashed-line / icon decoration.
+ * of ms into the GPS week). The host-side timestamp at sync time is
+ * recovered at scan time from the .raw byte stream — the writer emits
+ * records in arrival order on one host thread, so a sync record's
+ * host-time is ms-adjacent to the most recent non-sync record's
+ * payload timestamp. `ISSyncPoint::actualHostTimeMs` carries that
+ * recovered host-time, and `resolve()` uses it to bridge session-uptime
+ * queries into the ToW frame (SN-8107 / D0066).
  *
  * **Pure C++17.** No Qt, no exceptions; fallible paths return
  * `ISExpected<T>`.
@@ -104,8 +103,8 @@ public:
      *             snapshotted into the resolver's owned vector).
      * @return     A fully-built resolver, or `ISError` on internal
      *             failure (none expected at v1 — kept as the API
-     *             shape so future v3 schemas with fallible parses
-     *             have a place to surface errors).
+     *             shape so future fallible-parse scenarios have a
+     *             place to surface errors).
      */
     static ISExpected<ISTimeResolver> build(const ISDeviceLog& log);
 

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -223,7 +223,7 @@ TEST_F(TimeResolverTest, ResolveExactAtSyncPoint) {
     auto t = resolver->resolve(110000, kFixtureSerial);
     EXPECT_EQ(t.source, TimeSource::PayloadToW);
     EXPECT_EQ(t.confidence, TimeConfidence::Exact);
-    //! SN-8107 / D0066: epoch-anchored output (gpsWeek=2300 in makeIns2).
+    // SN-8107 / D0066: epoch-anchored output (gpsWeek=2300 in makeIns2).
     EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(110000));
 }
 

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -73,6 +73,19 @@ ins_2_t makeIns2(double towSec) {
     return s;
 }
 
+// SN-8107 / D0066: Unix-epoch ms for (gpsWeek=2300, towMs). The resolver
+// epoch-anchors all output when ANY sync point's gpsWeek != 0, so tests
+// assert against this anchored value rather than the raw ToW.
+//   GPS_EPOCH_UNIX_MS = 315,964,800,000 (1980-01-06 00:00:00 UTC)
+//   WEEK_MS           = 604,800,000
+//   unix_ms = gpsWeek * WEEK_MS + GPS_EPOCH_UNIX_MS + towMs
+inline uint64_t expectedUnixMsForFixtureWeek(uint64_t towMs,
+                                             uint32_t gpsWeek = 2300) {
+    constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
+    constexpr uint64_t kWeekMs         = 604'800'000ULL;
+    return static_cast<uint64_t>(gpsWeek) * kWeekMs + kGpsEpochUnixMs + towMs;
+}
+
 // IMU's `time` field is "seconds since boot" — `cISDataMappings::Timestamp`
 // returns it for DID_IMU but DID_IMU is NOT in the resolver's ToW-bearing
 // allowlist. So IMU records are non-sync (host_uptime_delta in their
@@ -210,7 +223,8 @@ TEST_F(TimeResolverTest, ResolveExactAtSyncPoint) {
     auto t = resolver->resolve(110000, kFixtureSerial);
     EXPECT_EQ(t.source, TimeSource::PayloadToW);
     EXPECT_EQ(t.confidence, TimeConfidence::Exact);
-    EXPECT_EQ(t.value, 110000u);
+    //! SN-8107 / D0066: epoch-anchored output (gpsWeek=2300 in makeIns2).
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(110000));
 }
 
 // ---------------------------------------------------------------------------
@@ -231,11 +245,12 @@ TEST_F(TimeResolverTest, ResolveInterpolated) {
 
     // 105_000 ms is halfway between syncs 100_000 and 110_000.
     // Slope is identity (host==ToW for v2 sync points), so the result
-    // value equals the input.
+    // ToW value equals the input; we then assert against the
+    // epoch-anchored output (SN-8107 / D0066).
     auto t = resolver->resolve(105000, kFixtureSerial);
     EXPECT_EQ(t.source, TimeSource::ResolvedViaSync);
     EXPECT_EQ(t.confidence, TimeConfidence::Interpolated);
-    EXPECT_EQ(t.value, 105000u);
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(105000));
 }
 
 // ---------------------------------------------------------------------------
@@ -363,30 +378,34 @@ TEST_F(TimeResolverTest, CrossDomainBridgeUnifiesPimuIntoTowFrame) {
 
     // Sanity: two sync points (411500, 411700), both anchored with
     // actualHostTimeMs == 150 (the IMU host uptime right before the
-    // first sync).
+    // first sync). Each sync also carries the GPS week (2300, from
+    // makeIns2) so the resolver epoch-anchors all output.
     const auto& syncs = resolver->syncPoints();
     ASSERT_EQ(syncs.size(), 2u);
     EXPECT_EQ(syncs[0].payloadToWMs, 411500u);
     EXPECT_EQ(syncs[0].actualHostTimeMs, 150u);
+    EXPECT_EQ(syncs[0].gpsWeek, 2300u);
 
     // Cross-domain bridge: resolve a session-uptime query (e.g. 100 ms).
-    // Expected: offset = 411500 - 150 = 411350; bridged = 100 + 411350 = 411450.
+    // Expected ToW: offset = 411500 - 150 = 411350; bridged ToW = 411450.
+    // Expected epoch-anchored: bridged ToW + (2300 * 604800000) + 315964800000.
     const TimeStamp bridged = resolver->resolve(100u, kFixtureSerial);
     EXPECT_EQ(bridged.source, TimeSource::ResolvedViaSync);
     EXPECT_EQ(bridged.confidence, TimeConfidence::ExtrapolatedBackward);
-    EXPECT_EQ(bridged.value, 411450u);
+    EXPECT_EQ(bridged.value, expectedUnixMsForFixtureWeek(411450));
 
     // A larger session-uptime query (e.g. 150 ms = exactly the captured
-    // actualHostTimeMs) bridges to the sync's ToW.
+    // actualHostTimeMs) bridges to the sync's ToW, epoch-anchored.
     const TimeStamp atSync = resolver->resolve(150u, kFixtureSerial);
-    EXPECT_EQ(atSync.value, 411500u);
+    EXPECT_EQ(atSync.value, expectedUnixMsForFixtureWeek(411500));
 
     // ToW-domain query (already in the resolver's anchor frame) falls
-    // through the non-bridge path: 411500 = first sync, Exact match.
+    // through the non-bridge path: 411500 = first sync, Exact match,
+    // epoch-anchored.
     const TimeStamp exact = resolver->resolve(411500u, kFixtureSerial);
     EXPECT_EQ(exact.source, TimeSource::PayloadToW);
     EXPECT_EQ(exact.confidence, TimeConfidence::Exact);
-    EXPECT_EQ(exact.value, 411500u);
+    EXPECT_EQ(exact.value, expectedUnixMsForFixtureWeek(411500));
 }
 
 // ---------------------------------------------------------------------------
@@ -414,10 +433,12 @@ TEST_F(TimeResolverTest, CrossDomainBridgeSkippedWhenNoPreSyncNonSync) {
 
     // resolve(100ms): legacy extrapolate-backward path with slope=1,
     // hostTimeMs - s0.hostTimeMs = 100 - 411500 = -411400; tow falls
-    // below zero and clamps to 0. NOT bridged into ToW.
+    // below zero and clamps to 0. Result IS epoch-anchored though,
+    // since the sync's gpsWeek=2300 — so the resolved value is exactly
+    // the GPS-epoch + 2300 weeks (no ToW added).
     const TimeStamp legacy = resolver->resolve(100u, kFixtureSerial);
     EXPECT_EQ(legacy.confidence, TimeConfidence::ExtrapolatedBackward);
-    EXPECT_LT(legacy.value, 411500u);  // legacy path, not bridged.
+    EXPECT_EQ(legacy.value, expectedUnixMsForFixtureWeek(0));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -287,13 +287,14 @@ TEST_F(TimeResolverTest, ResolveExtrapolated) {
 TEST_F(TimeResolverTest, DiscontinuityFromUnevenGaps) {
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
     // ToW sequence: 100, 110, 130, 130.0001.
-    // For v2-schema sync points, host==ToW, so the slope between any
-    // two non-zero-spaced sync points is exactly 1.0. The detector's
-    // ratio metric only fires on slope CHANGES — same slope = no
-    // discontinuity. To produce a slope change we need at least one
-    // pair with a non-1.0 slope, which v2's collapsed schema can't
-    // express. Instead we exercise the "no discontinuities" path here
-    // and document the v3-required test case in JOURNAL.
+    // Sync points have host==ToW per the .idx schema, so the slope
+    // between any two non-zero-spaced sync points is exactly 1.0.
+    // The detector's ratio metric only fires on slope CHANGES — same
+    // slope = no discontinuity. Producing a true slope-change scenario
+    // requires sync points with distinct host vs ToW values (i.e. the
+    // .raw-recovered actualHostTimeMs disagreeing with payloadToWMs),
+    // which we don't synthesize here. We exercise the "no
+    // discontinuities" path on uniform-slope syncs.
     for (double tow : { 100.0, 110.0, 130.0, 130.0001 }) {
         recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
     }

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -331,6 +331,96 @@ TEST_F(TimeResolverTest, StatsAddUpToRecordCount) {
 }
 
 // ---------------------------------------------------------------------------
+// SN-8107 / D0066: cross-domain bridge. A v2-.idx log mixes records in two
+// numeric domains (sync records carry GPS-ToW ms ≈ hundreds of millions;
+// non-sync records carry host uptime ms ≈ thousands). The resolver MUST
+// translate session-uptime queries into the ToW frame using the
+// `actualHostTimeMs` recovered during the byte scan from the most recent
+// non-sync record's payload-side timestamp.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, CrossDomainBridgeUnifiesPimuIntoTowFrame) {
+    // Build a fixture mimicking the IMX-6 fw3.0.0 layout: several IMU
+    // records (small host uptime, non-sync) followed by an INS_2 sync
+    // record carrying a large ToW. The cross-domain bridge should detect
+    // session-uptime queries and translate them into the ToW frame.
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // Three IMU records at host uptimes 0.100s, 0.123s, 0.150s.
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(0.100)));
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(0.123)));
+    recs.emplace_back(DID_IMU, bytesOf(makeImu(0.150)));
+    // First sync at ToW 411.500s (411500 ms). The scan should capture
+    // 150 ms as `actualHostTimeMs` (the most recent IMU's host time).
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(411.500)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(411.700)));
+
+    f = buildFixture("bridge", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // Sanity: two sync points (411500, 411700), both anchored with
+    // actualHostTimeMs == 150 (the IMU host uptime right before the
+    // first sync).
+    const auto& syncs = resolver->syncPoints();
+    ASSERT_EQ(syncs.size(), 2u);
+    EXPECT_EQ(syncs[0].payloadToWMs, 411500u);
+    EXPECT_EQ(syncs[0].actualHostTimeMs, 150u);
+
+    // Cross-domain bridge: resolve a session-uptime query (e.g. 100 ms).
+    // Expected: offset = 411500 - 150 = 411350; bridged = 100 + 411350 = 411450.
+    const TimeStamp bridged = resolver->resolve(100u, kFixtureSerial);
+    EXPECT_EQ(bridged.source, TimeSource::ResolvedViaSync);
+    EXPECT_EQ(bridged.confidence, TimeConfidence::ExtrapolatedBackward);
+    EXPECT_EQ(bridged.value, 411450u);
+
+    // A larger session-uptime query (e.g. 150 ms = exactly the captured
+    // actualHostTimeMs) bridges to the sync's ToW.
+    const TimeStamp atSync = resolver->resolve(150u, kFixtureSerial);
+    EXPECT_EQ(atSync.value, 411500u);
+
+    // ToW-domain query (already in the resolver's anchor frame) falls
+    // through the non-bridge path: 411500 = first sync, Exact match.
+    const TimeStamp exact = resolver->resolve(411500u, kFixtureSerial);
+    EXPECT_EQ(exact.source, TimeSource::PayloadToW);
+    EXPECT_EQ(exact.confidence, TimeConfidence::Exact);
+    EXPECT_EQ(exact.value, 411500u);
+}
+
+// ---------------------------------------------------------------------------
+// SN-8107: when no non-sync record precedes the first sync point in the
+// byte stream, actualHostTimeMs stays 0 and the bridge branch is skipped
+// — falls back to legacy classify-only behavior.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, CrossDomainBridgeSkippedWhenNoPreSyncNonSync) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // No IMU records before the first sync. Bridge should NOT engage.
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(411.500)));
+    recs.emplace_back(DID_IMU,   bytesOf(makeImu(0.200)));
+
+    f = buildFixture("no_presync_nonsync", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    const auto& syncs = resolver->syncPoints();
+    ASSERT_EQ(syncs.size(), 1u);
+    EXPECT_EQ(syncs[0].actualHostTimeMs, 0u);  // no recovery possible
+
+    // resolve(100ms): legacy extrapolate-backward path with slope=1,
+    // hostTimeMs - s0.hostTimeMs = 100 - 411500 = -411400; tow falls
+    // below zero and clamps to 0. NOT bridged into ToW.
+    const TimeStamp legacy = resolver->resolve(100u, kFixtureSerial);
+    EXPECT_EQ(legacy.confidence, TimeConfidence::ExtrapolatedBackward);
+    EXPECT_LT(legacy.value, 411500u);  // legacy path, not bridged.
+}
+
+// ---------------------------------------------------------------------------
 // Single-sync-point case: resolves backward / forward with slope 1.0.
 // ---------------------------------------------------------------------------
 TEST_F(TimeResolverTest, SingleSyncPointDegenerateSlope) {


### PR DESCRIPTION
## Summary

Implements [D0066](https://github.com/inertialsense/logalyzer/blob/SN-8101_canonical-timeline/docs/architecture/decisions.md#d0066) — cross-DID unified resolved time — **completely** in `ISTimeResolver`. The resolver now (1) translates session-uptime queries into the GPS-ToW frame using host-uptime captured at sync time, and (2) anchors all output to Unix-epoch ms when GPS week is known. Result: `resolve()`'s output is directly suitable for `QDateTime::fromMSecsSinceEpoch` / wall-clock display.

Surfaced on Kyle's real IMX-6 fw3.0.0 fixture during Logalyzer SN-8101 PR inertialsense/logalyzer#54 validation: `DID_PIMU` records landed at session-uptime values (`+0..+533s`) while `DID_GNSS1_POS` records from the **same device** in the **same log** landed at GPS-ToW values (`~+117h`), with wall-clock mode rendering 1970-epoch dates. The whole design intent of `ISTimeResolver` + the IDX v2 schema was that every record from a device's log resolves to one shared time axis with absolute wall-clock meaning. The shipped resolver classified domains but didn't translate; this PR closes that gap entirely.

## Approach

### Cross-domain bridge

The .idx schema doesn't preserve sync records' host-side capture time, but the byte stream does — the writer emits records in arrival order on one host thread, so any sync record's host-uptime is ms-adjacent to the most recent non-sync record's payload timestamp. `scanSegmentForSyncs` already walks .raw bytes; it now also tracks `lastNonSyncHostTimeMs` and stamps it onto each sync point as `actualHostTimeMs`.

`resolve()` detects session-uptime queries (input ms much smaller than the first sync's ToW) and bridges them with `offset = firstSync.payloadToWMs - firstSync.actualHostTimeMs`.

### Epoch anchoring

All ToW-bearing DID payload structs (`ins_1_t` through `ins_4_t`, `gnss_pos_t`) start with `uint32_t week` — `scanSegmentForSyncs` reads it from the first 4 payload bytes and stamps it onto each sync point as `gpsWeek`. `resolve()` then applies `gpsToUnixMs(week, towMs) = week * 604,800,000 + 315,964,800,000 + towMs` (GPS epoch = 1980-01-06 UTC) so all output is Unix-epoch ms. When `gpsWeek == 0` (devices that never established a week), output stays in ToW domain (opt-out, preserves behavior on unanchored logs).

Both transformations flow through a single `unixOrToW` helper at every output path (exact, interpolated, extrapolated fwd/bwd, bridge) so the API semantics are uniform.

## Changes

| File | Change |
|---|---|
| `src/ISSyncPoint.h` | `actualHostTimeMs` (host time at sync) + `gpsWeek` (week-number for epoch anchor) |
| `src/ISTimeResolver.cpp::scanSegmentForSyncs` | Tracks `lastNonSyncHostTimeMs` during byte walk; reads `gpsWeek` from first 4 payload bytes |
| `src/ISTimeResolver.cpp::resolve` | Cross-domain bridge branch + `unixOrToW` epoch anchor on every output path |
| `tests/test_time_resolver.cpp` | New tests for the bridge + epoch anchor; existing tests updated to assert against `expectedUnixMsForFixtureWeek` |

## Integration verified end-to-end

Built the SDK changes into Logalyzer locally + drove against `imx6_gpx1_v3.0.0/20260528_135448/` (IMX-6 fw 3.0.0, SN942745142, 2 segments, 8m 53s).

| Stage | `log extent T0` |
|---|---|
| Pre-D0066 | `2 ms` (mixed-domain, `DID_DEV_INFO` at +2ms session-uptime) |
| After cross-domain bridge alone | `417,306,720 ms` (unified GPS-ToW domain) |
| **After GPS-week epoch anchor (this PR)** | **`1,779,998,106,720 ms`** = **2026-05-28 19:55:06.720 UTC** |

Matches the fixture filename `20260528_135448` to the minute. Logalyzer's wall-clock mode now renders the actual capture date on both the chart X-axis ticks (`2026-05-28 19:56:46.720`, `19:58:26.720`, ...) and the playback dock cursor (`2026-05-28 19:55:06.720 (+0.000 s)`).

## Test plan

- [x] `tests/test_time_resolver.cpp::CrossDomainBridgeUnifiesPimuIntoTowFrame` — session-uptime queries bridge to ToW, epoch-anchored.
- [x] `tests/test_time_resolver.cpp::CrossDomainBridgeSkippedWhenNoPreSyncNonSync` — degenerate `actualHostTimeMs == 0` case.
- [x] Existing tests (`ResolveExactAtSyncPoint`, `ResolveInterpolated`, etc.) updated to assert against `expectedUnixMsForFixtureWeek` — same semantics, new value space.
- [x] **Logalyzer integration** (separate repo, PR inertialsense/logalyzer#54): real IMX-6 fixture log extent moves from mixed-domain to unified epoch-anchored ms; same fold logic, same fixture.
- [x] **Unanchored-log regression** (cltool_imx5_120s_ppd fixture, no GPS sync points): resolver falls back to ToW-domain output, no fabricated epoch anchor.

## Related

- Logalyzer SN-8101 PR inertialsense/logalyzer#54 — picks this up via submodule bump.
- D0066 (declaring ADR) — `docs/architecture/decisions.md` on the Logalyzer side.
- SN-8107 (this story).
- SN-8105 — `ISDeviceLog::spanStart/End` GPS-anchoring. Same root cause; the Logalyzer-side resolver routing in inertialsense/logalyzer#54 closes the user-visible symptoms.
- SN-8108 — GNSS-coarseness symptom in Logalyzer; expected to resolve as side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
