### PR TITLE
SN-8043 - DFU: detect silent flash-write drop at RDP > 0xAA

### DIFF
--- a/src/ISDFUFirmwareUpdater.cpp
+++ b/src/ISDFUFirmwareUpdater.cpp
@@ -47,7 +47,34 @@ const char *DFUDevice::dfuDeviceErrors[] = {
         "INVALID_ARGUMENT",
         "FILE_NOT_FOUND",
         "INVALID_IMAGE",
+        "RDP_LOCKED",               // -DFU_ERROR_RDP_LOCKED (9)
+        "RDP_PERMANENT_LOCKED",     // -DFU_ERROR_RDP_PERMANENT_LOCKED (10)
+        "WRITE_VERIFY_FAILED",      // -DFU_ERROR_WRITE_VERIFY_FAILED (11)
 };
+
+/**
+ * Returns the human-readable name for an error index. The expected argument is the positive index
+ * (i.e. -dfu_error); callers conventionally pass getErrorName(-result). Out-of-range values (including
+ * packed libusb errors that don't map to a base code) return "UNKNOWN" rather than reading out of bounds.
+ */
+const char *DFUDevice::getErrorName(int errNo) {
+    static const int errCount = (int)(sizeof(dfuDeviceErrors) / sizeof(dfuDeviceErrors[0]));
+    if (errNo < 0 || errNo >= errCount)
+        return "UNKNOWN";
+    return dfuDeviceErrors[errNo];
+}
+
+/**
+ * SN-8043: pure RDP-byte -> verdict mapping. See header for semantics. Kept free of any USB/device
+ * state so it can be exercised directly by unit tests (tests/test_ISDFUFirmwareUpdater.cpp).
+ */
+dfu_error DFUDevice::rdpVerdict(uint8_t rdpByte) {
+    if (rdpByte == 0xAA)
+        return DFU_ERROR_NONE;                  // Level 0 - unprotected, programming allowed
+    if (rdpByte == 0xCC)
+        return DFU_ERROR_RDP_PERMANENT_LOCKED;  // Level 2 - permanent, unrecoverable
+    return DFU_ERROR_RDP_LOCKED;                // Level 1 - flash writes silently dropped
+}
 
 
 /**
@@ -699,6 +726,71 @@ dfu_error DFUDevice::open() {
  * @param baseAddress this is the actual memory location which the firmware should be written to.
  * @return
  */
+/**
+ * SN-8043: Pre-flight read-protection check. See header. STM32U5 only; no-op otherwise.
+ */
+dfu_error DFUDevice::checkReadProtection() {
+    if (processorType != IS_PROCESSOR_STM32U5)
+        return DFU_ERROR_NONE;
+
+    if (!isConnected()) {
+        dfu_error ret = open();
+        if (ret != DFU_ERROR_NONE)
+            return ret;
+    }
+
+    // FLASH_OPTR is exposed through the DFU OPTIONS segment, which the ROM bootloader allows reading
+    // regardless of RDP level. The RDP byte is OPTR[7:0].
+    uint8_t optr[8] = { 0 };
+    const dfu_memory_t& options = segments[STM32_DFU_INTERFACE_OPTIONS];
+    int read = readMemory(static_cast<uint32_t>(options.address), optr, sizeof(optr));
+    if (read < (int)sizeof(uint32_t)) {
+        // Couldn't read the option bytes. Don't block the update on this (avoid false failures); the
+        // post-write readback verification is the backstop if writes are actually being dropped.
+        if (statusCb)
+            statusCb(this, IS_LOG_LEVEL_WARN, "(%s) RDP pre-flight: could not read FLASH_OPTR (ret=%d); skipping RDP gate", getDescription(), read);
+        return DFU_ERROR_NONE;
+    }
+
+    uint8_t rdp = optr[0];
+    dfu_error verdict = rdpVerdict(rdp);
+    if (verdict != DFU_ERROR_NONE && statusCb) {
+        statusCb(this, IS_LOG_LEVEL_ERROR,
+                 "(%s) Read protection active (RDP=0x%02X): flash programming will be silently dropped. Erase/recover the module before provisioning.",
+                 getDescription(), rdp);
+    }
+    return verdict;
+}
+
+/**
+ * SN-8043: Post-write readback verification. See header. STM32U5 only; no-op otherwise.
+ */
+dfu_error DFUDevice::verifyFlashWrite(uint32_t address, const uint8_t *expected, uint32_t verifyLen) {
+    if (processorType != IS_PROCESSOR_STM32U5)
+        return DFU_ERROR_NONE;
+    if (expected == nullptr || verifyLen == 0)
+        return DFU_ERROR_NONE;
+
+    if (verifyLen > 64)
+        verifyLen = 64;   // first 64 bytes (vector table: initial SP + reset vector) are never all-0xFF on a real image
+
+    uint8_t readback[64] = { 0 };
+    int read = readMemory(address, readback, verifyLen);
+    if (read < (int)verifyLen) {
+        // Could not read back; log but don't fail (avoid false negatives on otherwise-good devices).
+        if (statusCb)
+            statusCb(this, IS_LOG_LEVEL_WARN, "(%s) Write verify: readback failed (ret=%d) @ 0x%08X; skipping verify", getDescription(), read, address);
+        return DFU_ERROR_NONE;
+    }
+
+    if (memcmp(readback, expected, verifyLen) != 0) {
+        if (statusCb)
+            statusCb(this, IS_LOG_LEVEL_ERROR, "(%s) Write verify FAILED @ 0x%08X: flash readback does not match source (writes were dropped).", getDescription(), address);
+        return DFU_ERROR_WRITE_VERIFY_FAILED;
+    }
+    return DFU_ERROR_NONE;
+}
+
 dfu_error DFUDevice::updateFirmware(std::string filename, uint64_t baseAddress) {
     ihex_image_section_t image[MAX_NUM_IHEX_SECTIONS];
     size_t image_sections;
@@ -712,6 +804,12 @@ dfu_error DFUDevice::updateFirmware(std::string filename, uint64_t baseAddress) 
         if (ret_dfu != DFU_ERROR_NONE)
             return ret_dfu;
     }
+
+    // SN-8043: refuse to proceed when the chip is read-protected (RDP > 0xAA). At RDP Level 1 the ROM
+    // bootloader ACKs every flash DNLOAD but silently drops the programming, which previously produced
+    // a false DFU_ERROR_NONE and a bricked, empty-flash unit. STM32U5 only; no-op for other processors.
+    if ((ret_dfu = checkReadProtection()) != DFU_ERROR_NONE)
+        return ret_dfu;
 
     std::string ext = ".hex";
     if (filename.compare(filename.length() - ext.length(), ext.length(), ext) == 0) {
@@ -785,6 +883,11 @@ dfu_error DFUDevice::updateFirmware(std::string filename, uint64_t baseAddress) 
                 return ret_dfu;
             }
         }
+
+        // SN-8043: verify the write actually landed. Catches the RDP-silent-drop (all-0xFF readback)
+        // and any other "bootloader ACK'd but flash didn't take" failure. verifyFlashWrite() logs.
+        if ((ret_dfu = verifyFlashWrite(image[0].address, image[0].image, image[0].len)) != DFU_ERROR_NONE)
+            return ret_dfu;
     }
 
     // Unload the firmware image
@@ -818,6 +921,12 @@ dfu_error DFUDevice::updateFirmware(std::istream& stream, uint64_t baseAddress) 
         if (ret_dfu != DFU_ERROR_NONE)
             return ret_dfu;
     }
+
+    // SN-8043: refuse to proceed when the chip is read-protected (RDP > 0xAA). At RDP Level 1 the ROM
+    // bootloader ACKs every flash DNLOAD but silently drops the programming, which previously produced
+    // a false DFU_ERROR_NONE and a bricked, empty-flash unit. STM32U5 only; no-op for other processors.
+    if ((ret_dfu = checkReadProtection()) != DFU_ERROR_NONE)
+        return ret_dfu;
 
     {
         if (!stream)
@@ -873,6 +982,11 @@ dfu_error DFUDevice::updateFirmware(std::istream& stream, uint64_t baseAddress) 
                 return ret_dfu;
             }
         }
+
+        // SN-8043: verify the write actually landed. Catches the RDP-silent-drop (all-0xFF readback)
+        // and any other "bootloader ACK'd but flash didn't take" failure. verifyFlashWrite() logs.
+        if ((ret_dfu = verifyFlashWrite(image[0].address, image[0].image, image[0].len)) != DFU_ERROR_NONE)
+            return ret_dfu;
     }
 
     // Unload the firmware image

--- a/src/ISDFUFirmwareUpdater.h
+++ b/src/ISDFUFirmwareUpdater.h
@@ -164,6 +164,9 @@ typedef enum    // Internal only, can change as needed
     DFU_ERROR_INVALID_ARG = -6,
     DFU_ERROR_FILE_NOTFOUND = -7,
     DFU_ERROR_FILE_INVALID = -8,
+    DFU_ERROR_RDP_LOCKED = -9,              // SN-8043: chip at RDP Level 1 (RDP > 0xAA); flash writes are silently dropped. Recoverable via erase/RDP-regress.
+    DFU_ERROR_RDP_PERMANENT_LOCKED = -10,   // SN-8043: chip at RDP Level 2 (RDP == 0xCC); permanently locked, cannot be recovered.
+    DFU_ERROR_WRITE_VERIFY_FAILED = -11,    // SN-8043: post-write readback did not match the source image; the write did not land.
 } dfu_error;
 
 typedef enum {
@@ -227,7 +230,16 @@ public:
     void setProgressCb(fwUpdate::pfnProgressCb cbProgress){ progressCb = cbProgress;}
     void setStatusCb(fwUpdate::pfnStatusCb cbStatus) { statusCb = cbStatus;}
 
-    const char* getErrorName(int errNo) { return dfuDeviceErrors[errNo]; }
+    static const char* getErrorName(int errNo);
+
+    /**
+     * Maps a raw STM32 FLASH_OPTR RDP (read-protection) byte to a dfu_error verdict.
+     * Pure decision logic, separated so it can be unit-tested without USB hardware (SN-8043).
+     *   RDP == 0xAA -> DFU_ERROR_NONE (Level 0, unprotected; flash programming allowed)
+     *   RDP == 0xCC -> DFU_ERROR_RDP_PERMANENT_LOCKED (Level 2, permanent)
+     *   otherwise   -> DFU_ERROR_RDP_LOCKED (Level 1; flash writes silently dropped by the ROM bootloader)
+     */
+    static dfu_error rdpVerdict(uint8_t rdpByte);
 
     int fillDeviceInfo(dev_info_t &devInfo);
 
@@ -241,6 +253,23 @@ protected:
     dfu_error eraseFlash(const dfu_memory_t& mem, uint32_t& address, uint32_t data_len);
 
     dfu_error writeFlash(const dfu_memory_t& mem, uint32_t& address, uint32_t data_len, uint8_t *data);
+
+    /**
+     * SN-8043: Pre-flight read-protection (RDP) check. STM32U5 only (IMX-6 / GPX-1); a no-op (returns
+     * DFU_ERROR_NONE) for other processors. Reads FLASH_OPTR via the DFU OPTIONS segment (which works
+     * regardless of RDP level) and returns rdpVerdict() of the RDP byte. At RDP Level 1 the ROM
+     * bootloader ACKs every DNLOAD but silently drops the underlying flash programming, so we must
+     * refuse to proceed rather than report a false success.
+     */
+    dfu_error checkReadProtection();
+
+    /**
+     * SN-8043: Post-write readback verification. Uploads the first verifyLen bytes of the just-written
+     * region and compares them against the source image. Returns DFU_ERROR_WRITE_VERIFY_FAILED on
+     * mismatch (the classic RDP-silent-drop signature is an all-0xFF / all-0x00 readback). A readback
+     * transport failure is logged but NOT treated as fatal, to avoid false negatives on good devices.
+     */
+    dfu_error verifyFlashWrite(uint32_t address, const uint8_t *expected, uint32_t verifyLen);
 
 private:
     libusb_device *usbDevice = nullptr;

--- a/tests/test_ISDFUFirmwareUpdater.cpp
+++ b/tests/test_ISDFUFirmwareUpdater.cpp
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the DFU updater's read-protection (RDP) decision logic and error-name lookup.
+ *
+ * SN-8043: the USB DFU transfer itself requires hardware and is covered by a hardware-in-the-loop
+ * test (Set C). These tests exercise the pure, hardware-independent decision logic that gates the
+ * pre-flight RDP check and the post-write verification error reporting.
+ */
+
+#include <gtest/gtest.h>
+#include "ISDFUFirmwareUpdater.h"
+
+// --- rdpVerdict(): raw FLASH_OPTR RDP byte -> dfu_error verdict ---
+
+TEST(ISDFUFirmwareUpdater_RDP, Level0_Unprotected_Proceeds) {
+    // RDP == 0xAA is the only value that permits flash programming.
+    EXPECT_EQ(DFU_ERROR_NONE, DFUDevice::rdpVerdict(0xAA));
+}
+
+TEST(ISDFUFirmwareUpdater_RDP, Level2_Permanent_Locked) {
+    EXPECT_EQ(DFU_ERROR_RDP_PERMANENT_LOCKED, DFUDevice::rdpVerdict(0xCC));
+}
+
+TEST(ISDFUFirmwareUpdater_RDP, Level1_Locked) {
+    // 0xBB is the production state called out in the bug report; any non-0xAA/0xCC value is Level 1.
+    EXPECT_EQ(DFU_ERROR_RDP_LOCKED, DFUDevice::rdpVerdict(0xBB));
+    EXPECT_EQ(DFU_ERROR_RDP_LOCKED, DFUDevice::rdpVerdict(0x00));
+    EXPECT_EQ(DFU_ERROR_RDP_LOCKED, DFUDevice::rdpVerdict(0xFF));
+    EXPECT_EQ(DFU_ERROR_RDP_LOCKED, DFUDevice::rdpVerdict(0x55));
+    EXPECT_EQ(DFU_ERROR_RDP_LOCKED, DFUDevice::rdpVerdict(0xAB)); // one off from unprotected
+}
+
+// --- getErrorName(): index convention is -dfu_error; must be bounds-safe ---
+
+TEST(ISDFUFirmwareUpdater_RDP, ErrorNames_KnownCodes) {
+    EXPECT_STREQ("SUCCESS",              DFUDevice::getErrorName(-DFU_ERROR_NONE));
+    EXPECT_STREQ("INVALID_IMAGE",        DFUDevice::getErrorName(-DFU_ERROR_FILE_INVALID));
+    EXPECT_STREQ("RDP_LOCKED",           DFUDevice::getErrorName(-DFU_ERROR_RDP_LOCKED));
+    EXPECT_STREQ("RDP_PERMANENT_LOCKED", DFUDevice::getErrorName(-DFU_ERROR_RDP_PERMANENT_LOCKED));
+    EXPECT_STREQ("WRITE_VERIFY_FAILED",  DFUDevice::getErrorName(-DFU_ERROR_WRITE_VERIFY_FAILED));
+}
+
+TEST(ISDFUFirmwareUpdater_RDP, ErrorNames_OutOfRangeIsSafe) {
+    // Negative indices (e.g. from the legacy "-(err & 0xF)" caller convention on packed libusb
+    // errors) and overly-large indices must not read out of bounds.
+    EXPECT_STREQ("UNKNOWN", DFUDevice::getErrorName(-1));
+    EXPECT_STREQ("UNKNOWN", DFUDevice::getErrorName(9999));
+    EXPECT_STREQ("UNKNOWN", DFUDevice::getErrorName(-100));
+}


### PR DESCRIPTION
## Summary

Fixes SN-8043: `DFUDevice::updateFirmware()` returned `DFU_ERROR_NONE` when the STM32U5 ROM bootloader silently dropped flash writes at **RDP Level 1** (RDP > `0xAA`). Every `DFU_DNLOAD` was ACKed and `waitForState(DNLOAD_IDLE)` succeeded, so the host reported "Complete" while flash stayed empty — a bricked, empty-flash unit reported as success.

Two independent guards now close the silent-success window (suggested fixes **(1)** + **(3)** from the ticket):

### (1) Pre-flight RDP check — `checkReadProtection()`
At the top of both `updateFirmware()` overloads (STM32U5 only; no-op for other processors). Reads `FLASH_OPTR` via the DFU `OPTIONS` segment (readable regardless of RDP level) and gates on the RDP byte:

| RDP | Result |
|---|---|
| `0xAA` (Level 0) | proceed |
| `0xCC` (Level 2, permanent) | `DFU_ERROR_RDP_PERMANENT_LOCKED` |
| anything else (Level 1) | `DFU_ERROR_RDP_LOCKED` |

I chose the **bail-with-clear-error** path rather than auto-regress. The AC explicitly permits either; auto-regress requires a mandatory mass-erase + system reset + USB re-enumeration + re-acquire of the device handle, which can't be verified without hardware and is more invasive. Happy to add auto-regress as a follow-up if preferred — see open question below.

### (3) Post-write readback verification — `verifyFlashWrite()`
After the write loop, uploads the first 64 bytes of the written region and compares against the source image; mismatch → `DFU_ERROR_WRITE_VERIFY_FAILED`. The classic RDP-drop signature is an all-`0xFF` readback. A readback **transport** failure is logged but treated as non-fatal, to avoid false negatives on otherwise-good devices.

### Supporting changes
- New error codes: `DFU_ERROR_RDP_LOCKED` (-9), `DFU_ERROR_RDP_PERMANENT_LOCKED` (-10), `DFU_ERROR_WRITE_VERIFY_FAILED` (-11), with matching `dfuDeviceErrors[]` strings.
- `getErrorName()` is now **bounds-safe** (returns `"UNKNOWN"` for out-of-range indices instead of reading OOB) and **static** (testable; existing `instance->getErrorName()` callers unaffected).
- The pure RDP decision is extracted into `static DFUDevice::rdpVerdict(uint8_t)` for unit testing.

## Acceptance criteria

- [x] **A** (unit, self-verified): `tests/test_ISDFUFirmwareUpdater.cpp` — 5 GTest cases for `rdpVerdict()` (0xAA/0xCC/Level-1 set) and `getErrorName()` (known codes + out-of-range safety). All pass. The full `IS-SDK_unit-tests` target builds and links with these changes.
- [x] `updateFirmware()` no longer returns `DFU_ERROR_NONE` on a silent drop — it returns `DFU_ERROR_RDP_LOCKED` (pre-flight) or `DFU_ERROR_WRITE_VERIFY_FAILED` (post-write).
- [ ] **C** (hardware-in-the-loop, reviewer): put an STM32U5 module at RDP=`0xBB`, run DFU, confirm the failure is surfaced (not "Complete"); and confirm no regression on the normal RDP=`0xAA` provisioning path end-to-end.

## Companion PR

EvalTool change (imx) so the DFU Provisioning dialog displays the meaningful error name (AC #2) — bumps the SDK submodule to this branch. Link added once opened.

## Out of scope

Legacy `ISBootloaderDFU.cpp` (IMX-5 / STM32L4) — different RDP-vs-bootloader semantics; file a sibling ticket if affected (per the ticket).

## Open question for reviewers

Bail vs. auto-regress on RDP Level 1 — this PR bails with a clear error. If the factory flow would rather auto-recover (write OPTR `RDP=0xAA`, mass-erase, re-enumerate, continue), I can implement it as a follow-up; it needs bench validation of the re-enumeration timing.