### PR TITLE
SN-7919: structured status-decode API in ISDataMappings

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -286,64 +286,14 @@ std::string renderGnssStatusBits(const data_info_t& info, std::any value, int ar
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "status"))
         return "";
 
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
+    // SN-7919 (D-53): delegates to the GNSS status decode table (key "gnssStatus" — the on-wire
+    // field name "status" is shared with GPX, so this renderer requests its specific variant).
     try {
-        std::stringstream buff;
         uint32_t gpsStatusBits = std::any_cast<uint32_t>(value);
-
-        // satCount is to be deprecated - but we'll show it for backwards compatibility
-        uint8_t satCount = (gpsStatusBits & GNSS_STATUS_NUM_SATS_USED_MASK);
-        buff << utils::string_format("0x000000%02X - %d satellites used in solution (deprecated)", satCount, satCount) << std::endl;
-
-        switch (gpsStatusBits & GNSS_STATUS_FIX_MASK) {
-            case GNSS_STATUS_FIX_NONE                : buff << "0x00000000 - No GNSS" << std::endl; break;
-            case GNSS_STATUS_FIX_DEAD_RECKONING_ONLY : buff << "0x00000100 - GNSS Dead Reckoning Only" << std::endl; break;
-            case GNSS_STATUS_FIX_2D                  : buff << "0x00000200 - 2D Fix" << std::endl; break;
-            case GNSS_STATUS_FIX_3D                  : buff << "0x00000300 - 3D Fix" << std::endl; break;
-            case GNSS_STATUS_FIX_GPS_PLUS_DEAD_RECK  : buff << "0x00000400 - 3D Fix + Dead Reckoning" << std::endl; break;
-            case GNSS_STATUS_FIX_TIME_ONLY           : buff << "0x00000500 - Time-Only Fix" << std::endl; break;
-            case GNSS_STATUS_FIX_REF_LLA             : buff << "0x00000600 - Usign Reference LLA" << std::endl; break;
-            case GNSS_STATUS_FIX_UNUSED2             : buff << "0x00000700 - << UNUSED >>" << std::endl; break;
-            case GNSS_STATUS_FIX_DGPS                : buff << "0x00000800 - Using DGPS" << std::endl; break;
-            case GNSS_STATUS_FIX_SBAS                : buff << "0x00000900 - Using SBAS" << std::endl; break;
-            case GNSS_STATUS_FIX_RTK_SINGLE          : buff << "0x00000A00 - RTK Single" << std::endl; break;
-            case GNSS_STATUS_FIX_RTK_FLOAT           : buff << "0x00000B00 - RTK Float" << std::endl; break;
-            case GNSS_STATUS_FIX_RTK_FIX             : buff << "0x00000C00 - RTK Fix" << std::endl; break;
-        }
-
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_FIX_OK                          , "0x00010000 - within limits (e.g. DOP & accuracy)");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_DGPS_USED                       , "0x00020000 - Differential GPS (DGPS) used.");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD                , "0x00040000 - RTK feedback on the integer solutions to drive the float biases towards the resolved integers");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_1                        , "0x00080000 - << UNUSED >>");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_ENABLED       , "0x00100000 - GNSS1 RTK precision positioning mode enabled");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_STATIC_MODE                     , "0x00200000 - Static mode");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_ENABLED        , "0x00400000 - GNSS2 RTK moving base mode enabled");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR     , "0x00800000 - GNSS1 RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)");
-
-        uint32_t rtkError = (gpsStatusBits & GNSS_STATUS_FLAGS_ERROR_MASK);
-        switch (rtkError) {
-            case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_DATA_MISSING        : buff << "0x01000000 - GNSS1 RTK error: Either base observations or antenna position have not been received." << std::endl; break;
-            case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_MOVING     : buff << "0x02000000 - GNSS1 RTK error: base position moved when it should be stationary" << std::endl; break;
-            case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_INVALID    : buff << "0x03000000 - GNSS1 RTK error: base position is invalid or not surveyed well" << std::endl; break;
-        }
-
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_VALID         , "0x04000000 - GNSS1 RTK precision position and carrier phase range solution with fixed ambiguities.");
-        if (gpsStatusBits & GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_MASK) {
-            BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_VALID          , "0x08000000 - GNSS2 RTK moving base heading valid and available in DID_GNSS2_RTK_CMP_REL.");
-            BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_BAD   , "0x00002000 - GNSS2 RTK Compassing Baseline distance is invalid");
-            BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_UNSET , "0x00004000 - GNSS2 RTK Compassing Baseline distance is unset (must be > 0)");
-        }
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS_NMEA_DATA                   , "0x00008000 - Data from NMEA message. GPS velocity is NED (not ECEF).");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS_PPS_TIMESYNC                , "0x10000000 - Time is synchronized by GPS PPS.");
-
-
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_2                        , "0x20000000 - <<UNUSED>>");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_3                        , "0x40000000 - <<UNUSED>>");
-        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_4                        , "0x80000000 - <<UNUSED>>");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+        return dec ? RenderStatusFromDecode(*dec, gpsStatusBits) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -303,62 +303,13 @@ std::string renderGpxStatus_status(const data_info_t& info, std::any value, int 
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "status"))
         return "";
 
+    // SN-7919 (D-53): delegates to the GPX status decode table (key "gpxStatus").
     try {
-        std::stringstream buff;
         uint32_t status = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-    /** Communications parse error count */
-        BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_MASK      , "0x0000000F - Communications parse error count");
-        // BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET    , ""           = 0,
-
-#define GPX_STATUS_COM_PARSE_ERROR_COUNT(gpxStatus) ((gpxStatus&GPX_STATUS_COM_PARSE_ERR_COUNT_MASK)>>GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET)
-
-    /** Rx communications not dectected in last 30 seconds */
-        BIT_MSG(status, GPX_STATUS_COM0_RX_TRAFFIC_NOT_DECTECTED , "0x00000010 - COM0 RX traffic not dectected in last 30 seconds.");
-        BIT_MSG(status, GPX_STATUS_COM1_RX_TRAFFIC_NOT_DECTECTED , "0x00000020 - COM1 RX traffic not dectected in last 30 seconds.");
-        BIT_MSG(status, GPX_STATUS_COM2_RX_TRAFFIC_NOT_DECTECTED , "0x00000040 - COM2 RX traffic not dectected in last 30 seconds.");
-        BIT_MSG(status, GPX_STATUS_USB_RX_TRAFFIC_NOT_DECTECTED  , "0x00000080 - USB RX traffic not dectected in last 30 seconds.");
-
-    /** General Fault mask */
-        // BIT_MSG(status, GPX_STATUS_GENERAL_FAULT_MASK            , "0xFFFF0000 -
-
-    /** RTK buffer filled causing data loss */
-        BIT_MSG(status, GPX_STATUS_FAULT_RTK_QUEUE_LIMITED       , "0x00010000 - RTK buffer overflow.");
-
-    /** GNSS receiver time fault **/
-        BIT_MSG(status, GPX_STATUS_FAULT_GNSS_RCVR_TIME          , "0x00100000 - GNSS receiver time fault");
-    /** DMA Fault detected **/
-        BIT_MSG(status, GPX_STATUS_FAULT_DMA                     , "0x00800000 - DMA fault");
-
-    /** Fatal faults - critical failure resulting in CPU reset */
-        //BIT_MSG(status, GPX_STATUS_FATAL_MASK                    , 0x1F000000,
-        //BIT_MSG(status, GPX_STATUS_FATAL_OFFSET                  ,           = 24,
-
-        uint32_t fatalStatus = ((status & GPX_STATUS_FATAL_MASK) >> GPX_STATUS_FATAL_OFFSET);
-        switch (fatalStatus) {
-            case GPX_STATUS_FATAL_RESET_LOW_POW:                buff << "0x01000000 - Reset from low power" << std::endl; break;
-            case GPX_STATUS_FATAL_RESET_BROWN:                  buff << "0x02000000 - Reset from brown out" << std::endl; break;
-            case GPX_STATUS_FATAL_RESET_WATCHDOG:               buff << "0x03000000 - Reset from watchdog" << std::endl; break;
-            case GPX_STATUS_FATAL_CPU_EXCEPTION:                buff << "0x04000000 - CPU exception" << std::endl; break;
-            case GPX_STATUS_FATAL_UNHANDLED_INTERRUPT:          buff << "0x05000000 - Unhandled interrupt" << std::endl; break;
-            case GPX_STATUS_FATAL_STACK_OVERFLOW:               buff << "0x06000000 - Stack overflow" << std::endl; break;
-            case GPX_STATUS_FATAL_KERNEL_OOPS:                  buff << "0x07000000 - Kernel oops" << std::endl; break;
-            case GPX_STATUS_FATAL_KERNEL_PANIC:                 buff << "0x08000000 - Kernel panic" << std::endl; break;
-            case GPX_STATUS_FATAL_UNALIGNED_ACCESS:             buff << "0x09000000 - Unaligned access" << std::endl; break;
-            case GPX_STATUS_FATAL_MEMORY_ERROR:                 buff << "0x0A000000 - Memory error" << std::endl; break;
-            case GPX_STATUS_FATAL_BUS_ERROR:                    buff << "0x0B000000 - Bus error" << std::endl; break;
-            case GPX_STATUS_FATAL_USAGE_ERROR:                  buff << "0x0C000000 - Usage error" << std::endl; break;
-            case GPX_STATUS_FATAL_DIV_ZERO:                     buff << "0x0D000000 - Division by zero" << std::endl; break;
-            case GPX_STATUS_FATAL_SER0_REINIT:                  buff << "0x0E000000 - SER0 reinit" << std::endl; break;
-            case GPX_STATUS_FATAL_UNKNOWN:                      buff << "0x1F000000 - Unknown" << std::endl; break;
-        }
-
-    /** Internal use */
-        BIT_MSG(status, GPX_STATUS_FAULT_RP                     , "0x20000000 - RP fault");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
+        return dec ? RenderStatusFromDecode(*dec, status) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }
@@ -367,69 +318,13 @@ std::string renderGpxStatus_hdwStatus(const data_info_t& info, std::any value, i
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "hdwStatus"))
         return "";
 
+    // SN-7919 (D-53): delegates to the GPX hardware-status decode table (key "gpxHdwStatus").
     try {
-        std::stringstream buff;
         uint32_t hdwStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_SATELLITE_RX            , "0x00000001 - GNSS1 satellite signals are being received (antenna and cable are good)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_SATELLITE_RX            , "0x00000002 - GNSS2 satellite signals are being received (antenna and cable are good)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_TIME_OF_WEEK_VALID      , "0x00000004 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_TIME_OF_WEEK_VALID      , "0x00000008 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
-
-    /** GNSS 1 reset required count */
-    // GPX_HDW_STATUS_GNSS1_RESET_COUNT_MASK               = (int)0x00000070,
-    // GPX_HDW_STATUS_GNSS1_RESET_COUNT_OFFSET             = 4,
-#define GPX_HDW_STATUS_GNSS1_RESET_COUNT(hdwStatus)     ((hdwStatus&GPX_HDW_STATUS_GNSS1_RESET_COUNT_MASK)>>GPX_HDW_STATUS_GNSS1_RESET_COUNT_OFFSET)
-
-    /** Failed to communicate or setup GNSS receiver 1 */
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS1_INIT              , "0x00000080 - Failed to communicate or setup GNSS receiver 1");
-        // BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_FAULT_FLAG_OFFSET              = 7,
-
-    /** GNSS 2 reset required count */
-    // GPX_HDW_STATUS_GNSS2_RESET_COUNT_MASK               = (int)0x00000700,
-    // GPX_HDW_STATUS_GNSS2_RESET_COUNT_OFFSET             = 8,
-#define GPX_HDW_STATUS_GNSS2_RESET_COUNT(hdwStatus)     ((hdwStatus&GPX_HDW_STATUS_GNSS2_RESET_COUNT_MASK)>>GPX_HDW_STATUS_GNSS2_RESET_COUNT_OFFSET)
-
-    /** Failed to communicate or setup GNSS receiver 2 */
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS2_INIT              , "0x00000800 - Failed to communicate or setup GNSS receiver 2");
-        // BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_FAULT_FLAG_OFFSET              = 11,
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS_FW_UPDATE_REQUIRED       , "0x00001000 - GNSS is faulting firmware update REQUIRED");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_LED_ENABLED                   , "0x00002000 - Enables LED in Manufacturing TBed");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_SYSTEM_RESET_REQUIRED         , "0x00004000 - System Reset is Required for proper function");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FLASH_WRITE_PENDING           , "0x00008000 - System flash write staging or occuring now.");
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_TX_LIMITED            , "0x00010000 - Communications Tx buffer limited");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_RX_OVERRUN            , "0x00020000 - Communications Rx buffer overrun");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GNSS1_PPS               , "0x00040000 - GNSS1 PPS timepulse signal has not been received or is in error");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GNSS2_PPS               , "0x00080000 - GNSS2 PPS timepulse signal has not been received or is in error");
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GNSS1              , "0x00100000 - GNSS1 signal strength low (<20)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GNSS2              , "0x00200000 - GNSS2 signal strength low (<20)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GNSS1_IR               , "0x00400000 - GNSS1 signal irregular. High Cno standard deviation over 5 second period detected.");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GNSS2_IR               , "0x00800000 - GNSS2 signal irregular. High Cno standard deviation over 5 second period detected.");
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_RUNNING                   , "0x01000000 - (BIT) Built-in self-test running");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_PASSED                    , "0x02000000 - (BIT) Built-in self-test passed");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_FAULT                     , "0x03000000 - (BIT) Built-in self-test failure");
-        // GPX_HDW_STATUS_BIT_MASK                              = 0x03000000
-        // GPX_HDW_STATUS_BIT_OFFSET                            = 24,
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_TEMPERATURE               , "0x04000000 - Temperature outside spec'd operating range");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS_PPS_TIMESYNC              , "0x08000000 - Time synchronized by GPS PPS");
-
-    /** Cause of system reset */
-        // GPX_HDW_STATUS_RESET_CAUSE_MASK                     = (int)0x70000000,
-
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_BACKUP_MODE       , "0x10000000 - Reset from Backup mode (low-power state w/ CPU off)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_SOFT              , "0x20000000 - Reset from Software");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_HDW               , "0x40000000 - Reset from Hardware (NRST pin low)");
-        BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_SYS_CRITICAL            , "0x80000000 - Critical System Fault, CPU error.");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("gpxHdwStatus");
+        return dec ? RenderStatusFromDecode(*dec, hdwStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -177,66 +177,14 @@ std::string renderHdwStatus(const data_info_t& info, std::any value, int arrayId
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "hdwStatus"))
         return "";
 
+    // SN-7919 (D-53): delegates to the hdwStatus decode table (ISStatusDecode.cpp); see the
+    // renderInsStatus note above. test_ISStatusDecode.cpp asserts byte-identical output.
     try {
-        std::stringstream buff;
         uint32_t hdwStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-    //  BIT_MSG(hdwStatus, HDW_STATUS_MOTION_MASK                      , "0x00000003 - Unit is moving and NOT stationary");
-        BIT_MSG(hdwStatus, HDW_STATUS_MOTION_GYR                       , "0x00000001 - Gyro motion detected.");
-        BIT_MSG(hdwStatus, HDW_STATUS_MOTION_ACC                       , "0x00000002 - Accelerometer motion detected.");
-
-    //  BIT_MSG(hdwStatus, HDW_STATUS_IMU_FAULT_REJECT_MASK            , "0x0000000C - IMU fault rejection mask. A IMU sensors is divergent and being excluded.");
-        BIT_MSG(hdwStatus, HDW_STATUS_IMU_FAULT_REJECT_GYR             , "0x00000004 - IMU gyro fault rejection. A Gyro sensor is divergent and being excluded.");
-        BIT_MSG(hdwStatus, HDW_STATUS_IMU_FAULT_REJECT_ACC             , "0x00000008 - IMU accelerometer fault rejection. An accelerometer sensors is divergent and being excluded.");
-
-        BIT_MSG(hdwStatus, HDW_STATUS_GNSS_SATELLITE_RX_VALID           , "0x00000010 - GPS satellite signals are being received (antenna and cable are good).");
-        BIT_MSG(hdwStatus, HDW_STATUS_STROBE_IN_EVENT                  , "0x00000020 - Event occurred on strobe input pin.");
-        BIT_MSG(hdwStatus, HDW_STATUS_GNSS_TIME_OF_WEEK_VALID           , "0x00000040 - GPS time of week is valid and reported.");
-        BIT_MSG(hdwStatus, HDW_STATUS_REFERENCE_IMU_RX                 , "0x00000080 - Reference IMU data being received.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_GYR                   , "0x00000100 - Sensor saturation on gyro.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_ACC                   , "0x00000200 - Sensor saturation on accelerometer.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_MAG                   , "0x00000400 - Sensor saturation on magnetometer.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_BARO                  , "0x00000800 - Sensor saturation on barometric pressure.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SYSTEM_RESET_REQUIRED            , "0x00001000 - System Reset is required for proper function.");
-        BIT_MSG(hdwStatus, HDW_STATUS_ERR_GNSS_PPS_NOISE                , "0x00002000 - GPS PPS timepulse signal has noise and occurred too frequently.");
-        BIT_MSG(hdwStatus, HDW_STATUS_MAG_RECAL_COMPLETE               , "0x00004000 - Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset).");
-        BIT_MSG(hdwStatus, HDW_STATUS_FLASH_WRITE_PENDING              , "0x00008000 - System flash write staging or occurring now.");
-        BIT_MSG(hdwStatus, HDW_STATUS_ERR_COM_TX_LIMITED               , "0x00010000 - Communications Tx buffer limited.");
-        BIT_MSG(hdwStatus, HDW_STATUS_ERR_COM_RX_OVERRUN               , "0x00020000 - Communications Rx buffer overrun.");
-        BIT_MSG(hdwStatus, HDW_STATUS_ERR_NO_GNSS_PPS                   , "0x00040000 - GPS PPS timepulse signal has not been received or is in error.");
-        BIT_MSG(hdwStatus, HDW_STATUS_GNSS_PPS_TIMESYNC                 , "0x00080000 - Time synchronized by GPS PPS.");
-
-    //  BIT_MSG(hdwStatus, HDW_STATUS_COM_PARSE_ERR_COUNT_MASK         , "0x00F00000 - Communications parse error count");
-    //  BIT_MSG(hdwStatus, HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET       , = 20,
-    //  BIT_MSG(hdwStatus, #define HDW_STATUS_COM_PARSE_ERROR_COUNT(hdw, Status) ((hdwStatus&HDW_STATUS_COM_PARSE_ERR_COUNT_MASK)>>HDW_STATUS_COM_PARSE_ERR_COUNT_OFFSET));
-        uint8_t parseErrCount = (uint8_t)HDW_STATUS_COM_PARSE_ERROR_COUNT(hdwStatus);
-        if (parseErrCount) {                buff << utils::string_format("0x00F00000 - Communications parse errors (%d).", parseErrCount) << std::endl; }
-
-    //  BIT_MSG(hdwStatus, HDW_STATUS_BIT_MASK                         , "0x03000000 - (BIT) Built-in self-test mask");
-        uint32_t bitStatus = (hdwStatus & HDW_STATUS_BIT_MASK);
-        switch (bitStatus) {
-            case HDW_STATUS_BIT_RUNNING:                         buff << "0x01000000 - (BIT) Built-in self-test is running." << std::endl; break;
-            case HDW_STATUS_BIT_PASSED:                          buff << "0x02000000 - (BIT) Built-in self-test passed." << std::endl; break;
-            case HDW_STATUS_BIT_FAILED:                          buff << "0x03000000 - (BIT) Built-in self-test failed." << std::endl; break;
-        }
-
-        BIT_MSG(hdwStatus, HDW_STATUS_ERR_TEMPERATURE                  , "0x04000000 - Temperature outside operating range.");
-        BIT_MSG(hdwStatus, HDW_STATUS_SPI_INTERFACE_ENABLED            , "0x08000000 - IMX pins G5-G8 are configure for SPI use.");
-
-    //  BIT_MSG(hdwStatus, HDW_STATUS_RESET_CAUSE_MASK                 , "0x70000000 - Cause of system reset");
-        uint32_t rstCause = (hdwStatus & HDW_STATUS_RESET_CAUSE_MASK);
-        switch (rstCause) {
-            case HDW_STATUS_RESET_CAUSE_BACKUP_MODE:             buff << "0x10000000 - Reset from backup mode (low-power state w/ CPU off)." << std::endl; break;
-            case HDW_STATUS_RESET_CAUSE_WATCHDOG_FAULT:          buff << "0x20000000 - Reset from watchdog fault." << std::endl; break;
-            case HDW_STATUS_RESET_CAUSE_SOFT:                    buff << "0x30000000 - Reset from software." << std::endl; break;
-            case HDW_STATUS_RESET_CAUSE_HDW:                     buff << "0x40000000 - Reset from hardware." << std::endl; break;
-        }
-
-        BIT_MSG(hdwStatus, HDW_STATUS_FAULT_SYS_CRITICAL               , "0x80000000 - Critical System Fault, CPU error (see DID_SYS_FAULT.status).");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+        return dec ? RenderStatusFromDecode(*dec, hdwStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -193,16 +193,13 @@ std::string renderSysStatus(const data_info_t& info, std::any value, int arrayId
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "sysStatus"))
         return "";
 
+    // SN-7919 (D-53): delegates to the sysStatus decode table (ISStatusDecode.cpp).
     try {
-        std::stringstream buff;
         uint32_t sysStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-        BIT_MSG(sysStatus, SYS_STATUS_TBED3_LEDS_ENABLED            , "0x00000001 - IMX to drive Testbed-3 status LEDs.");
-        BIT_MSG(sysStatus, SYS_STATUS_PRIMARY_GNSS_SOURCE_IS_GNSS2  , "0x00000004 - NMEA source is GNSS2.");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("sysStatus");
+        return dec ? RenderStatusFromDecode(*dec, sysStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }
@@ -211,43 +208,13 @@ std::string renderGenFaultCode(const data_info_t& info, std::any value, int arra
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "genFaultCode"))
         return "";
 
+    // SN-7919 (D-53): delegates to the genFaultCode decode table (ISStatusDecode.cpp).
     try {
-        std::stringstream buff;
         uint32_t genFault = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-        BIT_MSG(genFault, GFC_INS_STATE_ORUN_UVW        , "0x00000001 - INS state limit overrun - UVW.");
-        BIT_MSG(genFault, GFC_INS_STATE_ORUN_LAT        , "0x00000002 - INS state limit overrun - Latitude.");
-        BIT_MSG(genFault, GFC_INS_STATE_ORUN_ALT        , "0x00000004 - INS state limit overrun - Altitude.");
-        BIT_MSG(genFault, GFC_UNHANDLED_INTERRUPT       , "0x00000010 - Unhandled interrupt.");
-        BIT_MSG(genFault, GFC_GNSS_CRITICAL_FAULT       , "0x00000020 - GNSS receiver critical fault (See the corresponding GPS status fault flags).");
-        BIT_MSG(genFault, GFC_GNSS_TX_LIMITED           , "0x00000040 - GNSS Tx limited.");
-        BIT_MSG(genFault, GFC_GNSS_RX_OVERRUN           , "0x00000080 - GNSS Rx overrun.");
-        BIT_MSG(genFault, GFC_INIT_SENSORS              , "0x00000100 - Fault: sensor initialization.");
-        BIT_MSG(genFault, GFC_INIT_SPI                  , "0x00000200 - Fault: SPI bus initialization.");
-        BIT_MSG(genFault, GFC_CONFIG_SPI                , "0x00000400 - Fault: SPI configuration.");
-        BIT_MSG(genFault, GFC_GNSS1_INIT                , "0x00000800 - Fault: GNSS1 init.");
-        BIT_MSG(genFault, GFC_GNSS2_INIT                , "0x00001000 - Fault: GNSS2 init>");
-        BIT_MSG(genFault, GFC_FLASH_INVALID_VALUES      , "0x00002000 - Flash failed to load valid values.");
-        BIT_MSG(genFault, GFC_FLASH_CHECKSUM_FAILURE    , "0x00004000 - Flash checksum failure.");
-        BIT_MSG(genFault, GFC_FLASH_WRITE_FAILURE       , "0x00008000 - Flash write failure.");
-        BIT_MSG(genFault, GFC_SYS_FAULT_GENERAL         , "0x00010000 - System Fault: general.");
-        BIT_MSG(genFault, GFC_SYS_FAULT_CRITICAL        , "0x00020000 - System Fault: CRITICAL system fault (see DID_SYS_FAULT).");
-        BIT_MSG(genFault, GFC_SENSOR_SATURATION         , "0x00040000 - Sensor(s) saturated.");
-        BIT_MSG(genFault, GFC_EKF_STATES_INVALID        , "0x00080000 - EKF states invalid.");
-        BIT_MSG(genFault, GFC_INIT_IMU                  , "0x00100000 - Fault: IMU initialization.");
-        BIT_MSG(genFault, GFC_INIT_BAROMETER            , "0x00200000 - Fault: Barometer initialization.");
-        BIT_MSG(genFault, GFC_INIT_MAGNETOMETER         , "0x00400000 - Fault: Magnetometer initialization.");
-        BIT_MSG(genFault, GFC_INIT_I2C                  , "0x00800000 - Fault: I2C initialization.");
-        BIT_MSG(genFault, GFC_CHIP_ERASE_INVALID        , "0x01000000 - Fault: Chip erase line toggled but did not meet required hold time.");
-        BIT_MSG(genFault, GFC_EKF_GNSS_TIME_FAULT       , "0x02000000 - Fault: EKF GPS time fault.");
-        BIT_MSG(genFault, GFC_GNSS_RECEIVER_TIME        , "0x04000000 - Fault: GPS receiver time fault.");
-        BIT_MSG(genFault, GFC_GNSS_GENERAL_FAULT        , "0x08000000 - Fault: GNSS receiver general fault (See the corresponding GPS status fault flags).");
-        BIT_MSG(genFault, GFC_EKF_INPUT_INVALID_IMU     , "0x10000000 - Fault: Invalid IMU input rejected by EKF.");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("genFaultCode");
+        return dec ? RenderStatusFromDecode(*dec, genFault) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -330,88 +330,64 @@ std::string renderGpxStatus_hdwStatus(const data_info_t& info, std::any value, i
 }
 
 std::string renderGpxStatus_gnssLastResetCause(const data_info_t& info, std::any value, int arrayIdx, int flags) {
-    static const char* rstReasons[] = {
-        "Power On", "Watchdog", "ErrOpCode", "ErrorOpCode_FwUp",
-        "ErrorOpCode_init", "UserRequested", "FWUpdate", "SysCmd",
-        "InitTimeout", "Status5", "StatusNot0", "flashUpdate",
-        "RTKEphMissing"
-    };
-
-    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("lastRstCause"))) {
-        try {
-            std::stringstream buff;
-            uint8_t msgIdx = std::any_cast<uint8_t>(value);
-            if (msgIdx < cxdRst_Max) {
-                return std::string(rstReasons[msgIdx]);
-            }
-        } catch (std::bad_any_cast& e) {
-        }
+    (void)arrayIdx; (void)flags;
+    if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || !STR_ENDS_WITH(info.name, std::string("lastRstCause")))
+        return "";
+    // SN-7919 (D-53): delegates to the gnssLastResetCause scalar-enum decode table.
+    try {
+        uint8_t v = std::any_cast<uint8_t>(value);
+        const status_field_decode_t* dec = GetStatusDecodeByField("gnssLastResetCause");
+        return dec ? RenderStatusFromDecode(*dec, v) : std::string();
+    } catch (std::bad_any_cast& e) {
+        (void)e;
+        return "";
     }
-    return "";
 }
 
 std::string renderGpxStatus_gnssInitState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
-    static const char* initStates[] = {
-        "Bootup", "UartSetting", "UartWait", "UartDone",
-        "VersionCheck", "StopPos", "SetL5", "SetSats",
-        "SetSatLimits", "SetOutput", "SetAlgo", "SetPeriod",
-        "SetRtcmMsgs", "SetRtcmTimeMode", "SetPinningMode", "SetVelocitySmoothing",
-        "SetAltituedSmoothing", "SetEphmOutputPeriod", "StartPos", "Done"
-        };
-
-    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("initState"))) {
-        try {
-            std::stringstream buff;
-            uint8_t msgIdx = std::any_cast<uint8_t>(value);
-            if (msgIdx <= 19) {
-                return std::string(initStates[msgIdx]);
-            }
-        } catch (std::bad_any_cast& e) {
-        }
+    (void)arrayIdx; (void)flags;
+    if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || !STR_ENDS_WITH(info.name, std::string("initState")))
+        return "";
+    // SN-7919 (D-53): delegates to the gnssInitState scalar-enum decode table.
+    try {
+        uint8_t v = std::any_cast<uint8_t>(value);
+        const status_field_decode_t* dec = GetStatusDecodeByField("gnssInitState");
+        return dec ? RenderStatusFromDecode(*dec, v) : std::string();
+    } catch (std::bad_any_cast& e) {
+        (void)e;
+        return "";
     }
-    return "";
 }
 
 std::string renderGpxStatus_gnssRunState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
-    static const char* runStates[] = {
-        "Reset", "Initializing", "Running", "Passthrough",
-        "FwUpdate Init", "FwUpdate", "Error", "Shutdown",
-        "ReInit", "Hard Reset"
-    };
-
-    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("runState"))) {
-        try {
-            std::stringstream buff;
-            uint8_t msgIdx = std::any_cast<uint8_t>(value);
-            if (msgIdx <= kHardReset) {
-                return std::string(runStates[msgIdx]);
-            }
-        } catch (std::bad_any_cast& e) {
-        }
+    (void)arrayIdx; (void)flags;
+    if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || !STR_ENDS_WITH(info.name, std::string("runState")))
+        return "";
+    // SN-7919 (D-53): delegates to the gnssRunState scalar-enum decode table.
+    try {
+        uint8_t v = std::any_cast<uint8_t>(value);
+        const status_field_decode_t* dec = GetStatusDecodeByField("gnssRunState");
+        return dec ? RenderStatusFromDecode(*dec, v) : std::string();
+    } catch (std::bad_any_cast& e) {
+        (void)e;
+        return "";
     }
-    return "";
 }
 
 
 std::string renderGpxStatus_gnssFwUpdateState(const data_info_t& info, std::any value, int arrayIdx, int flags) {
-    static const char* fwStates[] = {
-        "LockoutWait", "ResetSet", "ResetWait", "StartSet", "StartWait",
-        "BootModeSet", "BootModeWait", "BaudSet", "BaudWait", "BaudFinish",
-        "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
-        "WriteNvmWait", "WriteNvmFinish", "Done",
-    };
-
-    if ((info.type == DATA_TYPE_UINT8) && (info.size == 1) && STR_ENDS_WITH(info.name, std::string("fwUpdateState"))) {
-        try {
-            std::stringstream buff;
-            uint8_t msgIdx = std::any_cast<uint8_t>(value);
-            if (msgIdx < cxdRst_Max) {
-                return std::string(fwStates[msgIdx]);
-            }
-        } catch (std::bad_any_cast& e) {
-        }
+    (void)arrayIdx; (void)flags;
+    if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || !STR_ENDS_WITH(info.name, std::string("fwUpdateState")))
+        return "";
+    // SN-7919 (D-53): delegates to the gnssFwUpdateState scalar-enum decode table.
+    try {
+        uint8_t v = std::any_cast<uint8_t>(value);
+        const status_field_decode_t* dec = GetStatusDecodeByField("gnssFwUpdateState");
+        return dec ? RenderStatusFromDecode(*dec, v) : std::string();
+    } catch (std::bad_any_cast& e) {
+        (void)e;
+        return "";
     }
-    return "";
 }
 
 
@@ -419,33 +395,13 @@ std::string renderImxHdwBitStatus(const data_info_t& info, std::any value, int a
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "hdwBitStatus"))
         return "";
 
+    // SN-7919 (D-53): delegates to the hdwBitStatus decode table (key "hdwBitStatus").
     try {
-        std::stringstream buff;
         uint32_t hdwBitStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-        BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_ALL                      ,"0x00000001 - Passed all tests");
-        BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_NO_GNSS                   ,"0x00000002 - Passed without valid GPS signal");
-        if (HDW_BIT_MODE(hdwBitStatus)) {
-            buff << "0x000000" << std::hex << (hdwBitStatus & HDW_BIT_MODE_MASK) << std::dec
-                 << " - BIT mode: " << HDW_BIT_MODE(hdwBitStatus) << std::endl;
-        }
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_PQR                 ,"0x00000100 - FAULT: Gyro noise");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_ACC                 ,"0x00000200 - FAULT: Accelerometer noise");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_MAGNETOMETER              ,"0x00000400 - FAULT: Magnetometer");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_BAROMETER                 ,"0x00000800 - FAULT: Barometer");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_NO_COM                ,"0x00001000 - FAULT: No GPS serial communications");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_POOR_CNO              ,"0x00002000 - FAULT: Poor GPS signal strength");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_POOR_ACCURACY         ,"0x00004000 - FAULT: GPS poor accuracy");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_NOISE                 ,"0x00008000 - FAULT: GPS noise");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_IMU_FAULT_REJECTION       ,"0x00010000 - FAULT: IMU fault rejection failure");
-        BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_INCORRECT_HARDWARE_TYPE   ,"0x01000000 - FAULT: Hardware type does not match firmware");
-
-#undef BIT_MSG
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("hdwBitStatus");
+        return dec ? RenderStatusFromDecode(*dec, hdwBitStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }
@@ -454,42 +410,13 @@ std::string renderImxCalBitStatus(const data_info_t& info, std::any value, int a
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "calBitStatus"))
         return "";
 
+    // SN-7919 (D-53): delegates to the calBitStatus decode table (key "calBitStatus").
     try {
-        std::stringstream buff;
         uint32_t calBitStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-        BIT_MSG(calBitStatus, CAL_BIT_PASSED_ALL                      ,"0x00000001 - Passed all calibration tests");
-        if (CAL_BIT_MODE(calBitStatus)) {
-            buff << "0x000000" << std::hex << (calBitStatus & CAL_BIT_MODE_MASK) << std::dec
-                 << " - CAL BIT mode: " << CAL_BIT_MODE(calBitStatus) << std::endl;
-        }
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_EMPTY                ,"0x00000100 - FAULT: Temperature calibration not present");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_TSPAN                ,"0x00000200 - FAULT: Temperature calibration range inadequate");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_INCONSISTENT         ,"0x00000400 - FAULT: Temperature calibration inconsistent");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_CORRUPT              ,"0x00000800 - FAULT: Temperature calibration corrupt");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_BIAS             ,"0x00001000 - FAULT: Gyro bias temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_SLOPE            ,"0x00002000 - FAULT: Gyro slope temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_LIN              ,"0x00004000 - FAULT: Gyro linearity temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_BIAS             ,"0x00008000 - FAULT: Accel bias temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_SLOPE            ,"0x00010000 - FAULT: Accel slope temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_LIN              ,"0x00020000 - FAULT: Accel linearity temp cal");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_CAL_SERIAL_NUM            ,"0x00040000 - FAULT: Calibration serial number mismatch");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_MAG_INVALID          ,"0x00080000 - FAULT: Magnetometer cross-axis alignment invalid");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_EMPTY                ,"0x00100000 - FAULT: Motion calibration not present");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_IMU_INVALID          ,"0x00200000 - FAULT: IMU cross-axis alignment invalid");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_PQR                ,"0x00400000 - FAULT: Motion detected on gyros");
-        BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_ACC                ,"0x00800000 - FAULT: Motion detected on accelerometers");
-        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_PQR_BIAS            ,"0x01000000 - NOTICE: IMU 1 gyro bias offset detected");
-        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_PQR_BIAS            ,"0x02000000 - NOTICE: IMU 2 gyro bias offset detected");
-        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_ACC_BIAS            ,"0x10000000 - NOTICE: IMU 1 accel bias offset detected");
-        BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_ACC_BIAS            ,"0x20000000 - NOTICE: IMU 2 accel bias offset detected");
-
-#undef BIT_MSG
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("calBitStatus");
+        return dec ? RenderStatusFromDecode(*dec, calBitStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }
@@ -498,25 +425,13 @@ std::string renderGpxBitResults(const data_info_t& info, std::any value, int arr
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "results"))
         return "";
 
+    // SN-7919 (D-53): delegates to the GPX BIT results decode table (key "gpxBitResults").
     try {
-        std::stringstream buff;
         uint32_t results = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-        BIT_MSG(results, GPXBit_resultsBit_PPS1      ,"0x01 - PPS1 test passed");
-        BIT_MSG(results, GPXBit_resultsBit_PPS2      ,"0x02 - PPS2 test passed");
-        BIT_MSG(results, GPXBit_resultsBit_UART      ,"0x04 - UART test passed");
-        BIT_MSG(results, GPXBit_resultsBit_IO        ,"0x08 - IO test passed");
-        BIT_MSG(results, GPXBit_resultsBit_GNSS       ,"0x10 - GPS test passed");
-        BIT_MSG(results, GPXBit_resultsBit_FINISHED  ,"0x20 - Test finished");
-        BIT_MSG(results, GPXBit_resultsBit_CANCELED  ,"0x40 - Test canceled");
-        BIT_MSG(results, GPXBit_resultsBit_ERROR     ,"0x80 - Test error");
-
-#undef BIT_MSG
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("gpxBitResults");
+        return dec ? RenderStatusFromDecode(*dec, results) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }
@@ -525,25 +440,13 @@ std::string renderGpxBitState(const data_info_t& info, std::any value, int array
     if ((info.type != DATA_TYPE_UINT8) || (info.size != 1) || (info.name != "state"))
         return "";
 
+    // SN-7919 (D-53): delegates to the GPX BIT state decode table (key "gpxBitState").
     try {
-        std::stringstream buff;
         uint8_t state = std::any_cast<uint8_t>(value);
-
-        // eGPXBit_state values (from GPXBit.h)
-        switch (state) {
-            case 0: buff << "NOT_RUNNING" << std::endl; break;
-            case 1: buff << "MANUF_INIT" << std::endl; break;
-            case 2: buff << "MANUF_BLINK" << std::endl; break;
-            case 3: buff << "MANUF_UART" << std::endl; break;
-            case 4: buff << "MANUF_IO" << std::endl; break;
-            case 5: buff << "MANUF_PPS" << std::endl; break;
-            case 6: buff << "MANUF_GPS" << std::endl; break;
-            case 7: buff << "MANUF_REPORT" << std::endl; break;
-            default: buff << "UNKNOWN(" << (int)state << ")" << std::endl; break;
-        }
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("gpxBitState");
+        return dec ? RenderStatusFromDecode(*dec, state) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <sstream>
 
 #include "ISDataMappings.h"
+#include "ISStatusDecode.h"
 #include "DataJSON.h"
 #include "ISUtilities.h"
 #include "ISConstants.h"
@@ -153,93 +154,21 @@ std::string renderVariableAndStatsToString(const data_info_t& info, std::any val
  * @return
  */
 std::string renderInsStatus(const data_info_t& info, std::any value, int arrayIdx, int flags) {
+    (void)arrayIdx; (void)flags;
     if ((info.type != DATA_TYPE_UINT32) || (info.size != 4) || (info.name != "insStatus"))
         return "";
 
-/*
-    // In dead reckoning mode.  The GPS is not aiding the solution while the position is being estimated.
-    #define INS_STATUS_DEAD_RECKONING(insStatus)    (((insStatus)&(INS_STATUS_POS_ALIGN_FINE|INS_STATUS_POS_ALIGN_COARSE)) && (((insStatus)&INS_STATUS_GNSS_AIDING_POS)==0))
-
-    INS_STATUS_RTK_COMPASSING_MASK              = (INS_STATUS_RTK_COMPASSING_BASELINE_UNSET|INS_STATUS_RTK_COMPASSING_BASELINE_BAD),
-
-    INS_STATUS_SOLUTION_MASK                    = (int)0x000F0000,
-    INS_STATUS_SOLUTION_OFFSET                  = 16,
-    #define INS_STATUS_SOLUTION(insStatus)          (((insStatus)&INS_STATUS_SOLUTION_MASK)>>INS_STATUS_SOLUTION_OFFSET)
-
-    INS_STATUS_SOLUTION_OFF                     = 0,    // System is off
-    INS_STATUS_SOLUTION_ALIGNING                = 1,    // System is in alignment mode
-    INS_STATUS_SOLUTION_NAV                     = 3,    // System is in navigation mode and solution is good.
-    INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE       = 4,    // System is in navigation mode but the attitude uncertainty has exceeded the threshold.
-    INS_STATUS_SOLUTION_AHRS                    = 5,    // System is in AHRS mode and solution is good.
-    INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE      = 6,    // System is in AHRS mode but the attitude uncertainty has exceeded the threshold.
-    INS_STATUS_SOLUTION_VRS                     = 7,    // System is in VRS mode (no earth relative heading) and roll and pitch are good.
-    INS_STATUS_SOLUTION_VRS_HIGH_VARIANCE       = 8,    // System is in VRS mode (no earth relative heading) but roll and pitch uncertainty has exceeded the threshold.
-
-    // GPS navigation fix type (see eGnssNavFixStatus)
-    INS_STATUS_GNSS_NAV_FIX_MASK                 = (int)0x03000000,
-    INS_STATUS_GNSS_NAV_FIX_OFFSET               = 24,
-    #define INS_STATUS_NAV_FIX_STATUS(insStatus)    (((insStatus)&INS_STATUS_GNSS_NAV_FIX_MASK)>>INS_STATUS_GNSS_NAV_FIX_OFFSET)
-***/
-
+    // SN-7919 (D-53): insStatus bit semantics now live in a single structural source of truth —
+    // the decode table in ISStatusDecode.cpp. This renderer delegates to the table-driven
+    // RenderStatusFromDecode so the human prose and the structured decode the status-ribbon
+    // chart consumes can never drift. test_ISStatusDecode.cpp asserts this produces output
+    // byte-identical to the original hand-written renderer across a value sweep.
     try {
-        std::stringstream buff;
         uint32_t insStatus = std::any_cast<uint32_t>(value);
-
-#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
-
-     // BIT_MSG(insStatus, INS_STATUS_ALIGN_COARSE_MASK                    ,"0x00000007 - Estimate is COARSE mask (usable but outside spec)");
-        BIT_MSG(insStatus, INS_STATUS_HDG_ALIGN_COARSE                       ,"0x00000001 - Heading estimate is usable but outside spec (COARSE)");
-        BIT_MSG(insStatus, INS_STATUS_VEL_ALIGN_COARSE                       ,"0x00000002 - Velocity estimate is usable but outside spec (COARSE)");
-        BIT_MSG(insStatus, INS_STATUS_POS_ALIGN_COARSE                       ,"0x00000004 - Position estimate is usable but outside spec (COARSE)");
-        BIT_MSG(insStatus, INS_STATUS_WHEEL_AIDING_VEL                       ,"0x00000008 - Velocity aided by wheel sensor");
-     // BIT_MSG(insStatus, INS_STATUS_ALIGN_FINE_MASK                        ,"0x00000007 - Estimate is FINE mask");
-        BIT_MSG(insStatus, INS_STATUS_HDG_ALIGN_FINE                         ,"0x00000010 - Heading estimate is within spec (FINE).");
-        BIT_MSG(insStatus, INS_STATUS_VEL_ALIGN_FINE                         ,"0x00000020 - Velocity estimate is within spec (FINE)");
-        BIT_MSG(insStatus, INS_STATUS_POS_ALIGN_FINE                         ,"0x00000040 - Position estimate is within spec (FINE)");
-        BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_HEADING                     ,"0x00000080 - Heading aided by GPS");
-        BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_POS                         ,"0x00000100 - Position aided by GPS position");
-        BIT_MSG(insStatus, INS_STATUS_GNSS_UPDATE_IN_SOLUTION                 ,"0x00000200 - GPS update event occurred in solution, potentially causing discontinuity in position path");
-        BIT_MSG(insStatus, INS_STATUS_EKF_USING_REFERENCE_IMU                ,"0x00000400 - Reference IMU used in EKF");
-        BIT_MSG(insStatus, INS_STATUS_MAG_AIDING_HEADING                     ,"0x00000800 - Heading aided by magnetic heading");
-        BIT_MSG(insStatus, INS_STATUS_NAV_MODE                               ,"0x00001000 - Nav Mode - estimating velocity and position.");
-        BIT_MSG(insStatus, INS_STATUS_STATIONARY_MODE                        ,"0x00002000 - INS in stationary mode.");
-        BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_VEL                         ,"0x00004000 - Velocity aided by GPS velocity");
-        BIT_MSG(insStatus, INS_STATUS_KINEMATIC_CAL_GOOD                     ,"0x00008000 - Vehicle kinematic calibration is good");
-
-        uint32_t insSol = INS_STATUS_SOLUTION(insStatus);
-        switch (insSol) {
-            case INS_STATUS_SOLUTION_OFF:                     buff << "0x000(0)0000 - System is off" << std::endl; break;
-            case INS_STATUS_SOLUTION_ALIGNING:                buff << "0x000(1)0000 - System is in alignment mode" << std::endl; break;
-            case INS_STATUS_SOLUTION_NAV:                     buff << "0x000(3)0000 - System is in navigation mode" << std::endl; break;
-            case INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE:       buff << "0x000(4)0000 - System is in navigation mode but the attitude uncertainty has exceeded the threshold." << std::endl; break;
-            case INS_STATUS_SOLUTION_AHRS:                    buff << "0x000(5)0000 - System is in AHRS mode and solution is good." << std::endl; break;
-            case INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE:      buff << "0x000(6)0000 - System is in AHRS mode but the attitude uncertainty has exceeded the threshold." << std::endl; break;
-            case INS_STATUS_SOLUTION_VRS:                     buff << "0x000(7)0000 - System is in VRS mode (no earth relative heading) and roll and pitch are good." << std::endl; break;
-            case INS_STATUS_SOLUTION_VRS_HIGH_VARIANCE:       buff << "0x000(8)0000 - System is in VRS mode (no earth relative heading) but roll and pitch uncertainty has exceeded the threshold." << std::endl; break;
-        }
-
-        BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_BASELINE_UNSET          ,"0x00100000 - GPS compassing antenna offsets are not set in flashCfg.");
-        BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_BASELINE_BAD            ,"0x00200000 - GPS antenna baseline specified in flashCfg and measured by GPS do not match.");
-        BIT_MSG(insStatus, INS_STATUS_MAG_RECALIBRATING                      ,"0x00400000 - Magnetometer is being recalibrated.");
-        BIT_MSG(insStatus, INS_STATUS_MAG_INTERFERENCE_OR_BAD_CAL_OR_NO_CAL  ,"0x00800000 - Magnetometer is experiencing interference or calibration is bad.");
-        BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_VALID                   ,"0x04000000 - RTK compassing heading is accurate and aiding INS heading.");
-        BIT_MSG(insStatus, INS_STATUS_RTK_RAW_GNSS_DATA_ERROR                 ,"0x08000000 - RTK error: Observations invalid or not received.");
-
-        if (insStatus & INS_STATUS_RTK_ERROR_MASK) {
-            uint32_t rtkErr = (insStatus & INS_STATUS_RTK_ERR_BASE_MASK);
-            switch (rtkErr) {
-                case 0:                                               buff << "0x(0)0000000 - RTK error: NO base position received." << std::endl; break;
-                case INS_STATUS_RTK_ERR_BASE_DATA_MISSING:            buff << "0x(1)0000000 - RTK error: Either base observations or antenna position have not been received." << std::endl; break;
-                case INS_STATUS_RTK_ERR_BASE_POSITION_MOVING:         buff << "0x(2)0000000 - RTK error: base position moved when it should be stationary." << std::endl; break;
-                case INS_STATUS_RTK_ERR_BASE_POSITION_INVALID:        buff << "0x(3)0000000 - RTK error: base position invalid or not surveyed." << std::endl; break;
-            }
-        }
-
-        BIT_MSG(insStatus, INS_STATUS_RTOS_TASK_PERIOD_OVERRUN               ,"0x40000000 - RTOS task ran longer than allotted period.");
-        BIT_MSG(insStatus, INS_STATUS_GENERAL_FAULT                          ,"0x80000000 - General fault (see sys_params_t.genFaultCode).");
-
-        return buff.str();
+        const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+        return dec ? RenderStatusFromDecode(*dec, insStatus) : std::string();
     } catch (std::bad_any_cast& e) {
+        (void)e;
         return "";
     }
 }

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -148,12 +148,130 @@ status_field_decode_t buildInsStatusDecode()
     return d;
 }
 
+/**
+ * @brief hdwStatus decode table (eHdwStatusFlags). Sub-fields in legacy `renderHdwStatus` emission
+ *        order. Exercises all three kinds: bits, a Count (COM parse-error count), and two Enums
+ *        (built-in-test state, reset cause). isError follows HDW_STATUS_ERROR_MASK membership.
+ */
+status_field_decode_t buildHdwStatusDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "hdwStatus";
+    d.errorMask = (uint32_t)HDW_STATUS_ERROR_MASK;
+
+    d.subfields.push_back(bitField("Gyro motion", HDW_STATUS_MOTION_GYR, false,
+        "0x00000001 - Gyro motion detected."));
+    d.subfields.push_back(bitField("Accel motion", HDW_STATUS_MOTION_ACC, false,
+        "0x00000002 - Accelerometer motion detected."));
+    d.subfields.push_back(bitField("IMU gyro fault reject", HDW_STATUS_IMU_FAULT_REJECT_GYR, true,
+        "0x00000004 - IMU gyro fault rejection. A Gyro sensor is divergent and being excluded."));
+    d.subfields.push_back(bitField("IMU accel fault reject", HDW_STATUS_IMU_FAULT_REJECT_ACC, true,
+        "0x00000008 - IMU accelerometer fault rejection. An accelerometer sensors is divergent and being excluded."));
+    d.subfields.push_back(bitField("GNSS satellite RX valid", HDW_STATUS_GNSS_SATELLITE_RX_VALID, false,
+        "0x00000010 - GPS satellite signals are being received (antenna and cable are good)."));
+    d.subfields.push_back(bitField("Strobe input event", HDW_STATUS_STROBE_IN_EVENT, false,
+        "0x00000020 - Event occurred on strobe input pin."));
+    d.subfields.push_back(bitField("GNSS ToW valid", HDW_STATUS_GNSS_TIME_OF_WEEK_VALID, false,
+        "0x00000040 - GPS time of week is valid and reported."));
+    d.subfields.push_back(bitField("Reference IMU RX", HDW_STATUS_REFERENCE_IMU_RX, false,
+        "0x00000080 - Reference IMU data being received."));
+    d.subfields.push_back(bitField("Saturation: gyro", HDW_STATUS_SATURATION_GYR, true,
+        "0x00000100 - Sensor saturation on gyro."));
+    d.subfields.push_back(bitField("Saturation: accel", HDW_STATUS_SATURATION_ACC, true,
+        "0x00000200 - Sensor saturation on accelerometer."));
+    d.subfields.push_back(bitField("Saturation: mag", HDW_STATUS_SATURATION_MAG, true,
+        "0x00000400 - Sensor saturation on magnetometer."));
+    d.subfields.push_back(bitField("Saturation: baro", HDW_STATUS_SATURATION_BARO, true,
+        "0x00000800 - Sensor saturation on barometric pressure."));
+    d.subfields.push_back(bitField("System reset required", HDW_STATUS_SYSTEM_RESET_REQUIRED, false,
+        "0x00001000 - System Reset is required for proper function."));
+    d.subfields.push_back(bitField("GNSS PPS noise", HDW_STATUS_ERR_GNSS_PPS_NOISE, true,
+        "0x00002000 - GPS PPS timepulse signal has noise and occurred too frequently."));
+    d.subfields.push_back(bitField("Mag recal complete", HDW_STATUS_MAG_RECAL_COMPLETE, false,
+        "0x00004000 - Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset)."));
+    d.subfields.push_back(bitField("Flash write pending", HDW_STATUS_FLASH_WRITE_PENDING, false,
+        "0x00008000 - System flash write staging or occurring now."));
+    d.subfields.push_back(bitField("COM Tx limited", HDW_STATUS_ERR_COM_TX_LIMITED, true,
+        "0x00010000 - Communications Tx buffer limited."));
+    d.subfields.push_back(bitField("COM Rx overrun", HDW_STATUS_ERR_COM_RX_OVERRUN, true,
+        "0x00020000 - Communications Rx buffer overrun."));
+    d.subfields.push_back(bitField("GNSS PPS not received", HDW_STATUS_ERR_NO_GNSS_PPS, true,
+        "0x00040000 - GPS PPS timepulse signal has not been received or is in error."));
+    d.subfields.push_back(bitField("GNSS PPS timesync", HDW_STATUS_GNSS_PPS_TIMESYNC, false,
+        "0x00080000 - Time synchronized by GPS PPS."));
+
+    // COM parse-error count (Count). Legacy used utils::string_format with a %d.
+    {
+        const uint32_t mask = (uint32_t)HDW_STATUS_COM_PARSE_ERR_COUNT_MASK;
+        status_subfield_t s;
+        s.name       = "COM parse error count";
+        s.kind       = K::Count;
+        s.mask       = mask;
+        s.shift      = maskShift(mask);
+        s.isError    = false;   // not in HDW_STATUS_ERROR_MASK
+        s.gateMask   = 0;
+        s.legacyText = "0x00F00000 - Communications parse errors (%d).";
+        d.subfields.push_back(s);
+    }
+
+    // Built-in self-test state (Enum). Value 0 (mask clear) emits nothing -> no 0 entry.
+    {
+        const uint32_t mask  = (uint32_t)HDW_STATUS_BIT_MASK;
+        const uint32_t shift = maskShift(mask);
+        status_subfield_t s;
+        s.name     = "Built-in test (BIT)";
+        s.kind     = K::Enum;
+        s.mask     = mask;
+        s.shift    = shift;
+        s.isError  = true;   // FAILED is in the error mask
+        s.gateMask = 0;
+        s.values = {
+            { ((uint32_t)HDW_STATUS_BIT_RUNNING) >> shift, "Running", "0x01000000 - (BIT) Built-in self-test is running.", false },
+            { ((uint32_t)HDW_STATUS_BIT_PASSED)  >> shift, "Passed",  "0x02000000 - (BIT) Built-in self-test passed.",     false },
+            { ((uint32_t)HDW_STATUS_BIT_FAILED)  >> shift, "Failed",  "0x03000000 - (BIT) Built-in self-test failed.",     true  },
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("Temperature error", HDW_STATUS_ERR_TEMPERATURE, true,
+        "0x04000000 - Temperature outside operating range."));
+    d.subfields.push_back(bitField("SPI interface enabled", HDW_STATUS_SPI_INTERFACE_ENABLED, false,
+        "0x08000000 - IMX pins G5-G8 are configure for SPI use."));
+
+    // Reset cause (Enum). Value 0 emits nothing -> no 0 entry. Not in the error mask.
+    {
+        const uint32_t mask  = (uint32_t)HDW_STATUS_RESET_CAUSE_MASK;
+        const uint32_t shift = maskShift(mask);
+        status_subfield_t s;
+        s.name     = "Reset cause";
+        s.kind     = K::Enum;
+        s.mask     = mask;
+        s.shift    = shift;
+        s.isError  = false;
+        s.gateMask = 0;
+        s.values = {
+            { ((uint32_t)HDW_STATUS_RESET_CAUSE_BACKUP_MODE)    >> shift, "Backup mode", "0x10000000 - Reset from backup mode (low-power state w/ CPU off).", false },
+            { ((uint32_t)HDW_STATUS_RESET_CAUSE_WATCHDOG_FAULT) >> shift, "Watchdog",    "0x20000000 - Reset from watchdog fault.",                          false },
+            { ((uint32_t)HDW_STATUS_RESET_CAUSE_SOFT)           >> shift, "Software",    "0x30000000 - Reset from software.",                                false },
+            { ((uint32_t)HDW_STATUS_RESET_CAUSE_HDW)            >> shift, "Hardware",    "0x40000000 - Reset from hardware.",                                false },
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("Critical system fault", HDW_STATUS_FAULT_SYS_CRITICAL, true,
+        "0x80000000 - Critical System Fault, CPU error (see DID_SYS_FAULT.status)."));
+
+    return d;
+}
+
 /** @brief Process-wide registry of decode tables, keyed by field name. Built once. */
 const std::map<std::string, status_field_decode_t>& registry()
 {
     static const std::map<std::string, status_field_decode_t> r = [] {
         std::map<std::string, status_field_decode_t> m;
         m.emplace("insStatus", buildInsStatusDecode());
+        m.emplace("hdwStatus", buildHdwStatusDecode());
         return m;
     }();
     return r;

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -672,9 +672,11 @@ status_field_decode_t buildGnssFwUpdateStateDecode()
         "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
         "WriteNvmWait", "WriteNvmFinish", "Done",
     };
-    // Legacy bound is `msgIdx < cxdRst_Max` (13) — a latent SDK bug: values 13..16 (the array has
-    // 17 entries) never decode. Reproduced here for byte-identity; flagged as a follow-up.
-    return makeScalarEnum("gnssFwUpdateState", fwStates, 13);
+    // SN-7919: the original renderer bounded the index by `cxdRst_Max` (13) — a copy-paste bug
+    // that left fwStates 13..16 (ProgramExecutionFinish..Done) undecoded. Fixed here to the array
+    // size (17) so every state decodes. This is the one intentional behavior change vs the
+    // original renderer (all other fields stay byte-identical).
+    return makeScalarEnum("gnssFwUpdateState", fwStates, 17);
 }
 
 status_field_decode_t buildGnssLastResetCauseDecode()

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -618,18 +618,250 @@ status_field_decode_t buildGpxHdwStatusDecode()
     return d;
 }
 
+/**
+ * @brief Build a scalar-enum decode (single UINT8 value -> bare label, no newline) from a name
+ *        array. `count` may be fewer than the array length to reproduce a legacy bound.
+ */
+status_field_decode_t makeScalarEnum(const char* fieldName, const char* const* names, uint32_t count)
+{
+    status_field_decode_t d;
+    d.fieldName  = fieldName;
+    d.scalarEnum = true;
+    status_subfield_t s;
+    s.name  = fieldName;
+    s.kind  = eStatusSubfieldKind::Enum;
+    s.mask  = 0xFFu;
+    s.shift = 0;
+    for (uint32_t i = 0; i < count; ++i)
+        s.values.push_back({ i, names[i], std::string(), false });
+    d.subfields.push_back(std::move(s));
+    return d;
+}
+
+// --- GPX-GNSS per-receiver state enums (gpx_status_t.gnssStatus[N].*) --------------------------
+// These render as a bare state name (no hex prefix / newline). Registered under semantic keys;
+// the array-indexed field names ("gnssStatus0.initState", ...) resolve via GetStatusDecode.
+
+status_field_decode_t buildGnssInitStateDecode()
+{
+    static const char* const initStates[] = {
+        "Bootup", "UartSetting", "UartWait", "UartDone",
+        "VersionCheck", "StopPos", "SetL5", "SetSats",
+        "SetSatLimits", "SetOutput", "SetAlgo", "SetPeriod",
+        "SetRtcmMsgs", "SetRtcmTimeMode", "SetPinningMode", "SetVelocitySmoothing",
+        "SetAltituedSmoothing", "SetEphmOutputPeriod", "StartPos", "Done"
+    };
+    return makeScalarEnum("gnssInitState", initStates, 20);   // legacy bound: msgIdx <= 19
+}
+
+status_field_decode_t buildGnssRunStateDecode()
+{
+    static const char* const runStates[] = {
+        "Reset", "Initializing", "Running", "Passthrough",
+        "FwUpdate Init", "FwUpdate", "Error", "Shutdown",
+        "ReInit", "Hard Reset"
+    };
+    return makeScalarEnum("gnssRunState", runStates, 10);     // legacy bound: msgIdx <= kHardReset(9)
+}
+
+status_field_decode_t buildGnssFwUpdateStateDecode()
+{
+    static const char* const fwStates[] = {
+        "LockoutWait", "ResetSet", "ResetWait", "StartSet", "StartWait",
+        "BootModeSet", "BootModeWait", "BaudSet", "BaudWait", "BaudFinish",
+        "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
+        "WriteNvmWait", "WriteNvmFinish", "Done",
+    };
+    // Legacy bound is `msgIdx < cxdRst_Max` (13) — a latent SDK bug: values 13..16 (the array has
+    // 17 entries) never decode. Reproduced here for byte-identity; flagged as a follow-up.
+    return makeScalarEnum("gnssFwUpdateState", fwStates, 13);
+}
+
+status_field_decode_t buildGnssLastResetCauseDecode()
+{
+    static const char* const rstReasons[] = {
+        "Power On", "Watchdog", "ErrOpCode", "ErrorOpCode_FwUp",
+        "ErrorOpCode_init", "UserRequested", "FWUpdate", "SysCmd",
+        "InitTimeout", "Status5", "StatusNot0", "flashUpdate",
+        "RTKEphMissing"
+    };
+    return makeScalarEnum("gnssLastResetCause", rstReasons, 13);  // legacy bound: msgIdx < cxdRst_Max(13)
+}
+
+// --- IMX built-in-test fields (DID_BIT) -------------------------------------------------------
+
+status_field_decode_t buildImxHdwBitDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "hdwBitStatus";
+
+    d.subfields.push_back(bitField("Passed all", HDW_BIT_PASSED_ALL, false,
+        "0x00000001 - Passed all tests"));
+    d.subfields.push_back(bitField("Passed without GPS", HDW_BIT_PASSED_NO_GNSS, false,
+        "0x00000002 - Passed without valid GPS signal"));
+    {
+        const uint32_t mask = (uint32_t)HDW_BIT_MODE_MASK;
+        status_subfield_t s;
+        s.name       = "BIT mode";
+        s.kind       = K::Count;
+        s.mask       = mask;
+        s.shift      = maskShift(mask);
+        s.modeHexDec = true;
+        s.legacyText = "0x000000%x - BIT mode: %d";
+        d.subfields.push_back(s);
+    }
+    d.subfields.push_back(bitField("FAULT: gyro noise", HDW_BIT_FAULT_NOISE_PQR, true,
+        "0x00000100 - FAULT: Gyro noise"));
+    d.subfields.push_back(bitField("FAULT: accel noise", HDW_BIT_FAULT_NOISE_ACC, true,
+        "0x00000200 - FAULT: Accelerometer noise"));
+    d.subfields.push_back(bitField("FAULT: magnetometer", HDW_BIT_FAULT_MAGNETOMETER, true,
+        "0x00000400 - FAULT: Magnetometer"));
+    d.subfields.push_back(bitField("FAULT: barometer", HDW_BIT_FAULT_BAROMETER, true,
+        "0x00000800 - FAULT: Barometer"));
+    d.subfields.push_back(bitField("FAULT: no GPS comms", HDW_BIT_FAULT_GNSS_NO_COM, true,
+        "0x00001000 - FAULT: No GPS serial communications"));
+    d.subfields.push_back(bitField("FAULT: poor GPS C/No", HDW_BIT_FAULT_GNSS_POOR_CNO, true,
+        "0x00002000 - FAULT: Poor GPS signal strength"));
+    d.subfields.push_back(bitField("FAULT: poor GPS accuracy", HDW_BIT_FAULT_GNSS_POOR_ACCURACY, true,
+        "0x00004000 - FAULT: GPS poor accuracy"));
+    d.subfields.push_back(bitField("FAULT: GPS noise", HDW_BIT_FAULT_GNSS_NOISE, true,
+        "0x00008000 - FAULT: GPS noise"));
+    d.subfields.push_back(bitField("FAULT: IMU fault rejection", HDW_BIT_FAULT_IMU_FAULT_REJECTION, true,
+        "0x00010000 - FAULT: IMU fault rejection failure"));
+    d.subfields.push_back(bitField("FAULT: wrong hardware type", HDW_BIT_FAULT_INCORRECT_HARDWARE_TYPE, true,
+        "0x01000000 - FAULT: Hardware type does not match firmware"));
+
+    for (const auto& sf : d.subfields) if (sf.isError) d.errorMask |= sf.mask;
+    return d;
+}
+
+status_field_decode_t buildImxCalBitDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "calBitStatus";
+
+    d.subfields.push_back(bitField("Passed all", CAL_BIT_PASSED_ALL, false,
+        "0x00000001 - Passed all calibration tests"));
+    {
+        const uint32_t mask = (uint32_t)CAL_BIT_MODE_MASK;
+        status_subfield_t s;
+        s.name       = "CAL BIT mode";
+        s.kind       = K::Count;
+        s.mask       = mask;
+        s.shift      = maskShift(mask);
+        s.modeHexDec = true;
+        s.legacyText = "0x000000%x - CAL BIT mode: %d";
+        d.subfields.push_back(s);
+    }
+    d.subfields.push_back(bitField("FAULT: temp cal absent", CAL_BIT_FAULT_TCAL_EMPTY, true,
+        "0x00000100 - FAULT: Temperature calibration not present"));
+    d.subfields.push_back(bitField("FAULT: temp cal range", CAL_BIT_FAULT_TCAL_TSPAN, true,
+        "0x00000200 - FAULT: Temperature calibration range inadequate"));
+    d.subfields.push_back(bitField("FAULT: temp cal inconsistent", CAL_BIT_FAULT_TCAL_INCONSISTENT, true,
+        "0x00000400 - FAULT: Temperature calibration inconsistent"));
+    d.subfields.push_back(bitField("FAULT: temp cal corrupt", CAL_BIT_FAULT_TCAL_CORRUPT, true,
+        "0x00000800 - FAULT: Temperature calibration corrupt"));
+    d.subfields.push_back(bitField("FAULT: gyro bias temp cal", CAL_BIT_FAULT_TCAL_PQR_BIAS, true,
+        "0x00001000 - FAULT: Gyro bias temp cal"));
+    d.subfields.push_back(bitField("FAULT: gyro slope temp cal", CAL_BIT_FAULT_TCAL_PQR_SLOPE, true,
+        "0x00002000 - FAULT: Gyro slope temp cal"));
+    d.subfields.push_back(bitField("FAULT: gyro linearity temp cal", CAL_BIT_FAULT_TCAL_PQR_LIN, true,
+        "0x00004000 - FAULT: Gyro linearity temp cal"));
+    d.subfields.push_back(bitField("FAULT: accel bias temp cal", CAL_BIT_FAULT_TCAL_ACC_BIAS, true,
+        "0x00008000 - FAULT: Accel bias temp cal"));
+    d.subfields.push_back(bitField("FAULT: accel slope temp cal", CAL_BIT_FAULT_TCAL_ACC_SLOPE, true,
+        "0x00010000 - FAULT: Accel slope temp cal"));
+    d.subfields.push_back(bitField("FAULT: accel linearity temp cal", CAL_BIT_FAULT_TCAL_ACC_LIN, true,
+        "0x00020000 - FAULT: Accel linearity temp cal"));
+    d.subfields.push_back(bitField("FAULT: cal serial mismatch", CAL_BIT_FAULT_CAL_SERIAL_NUM, true,
+        "0x00040000 - FAULT: Calibration serial number mismatch"));
+    d.subfields.push_back(bitField("FAULT: mag alignment invalid", CAL_BIT_FAULT_MCAL_MAG_INVALID, true,
+        "0x00080000 - FAULT: Magnetometer cross-axis alignment invalid"));
+    d.subfields.push_back(bitField("FAULT: motion cal absent", CAL_BIT_FAULT_MCAL_EMPTY, true,
+        "0x00100000 - FAULT: Motion calibration not present"));
+    d.subfields.push_back(bitField("FAULT: IMU alignment invalid", CAL_BIT_FAULT_MCAL_IMU_INVALID, true,
+        "0x00200000 - FAULT: IMU cross-axis alignment invalid"));
+    d.subfields.push_back(bitField("FAULT: motion on gyros", CAL_BIT_FAULT_MOTION_PQR, true,
+        "0x00400000 - FAULT: Motion detected on gyros"));
+    d.subfields.push_back(bitField("FAULT: motion on accels", CAL_BIT_FAULT_MOTION_ACC, true,
+        "0x00800000 - FAULT: Motion detected on accelerometers"));
+    d.subfields.push_back(bitField("NOTICE: IMU1 gyro bias", CAL_BIT_NOTICE_IMU1_PQR_BIAS, false,
+        "0x01000000 - NOTICE: IMU 1 gyro bias offset detected"));
+    d.subfields.push_back(bitField("NOTICE: IMU2 gyro bias", CAL_BIT_NOTICE_IMU2_PQR_BIAS, false,
+        "0x02000000 - NOTICE: IMU 2 gyro bias offset detected"));
+    d.subfields.push_back(bitField("NOTICE: IMU1 accel bias", CAL_BIT_NOTICE_IMU1_ACC_BIAS, false,
+        "0x10000000 - NOTICE: IMU 1 accel bias offset detected"));
+    d.subfields.push_back(bitField("NOTICE: IMU2 accel bias", CAL_BIT_NOTICE_IMU2_ACC_BIAS, false,
+        "0x20000000 - NOTICE: IMU 2 accel bias offset detected"));
+
+    for (const auto& sf : d.subfields) if (sf.isError) d.errorMask |= sf.mask;
+    return d;
+}
+
+// --- GPX built-in-test fields (DID_GPX_BIT) ---------------------------------------------------
+
+status_field_decode_t buildGpxBitResultsDecode()
+{
+    status_field_decode_t d;
+    d.fieldName = "results";   // registry key "gpxBitResults"
+    d.subfields.push_back(bitField("PPS1 passed", GPXBit_resultsBit_PPS1, false,     "0x01 - PPS1 test passed"));
+    d.subfields.push_back(bitField("PPS2 passed", GPXBit_resultsBit_PPS2, false,     "0x02 - PPS2 test passed"));
+    d.subfields.push_back(bitField("UART passed", GPXBit_resultsBit_UART, false,     "0x04 - UART test passed"));
+    d.subfields.push_back(bitField("IO passed",   GPXBit_resultsBit_IO,   false,     "0x08 - IO test passed"));
+    d.subfields.push_back(bitField("GPS passed",  GPXBit_resultsBit_GNSS, false,     "0x10 - GPS test passed"));
+    d.subfields.push_back(bitField("Finished",    GPXBit_resultsBit_FINISHED, false, "0x20 - Test finished"));
+    d.subfields.push_back(bitField("Canceled",    GPXBit_resultsBit_CANCELED, false, "0x40 - Test canceled"));
+    d.subfields.push_back(bitField("Error",       GPXBit_resultsBit_ERROR, true,     "0x80 - Test error"));
+    d.errorMask = (uint32_t)GPXBit_resultsBit_ERROR;
+    return d;
+}
+
+status_field_decode_t buildGpxBitStateDecode()
+{
+    status_field_decode_t d;
+    d.fieldName = "state";   // registry key "gpxBitState"
+    status_subfield_t s;
+    s.name              = "BIT state";
+    s.kind              = eStatusSubfieldKind::Enum;
+    s.mask              = 0xFFu;
+    s.shift             = 0;
+    s.defaultLegacyText = "UNKNOWN(%d)";
+    s.values = {
+        { 0, "Not running", "NOT_RUNNING",  false },
+        { 1, "Manuf init",  "MANUF_INIT",   false },
+        { 2, "Manuf blink", "MANUF_BLINK",  false },
+        { 3, "Manuf UART",  "MANUF_UART",   false },
+        { 4, "Manuf IO",    "MANUF_IO",     false },
+        { 5, "Manuf PPS",   "MANUF_PPS",    false },
+        { 6, "Manuf GPS",   "MANUF_GPS",    false },
+        { 7, "Manuf report","MANUF_REPORT", false },
+    };
+    d.subfields.push_back(std::move(s));
+    return d;
+}
+
 /** @brief Process-wide registry of decode tables, keyed by an unambiguous internal key. Built once. */
 const std::map<std::string, status_field_decode_t>& registry()
 {
     static const std::map<std::string, status_field_decode_t> r = [] {
         std::map<std::string, status_field_decode_t> m;
-        m.emplace("insStatus",    buildInsStatusDecode());
-        m.emplace("hdwStatus",    buildHdwStatusDecode());
-        m.emplace("sysStatus",    buildSysStatusDecode());
-        m.emplace("genFaultCode", buildGenFaultCodeDecode());
-        m.emplace("gnssStatus",   buildGnssStatusDecode());
-        m.emplace("gpxStatus",    buildGpxStatusDecode());
-        m.emplace("gpxHdwStatus", buildGpxHdwStatusDecode());
+        m.emplace("insStatus",          buildInsStatusDecode());
+        m.emplace("hdwStatus",          buildHdwStatusDecode());
+        m.emplace("sysStatus",          buildSysStatusDecode());
+        m.emplace("genFaultCode",       buildGenFaultCodeDecode());
+        m.emplace("gnssStatus",         buildGnssStatusDecode());
+        m.emplace("gpxStatus",          buildGpxStatusDecode());
+        m.emplace("gpxHdwStatus",       buildGpxHdwStatusDecode());
+        m.emplace("gnssInitState",      buildGnssInitStateDecode());
+        m.emplace("gnssRunState",       buildGnssRunStateDecode());
+        m.emplace("gnssFwUpdateState",  buildGnssFwUpdateStateDecode());
+        m.emplace("gnssLastResetCause", buildGnssLastResetCauseDecode());
+        m.emplace("hdwBitStatus",       buildImxHdwBitDecode());
+        m.emplace("calBitStatus",       buildImxCalBitDecode());
+        m.emplace("gpxBitResults",      buildGpxBitResultsDecode());
+        m.emplace("gpxBitState",        buildGpxBitStateDecode());
         return m;
     }();
     return r;
@@ -639,6 +871,21 @@ const std::map<std::string, status_field_decode_t>& registry()
 
 std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t value)
 {
+    // Scalar-enum fields render as a single bare label (no hex prefix, no trailing newline),
+    // and an empty string when the value is out of range — matching the GPX-GNSS state renderers.
+    if (dec.scalarEnum)
+    {
+        if (!dec.subfields.empty())
+        {
+            const auto& sf = dec.subfields.front();
+            const uint32_t raw = (value & sf.mask) >> sf.shift;
+            for (const auto& vl : sf.values)
+                if (vl.value == raw)
+                    return vl.legacyText.empty() ? vl.label : vl.legacyText;
+        }
+        return std::string();
+    }
+
     std::stringstream buff;
     for (const auto& sf : dec.subfields)
     {
@@ -654,14 +901,18 @@ std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t va
         case eStatusSubfieldKind::Enum:
         {
             const uint32_t raw = (value & sf.mask) >> sf.shift;
+            bool matched = false;
             for (const auto& vl : sf.values)
             {
                 if (vl.value == raw)
                 {
                     buff << (vl.legacyText.empty() ? vl.label : vl.legacyText) << std::endl;
+                    matched = true;
                     break;
                 }
             }
+            if (!matched && !sf.defaultLegacyText.empty())
+                buff << utils::string_format(sf.defaultLegacyText, raw) << std::endl;
             break;
         }
 
@@ -673,9 +924,13 @@ std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t va
                 const std::string& fmt = sf.legacyText.empty() ? sf.name : sf.legacyText;
                 if (fmt.find('%') != std::string::npos)
                 {
-                    // Supply the value up to twice so single- and dual-substitution formats both
-                    // work (a single-conversion format harmlessly ignores the extra argument).
-                    buff << utils::string_format(fmt, cnt, cnt) << std::endl;
+                    // modeHexDec: format the masked value (hex) and the shifted value (dec).
+                    // Otherwise supply the value up to twice so single- and dual-substitution
+                    // formats both work (a single-conversion format ignores the extra argument).
+                    if (sf.modeHexDec)
+                        buff << utils::string_format(fmt, (value & sf.mask), cnt) << std::endl;
+                    else
+                        buff << utils::string_format(fmt, cnt, cnt) << std::endl;
                 }
                 else
                 {
@@ -698,13 +953,28 @@ const status_field_decode_t* GetStatusDecodeByField(const std::string& fieldName
 
 const status_field_decode_t* GetStatusDecode(uint32_t did, const std::string& fieldName)
 {
-    // The on-wire field names "status" and "hdwStatus" are shared across device variants
-    // (GNSS pos/vel vs GPX; IMX vs GPX), so disambiguate by DID. Unambiguous field names
-    // (insStatus, sysStatus, genFaultCode, ...) fall through to a direct key lookup.
+    // The on-wire field names "status"/"hdwStatus"/"results"/"state" are shared across device
+    // variants, so disambiguate by DID. Unambiguous names fall through to a direct key lookup.
+    auto ends = [&](const char* suffix) {
+        const std::string s(suffix);
+        return fieldName.size() >= s.size() &&
+               fieldName.compare(fieldName.size() - s.size(), s.size(), s) == 0;
+    };
+
     if (did == DID_GPX_STATUS)
     {
         if (fieldName == "status")    return GetStatusDecodeByField("gpxStatus");
         if (fieldName == "hdwStatus") return GetStatusDecodeByField("gpxHdwStatus");
+        // Per-receiver array fields: "gnssStatus<N>.<state>".
+        if (ends("initState"))        return GetStatusDecodeByField("gnssInitState");
+        if (ends("runState"))         return GetStatusDecodeByField("gnssRunState");
+        if (ends("fwUpdateState"))    return GetStatusDecodeByField("gnssFwUpdateState");
+        if (ends("lastRstCause"))     return GetStatusDecodeByField("gnssLastResetCause");
+    }
+    if (did == DID_GPX_BIT)
+    {
+        if (fieldName == "results")   return GetStatusDecodeByField("gpxBitResults");
+        if (fieldName == "state")     return GetStatusDecodeByField("gpxBitState");
     }
     if (fieldName == "status")
         return GetStatusDecodeByField("gnssStatus");   // GNSS pos/vel status (DIDs 13/14/6/30/31/54)

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -476,6 +476,148 @@ status_field_decode_t buildGnssStatusDecode()
     return d;
 }
 
+/** @brief GPX status decode table (eGpxStatus). Registered under key "gpxStatus" (field "status"). */
+status_field_decode_t buildGpxStatusDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "status";   // registry key is "gpxStatus"
+    d.errorMask = (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK;
+
+    auto gerr = [](const char* name, uint32_t mask, const char* legacy) {
+        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy);
+    };
+
+    // Parse-error count is rendered by the legacy code as a presence flag (any of the low nibble),
+    // not a number — model it as a Bit on the count mask.
+    d.subfields.push_back(gerr("COM parse errors", GPX_STATUS_COM_PARSE_ERR_COUNT_MASK,
+        "0x0000000F - Communications parse error count"));
+    d.subfields.push_back(gerr("COM0 RX traffic lost", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DECTECTED,
+        "0x00000010 - COM0 RX traffic not dectected in last 30 seconds."));
+    d.subfields.push_back(gerr("COM1 RX traffic lost", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DECTECTED,
+        "0x00000020 - COM1 RX traffic not dectected in last 30 seconds."));
+    d.subfields.push_back(gerr("COM2 RX traffic lost", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DECTECTED,
+        "0x00000040 - COM2 RX traffic not dectected in last 30 seconds."));
+    d.subfields.push_back(gerr("USB RX traffic lost", GPX_STATUS_USB_RX_TRAFFIC_NOT_DECTECTED,
+        "0x00000080 - USB RX traffic not dectected in last 30 seconds."));
+    d.subfields.push_back(gerr("RTK buffer overflow", GPX_STATUS_FAULT_RTK_QUEUE_LIMITED,
+        "0x00010000 - RTK buffer overflow."));
+    d.subfields.push_back(gerr("GNSS receiver time fault", GPX_STATUS_FAULT_GNSS_RCVR_TIME,
+        "0x00100000 - GNSS receiver time fault"));
+    d.subfields.push_back(gerr("DMA fault", GPX_STATUS_FAULT_DMA,
+        "0x00800000 - DMA fault"));
+
+    // Fatal reset cause (Enum). Value 0 emits nothing.
+    {
+        const uint32_t mask  = (uint32_t)GPX_STATUS_FATAL_MASK;
+        const uint32_t shift = maskShift(mask);
+        auto fv = [](uint32_t v, const char* label, const char* legacy) {
+            return status_value_label_t{ v, label, legacy, true };
+        };
+        status_subfield_t s;
+        s.name    = "Fatal reset";
+        s.kind    = K::Enum;
+        s.mask    = mask;
+        s.shift   = shift;
+        s.isError = true;
+        s.values = {
+            fv(GPX_STATUS_FATAL_RESET_LOW_POW,       "Low power",          "0x01000000 - Reset from low power"),
+            fv(GPX_STATUS_FATAL_RESET_BROWN,         "Brown out",          "0x02000000 - Reset from brown out"),
+            fv(GPX_STATUS_FATAL_RESET_WATCHDOG,      "Watchdog",           "0x03000000 - Reset from watchdog"),
+            fv(GPX_STATUS_FATAL_CPU_EXCEPTION,       "CPU exception",      "0x04000000 - CPU exception"),
+            fv(GPX_STATUS_FATAL_UNHANDLED_INTERRUPT, "Unhandled interrupt","0x05000000 - Unhandled interrupt"),
+            fv(GPX_STATUS_FATAL_STACK_OVERFLOW,      "Stack overflow",     "0x06000000 - Stack overflow"),
+            fv(GPX_STATUS_FATAL_KERNEL_OOPS,         "Kernel oops",        "0x07000000 - Kernel oops"),
+            fv(GPX_STATUS_FATAL_KERNEL_PANIC,        "Kernel panic",       "0x08000000 - Kernel panic"),
+            fv(GPX_STATUS_FATAL_UNALIGNED_ACCESS,    "Unaligned access",   "0x09000000 - Unaligned access"),
+            fv(GPX_STATUS_FATAL_MEMORY_ERROR,        "Memory error",       "0x0A000000 - Memory error"),
+            fv(GPX_STATUS_FATAL_BUS_ERROR,           "Bus error",          "0x0B000000 - Bus error"),
+            fv(GPX_STATUS_FATAL_USAGE_ERROR,         "Usage error",        "0x0C000000 - Usage error"),
+            fv(GPX_STATUS_FATAL_DIV_ZERO,            "Division by zero",   "0x0D000000 - Division by zero"),
+            fv(GPX_STATUS_FATAL_SER0_REINIT,         "SER0 reinit",        "0x0E000000 - SER0 reinit"),
+            fv(GPX_STATUS_FATAL_UNKNOWN,             "Unknown",            "0x1F000000 - Unknown"),
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(gerr("RP fault", GPX_STATUS_FAULT_RP, "0x20000000 - RP fault"));
+    return d;
+}
+
+/**
+ * @brief GPX hdwStatus decode table (eGPXHdwStatusFlags). Registered under key "gpxHdwStatus".
+ *        All flat bits in legacy order — including the BIT running/passed/fault and reset-cause,
+ *        which the legacy renderer tests individually (not as switches). isError is derived from
+ *        GPX_HDW_STATUS_ERROR_MASK, with BIT_FAULT forced true (a failed self-test is an error
+ *        even though the BIT bits aren't in the SDK error mask).
+ */
+status_field_decode_t buildGpxHdwStatusDecode()
+{
+    status_field_decode_t d;
+    d.fieldName = "hdwStatus";   // registry key is "gpxHdwStatus"
+    d.errorMask = (uint32_t)GPX_HDW_STATUS_ERROR_MASK;
+
+    auto gbit = [](const char* name, uint32_t mask, const char* legacy) {
+        return bitField(name, mask, (mask & (uint32_t)GPX_HDW_STATUS_ERROR_MASK) != 0, legacy);
+    };
+
+    d.subfields.push_back(gbit("GNSS1 satellite RX", GPX_HDW_STATUS_GNSS1_SATELLITE_RX,
+        "0x00000001 - GNSS1 satellite signals are being received (antenna and cable are good)"));
+    d.subfields.push_back(gbit("GNSS2 satellite RX", GPX_HDW_STATUS_GNSS2_SATELLITE_RX,
+        "0x00000002 - GNSS2 satellite signals are being received (antenna and cable are good)"));
+    d.subfields.push_back(gbit("GNSS1 ToW valid", GPX_HDW_STATUS_GNSS1_TIME_OF_WEEK_VALID,
+        "0x00000004 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time."));
+    d.subfields.push_back(gbit("GNSS2 ToW valid", GPX_HDW_STATUS_GNSS2_TIME_OF_WEEK_VALID,
+        "0x00000008 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time."));
+    d.subfields.push_back(gbit("GNSS1 init fault", GPX_HDW_STATUS_FAULT_GNSS1_INIT,
+        "0x00000080 - Failed to communicate or setup GNSS receiver 1"));
+    d.subfields.push_back(gbit("GNSS2 init fault", GPX_HDW_STATUS_FAULT_GNSS2_INIT,
+        "0x00000800 - Failed to communicate or setup GNSS receiver 2"));
+    d.subfields.push_back(gbit("GNSS FW update required", GPX_HDW_STATUS_GNSS_FW_UPDATE_REQUIRED,
+        "0x00001000 - GNSS is faulting firmware update REQUIRED"));
+    d.subfields.push_back(gbit("LED enabled", GPX_HDW_STATUS_LED_ENABLED,
+        "0x00002000 - Enables LED in Manufacturing TBed"));
+    d.subfields.push_back(gbit("System reset required", GPX_HDW_STATUS_SYSTEM_RESET_REQUIRED,
+        "0x00004000 - System Reset is Required for proper function"));
+    d.subfields.push_back(gbit("Flash write pending", GPX_HDW_STATUS_FLASH_WRITE_PENDING,
+        "0x00008000 - System flash write staging or occuring now."));
+    d.subfields.push_back(gbit("COM Tx limited", GPX_HDW_STATUS_ERR_COM_TX_LIMITED,
+        "0x00010000 - Communications Tx buffer limited"));
+    d.subfields.push_back(gbit("COM Rx overrun", GPX_HDW_STATUS_ERR_COM_RX_OVERRUN,
+        "0x00020000 - Communications Rx buffer overrun"));
+    d.subfields.push_back(gbit("GNSS1 no PPS", GPX_HDW_STATUS_ERR_NO_GNSS1_PPS,
+        "0x00040000 - GNSS1 PPS timepulse signal has not been received or is in error"));
+    d.subfields.push_back(gbit("GNSS2 no PPS", GPX_HDW_STATUS_ERR_NO_GNSS2_PPS,
+        "0x00080000 - GNSS2 PPS timepulse signal has not been received or is in error"));
+    d.subfields.push_back(gbit("GNSS1 low C/No", GPX_HDW_STATUS_ERR_LOW_CNO_GNSS1,
+        "0x00100000 - GNSS1 signal strength low (<20)"));
+    d.subfields.push_back(gbit("GNSS2 low C/No", GPX_HDW_STATUS_ERR_LOW_CNO_GNSS2,
+        "0x00200000 - GNSS2 signal strength low (<20)"));
+    d.subfields.push_back(gbit("GNSS1 C/No irregular", GPX_HDW_STATUS_ERR_CNO_GNSS1_IR,
+        "0x00400000 - GNSS1 signal irregular. High Cno standard deviation over 5 second period detected."));
+    d.subfields.push_back(gbit("GNSS2 C/No irregular", GPX_HDW_STATUS_ERR_CNO_GNSS2_IR,
+        "0x00800000 - GNSS2 signal irregular. High Cno standard deviation over 5 second period detected."));
+    d.subfields.push_back(gbit("BIT running", GPX_HDW_STATUS_BIT_RUNNING,
+        "0x01000000 - (BIT) Built-in self-test running"));
+    d.subfields.push_back(gbit("BIT passed", GPX_HDW_STATUS_BIT_PASSED,
+        "0x02000000 - (BIT) Built-in self-test passed"));
+    d.subfields.push_back(bitField("BIT fault", GPX_HDW_STATUS_BIT_FAULT, true,
+        "0x03000000 - (BIT) Built-in self-test failure"));
+    d.subfields.push_back(gbit("Temperature error", GPX_HDW_STATUS_ERR_TEMPERATURE,
+        "0x04000000 - Temperature outside spec'd operating range"));
+    d.subfields.push_back(gbit("GNSS PPS timesync", GPX_HDW_STATUS_GNSS_PPS_TIMESYNC,
+        "0x08000000 - Time synchronized by GPS PPS"));
+    d.subfields.push_back(gbit("Reset cause: backup mode", GPX_HDW_STATUS_RESET_CAUSE_BACKUP_MODE,
+        "0x10000000 - Reset from Backup mode (low-power state w/ CPU off)"));
+    d.subfields.push_back(gbit("Reset cause: software", GPX_HDW_STATUS_RESET_CAUSE_SOFT,
+        "0x20000000 - Reset from Software"));
+    d.subfields.push_back(gbit("Reset cause: hardware", GPX_HDW_STATUS_RESET_CAUSE_HDW,
+        "0x40000000 - Reset from Hardware (NRST pin low)"));
+    d.subfields.push_back(gbit("Critical system fault", GPX_HDW_STATUS_FAULT_SYS_CRITICAL,
+        "0x80000000 - Critical System Fault, CPU error."));
+    return d;
+}
+
 /** @brief Process-wide registry of decode tables, keyed by an unambiguous internal key. Built once. */
 const std::map<std::string, status_field_decode_t>& registry()
 {
@@ -486,6 +628,8 @@ const std::map<std::string, status_field_decode_t>& registry()
         m.emplace("sysStatus",    buildSysStatusDecode());
         m.emplace("genFaultCode", buildGenFaultCodeDecode());
         m.emplace("gnssStatus",   buildGnssStatusDecode());
+        m.emplace("gpxStatus",    buildGpxStatusDecode());
+        m.emplace("gpxHdwStatus", buildGpxHdwStatusDecode());
         return m;
     }();
     return r;

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -1,0 +1,227 @@
+/**
+ * @file ISStatusDecode.cpp
+ * @brief Structured status-field decode tables + table-driven renderer.
+ *        See ISStatusDecode.h.
+ *
+ * @note D-53 / SN-7919.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include "ISStatusDecode.h"
+
+#include "data_sets.h"
+
+#include <cstdio>
+#include <map>
+#include <sstream>
+
+namespace {
+
+/** @brief Trailing-zero count of `mask` — the right-shift that lands a sub-field at bit 0. */
+uint32_t maskShift(uint32_t mask)
+{
+    if (mask == 0) return 0;
+    uint32_t s = 0;
+    while (!(mask & 1u)) { mask >>= 1; ++s; }
+    return s;
+}
+
+/** @brief Build a single on/off-bit sub-field descriptor. */
+status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const char* legacy)
+{
+    status_subfield_t s;
+    s.name       = name;
+    s.kind       = eStatusSubfieldKind::Bit;
+    s.mask       = mask;
+    s.shift      = 0;
+    s.isError    = isError;
+    s.gateMask   = 0;
+    s.legacyText = legacy;
+    return s;
+}
+
+/**
+ * @brief insStatus decode table (eInsStatusFlags). Sub-fields are listed in the exact order the
+ *        legacy `renderInsStatus` emitted them so `RenderStatusFromDecode` reproduces it byte-for-byte.
+ *        All masks/shifts/values derive from the data_sets.h symbols — no transcribed hex.
+ */
+status_field_decode_t buildInsStatusDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "insStatus";
+    d.errorMask = (uint32_t)INS_STATUS_ERROR_MASK;
+
+    d.subfields.push_back(bitField("Heading align (coarse)", INS_STATUS_HDG_ALIGN_COARSE, false,
+        "0x00000001 - Heading estimate is usable but outside spec (COARSE)"));
+    d.subfields.push_back(bitField("Velocity align (coarse)", INS_STATUS_VEL_ALIGN_COARSE, false,
+        "0x00000002 - Velocity estimate is usable but outside spec (COARSE)"));
+    d.subfields.push_back(bitField("Position align (coarse)", INS_STATUS_POS_ALIGN_COARSE, false,
+        "0x00000004 - Position estimate is usable but outside spec (COARSE)"));
+    d.subfields.push_back(bitField("Wheel velocity aiding", INS_STATUS_WHEEL_AIDING_VEL, false,
+        "0x00000008 - Velocity aided by wheel sensor"));
+    d.subfields.push_back(bitField("Heading align (fine)", INS_STATUS_HDG_ALIGN_FINE, false,
+        "0x00000010 - Heading estimate is within spec (FINE)."));
+    d.subfields.push_back(bitField("Velocity align (fine)", INS_STATUS_VEL_ALIGN_FINE, false,
+        "0x00000020 - Velocity estimate is within spec (FINE)"));
+    d.subfields.push_back(bitField("Position align (fine)", INS_STATUS_POS_ALIGN_FINE, false,
+        "0x00000040 - Position estimate is within spec (FINE)"));
+    d.subfields.push_back(bitField("GNSS heading aiding", INS_STATUS_GNSS_AIDING_HEADING, false,
+        "0x00000080 - Heading aided by GPS"));
+    d.subfields.push_back(bitField("GNSS position aiding", INS_STATUS_GNSS_AIDING_POS, false,
+        "0x00000100 - Position aided by GPS position"));
+    d.subfields.push_back(bitField("GNSS update in solution", INS_STATUS_GNSS_UPDATE_IN_SOLUTION, false,
+        "0x00000200 - GPS update event occurred in solution, potentially causing discontinuity in position path"));
+    d.subfields.push_back(bitField("Reference IMU in EKF", INS_STATUS_EKF_USING_REFERENCE_IMU, false,
+        "0x00000400 - Reference IMU used in EKF"));
+    d.subfields.push_back(bitField("Mag heading aiding", INS_STATUS_MAG_AIDING_HEADING, false,
+        "0x00000800 - Heading aided by magnetic heading"));
+    d.subfields.push_back(bitField("Nav mode", INS_STATUS_NAV_MODE, false,
+        "0x00001000 - Nav Mode - estimating velocity and position."));
+    d.subfields.push_back(bitField("Stationary mode", INS_STATUS_STATIONARY_MODE, false,
+        "0x00002000 - INS in stationary mode."));
+    d.subfields.push_back(bitField("GNSS velocity aiding", INS_STATUS_GNSS_AIDING_VEL, false,
+        "0x00004000 - Velocity aided by GPS velocity"));
+    d.subfields.push_back(bitField("Kinematic cal good", INS_STATUS_KINEMATIC_CAL_GOOD, false,
+        "0x00008000 - Vehicle kinematic calibration is good"));
+
+    // Solution / nav stage (enum). Not in the error mask -> isError=false for every state.
+    {
+        status_subfield_t s;
+        s.name     = "Solution mode";
+        s.kind     = K::Enum;
+        s.mask     = (uint32_t)INS_STATUS_SOLUTION_MASK;
+        s.shift    = maskShift((uint32_t)INS_STATUS_SOLUTION_MASK);
+        s.isError  = false;
+        s.gateMask = 0;
+        s.values = {
+            { (uint32_t)INS_STATUS_SOLUTION_OFF,               "Off",                "0x000(0)0000 - System is off",                                                                          false },
+            { (uint32_t)INS_STATUS_SOLUTION_ALIGNING,          "Aligning",           "0x000(1)0000 - System is in alignment mode",                                                            false },
+            { (uint32_t)INS_STATUS_SOLUTION_NAV,               "Nav",                "0x000(3)0000 - System is in navigation mode",                                                           false },
+            { (uint32_t)INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE, "Nav (high variance)","0x000(4)0000 - System is in navigation mode but the attitude uncertainty has exceeded the threshold.",  false },
+            { (uint32_t)INS_STATUS_SOLUTION_AHRS,              "AHRS",               "0x000(5)0000 - System is in AHRS mode and solution is good.",                                           false },
+            { (uint32_t)INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE,"AHRS (high variance)","0x000(6)0000 - System is in AHRS mode but the attitude uncertainty has exceeded the threshold.",       false },
+            { (uint32_t)INS_STATUS_SOLUTION_VRS,               "VRS",                "0x000(7)0000 - System is in VRS mode (no earth relative heading) and roll and pitch are good.",          false },
+            { (uint32_t)INS_STATUS_SOLUTION_VRS_HIGH_VARIANCE, "VRS (high variance)","0x000(8)0000 - System is in VRS mode (no earth relative heading) but roll and pitch uncertainty has exceeded the threshold.", false },
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("RTK compassing baseline unset", INS_STATUS_RTK_COMPASSING_BASELINE_UNSET, true,
+        "0x00100000 - GPS compassing antenna offsets are not set in flashCfg."));
+    d.subfields.push_back(bitField("RTK compassing baseline bad", INS_STATUS_RTK_COMPASSING_BASELINE_BAD, true,
+        "0x00200000 - GPS antenna baseline specified in flashCfg and measured by GPS do not match."));
+    d.subfields.push_back(bitField("Mag recalibrating", INS_STATUS_MAG_RECALIBRATING, false,
+        "0x00400000 - Magnetometer is being recalibrated."));
+    d.subfields.push_back(bitField("Mag interference / bad cal", INS_STATUS_MAG_INTERFERENCE_OR_BAD_CAL_OR_NO_CAL, true,
+        "0x00800000 - Magnetometer is experiencing interference or calibration is bad."));
+    d.subfields.push_back(bitField("RTK compassing valid", INS_STATUS_RTK_COMPASSING_VALID, false,
+        "0x04000000 - RTK compassing heading is accurate and aiding INS heading."));
+    d.subfields.push_back(bitField("RTK raw GNSS data error", INS_STATUS_RTK_RAW_GNSS_DATA_ERROR, true,
+        "0x08000000 - RTK error: Observations invalid or not received."));
+
+    // RTK base-position error (enum) — hybrid: only decoded when any RTK error bit is set.
+    {
+        const uint32_t mask  = (uint32_t)INS_STATUS_RTK_ERR_BASE_MASK;
+        const uint32_t shift = maskShift(mask);
+        status_subfield_t s;
+        s.name     = "RTK base error";
+        s.kind     = K::Enum;
+        s.mask     = mask;
+        s.shift    = shift;
+        s.isError  = true;
+        s.gateMask = (uint32_t)INS_STATUS_RTK_ERROR_MASK;
+        s.values = {
+            { 0u,                                                          "No base position", "0x(0)0000000 - RTK error: NO base position received.",                                              true },
+            { ((uint32_t)INS_STATUS_RTK_ERR_BASE_DATA_MISSING)     >> shift, "Base data missing","0x(1)0000000 - RTK error: Either base observations or antenna position have not been received.",   true },
+            { ((uint32_t)INS_STATUS_RTK_ERR_BASE_POSITION_MOVING)  >> shift, "Base moving",      "0x(2)0000000 - RTK error: base position moved when it should be stationary.",                       true },
+            { ((uint32_t)INS_STATUS_RTK_ERR_BASE_POSITION_INVALID) >> shift, "Base invalid",     "0x(3)0000000 - RTK error: base position invalid or not surveyed.",                                  true },
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("RTOS task overrun", INS_STATUS_RTOS_TASK_PERIOD_OVERRUN, true,
+        "0x40000000 - RTOS task ran longer than allotted period."));
+    d.subfields.push_back(bitField("General fault", INS_STATUS_GENERAL_FAULT, true,
+        "0x80000000 - General fault (see sys_params_t.genFaultCode)."));
+
+    return d;
+}
+
+/** @brief Process-wide registry of decode tables, keyed by field name. Built once. */
+const std::map<std::string, status_field_decode_t>& registry()
+{
+    static const std::map<std::string, status_field_decode_t> r = [] {
+        std::map<std::string, status_field_decode_t> m;
+        m.emplace("insStatus", buildInsStatusDecode());
+        return m;
+    }();
+    return r;
+}
+
+} // namespace
+
+std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t value)
+{
+    std::stringstream buff;
+    for (const auto& sf : dec.subfields)
+    {
+        if (sf.gateMask && !(value & sf.gateMask)) continue;
+
+        switch (sf.kind)
+        {
+        case eStatusSubfieldKind::Bit:
+            if (value & sf.mask)
+                buff << (sf.legacyText.empty() ? sf.name : sf.legacyText) << std::endl;
+            break;
+
+        case eStatusSubfieldKind::Enum:
+        {
+            const uint32_t raw = (value & sf.mask) >> sf.shift;
+            for (const auto& vl : sf.values)
+            {
+                if (vl.value == raw)
+                {
+                    buff << (vl.legacyText.empty() ? vl.label : vl.legacyText) << std::endl;
+                    break;
+                }
+            }
+            break;
+        }
+
+        case eStatusSubfieldKind::Count:
+        {
+            const uint32_t cnt = (value & sf.mask) >> sf.shift;
+            if (cnt)
+            {
+                if (!sf.legacyText.empty() && sf.legacyText.find("%d") != std::string::npos)
+                {
+                    char line[256];
+                    std::snprintf(line, sizeof(line), sf.legacyText.c_str(), cnt);
+                    buff << line << std::endl;
+                }
+                else
+                {
+                    buff << (sf.legacyText.empty() ? sf.name : sf.legacyText) << std::endl;
+                }
+            }
+            break;
+        }
+        }
+    }
+    return buff.str();
+}
+
+const status_field_decode_t* GetStatusDecodeByField(const std::string& fieldName)
+{
+    const auto& r = registry();
+    auto it = r.find(fieldName);
+    return (it == r.end()) ? nullptr : &it->second;
+}
+
+const status_field_decode_t* GetStatusDecode(uint32_t /*did*/, const std::string& fieldName)
+{
+    // v1: status semantics are DID-independent for shared fields (insStatus on DIDs 4/5/10/65/66
+    // all decode identically). The `did` parameter is reserved for future DID-specific variants.
+    return GetStatusDecodeByField(fieldName);
+}

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -265,13 +265,101 @@ status_field_decode_t buildHdwStatusDecode()
     return d;
 }
 
+/** @brief sysStatus decode table (eSysStatusFlags). Two informational bits; no error states. */
+status_field_decode_t buildSysStatusDecode()
+{
+    status_field_decode_t d;
+    d.fieldName = "sysStatus";
+    d.errorMask = 0;
+    d.subfields.push_back(bitField("Testbed-3 LEDs enabled", SYS_STATUS_TBED3_LEDS_ENABLED, false,
+        "0x00000001 - IMX to drive Testbed-3 status LEDs."));
+    d.subfields.push_back(bitField("Primary GNSS source is GNSS2", SYS_STATUS_PRIMARY_GNSS_SOURCE_IS_GNSS2, false,
+        "0x00000004 - NMEA source is GNSS2."));
+    return d;
+}
+
+/**
+ * @brief genFaultCode decode table (eGenFaultCodes). All defined bits are fault conditions, so
+ *        every subfield isError=true and errorMask = OR of all bits. Note the verbatim legacy
+ *        text quirk on GNSS2 init ("init>").
+ */
+status_field_decode_t buildGenFaultCodeDecode()
+{
+    status_field_decode_t d;
+    d.fieldName = "genFaultCode";
+
+    d.subfields.push_back(bitField("INS state overrun: UVW", GFC_INS_STATE_ORUN_UVW, true,
+        "0x00000001 - INS state limit overrun - UVW."));
+    d.subfields.push_back(bitField("INS state overrun: Latitude", GFC_INS_STATE_ORUN_LAT, true,
+        "0x00000002 - INS state limit overrun - Latitude."));
+    d.subfields.push_back(bitField("INS state overrun: Altitude", GFC_INS_STATE_ORUN_ALT, true,
+        "0x00000004 - INS state limit overrun - Altitude."));
+    d.subfields.push_back(bitField("Unhandled interrupt", GFC_UNHANDLED_INTERRUPT, true,
+        "0x00000010 - Unhandled interrupt."));
+    d.subfields.push_back(bitField("GNSS critical fault", GFC_GNSS_CRITICAL_FAULT, true,
+        "0x00000020 - GNSS receiver critical fault (See the corresponding GPS status fault flags)."));
+    d.subfields.push_back(bitField("GNSS Tx limited", GFC_GNSS_TX_LIMITED, true,
+        "0x00000040 - GNSS Tx limited."));
+    d.subfields.push_back(bitField("GNSS Rx overrun", GFC_GNSS_RX_OVERRUN, true,
+        "0x00000080 - GNSS Rx overrun."));
+    d.subfields.push_back(bitField("Sensor init fault", GFC_INIT_SENSORS, true,
+        "0x00000100 - Fault: sensor initialization."));
+    d.subfields.push_back(bitField("SPI bus init fault", GFC_INIT_SPI, true,
+        "0x00000200 - Fault: SPI bus initialization."));
+    d.subfields.push_back(bitField("SPI config fault", GFC_CONFIG_SPI, true,
+        "0x00000400 - Fault: SPI configuration."));
+    d.subfields.push_back(bitField("GNSS1 init fault", GFC_GNSS1_INIT, true,
+        "0x00000800 - Fault: GNSS1 init."));
+    d.subfields.push_back(bitField("GNSS2 init fault", GFC_GNSS2_INIT, true,
+        "0x00001000 - Fault: GNSS2 init>"));
+    d.subfields.push_back(bitField("Flash invalid values", GFC_FLASH_INVALID_VALUES, true,
+        "0x00002000 - Flash failed to load valid values."));
+    d.subfields.push_back(bitField("Flash checksum failure", GFC_FLASH_CHECKSUM_FAILURE, true,
+        "0x00004000 - Flash checksum failure."));
+    d.subfields.push_back(bitField("Flash write failure", GFC_FLASH_WRITE_FAILURE, true,
+        "0x00008000 - Flash write failure."));
+    d.subfields.push_back(bitField("System fault: general", GFC_SYS_FAULT_GENERAL, true,
+        "0x00010000 - System Fault: general."));
+    d.subfields.push_back(bitField("System fault: critical", GFC_SYS_FAULT_CRITICAL, true,
+        "0x00020000 - System Fault: CRITICAL system fault (see DID_SYS_FAULT)."));
+    d.subfields.push_back(bitField("Sensor saturation", GFC_SENSOR_SATURATION, true,
+        "0x00040000 - Sensor(s) saturated."));
+    d.subfields.push_back(bitField("EKF states invalid", GFC_EKF_STATES_INVALID, true,
+        "0x00080000 - EKF states invalid."));
+    d.subfields.push_back(bitField("IMU init fault", GFC_INIT_IMU, true,
+        "0x00100000 - Fault: IMU initialization."));
+    d.subfields.push_back(bitField("Barometer init fault", GFC_INIT_BAROMETER, true,
+        "0x00200000 - Fault: Barometer initialization."));
+    d.subfields.push_back(bitField("Magnetometer init fault", GFC_INIT_MAGNETOMETER, true,
+        "0x00400000 - Fault: Magnetometer initialization."));
+    d.subfields.push_back(bitField("I2C init fault", GFC_INIT_I2C, true,
+        "0x00800000 - Fault: I2C initialization."));
+    d.subfields.push_back(bitField("Chip erase invalid", GFC_CHIP_ERASE_INVALID, true,
+        "0x01000000 - Fault: Chip erase line toggled but did not meet required hold time."));
+    d.subfields.push_back(bitField("EKF GPS time fault", GFC_EKF_GNSS_TIME_FAULT, true,
+        "0x02000000 - Fault: EKF GPS time fault."));
+    d.subfields.push_back(bitField("GPS receiver time fault", GFC_GNSS_RECEIVER_TIME, true,
+        "0x04000000 - Fault: GPS receiver time fault."));
+    d.subfields.push_back(bitField("GNSS general fault", GFC_GNSS_GENERAL_FAULT, true,
+        "0x08000000 - Fault: GNSS receiver general fault (See the corresponding GPS status fault flags)."));
+    d.subfields.push_back(bitField("EKF invalid IMU input", GFC_EKF_INPUT_INVALID_IMU, true,
+        "0x10000000 - Fault: Invalid IMU input rejected by EKF."));
+
+    // No single error-mask symbol exists; every defined bit is a fault, so the roll-up is their OR.
+    d.errorMask = 0;
+    for (const auto& sf : d.subfields) d.errorMask |= sf.mask;
+    return d;
+}
+
 /** @brief Process-wide registry of decode tables, keyed by field name. Built once. */
 const std::map<std::string, status_field_decode_t>& registry()
 {
     static const std::map<std::string, status_field_decode_t> r = [] {
         std::map<std::string, status_field_decode_t> m;
-        m.emplace("insStatus", buildInsStatusDecode());
-        m.emplace("hdwStatus", buildHdwStatusDecode());
+        m.emplace("insStatus",    buildInsStatusDecode());
+        m.emplace("hdwStatus",    buildHdwStatusDecode());
+        m.emplace("sysStatus",    buildSysStatusDecode());
+        m.emplace("genFaultCode", buildGenFaultCodeDecode());
         return m;
     }();
     return r;

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -10,8 +10,8 @@
 #include "ISStatusDecode.h"
 
 #include "data_sets.h"
+#include "util/util.h"
 
-#include <cstdio>
 #include <map>
 #include <sstream>
 
@@ -351,7 +351,132 @@ status_field_decode_t buildGenFaultCodeDecode()
     return d;
 }
 
-/** @brief Process-wide registry of decode tables, keyed by field name. Built once. */
+/**
+ * @brief GNSS pos/vel `status` decode table (eGnssStatus). Registered under the unambiguous key
+ *        "gnssStatus" (the on-wire field name "status" is shared with GPX — see GetStatusDecode).
+ *        Sub-fields in legacy `renderGnssStatusBits` emission order.
+ */
+status_field_decode_t buildGnssStatusDecode()
+{
+    using K = eStatusSubfieldKind;
+    status_field_decode_t d;
+    d.fieldName = "status";   // on-wire field name (the registry key is "gnssStatus")
+    d.errorMask = (uint32_t)GNSS_STATUS_FLAGS_ERROR_MASK;
+
+    // Deprecated satellite count (low byte) — always emitted, dual-substitution format.
+    {
+        status_subfield_t s;
+        s.name       = "Satellites used (deprecated)";
+        s.kind       = K::Count;
+        s.mask       = (uint32_t)GNSS_STATUS_NUM_SATS_USED_MASK;
+        s.shift      = 0;
+        s.isError    = false;
+        s.emitZero   = true;
+        s.legacyText = "0x000000%02X - %d satellites used in solution (deprecated)";
+        d.subfields.push_back(s);
+    }
+
+    // Fix type (Enum). Includes value 0 ("No GNSS"); only 0..0xC are defined.
+    {
+        const uint32_t mask  = (uint32_t)GNSS_STATUS_FIX_MASK;
+        const uint32_t shift = maskShift(mask);
+        auto fix = [&](uint32_t sym, const char* label, const char* legacy) {
+            return status_value_label_t{ ((uint32_t)sym & mask) >> shift, label, legacy, false };
+        };
+        status_subfield_t s;
+        s.name  = "Fix type";
+        s.kind  = K::Enum;
+        s.mask  = mask;
+        s.shift = shift;
+        s.values = {
+            fix(GNSS_STATUS_FIX_NONE,                "No fix",               "0x00000000 - No GNSS"),
+            fix(GNSS_STATUS_FIX_DEAD_RECKONING_ONLY, "Dead reckoning only",  "0x00000100 - GNSS Dead Reckoning Only"),
+            fix(GNSS_STATUS_FIX_2D,                  "2D fix",               "0x00000200 - 2D Fix"),
+            fix(GNSS_STATUS_FIX_3D,                  "3D fix",               "0x00000300 - 3D Fix"),
+            fix(GNSS_STATUS_FIX_GPS_PLUS_DEAD_RECK,  "3D + dead reckoning",  "0x00000400 - 3D Fix + Dead Reckoning"),
+            fix(GNSS_STATUS_FIX_TIME_ONLY,           "Time only",            "0x00000500 - Time-Only Fix"),
+            fix(GNSS_STATUS_FIX_REF_LLA,             "Reference LLA",        "0x00000600 - Usign Reference LLA"),
+            fix(GNSS_STATUS_FIX_UNUSED2,             "Unused",               "0x00000700 - << UNUSED >>"),
+            fix(GNSS_STATUS_FIX_DGPS,                "DGPS",                 "0x00000800 - Using DGPS"),
+            fix(GNSS_STATUS_FIX_SBAS,                "SBAS",                 "0x00000900 - Using SBAS"),
+            fix(GNSS_STATUS_FIX_RTK_SINGLE,          "RTK single",           "0x00000A00 - RTK Single"),
+            fix(GNSS_STATUS_FIX_RTK_FLOAT,           "RTK float",            "0x00000B00 - RTK Float"),
+            fix(GNSS_STATUS_FIX_RTK_FIX,             "RTK fix",              "0x00000C00 - RTK Fix"),
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("Fix OK", GNSS_STATUS_FLAGS_FIX_OK, false,
+        "0x00010000 - within limits (e.g. DOP & accuracy)"));
+    d.subfields.push_back(bitField("DGPS used", GNSS_STATUS_FLAGS_DGPS_USED, false,
+        "0x00020000 - Differential GPS (DGPS) used."));
+    d.subfields.push_back(bitField("RTK fix and hold", GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD, false,
+        "0x00040000 - RTK feedback on the integer solutions to drive the float biases towards the resolved integers"));
+    d.subfields.push_back(bitField("Unused 1", GNSS_STATUS_FLAGS_UNUSED_1, false,
+        "0x00080000 - << UNUSED >>"));
+    d.subfields.push_back(bitField("GNSS1 RTK positioning enabled", GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_ENABLED, false,
+        "0x00100000 - GNSS1 RTK precision positioning mode enabled"));
+    d.subfields.push_back(bitField("Static mode", GNSS_STATUS_FLAGS_STATIC_MODE, false,
+        "0x00200000 - Static mode"));
+    d.subfields.push_back(bitField("GNSS2 RTK compassing enabled", GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_ENABLED, false,
+        "0x00400000 - GNSS2 RTK moving base mode enabled"));
+    d.subfields.push_back(bitField("GNSS1 RTK raw data error", GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR, true,
+        "0x00800000 - GNSS1 RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)"));
+
+    // RTK base error (Enum). Legacy switches on (value & FLAGS_ERROR_MASK), which folds in the
+    // raw-data-error bit — so when that bit is also set, no case matches and nothing emits. Using
+    // mask=FLAGS_ERROR_MASK reproduces that exactly: only raw values {2,4,6} resolve to a label.
+    {
+        const uint32_t mask  = (uint32_t)GNSS_STATUS_FLAGS_ERROR_MASK;
+        const uint32_t shift = maskShift(mask);
+        auto be = [&](uint32_t sym, const char* label, const char* legacy) {
+            return status_value_label_t{ ((uint32_t)sym & mask) >> shift, label, legacy, true };
+        };
+        status_subfield_t s;
+        s.name    = "RTK base error";
+        s.kind    = K::Enum;
+        s.mask    = mask;
+        s.shift   = shift;
+        s.isError = true;
+        s.values = {
+            be(GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_DATA_MISSING,     "Base data missing", "0x01000000 - GNSS1 RTK error: Either base observations or antenna position have not been received."),
+            be(GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_MOVING,  "Base moving",       "0x02000000 - GNSS1 RTK error: base position moved when it should be stationary"),
+            be(GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_INVALID, "Base invalid",      "0x03000000 - GNSS1 RTK error: base position is invalid or not surveyed well"),
+        };
+        d.subfields.push_back(s);
+    }
+
+    d.subfields.push_back(bitField("GNSS1 RTK position valid", GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_VALID, false,
+        "0x04000000 - GNSS1 RTK precision position and carrier phase range solution with fixed ambiguities."));
+
+    // GNSS2 compass block — only emitted when any compass bit is set (gated on COMPASS_MASK).
+    {
+        const uint32_t gate = (uint32_t)GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_MASK;
+        auto compassBit = [&](const char* name, uint32_t mask, const char* legacy) {
+            status_subfield_t s = bitField(name, mask, false, legacy);
+            s.gateMask = gate;
+            return s;
+        };
+        d.subfields.push_back(compassBit("GNSS2 RTK compassing valid", GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_VALID,
+            "0x08000000 - GNSS2 RTK moving base heading valid and available in DID_GNSS2_RTK_CMP_REL."));
+        d.subfields.push_back(compassBit("GNSS2 compassing baseline bad", GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_BAD,
+            "0x00002000 - GNSS2 RTK Compassing Baseline distance is invalid"));
+        d.subfields.push_back(compassBit("GNSS2 compassing baseline unset", GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_UNSET,
+            "0x00004000 - GNSS2 RTK Compassing Baseline distance is unset (must be > 0)"));
+    }
+
+    d.subfields.push_back(bitField("NMEA data", GNSS_STATUS_FLAGS_GNSS_NMEA_DATA, false,
+        "0x00008000 - Data from NMEA message. GPS velocity is NED (not ECEF)."));
+    d.subfields.push_back(bitField("PPS timesync", GNSS_STATUS_FLAGS_GNSS_PPS_TIMESYNC, false,
+        "0x10000000 - Time is synchronized by GPS PPS."));
+    d.subfields.push_back(bitField("Unused 2", GNSS_STATUS_FLAGS_UNUSED_2, false, "0x20000000 - <<UNUSED>>"));
+    d.subfields.push_back(bitField("Unused 3", GNSS_STATUS_FLAGS_UNUSED_3, false, "0x40000000 - <<UNUSED>>"));
+    d.subfields.push_back(bitField("Unused 4", GNSS_STATUS_FLAGS_UNUSED_4, false, "0x80000000 - <<UNUSED>>"));
+
+    return d;
+}
+
+/** @brief Process-wide registry of decode tables, keyed by an unambiguous internal key. Built once. */
 const std::map<std::string, status_field_decode_t>& registry()
 {
     static const std::map<std::string, status_field_decode_t> r = [] {
@@ -360,6 +485,7 @@ const std::map<std::string, status_field_decode_t>& registry()
         m.emplace("hdwStatus",    buildHdwStatusDecode());
         m.emplace("sysStatus",    buildSysStatusDecode());
         m.emplace("genFaultCode", buildGenFaultCodeDecode());
+        m.emplace("gnssStatus",   buildGnssStatusDecode());
         return m;
     }();
     return r;
@@ -398,17 +524,18 @@ std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t va
         case eStatusSubfieldKind::Count:
         {
             const uint32_t cnt = (value & sf.mask) >> sf.shift;
-            if (cnt)
+            if (cnt || sf.emitZero)
             {
-                if (!sf.legacyText.empty() && sf.legacyText.find("%d") != std::string::npos)
+                const std::string& fmt = sf.legacyText.empty() ? sf.name : sf.legacyText;
+                if (fmt.find('%') != std::string::npos)
                 {
-                    char line[256];
-                    std::snprintf(line, sizeof(line), sf.legacyText.c_str(), cnt);
-                    buff << line << std::endl;
+                    // Supply the value up to twice so single- and dual-substitution formats both
+                    // work (a single-conversion format harmlessly ignores the extra argument).
+                    buff << utils::string_format(fmt, cnt, cnt) << std::endl;
                 }
                 else
                 {
-                    buff << (sf.legacyText.empty() ? sf.name : sf.legacyText) << std::endl;
+                    buff << fmt << std::endl;
                 }
             }
             break;
@@ -425,9 +552,17 @@ const status_field_decode_t* GetStatusDecodeByField(const std::string& fieldName
     return (it == r.end()) ? nullptr : &it->second;
 }
 
-const status_field_decode_t* GetStatusDecode(uint32_t /*did*/, const std::string& fieldName)
+const status_field_decode_t* GetStatusDecode(uint32_t did, const std::string& fieldName)
 {
-    // v1: status semantics are DID-independent for shared fields (insStatus on DIDs 4/5/10/65/66
-    // all decode identically). The `did` parameter is reserved for future DID-specific variants.
+    // The on-wire field names "status" and "hdwStatus" are shared across device variants
+    // (GNSS pos/vel vs GPX; IMX vs GPX), so disambiguate by DID. Unambiguous field names
+    // (insStatus, sysStatus, genFaultCode, ...) fall through to a direct key lookup.
+    if (did == DID_GPX_STATUS)
+    {
+        if (fieldName == "status")    return GetStatusDecodeByField("gpxStatus");
+        if (fieldName == "hdwStatus") return GetStatusDecodeByField("gpxHdwStatus");
+    }
+    if (fieldName == "status")
+        return GetStatusDecodeByField("gnssStatus");   // GNSS pos/vel status (DIDs 13/14/6/30/31/54)
     return GetStatusDecodeByField(fieldName);
 }

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -1,0 +1,101 @@
+/**
+ * @file ISStatusDecode.h
+ * @brief Structured, machine-readable decode of status / bitfield / enumerated
+ *        device fields (insStatus, hdwStatus, GNSS status, ...).
+ *
+ * The hand-written `render*` functions in `ISDataMappings.cpp` historically
+ * encoded each status field's bit semantics as inline prose (one
+ * `std::stringstream` line per set bit / decoded sub-field). That is fine for
+ * a human tooltip but useless to a consumer that needs the *structure* — e.g.
+ * Logalyzer's status-ribbon chart (SN-7919), which must draw one row per
+ * sub-field and color each segment by its decoded value.
+ *
+ * This header defines a declarative descriptor model for those fields. The
+ * descriptor tables are the single structural source of truth: masks, shifts,
+ * value->label maps, and error classification live here, referencing the
+ * `data_sets.h` enum/macro symbols by name (never transcribed hex). The legacy
+ * `render*` functions are refactored to render *from* these tables via
+ * `RenderStatusFromDecode`, so their output stays byte-identical (guarded by a
+ * round-trip unit test) while the structure becomes queryable.
+ *
+ * @note D-53 / SN-7919.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#ifndef IS_STATUS_DECODE_H
+#define IS_STATUS_DECODE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/** @brief Kind of a decoded sub-field within a status value. */
+enum class eStatusSubfieldKind : uint8_t
+{
+    Bit,    //!< Single on/off flag; `mask` selects exactly one bit.
+    Enum,   //!< Multi-bit sub-field decoded to a named state via (mask, shift) + a value table.
+    Count,  //!< Multi-bit sub-field reported as an integer count via (mask, shift).
+};
+
+/** @brief One (value -> label) entry for an `Enum` sub-field. `value` is post-shift. */
+struct status_value_label_t
+{
+    uint32_t    value;        //!< Decoded value AFTER `(raw & mask) >> shift`.
+    std::string label;        //!< Clean human label (UI / status-ribbon legend).
+    std::string legacyText;   //!< Verbose line the legacy render* emitted; empty -> use `label`.
+    bool        isError;      //!< This particular state is an error / fault condition.
+};
+
+/** @brief One decodable sub-field of a status field. */
+struct status_subfield_t
+{
+    std::string                       name;       //!< Clean row label (status-ribbon row title).
+    eStatusSubfieldKind               kind;       //!< Bit / Enum / Count.
+    uint32_t                          mask;       //!< Bit(s) this sub-field occupies in the raw value.
+    uint32_t                          shift;      //!< Right-shift for Enum/Count extraction; 0 for Bit.
+    bool                              isError;    //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
+    uint32_t                          gateMask;   //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
+    std::string                       legacyText; //!< Bit/Count verbose line for byte-identical render*; a Count line may contain one `%d`. Empty -> use `name`.
+    std::vector<status_value_label_t> values;     //!< Enum only: the value table.
+};
+
+/** @brief Structured decode for one named status field. */
+struct status_field_decode_t
+{
+    std::string                    fieldName;   //!< e.g. `"insStatus"`.
+    uint32_t                       errorMask;   //!< `(raw & errorMask) != 0` => field is in an error state.
+    std::vector<status_subfield_t> subfields;   //!< In legacy emission order.
+};
+
+/**
+ * @brief Reproduce the legacy multi-line human string for a status value from its decode table.
+ *
+ * Iterates `dec.subfields` in order, emitting one newline-terminated line per set bit, matching
+ * enum value, or non-zero count — exactly as the hand-written render* functions did.
+ *
+ * @param dec   The field's decode table.
+ * @param value The raw status value.
+ * @return The rendered multi-line string (may be empty if nothing is set).
+ */
+std::string RenderStatusFromDecode(const status_field_decode_t& dec, uint32_t value);
+
+/**
+ * @brief Look up the structured decode for `(did, fieldName)`.
+ *
+ * @param did       DID id (accepted for future DID-specific variants; v1 dispatches on field name,
+ *                  since shared fields like `insStatus` carry identical semantics across DIDs).
+ * @param fieldName Field name, e.g. `"insStatus"`.
+ * @return Pointer to the decode table, or `nullptr` when the field has no structured decode.
+ */
+const status_field_decode_t* GetStatusDecode(uint32_t did, const std::string& fieldName);
+
+/**
+ * @brief Convenience: look up a structured decode by field name alone.
+ *
+ * @param fieldName Field name, e.g. `"insStatus"`.
+ * @return Pointer to the decode table, or `nullptr`.
+ */
+const status_field_decode_t* GetStatusDecodeByField(const std::string& fieldName);
+
+#endif // IS_STATUS_DECODE_H

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -50,14 +50,15 @@ struct status_value_label_t
 /** @brief One decodable sub-field of a status field. */
 struct status_subfield_t
 {
-    std::string                       name;       //!< Clean row label (status-ribbon row title).
-    eStatusSubfieldKind               kind;       //!< Bit / Enum / Count.
-    uint32_t                          mask;       //!< Bit(s) this sub-field occupies in the raw value.
-    uint32_t                          shift;      //!< Right-shift for Enum/Count extraction; 0 for Bit.
-    bool                              isError;    //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
-    uint32_t                          gateMask;   //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
-    std::string                       legacyText; //!< Bit/Count verbose line for byte-identical render*; a Count line may contain one `%d`. Empty -> use `name`.
-    std::vector<status_value_label_t> values;     //!< Enum only: the value table.
+    std::string                       name;                                    //!< Clean row label (status-ribbon row title).
+    eStatusSubfieldKind               kind     = eStatusSubfieldKind::Bit;     //!< Bit / Enum / Count.
+    uint32_t                          mask     = 0;                            //!< Bit(s) this sub-field occupies in the raw value.
+    uint32_t                          shift    = 0;                            //!< Right-shift for Enum/Count extraction; 0 for Bit.
+    bool                              isError  = false;                        //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
+    uint32_t                          gateMask = 0;                            //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
+    bool                              emitZero = false;                        //!< Count: emit a line even when the extracted value is 0 (e.g. GNSS satellite count). Default: skip zero.
+    std::string                       legacyText;                              //!< Bit/Count verbose line for byte-identical render*; a Count line may contain printf conversions (the value is supplied up to twice). Empty -> use `name`.
+    std::vector<status_value_label_t> values;                                  //!< Enum only: the value table.
 };
 
 /** @brief Structured decode for one named status field. */

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -57,16 +57,19 @@ struct status_subfield_t
     bool                              isError  = false;                        //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
     uint32_t                          gateMask = 0;                            //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
     bool                              emitZero = false;                        //!< Count: emit a line even when the extracted value is 0 (e.g. GNSS satellite count). Default: skip zero.
+    bool                              modeHexDec = false;                      //!< Count: format args are `(masked, shifted)` instead of `(value, value)` — for "hex(masked) ... dec(shifted)" lines (the BIT-mode pattern).
     std::string                       legacyText;                              //!< Bit/Count verbose line for byte-identical render*; a Count line may contain printf conversions (the value is supplied up to twice). Empty -> use `name`.
+    std::string                       defaultLegacyText;                       //!< Enum only: catch-all format (may contain one `%d` for the raw value) emitted when no value matches (e.g. "UNKNOWN(%d)"). Empty -> emit nothing on no match.
     std::vector<status_value_label_t> values;                                  //!< Enum only: the value table.
 };
 
 /** @brief Structured decode for one named status field. */
 struct status_field_decode_t
 {
-    std::string                    fieldName;   //!< e.g. `"insStatus"`.
-    uint32_t                       errorMask;   //!< `(raw & errorMask) != 0` => field is in an error state.
-    std::vector<status_subfield_t> subfields;   //!< In legacy emission order.
+    std::string                    fieldName;          //!< e.g. `"insStatus"`.
+    uint32_t                       errorMask = 0;      //!< `(raw & errorMask) != 0` => field is in an error state.
+    bool                           scalarEnum = false; //!< Whole field is a single enum value rendered as a bare label (no hex prefix, no trailing newline); empty when out of range. Uses `subfields[0]`'s value table. For the GPX-GNSS state enums.
+    std::vector<status_subfield_t> subfields;          //!< In legacy emission order.
 };
 
 /**

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -143,6 +143,54 @@ std::string legacyRenderHdwStatusReference(uint32_t hdwStatus)
     return buff.str();
 }
 
+/** @brief Oracle: faithful copy of the original `renderSysStatus` body. */
+std::string legacyRenderSysStatusReference(uint32_t sysStatus)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(sysStatus, SYS_STATUS_TBED3_LEDS_ENABLED            , "0x00000001 - IMX to drive Testbed-3 status LEDs.");
+    BIT_MSG(sysStatus, SYS_STATUS_PRIMARY_GNSS_SOURCE_IS_GNSS2  , "0x00000004 - NMEA source is GNSS2.");
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Oracle: faithful copy of the original `renderGenFaultCode` body. */
+std::string legacyRenderGenFaultCodeReference(uint32_t genFault)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(genFault, GFC_INS_STATE_ORUN_UVW        , "0x00000001 - INS state limit overrun - UVW.");
+    BIT_MSG(genFault, GFC_INS_STATE_ORUN_LAT        , "0x00000002 - INS state limit overrun - Latitude.");
+    BIT_MSG(genFault, GFC_INS_STATE_ORUN_ALT        , "0x00000004 - INS state limit overrun - Altitude.");
+    BIT_MSG(genFault, GFC_UNHANDLED_INTERRUPT       , "0x00000010 - Unhandled interrupt.");
+    BIT_MSG(genFault, GFC_GNSS_CRITICAL_FAULT       , "0x00000020 - GNSS receiver critical fault (See the corresponding GPS status fault flags).");
+    BIT_MSG(genFault, GFC_GNSS_TX_LIMITED           , "0x00000040 - GNSS Tx limited.");
+    BIT_MSG(genFault, GFC_GNSS_RX_OVERRUN           , "0x00000080 - GNSS Rx overrun.");
+    BIT_MSG(genFault, GFC_INIT_SENSORS              , "0x00000100 - Fault: sensor initialization.");
+    BIT_MSG(genFault, GFC_INIT_SPI                  , "0x00000200 - Fault: SPI bus initialization.");
+    BIT_MSG(genFault, GFC_CONFIG_SPI                , "0x00000400 - Fault: SPI configuration.");
+    BIT_MSG(genFault, GFC_GNSS1_INIT                , "0x00000800 - Fault: GNSS1 init.");
+    BIT_MSG(genFault, GFC_GNSS2_INIT                , "0x00001000 - Fault: GNSS2 init>");
+    BIT_MSG(genFault, GFC_FLASH_INVALID_VALUES      , "0x00002000 - Flash failed to load valid values.");
+    BIT_MSG(genFault, GFC_FLASH_CHECKSUM_FAILURE    , "0x00004000 - Flash checksum failure.");
+    BIT_MSG(genFault, GFC_FLASH_WRITE_FAILURE       , "0x00008000 - Flash write failure.");
+    BIT_MSG(genFault, GFC_SYS_FAULT_GENERAL         , "0x00010000 - System Fault: general.");
+    BIT_MSG(genFault, GFC_SYS_FAULT_CRITICAL        , "0x00020000 - System Fault: CRITICAL system fault (see DID_SYS_FAULT).");
+    BIT_MSG(genFault, GFC_SENSOR_SATURATION         , "0x00040000 - Sensor(s) saturated.");
+    BIT_MSG(genFault, GFC_EKF_STATES_INVALID        , "0x00080000 - EKF states invalid.");
+    BIT_MSG(genFault, GFC_INIT_IMU                  , "0x00100000 - Fault: IMU initialization.");
+    BIT_MSG(genFault, GFC_INIT_BAROMETER            , "0x00200000 - Fault: Barometer initialization.");
+    BIT_MSG(genFault, GFC_INIT_MAGNETOMETER         , "0x00400000 - Fault: Magnetometer initialization.");
+    BIT_MSG(genFault, GFC_INIT_I2C                  , "0x00800000 - Fault: I2C initialization.");
+    BIT_MSG(genFault, GFC_CHIP_ERASE_INVALID        , "0x01000000 - Fault: Chip erase line toggled but did not meet required hold time.");
+    BIT_MSG(genFault, GFC_EKF_GNSS_TIME_FAULT       , "0x02000000 - Fault: EKF GPS time fault.");
+    BIT_MSG(genFault, GFC_GNSS_RECEIVER_TIME        , "0x04000000 - Fault: GPS receiver time fault.");
+    BIT_MSG(genFault, GFC_GNSS_GENERAL_FAULT        , "0x08000000 - Fault: GNSS receiver general fault (See the corresponding GPS status fault flags).");
+    BIT_MSG(genFault, GFC_EKF_INPUT_INVALID_IMU     , "0x10000000 - Fault: Invalid IMU input rejected by EKF.");
+#undef BIT_MSG
+    return buff.str();
+}
+
 /** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
 uint32_t xorshift32(uint32_t& s)
 {
@@ -370,4 +418,53 @@ TEST(ISStatusDecode, HdwStatus_StructuredDecode)
     for (const auto& vl : bit->values)
         if (vl.label == "Failed") failedIsError = vl.isError;
     EXPECT_TRUE(failedIsError);
+}
+
+// ---- sysStatus / genFaultCode -------------------------------------------------
+
+TEST(ISStatusDecode, SysStatus_RoundTrip)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("sysStatus");
+    ASSERT_NE(dec, nullptr);
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderSysStatusReference(v)) << "bit " << b;
+    }
+    EXPECT_EQ(dec->errorMask, 0u);   // sysStatus has no error states
+}
+
+TEST(ISStatusDecode, GenFaultCode_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("genFaultCode");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderGenFaultCodeReference(0u));
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGenFaultCodeReference(v)) << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, GenFaultCode_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("genFaultCode");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0xFEEDFACEu;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGenFaultCodeReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GenFaultCode_AllBitsAreErrors)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("genFaultCode");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_FALSE(dec->subfields.empty());
+    uint32_t orMask = 0;
+    for (const auto& sf : dec->subfields) {
+        EXPECT_TRUE(sf.isError) << sf.name;
+        orMask |= sf.mask;
+    }
+    EXPECT_EQ(dec->errorMask, orMask);   // roll-up = OR of all fault bits
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -1,0 +1,231 @@
+/**
+ * @file test_ISStatusDecode.cpp
+ * @brief Unit tests for the structured status-decode API (SN-7919 / D-53).
+ *
+ * Two guarantees are tested:
+ *  1. Round-trip fidelity: `RenderStatusFromDecode` over the insStatus table reproduces the
+ *     ORIGINAL hand-written renderer byte-for-byte. The oracle below is a faithful copy of the
+ *     pre-refactor `renderInsStatus` body, so any drift between table and legacy semantics fails
+ *     the test.
+ *  2. Structured decode: the table exposes the masks/shifts/values/error-classification a
+ *     consumer (Logalyzer's status-ribbon chart) needs.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+#include "ISStatusDecode.h"
+#include "data_sets.h"
+
+namespace {
+
+/**
+ * @brief Oracle: a faithful copy of the original (pre-SN-7919) `renderInsStatus` body, sans the
+ *        data_info_t type guard. Equality with `RenderStatusFromDecode` proves the table-driven
+ *        renderer reproduces legacy output exactly.
+ */
+std::string legacyRenderInsStatusReference(uint32_t insStatus)
+{
+    std::stringstream buff;
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+    BIT_MSG(insStatus, INS_STATUS_HDG_ALIGN_COARSE                       ,"0x00000001 - Heading estimate is usable but outside spec (COARSE)");
+    BIT_MSG(insStatus, INS_STATUS_VEL_ALIGN_COARSE                       ,"0x00000002 - Velocity estimate is usable but outside spec (COARSE)");
+    BIT_MSG(insStatus, INS_STATUS_POS_ALIGN_COARSE                       ,"0x00000004 - Position estimate is usable but outside spec (COARSE)");
+    BIT_MSG(insStatus, INS_STATUS_WHEEL_AIDING_VEL                       ,"0x00000008 - Velocity aided by wheel sensor");
+    BIT_MSG(insStatus, INS_STATUS_HDG_ALIGN_FINE                         ,"0x00000010 - Heading estimate is within spec (FINE).");
+    BIT_MSG(insStatus, INS_STATUS_VEL_ALIGN_FINE                         ,"0x00000020 - Velocity estimate is within spec (FINE)");
+    BIT_MSG(insStatus, INS_STATUS_POS_ALIGN_FINE                         ,"0x00000040 - Position estimate is within spec (FINE)");
+    BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_HEADING                    ,"0x00000080 - Heading aided by GPS");
+    BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_POS                        ,"0x00000100 - Position aided by GPS position");
+    BIT_MSG(insStatus, INS_STATUS_GNSS_UPDATE_IN_SOLUTION                ,"0x00000200 - GPS update event occurred in solution, potentially causing discontinuity in position path");
+    BIT_MSG(insStatus, INS_STATUS_EKF_USING_REFERENCE_IMU               ,"0x00000400 - Reference IMU used in EKF");
+    BIT_MSG(insStatus, INS_STATUS_MAG_AIDING_HEADING                    ,"0x00000800 - Heading aided by magnetic heading");
+    BIT_MSG(insStatus, INS_STATUS_NAV_MODE                              ,"0x00001000 - Nav Mode - estimating velocity and position.");
+    BIT_MSG(insStatus, INS_STATUS_STATIONARY_MODE                       ,"0x00002000 - INS in stationary mode.");
+    BIT_MSG(insStatus, INS_STATUS_GNSS_AIDING_VEL                       ,"0x00004000 - Velocity aided by GPS velocity");
+    BIT_MSG(insStatus, INS_STATUS_KINEMATIC_CAL_GOOD                    ,"0x00008000 - Vehicle kinematic calibration is good");
+
+    uint32_t insSol = INS_STATUS_SOLUTION(insStatus);
+    switch (insSol) {
+        case INS_STATUS_SOLUTION_OFF:                     buff << "0x000(0)0000 - System is off" << std::endl; break;
+        case INS_STATUS_SOLUTION_ALIGNING:                buff << "0x000(1)0000 - System is in alignment mode" << std::endl; break;
+        case INS_STATUS_SOLUTION_NAV:                     buff << "0x000(3)0000 - System is in navigation mode" << std::endl; break;
+        case INS_STATUS_SOLUTION_NAV_HIGH_VARIANCE:       buff << "0x000(4)0000 - System is in navigation mode but the attitude uncertainty has exceeded the threshold." << std::endl; break;
+        case INS_STATUS_SOLUTION_AHRS:                    buff << "0x000(5)0000 - System is in AHRS mode and solution is good." << std::endl; break;
+        case INS_STATUS_SOLUTION_AHRS_HIGH_VARIANCE:      buff << "0x000(6)0000 - System is in AHRS mode but the attitude uncertainty has exceeded the threshold." << std::endl; break;
+        case INS_STATUS_SOLUTION_VRS:                     buff << "0x000(7)0000 - System is in VRS mode (no earth relative heading) and roll and pitch are good." << std::endl; break;
+        case INS_STATUS_SOLUTION_VRS_HIGH_VARIANCE:       buff << "0x000(8)0000 - System is in VRS mode (no earth relative heading) but roll and pitch uncertainty has exceeded the threshold." << std::endl; break;
+    }
+
+    BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_BASELINE_UNSET         ,"0x00100000 - GPS compassing antenna offsets are not set in flashCfg.");
+    BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_BASELINE_BAD           ,"0x00200000 - GPS antenna baseline specified in flashCfg and measured by GPS do not match.");
+    BIT_MSG(insStatus, INS_STATUS_MAG_RECALIBRATING                     ,"0x00400000 - Magnetometer is being recalibrated.");
+    BIT_MSG(insStatus, INS_STATUS_MAG_INTERFERENCE_OR_BAD_CAL_OR_NO_CAL ,"0x00800000 - Magnetometer is experiencing interference or calibration is bad.");
+    BIT_MSG(insStatus, INS_STATUS_RTK_COMPASSING_VALID                  ,"0x04000000 - RTK compassing heading is accurate and aiding INS heading.");
+    BIT_MSG(insStatus, INS_STATUS_RTK_RAW_GNSS_DATA_ERROR               ,"0x08000000 - RTK error: Observations invalid or not received.");
+
+    if (insStatus & INS_STATUS_RTK_ERROR_MASK) {
+        uint32_t rtkErr = (insStatus & INS_STATUS_RTK_ERR_BASE_MASK);
+        switch (rtkErr) {
+            case 0:                                            buff << "0x(0)0000000 - RTK error: NO base position received." << std::endl; break;
+            case INS_STATUS_RTK_ERR_BASE_DATA_MISSING:         buff << "0x(1)0000000 - RTK error: Either base observations or antenna position have not been received." << std::endl; break;
+            case INS_STATUS_RTK_ERR_BASE_POSITION_MOVING:      buff << "0x(2)0000000 - RTK error: base position moved when it should be stationary." << std::endl; break;
+            case INS_STATUS_RTK_ERR_BASE_POSITION_INVALID:     buff << "0x(3)0000000 - RTK error: base position invalid or not surveyed." << std::endl; break;
+        }
+    }
+
+    BIT_MSG(insStatus, INS_STATUS_RTOS_TASK_PERIOD_OVERRUN              ,"0x40000000 - RTOS task ran longer than allotted period.");
+    BIT_MSG(insStatus, INS_STATUS_GENERAL_FAULT                         ,"0x80000000 - General fault (see sys_params_t.genFaultCode).");
+
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
+uint32_t xorshift32(uint32_t& s)
+{
+    s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+    return s;
+}
+
+} // namespace
+
+// ---- Round-trip fidelity ------------------------------------------------------
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_Zero)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderInsStatusReference(0u));
+}
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderInsStatusReference(v))
+            << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_EverySolutionState)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t sol = 0; sol <= 0xF; ++sol) {
+        const uint32_t v = (sol << INS_STATUS_SOLUTION_OFFSET);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderInsStatusReference(v))
+            << "solution " << sol;
+    }
+}
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_RtkErrorCombos)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    // Including the hybrid case: RAW_GNSS_DATA_ERROR set but base bits clear -> "NO base position".
+    const uint32_t cases[] = {
+        INS_STATUS_RTK_RAW_GNSS_DATA_ERROR,
+        INS_STATUS_RTK_ERR_BASE_DATA_MISSING,
+        INS_STATUS_RTK_ERR_BASE_POSITION_MOVING,
+        INS_STATUS_RTK_ERR_BASE_POSITION_INVALID,
+        INS_STATUS_RTK_RAW_GNSS_DATA_ERROR | INS_STATUS_RTK_ERR_BASE_POSITION_INVALID,
+    };
+    for (uint32_t v : cases) {
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderInsStatusReference(v))
+            << "rtk combo 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_AllBits)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0xFFFFFFFFu),
+              legacyRenderInsStatusReference(0xFFFFFFFFu));
+}
+
+TEST(ISStatusDecode, InsStatus_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0xC0FFEEu;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderInsStatusReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+// ---- Structured decode --------------------------------------------------------
+
+TEST(ISStatusDecode, InsStatus_TableMetadata)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(dec->fieldName, "insStatus");
+    EXPECT_EQ(dec->errorMask, (uint32_t)INS_STATUS_ERROR_MASK);
+    EXPECT_FALSE(dec->subfields.empty());
+
+    // GetStatusDecode(did, name) is DID-agnostic in v1 and must agree with the by-field lookup.
+    EXPECT_EQ(GetStatusDecode(DID_INS_2, "insStatus"), dec);
+    EXPECT_EQ(GetStatusDecode(DID_SYS_PARAMS, "insStatus"), dec);
+    EXPECT_EQ(GetStatusDecodeByField("nonexistentField"), nullptr);
+}
+
+TEST(ISStatusDecode, InsStatus_SolutionSubfieldDecodes)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+
+    const status_subfield_t* sol = nullptr;
+    for (const auto& sf : dec->subfields)
+        if (sf.name == "Solution mode") { sol = &sf; break; }
+    ASSERT_NE(sol, nullptr);
+    EXPECT_EQ(sol->kind, eStatusSubfieldKind::Enum);
+    EXPECT_EQ(sol->mask, (uint32_t)INS_STATUS_SOLUTION_MASK);
+    EXPECT_EQ(sol->shift, (uint32_t)INS_STATUS_SOLUTION_OFFSET);
+
+    // The decoded post-shift value of a NAV solution must map to the "Nav" state.
+    const uint32_t navVal = (uint32_t)INS_STATUS_SOLUTION_NAV;
+    bool found = false;
+    for (const auto& vl : sol->values)
+        if (vl.value == navVal) { EXPECT_EQ(vl.label, "Nav"); EXPECT_FALSE(vl.isError); found = true; }
+    EXPECT_TRUE(found);
+}
+
+TEST(ISStatusDecode, InsStatus_RtkBaseErrorIsHybridGated)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+
+    const status_subfield_t* rtk = nullptr;
+    for (const auto& sf : dec->subfields)
+        if (sf.name == "RTK base error") { rtk = &sf; break; }
+    ASSERT_NE(rtk, nullptr);
+    EXPECT_EQ(rtk->kind, eStatusSubfieldKind::Enum);
+    EXPECT_EQ(rtk->gateMask, (uint32_t)INS_STATUS_RTK_ERROR_MASK);
+    EXPECT_TRUE(rtk->isError);
+    // All four base-error states are errors.
+    for (const auto& vl : rtk->values) EXPECT_TRUE(vl.isError);
+}
+
+TEST(ISStatusDecode, InsStatus_ErrorRollup)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("insStatus");
+    ASSERT_NE(dec, nullptr);
+    // A pure-info value (e.g. NAV mode + fine alignment) is NOT an error.
+    const uint32_t okVal = INS_STATUS_NAV_MODE | INS_STATUS_HDG_ALIGN_FINE |
+                           ((uint32_t)INS_STATUS_SOLUTION_NAV << INS_STATUS_SOLUTION_OFFSET);
+    EXPECT_EQ(okVal & dec->errorMask, 0u);
+    // A general fault trips the error roll-up.
+    EXPECT_NE((uint32_t)(INS_STATUS_GENERAL_FAULT) & dec->errorMask, 0u);
+}

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -87,6 +87,62 @@ std::string legacyRenderInsStatusReference(uint32_t insStatus)
     return buff.str();
 }
 
+/** @brief Oracle: faithful copy of the original (pre-SN-7919) `renderHdwStatus` body. */
+std::string legacyRenderHdwStatusReference(uint32_t hdwStatus)
+{
+    std::stringstream buff;
+
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(hdwStatus, HDW_STATUS_MOTION_GYR                       , "0x00000001 - Gyro motion detected.");
+    BIT_MSG(hdwStatus, HDW_STATUS_MOTION_ACC                       , "0x00000002 - Accelerometer motion detected.");
+    BIT_MSG(hdwStatus, HDW_STATUS_IMU_FAULT_REJECT_GYR             , "0x00000004 - IMU gyro fault rejection. A Gyro sensor is divergent and being excluded.");
+    BIT_MSG(hdwStatus, HDW_STATUS_IMU_FAULT_REJECT_ACC             , "0x00000008 - IMU accelerometer fault rejection. An accelerometer sensors is divergent and being excluded.");
+    BIT_MSG(hdwStatus, HDW_STATUS_GNSS_SATELLITE_RX_VALID          , "0x00000010 - GPS satellite signals are being received (antenna and cable are good).");
+    BIT_MSG(hdwStatus, HDW_STATUS_STROBE_IN_EVENT                  , "0x00000020 - Event occurred on strobe input pin.");
+    BIT_MSG(hdwStatus, HDW_STATUS_GNSS_TIME_OF_WEEK_VALID          , "0x00000040 - GPS time of week is valid and reported.");
+    BIT_MSG(hdwStatus, HDW_STATUS_REFERENCE_IMU_RX                 , "0x00000080 - Reference IMU data being received.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_GYR                   , "0x00000100 - Sensor saturation on gyro.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_ACC                   , "0x00000200 - Sensor saturation on accelerometer.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_MAG                   , "0x00000400 - Sensor saturation on magnetometer.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SATURATION_BARO                  , "0x00000800 - Sensor saturation on barometric pressure.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SYSTEM_RESET_REQUIRED            , "0x00001000 - System Reset is required for proper function.");
+    BIT_MSG(hdwStatus, HDW_STATUS_ERR_GNSS_PPS_NOISE               , "0x00002000 - GPS PPS timepulse signal has noise and occurred too frequently.");
+    BIT_MSG(hdwStatus, HDW_STATUS_MAG_RECAL_COMPLETE              , "0x00004000 - Magnetometer recalibration has finished (when INS_STATUS_MAG_RECALIBRATING is unset).");
+    BIT_MSG(hdwStatus, HDW_STATUS_FLASH_WRITE_PENDING              , "0x00008000 - System flash write staging or occurring now.");
+    BIT_MSG(hdwStatus, HDW_STATUS_ERR_COM_TX_LIMITED              , "0x00010000 - Communications Tx buffer limited.");
+    BIT_MSG(hdwStatus, HDW_STATUS_ERR_COM_RX_OVERRUN             , "0x00020000 - Communications Rx buffer overrun.");
+    BIT_MSG(hdwStatus, HDW_STATUS_ERR_NO_GNSS_PPS                 , "0x00040000 - GPS PPS timepulse signal has not been received or is in error.");
+    BIT_MSG(hdwStatus, HDW_STATUS_GNSS_PPS_TIMESYNC               , "0x00080000 - Time synchronized by GPS PPS.");
+
+    uint8_t parseErrCount = (uint8_t)HDW_STATUS_COM_PARSE_ERROR_COUNT(hdwStatus);
+    if (parseErrCount) {
+        char b[256];
+        std::snprintf(b, sizeof(b), "0x00F00000 - Communications parse errors (%d).", parseErrCount);
+        buff << b << std::endl;
+    }
+
+    switch (hdwStatus & HDW_STATUS_BIT_MASK) {
+        case HDW_STATUS_BIT_RUNNING:  buff << "0x01000000 - (BIT) Built-in self-test is running." << std::endl; break;
+        case HDW_STATUS_BIT_PASSED:   buff << "0x02000000 - (BIT) Built-in self-test passed." << std::endl; break;
+        case HDW_STATUS_BIT_FAILED:   buff << "0x03000000 - (BIT) Built-in self-test failed." << std::endl; break;
+    }
+
+    BIT_MSG(hdwStatus, HDW_STATUS_ERR_TEMPERATURE                 , "0x04000000 - Temperature outside operating range.");
+    BIT_MSG(hdwStatus, HDW_STATUS_SPI_INTERFACE_ENABLED          , "0x08000000 - IMX pins G5-G8 are configure for SPI use.");
+
+    switch (hdwStatus & HDW_STATUS_RESET_CAUSE_MASK) {
+        case HDW_STATUS_RESET_CAUSE_BACKUP_MODE:    buff << "0x10000000 - Reset from backup mode (low-power state w/ CPU off)." << std::endl; break;
+        case HDW_STATUS_RESET_CAUSE_WATCHDOG_FAULT: buff << "0x20000000 - Reset from watchdog fault." << std::endl; break;
+        case HDW_STATUS_RESET_CAUSE_SOFT:           buff << "0x30000000 - Reset from software." << std::endl; break;
+        case HDW_STATUS_RESET_CAUSE_HDW:            buff << "0x40000000 - Reset from hardware." << std::endl; break;
+    }
+
+    BIT_MSG(hdwStatus, HDW_STATUS_FAULT_SYS_CRITICAL             , "0x80000000 - Critical System Fault, CPU error (see DID_SYS_FAULT.status).");
+
+#undef BIT_MSG
+    return buff.str();
+}
+
 /** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
 uint32_t xorshift32(uint32_t& s)
 {
@@ -228,4 +284,90 @@ TEST(ISStatusDecode, InsStatus_ErrorRollup)
     EXPECT_EQ(okVal & dec->errorMask, 0u);
     // A general fault trips the error roll-up.
     EXPECT_NE((uint32_t)(INS_STATUS_GENERAL_FAULT) & dec->errorMask, 0u);
+}
+
+// ---- hdwStatus ----------------------------------------------------------------
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderHdwStatusReference(0u));
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderHdwStatusReference(v)) << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_BitStateEnum)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t st = 0; st <= 3; ++st) {
+        const uint32_t v = (st << 24);   // HDW_STATUS_BIT_MASK = 0x03000000
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderHdwStatusReference(v)) << "bit-state " << st;
+    }
+}
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_ResetCauseEnum)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t rc = 0; rc <= 7; ++rc) {
+        const uint32_t v = (rc << 28);   // HDW_STATUS_RESET_CAUSE_MASK = 0x70000000
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderHdwStatusReference(v)) << "reset-cause " << rc;
+    }
+}
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_ParseErrorCounts)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t c = 0; c <= 15; ++c) {
+        const uint32_t v = (c << 20);    // HDW_STATUS_COM_PARSE_ERR_COUNT_MASK = 0x00F00000
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderHdwStatusReference(v)) << "parse-count " << c;
+    }
+}
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_AllBits)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0xFFFFFFFFu), legacyRenderHdwStatusReference(0xFFFFFFFFu));
+}
+
+TEST(ISStatusDecode, HdwStatus_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0xBADF00Du;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderHdwStatusReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, HdwStatus_StructuredDecode)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(dec->errorMask, (uint32_t)HDW_STATUS_ERROR_MASK);
+
+    const status_subfield_t* count = nullptr;
+    const status_subfield_t* bit   = nullptr;
+    for (const auto& sf : dec->subfields) {
+        if (sf.name == "COM parse error count") count = &sf;
+        if (sf.name == "Built-in test (BIT)")   bit   = &sf;
+    }
+    ASSERT_NE(count, nullptr);
+    EXPECT_EQ(count->kind, eStatusSubfieldKind::Count);
+    EXPECT_EQ(count->mask, (uint32_t)HDW_STATUS_COM_PARSE_ERR_COUNT_MASK);
+
+    ASSERT_NE(bit, nullptr);
+    EXPECT_EQ(bit->kind, eStatusSubfieldKind::Enum);
+    bool failedIsError = false;
+    for (const auto& vl : bit->values)
+        if (vl.label == "Failed") failedIsError = vl.isError;
+    EXPECT_TRUE(failedIsError);
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -252,6 +252,78 @@ std::string legacyRenderGnssStatusBitsReference(uint32_t gpsStatusBits)
     return buff.str();
 }
 
+/** @brief Oracle: faithful copy of the original `renderGpxStatus_status` body. */
+std::string legacyRenderGpxStatusReference(uint32_t status)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_MASK      , "0x0000000F - Communications parse error count");
+    BIT_MSG(status, GPX_STATUS_COM0_RX_TRAFFIC_NOT_DECTECTED , "0x00000010 - COM0 RX traffic not dectected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_COM1_RX_TRAFFIC_NOT_DECTECTED , "0x00000020 - COM1 RX traffic not dectected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_COM2_RX_TRAFFIC_NOT_DECTECTED , "0x00000040 - COM2 RX traffic not dectected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_USB_RX_TRAFFIC_NOT_DECTECTED  , "0x00000080 - USB RX traffic not dectected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_FAULT_RTK_QUEUE_LIMITED       , "0x00010000 - RTK buffer overflow.");
+    BIT_MSG(status, GPX_STATUS_FAULT_GNSS_RCVR_TIME          , "0x00100000 - GNSS receiver time fault");
+    BIT_MSG(status, GPX_STATUS_FAULT_DMA                     , "0x00800000 - DMA fault");
+    uint32_t fatalStatus = ((status & GPX_STATUS_FATAL_MASK) >> GPX_STATUS_FATAL_OFFSET);
+    switch (fatalStatus) {
+        case GPX_STATUS_FATAL_RESET_LOW_POW:        buff << "0x01000000 - Reset from low power" << std::endl; break;
+        case GPX_STATUS_FATAL_RESET_BROWN:          buff << "0x02000000 - Reset from brown out" << std::endl; break;
+        case GPX_STATUS_FATAL_RESET_WATCHDOG:       buff << "0x03000000 - Reset from watchdog" << std::endl; break;
+        case GPX_STATUS_FATAL_CPU_EXCEPTION:        buff << "0x04000000 - CPU exception" << std::endl; break;
+        case GPX_STATUS_FATAL_UNHANDLED_INTERRUPT:  buff << "0x05000000 - Unhandled interrupt" << std::endl; break;
+        case GPX_STATUS_FATAL_STACK_OVERFLOW:       buff << "0x06000000 - Stack overflow" << std::endl; break;
+        case GPX_STATUS_FATAL_KERNEL_OOPS:          buff << "0x07000000 - Kernel oops" << std::endl; break;
+        case GPX_STATUS_FATAL_KERNEL_PANIC:         buff << "0x08000000 - Kernel panic" << std::endl; break;
+        case GPX_STATUS_FATAL_UNALIGNED_ACCESS:     buff << "0x09000000 - Unaligned access" << std::endl; break;
+        case GPX_STATUS_FATAL_MEMORY_ERROR:         buff << "0x0A000000 - Memory error" << std::endl; break;
+        case GPX_STATUS_FATAL_BUS_ERROR:            buff << "0x0B000000 - Bus error" << std::endl; break;
+        case GPX_STATUS_FATAL_USAGE_ERROR:          buff << "0x0C000000 - Usage error" << std::endl; break;
+        case GPX_STATUS_FATAL_DIV_ZERO:             buff << "0x0D000000 - Division by zero" << std::endl; break;
+        case GPX_STATUS_FATAL_SER0_REINIT:          buff << "0x0E000000 - SER0 reinit" << std::endl; break;
+        case GPX_STATUS_FATAL_UNKNOWN:              buff << "0x1F000000 - Unknown" << std::endl; break;
+    }
+    BIT_MSG(status, GPX_STATUS_FAULT_RP                     , "0x20000000 - RP fault");
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Oracle: faithful copy of the original `renderGpxStatus_hdwStatus` body. */
+std::string legacyRenderGpxHdwStatusReference(uint32_t hdwStatus)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_SATELLITE_RX            , "0x00000001 - GNSS1 satellite signals are being received (antenna and cable are good)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_SATELLITE_RX            , "0x00000002 - GNSS2 satellite signals are being received (antenna and cable are good)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS1_TIME_OF_WEEK_VALID      , "0x00000004 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS2_TIME_OF_WEEK_VALID      , "0x00000008 - GPS time of week is valid and reported.  Otherwise the timeOfWeek is local system time.");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS1_INIT              , "0x00000080 - Failed to communicate or setup GNSS receiver 1");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_GNSS2_INIT              , "0x00000800 - Failed to communicate or setup GNSS receiver 2");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS_FW_UPDATE_REQUIRED       , "0x00001000 - GNSS is faulting firmware update REQUIRED");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_LED_ENABLED                   , "0x00002000 - Enables LED in Manufacturing TBed");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_SYSTEM_RESET_REQUIRED         , "0x00004000 - System Reset is Required for proper function");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_FLASH_WRITE_PENDING           , "0x00008000 - System flash write staging or occuring now.");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_TX_LIMITED            , "0x00010000 - Communications Tx buffer limited");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_COM_RX_OVERRUN            , "0x00020000 - Communications Rx buffer overrun");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GNSS1_PPS              , "0x00040000 - GNSS1 PPS timepulse signal has not been received or is in error");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_NO_GNSS2_PPS              , "0x00080000 - GNSS2 PPS timepulse signal has not been received or is in error");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GNSS1             , "0x00100000 - GNSS1 signal strength low (<20)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_LOW_CNO_GNSS2             , "0x00200000 - GNSS2 signal strength low (<20)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GNSS1_IR             , "0x00400000 - GNSS1 signal irregular. High Cno standard deviation over 5 second period detected.");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_CNO_GNSS2_IR             , "0x00800000 - GNSS2 signal irregular. High Cno standard deviation over 5 second period detected.");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_RUNNING                   , "0x01000000 - (BIT) Built-in self-test running");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_PASSED                    , "0x02000000 - (BIT) Built-in self-test passed");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_BIT_FAULT                     , "0x03000000 - (BIT) Built-in self-test failure");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_ERR_TEMPERATURE               , "0x04000000 - Temperature outside spec'd operating range");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_GNSS_PPS_TIMESYNC             , "0x08000000 - Time synchronized by GPS PPS");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_BACKUP_MODE       , "0x10000000 - Reset from Backup mode (low-power state w/ CPU off)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_SOFT              , "0x20000000 - Reset from Software");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_RESET_CAUSE_HDW               , "0x40000000 - Reset from Hardware (NRST pin low)");
+    BIT_MSG(hdwStatus, GPX_HDW_STATUS_FAULT_SYS_CRITICAL            , "0x80000000 - Critical System Fault, CPU error.");
+#undef BIT_MSG
+    return buff.str();
+}
+
 /** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
 uint32_t xorshift32(uint32_t& s)
 {
@@ -643,4 +715,65 @@ TEST(ISStatusDecode, DidAwareLookup_StatusFieldDisambiguation)
     // NOT return the GNSS/IMX tables).
     EXPECT_NE(GetStatusDecode(DID_GPX_STATUS, "status"), gnss);
     EXPECT_NE(GetStatusDecode(DID_GPX_STATUS, "hdwStatus"), GetStatusDecodeByField("hdwStatus"));
+    // GPX variants now registered: (DID_GPX_STATUS, status/hdwStatus) resolve to the GPX tables.
+    EXPECT_EQ(GetStatusDecode(DID_GPX_STATUS, "status"),    GetStatusDecodeByField("gpxStatus"));
+    EXPECT_EQ(GetStatusDecode(DID_GPX_STATUS, "hdwStatus"), GetStatusDecodeByField("gpxHdwStatus"));
+}
+
+// ---- GPX status / hdwStatus ---------------------------------------------------
+
+TEST(ISStatusDecode, GpxStatus_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderGpxStatusReference(0u));
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxStatusReference(v)) << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, GpxStatus_RoundTrip_FatalResets)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t f = 0; f <= 0x1F; ++f) {
+        const uint32_t v = (f << 24);   // GPX_STATUS_FATAL_MASK = 0x1F000000
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxStatusReference(v)) << "fatal " << f;
+    }
+}
+
+TEST(ISStatusDecode, GpxStatus_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0x60B5A1u;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxStatusReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GpxHdwStatus_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxHdwStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderGpxHdwStatusReference(0u));
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxHdwStatusReference(v)) << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, GpxHdwStatus_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxHdwStatus");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0x9D7E11u;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxHdwStatusReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -191,6 +191,67 @@ std::string legacyRenderGenFaultCodeReference(uint32_t genFault)
     return buff.str();
 }
 
+/** @brief Oracle: faithful copy of the original `renderGnssStatusBits` body. */
+std::string legacyRenderGnssStatusBitsReference(uint32_t gpsStatusBits)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+
+    uint8_t satCount = (gpsStatusBits & GNSS_STATUS_NUM_SATS_USED_MASK);
+    {
+        char b[256];
+        std::snprintf(b, sizeof(b), "0x000000%02X - %d satellites used in solution (deprecated)", satCount, satCount);
+        buff << b << std::endl;
+    }
+
+    switch (gpsStatusBits & GNSS_STATUS_FIX_MASK) {
+        case GNSS_STATUS_FIX_NONE                : buff << "0x00000000 - No GNSS" << std::endl; break;
+        case GNSS_STATUS_FIX_DEAD_RECKONING_ONLY : buff << "0x00000100 - GNSS Dead Reckoning Only" << std::endl; break;
+        case GNSS_STATUS_FIX_2D                  : buff << "0x00000200 - 2D Fix" << std::endl; break;
+        case GNSS_STATUS_FIX_3D                  : buff << "0x00000300 - 3D Fix" << std::endl; break;
+        case GNSS_STATUS_FIX_GPS_PLUS_DEAD_RECK  : buff << "0x00000400 - 3D Fix + Dead Reckoning" << std::endl; break;
+        case GNSS_STATUS_FIX_TIME_ONLY           : buff << "0x00000500 - Time-Only Fix" << std::endl; break;
+        case GNSS_STATUS_FIX_REF_LLA             : buff << "0x00000600 - Usign Reference LLA" << std::endl; break;
+        case GNSS_STATUS_FIX_UNUSED2             : buff << "0x00000700 - << UNUSED >>" << std::endl; break;
+        case GNSS_STATUS_FIX_DGPS                : buff << "0x00000800 - Using DGPS" << std::endl; break;
+        case GNSS_STATUS_FIX_SBAS                : buff << "0x00000900 - Using SBAS" << std::endl; break;
+        case GNSS_STATUS_FIX_RTK_SINGLE          : buff << "0x00000A00 - RTK Single" << std::endl; break;
+        case GNSS_STATUS_FIX_RTK_FLOAT           : buff << "0x00000B00 - RTK Float" << std::endl; break;
+        case GNSS_STATUS_FIX_RTK_FIX             : buff << "0x00000C00 - RTK Fix" << std::endl; break;
+    }
+
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_FIX_OK                          , "0x00010000 - within limits (e.g. DOP & accuracy)");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_DGPS_USED                       , "0x00020000 - Differential GPS (DGPS) used.");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD                , "0x00040000 - RTK feedback on the integer solutions to drive the float biases towards the resolved integers");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_1                        , "0x00080000 - << UNUSED >>");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_ENABLED       , "0x00100000 - GNSS1 RTK precision positioning mode enabled");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_STATIC_MODE                     , "0x00200000 - Static mode");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_ENABLED        , "0x00400000 - GNSS2 RTK moving base mode enabled");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR     , "0x00800000 - GNSS1 RTK error: observations or ephemeris are invalid or not received (i.e. RTK differential corrections)");
+
+    uint32_t rtkError = (gpsStatusBits & GNSS_STATUS_FLAGS_ERROR_MASK);
+    switch (rtkError) {
+        case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_DATA_MISSING        : buff << "0x01000000 - GNSS1 RTK error: Either base observations or antenna position have not been received." << std::endl; break;
+        case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_MOVING     : buff << "0x02000000 - GNSS1 RTK error: base position moved when it should be stationary" << std::endl; break;
+        case GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_INVALID    : buff << "0x03000000 - GNSS1 RTK error: base position is invalid or not surveyed well" << std::endl; break;
+    }
+
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS1_RTK_POSITION_VALID         , "0x04000000 - GNSS1 RTK precision position and carrier phase range solution with fixed ambiguities.");
+    if (gpsStatusBits & GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_MASK) {
+        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_VALID          , "0x08000000 - GNSS2 RTK moving base heading valid and available in DID_GNSS2_RTK_CMP_REL.");
+        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_BAD   , "0x00002000 - GNSS2 RTK Compassing Baseline distance is invalid");
+        BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_UNSET , "0x00004000 - GNSS2 RTK Compassing Baseline distance is unset (must be > 0)");
+    }
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS_NMEA_DATA                   , "0x00008000 - Data from NMEA message. GPS velocity is NED (not ECEF).");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_GNSS_PPS_TIMESYNC                , "0x10000000 - Time is synchronized by GPS PPS.");
+
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_2                        , "0x20000000 - <<UNUSED>>");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_3                        , "0x40000000 - <<UNUSED>>");
+    BIT_MSG(gpsStatusBits, GNSS_STATUS_FLAGS_UNUSED_4                        , "0x80000000 - <<UNUSED>>");
+#undef BIT_MSG
+    return buff.str();
+}
+
 /** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
 uint32_t xorshift32(uint32_t& s)
 {
@@ -467,4 +528,119 @@ TEST(ISStatusDecode, GenFaultCode_AllBitsAreErrors)
         orMask |= sf.mask;
     }
     EXPECT_EQ(dec->errorMask, orMask);   // roll-up = OR of all fault bits
+}
+
+// ---- GNSS status --------------------------------------------------------------
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_EverySingleBit)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*dec, 0u), legacyRenderGnssStatusBitsReference(0u));
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGnssStatusBitsReference(v)) << "bit " << b;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_FixTypes)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t fix = 0; fix <= 0x1F; ++fix) {        // covers defined (0..C) + undefined (D..1F)
+        const uint32_t v = (fix << 8);                  // GNSS_STATUS_FIX_MASK = 0x1F00
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGnssStatusBitsReference(v)) << "fix " << fix;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_SatCounts)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t n = 0; n <= 255; ++n) {               // always-emitted, dual-format count
+        EXPECT_EQ(RenderStatusFromDecode(*dec, n), legacyRenderGnssStatusBitsReference(n)) << "sats " << n;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_RtkErrorMaskQuirk)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    // Exercise the legacy quirk: the base-error switch keys on (value & FLAGS_ERROR_MASK), so when
+    // the raw-data-error bit is also set, no base-error line is emitted.
+    const uint32_t cases[] = {
+        GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_DATA_MISSING,
+        GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_MOVING,
+        GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_INVALID,
+        GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR,
+        GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR | GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_DATA_MISSING,
+        GNSS_STATUS_FLAGS_GNSS1_RTK_RAW_GPS_DATA_ERROR | GNSS_STATUS_FLAGS_GNSS1_RTK_BASE_POSITION_INVALID,
+    };
+    for (uint32_t v : cases) {
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGnssStatusBitsReference(v))
+            << "rtk combo 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_CompassGate)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    // Baseline-bad bit alone is gated off (compass mask not set) unless a compass-mask bit is set.
+    const uint32_t cases[] = {
+        GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_BAD,                                                  // gated OFF
+        GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_ENABLED | GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_BASELINE_BAD,    // gate open
+        GNSS_STATUS_FLAGS_GNSS2_RTK_COMPASS_VALID,                                                         // gate open (valid is in mask)
+    };
+    for (uint32_t v : cases) {
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGnssStatusBitsReference(v))
+            << "compass combo 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_RoundTrip_RandomSweep)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    uint32_t s = 0x5A7C0DEu;
+    for (int i = 0; i < 40000; ++i) {                   // larger sweep — this field has the most quirks
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGnssStatusBitsReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GnssStatus_StructuredDecode)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(dec, nullptr);
+    EXPECT_EQ(dec->errorMask, (uint32_t)GNSS_STATUS_FLAGS_ERROR_MASK);
+
+    const status_subfield_t* sats = nullptr;
+    const status_subfield_t* fix  = nullptr;
+    for (const auto& sf : dec->subfields) {
+        if (sf.kind == eStatusSubfieldKind::Count) sats = &sf;
+        if (sf.name == "Fix type")                 fix  = &sf;
+    }
+    ASSERT_NE(sats, nullptr);
+    EXPECT_TRUE(sats->emitZero);                       // satellite count always shown
+    ASSERT_NE(fix, nullptr);
+    EXPECT_EQ(fix->shift, 8u);
+    // 13 defined fix states (0..0xC).
+    EXPECT_EQ(fix->values.size(), 13u);
+}
+
+// ---- DID-aware lookup ---------------------------------------------------------
+
+TEST(ISStatusDecode, DidAwareLookup_StatusFieldDisambiguation)
+{
+    // "status" on a GNSS DID resolves to the gnssStatus table.
+    const status_field_decode_t* gnss = GetStatusDecodeByField("gnssStatus");
+    ASSERT_NE(gnss, nullptr);
+    EXPECT_EQ(GetStatusDecode(DID_GNSS1_POS, "status"), gnss);
+    EXPECT_EQ(GetStatusDecode(DID_GNSS2_VEL, "status"), gnss);
+    // GPX "status"/"hdwStatus" resolve to GPX keys (not yet registered -> nullptr for now, but must
+    // NOT return the GNSS/IMX tables).
+    EXPECT_NE(GetStatusDecode(DID_GPX_STATUS, "status"), gnss);
+    EXPECT_NE(GetStatusDecode(DID_GPX_STATUS, "hdwStatus"), GetStatusDecodeByField("hdwStatus"));
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -324,6 +324,148 @@ std::string legacyRenderGpxHdwStatusReference(uint32_t hdwStatus)
     return buff.str();
 }
 
+// --- GPX-GNSS scalar-enum oracles (faithful copies of the originals) --------------------------
+
+std::string legacyRenderGnssLastResetCauseReference(uint8_t v)
+{
+    static const char* rstReasons[] = {
+        "Power On", "Watchdog", "ErrOpCode", "ErrorOpCode_FwUp",
+        "ErrorOpCode_init", "UserRequested", "FWUpdate", "SysCmd",
+        "InitTimeout", "Status5", "StatusNot0", "flashUpdate", "RTKEphMissing"
+    };
+    if (v < cxdRst_Max) return std::string(rstReasons[v]);
+    return "";
+}
+
+std::string legacyRenderGnssInitStateReference(uint8_t v)
+{
+    static const char* initStates[] = {
+        "Bootup", "UartSetting", "UartWait", "UartDone",
+        "VersionCheck", "StopPos", "SetL5", "SetSats",
+        "SetSatLimits", "SetOutput", "SetAlgo", "SetPeriod",
+        "SetRtcmMsgs", "SetRtcmTimeMode", "SetPinningMode", "SetVelocitySmoothing",
+        "SetAltituedSmoothing", "SetEphmOutputPeriod", "StartPos", "Done"
+    };
+    if (v <= 19) return std::string(initStates[v]);
+    return "";
+}
+
+std::string legacyRenderGnssRunStateReference(uint8_t v)
+{
+    static const char* runStates[] = {
+        "Reset", "Initializing", "Running", "Passthrough",
+        "FwUpdate Init", "FwUpdate", "Error", "Shutdown", "ReInit", "Hard Reset"
+    };
+    if (v <= kHardReset) return std::string(runStates[v]);
+    return "";
+}
+
+std::string legacyRenderGnssFwUpdateStateReference(uint8_t v)
+{
+    static const char* fwStates[] = {
+        "LockoutWait", "ResetSet", "ResetWait", "StartSet", "StartWait",
+        "BootModeSet", "BootModeWait", "BaudSet", "BaudWait", "BaudFinish",
+        "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
+        "WriteNvmWait", "WriteNvmFinish", "Done",
+    };
+    if (v < cxdRst_Max) return std::string(fwStates[v]);   // legacy bug: bound is cxdRst_Max, not 17
+    return "";
+}
+
+/** @brief Oracle: faithful copy of the original `renderImxHdwBitStatus` body. */
+std::string legacyRenderImxHdwBitReference(uint32_t hdwBitStatus)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_ALL                      ,"0x00000001 - Passed all tests");
+    BIT_MSG(hdwBitStatus, HDW_BIT_PASSED_NO_GNSS                   ,"0x00000002 - Passed without valid GPS signal");
+    if (HDW_BIT_MODE(hdwBitStatus)) {
+        buff << "0x000000" << std::hex << (hdwBitStatus & HDW_BIT_MODE_MASK) << std::dec
+             << " - BIT mode: " << HDW_BIT_MODE(hdwBitStatus) << std::endl;
+    }
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_PQR                 ,"0x00000100 - FAULT: Gyro noise");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_NOISE_ACC                 ,"0x00000200 - FAULT: Accelerometer noise");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_MAGNETOMETER              ,"0x00000400 - FAULT: Magnetometer");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_BAROMETER                 ,"0x00000800 - FAULT: Barometer");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_NO_COM                ,"0x00001000 - FAULT: No GPS serial communications");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_POOR_CNO              ,"0x00002000 - FAULT: Poor GPS signal strength");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_POOR_ACCURACY         ,"0x00004000 - FAULT: GPS poor accuracy");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_GNSS_NOISE                 ,"0x00008000 - FAULT: GPS noise");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_IMU_FAULT_REJECTION       ,"0x00010000 - FAULT: IMU fault rejection failure");
+    BIT_MSG(hdwBitStatus, HDW_BIT_FAULT_INCORRECT_HARDWARE_TYPE   ,"0x01000000 - FAULT: Hardware type does not match firmware");
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Oracle: faithful copy of the original `renderImxCalBitStatus` body. */
+std::string legacyRenderImxCalBitReference(uint32_t calBitStatus)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(calBitStatus, CAL_BIT_PASSED_ALL                      ,"0x00000001 - Passed all calibration tests");
+    if (CAL_BIT_MODE(calBitStatus)) {
+        buff << "0x000000" << std::hex << (calBitStatus & CAL_BIT_MODE_MASK) << std::dec
+             << " - CAL BIT mode: " << CAL_BIT_MODE(calBitStatus) << std::endl;
+    }
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_EMPTY                ,"0x00000100 - FAULT: Temperature calibration not present");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_TSPAN                ,"0x00000200 - FAULT: Temperature calibration range inadequate");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_INCONSISTENT         ,"0x00000400 - FAULT: Temperature calibration inconsistent");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_CORRUPT              ,"0x00000800 - FAULT: Temperature calibration corrupt");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_BIAS             ,"0x00001000 - FAULT: Gyro bias temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_SLOPE            ,"0x00002000 - FAULT: Gyro slope temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_PQR_LIN              ,"0x00004000 - FAULT: Gyro linearity temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_BIAS             ,"0x00008000 - FAULT: Accel bias temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_SLOPE            ,"0x00010000 - FAULT: Accel slope temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_TCAL_ACC_LIN              ,"0x00020000 - FAULT: Accel linearity temp cal");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_CAL_SERIAL_NUM            ,"0x00040000 - FAULT: Calibration serial number mismatch");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_MAG_INVALID          ,"0x00080000 - FAULT: Magnetometer cross-axis alignment invalid");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_EMPTY                ,"0x00100000 - FAULT: Motion calibration not present");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_MCAL_IMU_INVALID          ,"0x00200000 - FAULT: IMU cross-axis alignment invalid");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_PQR                ,"0x00400000 - FAULT: Motion detected on gyros");
+    BIT_MSG(calBitStatus, CAL_BIT_FAULT_MOTION_ACC                ,"0x00800000 - FAULT: Motion detected on accelerometers");
+    BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_PQR_BIAS            ,"0x01000000 - NOTICE: IMU 1 gyro bias offset detected");
+    BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_PQR_BIAS            ,"0x02000000 - NOTICE: IMU 2 gyro bias offset detected");
+    BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU1_ACC_BIAS            ,"0x10000000 - NOTICE: IMU 1 accel bias offset detected");
+    BIT_MSG(calBitStatus, CAL_BIT_NOTICE_IMU2_ACC_BIAS            ,"0x20000000 - NOTICE: IMU 2 accel bias offset detected");
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Oracle: faithful copy of the original `renderGpxBitResults` body. */
+std::string legacyRenderGpxBitResultsReference(uint32_t results)
+{
+    std::stringstream buff;
+#define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
+    BIT_MSG(results, GPXBit_resultsBit_PPS1      ,"0x01 - PPS1 test passed");
+    BIT_MSG(results, GPXBit_resultsBit_PPS2      ,"0x02 - PPS2 test passed");
+    BIT_MSG(results, GPXBit_resultsBit_UART      ,"0x04 - UART test passed");
+    BIT_MSG(results, GPXBit_resultsBit_IO        ,"0x08 - IO test passed");
+    BIT_MSG(results, GPXBit_resultsBit_GNSS       ,"0x10 - GPS test passed");
+    BIT_MSG(results, GPXBit_resultsBit_FINISHED  ,"0x20 - Test finished");
+    BIT_MSG(results, GPXBit_resultsBit_CANCELED  ,"0x40 - Test canceled");
+    BIT_MSG(results, GPXBit_resultsBit_ERROR     ,"0x80 - Test error");
+#undef BIT_MSG
+    return buff.str();
+}
+
+/** @brief Oracle: faithful copy of the original `renderGpxBitState` body. */
+std::string legacyRenderGpxBitStateReference(uint8_t state)
+{
+    std::stringstream buff;
+    switch (state) {
+        case 0: buff << "NOT_RUNNING" << std::endl; break;
+        case 1: buff << "MANUF_INIT" << std::endl; break;
+        case 2: buff << "MANUF_BLINK" << std::endl; break;
+        case 3: buff << "MANUF_UART" << std::endl; break;
+        case 4: buff << "MANUF_IO" << std::endl; break;
+        case 5: buff << "MANUF_PPS" << std::endl; break;
+        case 6: buff << "MANUF_GPS" << std::endl; break;
+        case 7: buff << "MANUF_REPORT" << std::endl; break;
+        default: buff << "UNKNOWN(" << (int)state << ")" << std::endl; break;
+    }
+    return buff.str();
+}
+
 /** @brief Deterministic xorshift32 so the sweep is reproducible across runs/platforms. */
 uint32_t xorshift32(uint32_t& s)
 {
@@ -775,5 +917,94 @@ TEST(ISStatusDecode, GpxHdwStatus_RoundTrip_RandomSweep)
         const uint32_t v = xorshift32(s);
         ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxHdwStatusReference(v))
             << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+// ---- GPX-GNSS scalar-enum state fields ----------------------------------------
+
+TEST(ISStatusDecode, GnssStateEnums_RoundTrip_FullByteRange)
+{
+    const status_field_decode_t* init = GetStatusDecodeByField("gnssInitState");
+    const status_field_decode_t* run  = GetStatusDecodeByField("gnssRunState");
+    const status_field_decode_t* fw   = GetStatusDecodeByField("gnssFwUpdateState");
+    const status_field_decode_t* rst  = GetStatusDecodeByField("gnssLastResetCause");
+    ASSERT_NE(init, nullptr); ASSERT_NE(run, nullptr); ASSERT_NE(fw, nullptr); ASSERT_NE(rst, nullptr);
+    EXPECT_TRUE(init->scalarEnum);
+    for (uint32_t v = 0; v <= 255; ++v) {
+        EXPECT_EQ(RenderStatusFromDecode(*init, v), legacyRenderGnssInitStateReference((uint8_t)v)) << "init " << v;
+        EXPECT_EQ(RenderStatusFromDecode(*run,  v), legacyRenderGnssRunStateReference((uint8_t)v))  << "run " << v;
+        EXPECT_EQ(RenderStatusFromDecode(*fw,   v), legacyRenderGnssFwUpdateStateReference((uint8_t)v)) << "fw " << v;
+        EXPECT_EQ(RenderStatusFromDecode(*rst,  v), legacyRenderGnssLastResetCauseReference((uint8_t)v)) << "rst " << v;
+    }
+}
+
+TEST(ISStatusDecode, GnssFwUpdateState_BoundBugReproduced)
+{
+    // Latent SDK bug: fwUpdateState is bounded by cxdRst_Max (13), so values 13..16 never decode
+    // even though the name array has 17 entries. We reproduce it byte-for-byte.
+    const status_field_decode_t* fw = GetStatusDecodeByField("gnssFwUpdateState");
+    ASSERT_NE(fw, nullptr);
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 12u), "ProgramExecutionWait");   // last decodable
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 13u), "");                       // bug: would be ProgramExecutionFinish
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 16u), "");                       // bug: would be Done
+}
+
+// ---- IMX / GPX built-in-test fields -------------------------------------------
+
+TEST(ISStatusDecode, ImxHdwBit_RoundTrip)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("hdwBitStatus");
+    ASSERT_NE(dec, nullptr);
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxHdwBitReference(v)) << "bit " << b;
+    }
+    for (uint32_t mode = 0; mode <= 0xF; ++mode) {                 // exercise the hex/dec BIT-mode line
+        const uint32_t v = (mode << 4);                           // HDW_BIT_MODE_MASK = 0x000000F0
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxHdwBitReference(v)) << "mode " << mode;
+    }
+    uint32_t s = 0x1357BDu;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxHdwBitReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, ImxCalBit_RoundTrip)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("calBitStatus");
+    ASSERT_NE(dec, nullptr);
+    for (int b = 0; b < 32; ++b) {
+        const uint32_t v = (1u << b);
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxCalBitReference(v)) << "bit " << b;
+    }
+    for (uint32_t mode = 0; mode <= 0xF; ++mode) {
+        const uint32_t v = (mode << 4);                           // CAL_BIT_MODE_MASK = 0x000000F0
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxCalBitReference(v)) << "mode " << mode;
+    }
+    uint32_t s = 0x2468ACu;
+    for (int i = 0; i < 20000; ++i) {
+        const uint32_t v = xorshift32(s);
+        ASSERT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderImxCalBitReference(v))
+            << "iteration " << i << " value 0x" << std::hex << v;
+    }
+}
+
+TEST(ISStatusDecode, GpxBitResults_RoundTrip)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxBitResults");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t v = 0; v <= 0xFF; ++v) {                        // results live in the low byte
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxBitResultsReference(v)) << "results " << v;
+    }
+}
+
+TEST(ISStatusDecode, GpxBitState_RoundTrip)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxBitState");
+    ASSERT_NE(dec, nullptr);
+    for (uint32_t v = 0; v <= 255; ++v) {                        // includes the UNKNOWN(n) default path
+        EXPECT_EQ(RenderStatusFromDecode(*dec, v), legacyRenderGpxBitStateReference((uint8_t)v)) << "state " << v;
     }
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -368,7 +368,7 @@ std::string legacyRenderGnssFwUpdateStateReference(uint8_t v)
         "InjectWait", "InjectFinish", "ProgramExecutionWait", "ProgramExecutionFinish",
         "WriteNvmWait", "WriteNvmFinish", "Done",
     };
-    if (v < cxdRst_Max) return std::string(fwStates[v]);   // legacy bug: bound is cxdRst_Max, not 17
+    if (v < 17) return std::string(fwStates[v]);   // SN-7919: corrected bound (array size), was cxdRst_Max
     return "";
 }
 
@@ -938,15 +938,16 @@ TEST(ISStatusDecode, GnssStateEnums_RoundTrip_FullByteRange)
     }
 }
 
-TEST(ISStatusDecode, GnssFwUpdateState_BoundBugReproduced)
+TEST(ISStatusDecode, GnssFwUpdateState_AllStatesDecode)
 {
-    // Latent SDK bug: fwUpdateState is bounded by cxdRst_Max (13), so values 13..16 never decode
-    // even though the name array has 17 entries. We reproduce it byte-for-byte.
+    // SN-7919 fix: the original renderer's `cxdRst_Max` (13) bound left states 13..16 undecoded;
+    // now bounded by the array size (17) so every firmware-update state decodes.
     const status_field_decode_t* fw = GetStatusDecodeByField("gnssFwUpdateState");
     ASSERT_NE(fw, nullptr);
-    EXPECT_EQ(RenderStatusFromDecode(*fw, 12u), "ProgramExecutionWait");   // last decodable
-    EXPECT_EQ(RenderStatusFromDecode(*fw, 13u), "");                       // bug: would be ProgramExecutionFinish
-    EXPECT_EQ(RenderStatusFromDecode(*fw, 16u), "");                       // bug: would be Done
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 12u), "ProgramExecutionWait");
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 13u), "ProgramExecutionFinish");   // fixed (was empty)
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 16u), "Done");                     // fixed (was empty)
+    EXPECT_EQ(RenderStatusFromDecode(*fw, 17u), "");                         // genuinely out of range
 }
 
 // ---- IMX / GPX built-in-test fields -------------------------------------------


### PR DESCRIPTION
## Summary

Adds a machine-readable, structured decode of every status / bitfield / enumerated device field to `ISDataMappings`, and refactors the hand-written `render*` functions to render *from* those tables. This is the SDK foundation for the Logalyzer status-ribbon chart (SN-7919 / D-53), which needs the *structure* of each status field (one row per sub-field, colored per decoded value) — something the prose renderers couldn't provide.

Single structural source of truth: masks/shifts/value-labels/error-classification live in one place, referencing the `data_sets.h` enum/macro symbols by name (no transcribed hex). Each `render*` now delegates, so its output is **byte-identical** to before — proven by a round-trip oracle test over per-field bit/enum/count sweeps + 20k–40k randomized values. (One intentional exception: see the `gnssFwUpdateState` fix below.)

## What's here

- New `src/ISStatusDecode.{h,cpp}`: the descriptor model (`status_field_decode_t` / `status_subfield_t`, kinds Bit/Enum/Count), `RenderStatusFromDecode`, and `GetStatusDecode(did, field)` / `GetStatusDecodeByField`.
- `src/ISDataMappings.cpp`: the 15 status renderers now delegate to the tables (net ~500 fewer lines).
- `tests/test_ISStatusDecode.cpp`: 40 tests, all green.

Fields covered: `insStatus`, `hdwStatus`, `sysStatus`, `genFaultCode`, GNSS `status`, GPX `status`/`hdwStatus`, the GPX-GNSS state enums (`initState`/`runState`/`fwUpdateState`/`lastRstCause`), and the IMX/GPX BIT fields (`hdwBitStatus`, `calBitStatus`, GPX bit `results`/`state`). `RTKCfgBits` is intentionally left as-is (hierarchical config, reserved for the table-view chart, not the ribbon).

DID-aware lookup disambiguates the field names shared across device variants (`status`/`hdwStatus` for IMX/GNSS/GPX, `results`/`state` for GPX BIT) and resolves the array-indexed `gnssStatusN.*` fields.

## Notable

- **Bug fixed (one intentional behavior change):** `renderGpxStatus_gnssFwUpdateState` bounded its index by `cxdRst_Max` (13), but the state-name array has 17 entries — so firmware-update states 13–16 (`ProgramExecutionFinish`…`Done`) silently rendered empty. The decode now covers all 17 states; a test asserts the corrected output. Every other field stays byte-identical to its original renderer.
- Two further gaps were filed as separate low-priority bugs (not addressed here): `eGnssStatus2` jam/spoof flags have no decode (SN-8126), and the commented-out `DID_DIAGNOSTIC_MESSAGE` map (SN-8127).

## Testing

```
cd tests && cmake -S . -B build && cmake --build build --target IS-SDK_unit-tests && ./build/IS-SDK_unit-tests --gtest_filter='ISStatusDecode.*'
```
40/40 pass. Apart from the `gnssFwUpdateState` fix, no `render*` output changes (byte-identical), so existing `ISDataMappings` consumers (EvalTool, cltool) are unaffected.

Targets `logalyzer-develop` per the SDK co-development convention; the Logalyzer submodule pointer bump follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)