### PR TITLE
SN-7919: per-field count color-ramp defaults (countRampMax / countRampInvert)

### DIFF
--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -372,6 +372,10 @@ status_field_decode_t buildGnssStatusDecode()
         s.shift      = 0;
         s.isError    = false;
         s.emitZero   = true;
+        // Gauge, not an error count: 0 sats = bad (red), many = good (green).
+        // Ramp saturates to green at ~25 used satellites (a strong fix).
+        s.countRampMax    = 25;
+        s.countRampInvert = true;
         s.legacyText = "0x000000%02X - %d satellites used in solution (deprecated)";
         d.subfields.push_back(s);
     }

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -58,6 +58,8 @@ struct status_subfield_t
     uint32_t                          gateMask = 0;                            //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
     bool                              emitZero = false;                        //!< Count: emit a line even when the extracted value is 0 (e.g. GNSS satellite count). Default: skip zero.
     bool                              modeHexDec = false;                      //!< Count: format args are `(masked, shifted)` instead of `(value, value)` — for "hex(masked) ... dec(shifted)" lines (the BIT-mode pattern).
+    uint32_t                          countRampMax = 0;                        //!< Count: value at which a magnitude color ramp saturates. 0 = use the field's bit-width max. Consumer hint (e.g. ~25 for GNSS satellites-used).
+    bool                              countRampInvert = false;                 //!< Count: invert the ramp so a HIGH value is "good" (green) and 0 is "bad" (red), e.g. satellites used. Default false = high is worse (error/event counts).
     std::string                       legacyText;                              //!< Bit/Count verbose line for byte-identical render*; a Count line may contain printf conversions (the value is supplied up to twice). Empty -> use `name`.
     std::string                       defaultLegacyText;                       //!< Enum only: catch-all format (may contain one `%d` for the raw value) emitted when no value matches (e.g. "UNKNOWN(%d)"). Empty -> emit nothing on no match.
     std::vector<status_value_label_t> values;                                  //!< Enum only: the value table.


### PR DESCRIPTION
Adds two consumer hints to `status_subfield_t` for the Logalyzer status-ribbon count color ramp (SN-7919 / PR inertialsense/logalyzer#56):

- `countRampMax` — value where a magnitude ramp saturates (0 = field bit-width max).
- `countRampInvert` — high value is good/green (gauge), e.g. GNSS satellites-used.

Sets the GNSS "Satellites used" count to invert with max 25 (0 sats = red, strong fix = green). Additive only; `render*()` byte-output is unchanged (hints aren't read by the legacy renderers). Logalyzer consumes these as the default ramp; users can still override per-row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)