### PR TITLE
SN-8115: resolver idempotency guard (no double-anchor of already-absolute inputs)

### DIFF
--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -256,6 +256,22 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
 // ============================================================
 
 TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const {
+    // SN-8115: idempotency / already-anchored guard. Legitimate raw inputs are
+    // either a GPS time-of-week (always < one week, 604,800,000 ms) or a
+    // session-uptime (ms since session start — at most hours). Neither can
+    // reach the GPS Unix epoch (1980-01-06 = 315,964,800,000 ms). An input at
+    // or beyond that is therefore ALREADY an absolute Unix-ms timestamp — a
+    // value that previously went through `resolve()` (re-resolving it must be a
+    // no-op for `resolve(resolve(x)) == resolve(x)` to hold), or a
+    // wall-clock-poisoned `.idx` span endpoint. Re-anchoring it would
+    // double-add the epoch + week offset via `gpsToUnixMs`, producing ~2x the
+    // wall-clock (the year-2082 spanEnd seen on the 16-device compass fixture).
+    // Pass it through unchanged.
+    if (hostTimeMs >= kGpsEpochUnixMs) {
+        return TimeStamp::fromResolvedViaSync(hostTimeMs, deviceId,
+                                              TimeConfidence::Exact);
+    }
+
     if (syncPoints_.empty()) {
         // No anchors. Best we can do is a SessionOnly tag with the
         // input value passed through.

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -433,13 +433,14 @@ TEST_F(TimeResolverTest, CrossDomainBridgeSkippedWhenNoPreSyncNonSync) {
     EXPECT_EQ(syncs[0].actualHostTimeMs, 0u);  // no recovery possible
 
     // resolve(100ms): legacy extrapolate-backward path with slope=1,
-    // hostTimeMs - s0.hostTimeMs = 100 - 411500 = -411400; tow falls
-    // below zero and clamps to 0. Result IS epoch-anchored though,
-    // since the sync's gpsWeek=2300 — so the resolved value is exactly
-    // the GPS-epoch + 2300 weeks (no ToW added).
+    // tow = s0.payloadToWMs + 1.0 * (100 - s0.hostTimeMs)
+    //     = 411500 + (100 - 411500) = 100 (stays positive; no clamp).
+    // Result IS epoch-anchored (sync's gpsWeek=2300), so the value is
+    // GPS-epoch + 2300 weeks + 100 ms.
+    // SN-8107/D0066: prior expectation (ToW-0) predated epoch anchoring.
     const TimeStamp legacy = resolver->resolve(100u, kFixtureSerial);
     EXPECT_EQ(legacy.confidence, TimeConfidence::ExtrapolatedBackward);
-    EXPECT_EQ(legacy.value, expectedUnixMsForFixtureWeek(0));
+    EXPECT_EQ(legacy.value, expectedUnixMsForFixtureWeek(100));
 }
 
 // ---------------------------------------------------------------------------
@@ -459,12 +460,66 @@ TEST_F(TimeResolverTest, SingleSyncPointDegenerateSlope) {
 
     auto t = resolver->resolve(105000, kFixtureSerial);
     EXPECT_EQ(t.confidence, TimeConfidence::ExtrapolatedForward);
-    // Slope defaults to 1.0 with a single sync point: 100_000 + (105_000 - 100_000) = 105_000.
-    EXPECT_EQ(t.value, 105000u);
+    // Slope defaults to 1.0 with a single sync point: ToW = 100_000 +
+    // (105_000 - 100_000) = 105_000, then epoch-anchored (gpsWeek=2300).
+    // SN-8107/D0066: prior expectation (raw ToW) predated epoch anchoring.
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(105000));
 
     auto bwd = resolver->resolve(95000, kFixtureSerial);
     EXPECT_EQ(bwd.confidence, TimeConfidence::ExtrapolatedBackward);
-    EXPECT_EQ(bwd.value, 95000u);
+    EXPECT_EQ(bwd.value, expectedUnixMsForFixtureWeek(95000));
+}
+
+// ---------------------------------------------------------------------------
+// SN-8115: an input that is ALREADY an absolute Unix-ms timestamp (at or
+// beyond the GPS Unix epoch, 1980) is returned unchanged — never re-anchored.
+// This is the guard against the year-2082 double-anchor seen on the 16-device
+// compass fixture, where a wall-clock-poisoned spanEnd (~1.78e12) fed into
+// resolve() had the epoch + week offset added on top (-> ~3.55e12).
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, AlreadyAnchoredInputPassesThroughUnchanged) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(100.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(200.0)));
+    f = buildFixture("already_anchored", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // A real 2026 wall-clock value (the compass fixture's poisoned spanEnd
+    // sat right here). It is >> any ToW (< 1 week) or session-uptime, so the
+    // resolver must treat it as already-anchored and return it verbatim, NOT
+    // run gpsToUnixMs on it (which would yield ~2x = year 2082).
+    constexpr uint64_t kAnchored2026 = 1779821742200ULL;
+    const TimeStamp t = resolver->resolve(kAnchored2026, kFixtureSerial);
+    EXPECT_EQ(t.value, kAnchored2026);
+    EXPECT_LT(t.value, 2ULL * kAnchored2026);  // explicitly: not doubled
+}
+
+// resolve() is idempotent for already-resolved values: feeding a resolved
+// (epoch-anchored) output back in returns the same value. Guarantees
+// `resolve(resolve(x)) == resolve(x)`.
+TEST_F(TimeResolverTest, ResolveIsIdempotent) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(411.500)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(411.700)));
+    f = buildFixture("idempotent", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // First pass: a raw ToW query resolves to an epoch-anchored Unix-ms value.
+    const TimeStamp once = resolver->resolve(411500u, kFixtureSerial);
+    EXPECT_EQ(once.value, expectedUnixMsForFixtureWeek(411500));
+    // Second pass on the already-resolved value is a no-op.
+    const TimeStamp twice = resolver->resolve(once.value, kFixtureSerial);
+    EXPECT_EQ(twice.value, once.value);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## SN-8115 (part 1): resolver idempotency — never re-anchor an already-absolute input

Targets `logalyzer-develop`. Follow-up to SN-8102 (logalyzer#55), which made the Logalyzer playback-timeline fold *safe* against contaminated spans. This fixes the upstream root cause for one of the two contamination modes that fixture exposed.

### Problem

`ISTimeResolver::resolve()` applies `gpsToUnixMs()` (GPS Unix epoch + week offset) to inputs that reach the ToW resolution paths — but it never checked whether the input was *already* an absolute Unix-ms value. On the real 16-device compass fixture (`20260526_125513`), one device's `spanEnd` came in already wall-clock-anchored (~`1779821742200`, year 2026); `resolve()` added the epoch + 2300-week offset on top, yielding `3559404286000` (year ~2082). That blew the global log extent out to a 56-year span (scrub bar unusable).

### Fix

A guard at the top of `resolve()`:

```cpp
if (hostTimeMs >= kGpsEpochUnixMs) {
    return TimeStamp::fromResolvedViaSync(hostTimeMs, deviceId, TimeConfidence::Exact);
}
```

Rationale: a legitimate raw input is either a GPS time-of-week (always < one week = 604,800,000 ms) or a session-uptime (at most hours). Neither can reach the GPS Unix epoch (315,964,800,000 ms = 1980). An input at or beyond that is therefore *already* an absolute Unix-ms timestamp — a prior `resolve()` output, or a wall-clock-poisoned span endpoint — so it's returned unchanged. This also makes `resolve()` idempotent: `resolve(resolve(x)) == resolve(x)`.

### Tests

- `TimeResolverTest.AlreadyAnchoredInputPassesThroughUnchanged` — a 2026 wall-clock value (the fixture's poisoned spanEnd) passes through verbatim, explicitly asserting it is NOT doubled.
- `TimeResolverTest.ResolveIsIdempotent` — `resolve(resolve(x)) == resolve(x)`.
- Also updates **three pre-existing expectations** (`SingleSyncPointDegenerateSlope` ×2, `CrossDomainBridgeSkippedWhenNoPreSyncNonSync` ×1) that predated the SN-8107/D0066 epoch-anchoring and were failing on `logalyzer-develop` — they asserted raw-ToW outputs the resolver now (correctly) epoch-anchors.

**Full SDK unit suite: 262 passed, 0 failed, 3 skipped (live-fixture).**

### End-to-end validation (real compass fixture, via Logalyzer)

| device | before | after |
|---|---|---|
| `…593c` resolved spanEnd | `3559404286000` (2082) | `1779823486000` (2026) ✓ |
| Logalyzer fold | 2 devices, 1 dropped over-wide | **3 devices, 0 dropped** |
| global extent (T1) | sane only via Logalyzer backstop | sane at the source |

The Logalyzer-side over-wide-span rejection (SN-8102 / logalyzer#55) becomes a true backstop once this lands.

### Out of scope (SN-8115 part 2, separate)

The other 14 fixture devices are excluded by Logalyzer's per-device filter because their raw `ISDeviceLog::spanStart/End` come back degenerate (`spanStart=0` / `spanEnd=0`) — GPX session-uptime / no-sync-point devices, and the structural `spanStart/End` resolver-clamping the SN-8115 ticket also describes. That's a heavier change; this PR is the clean, validated idempotency half. Tracking the spanStart/End recovery separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
