### PR TITLE
Fix LogInspector NPP reprocessing ability

### DIFF
--- a/python/inertialsense/logInspector/logInspector.py
+++ b/python/inertialsense/logInspector/logInspector.py
@@ -919,8 +919,9 @@ class LogInspectorWindow(QMainWindow):
         
         # Select post_processed directory in file tree view
         for row in range(index.model().rowCount(index)):
-            if self.fileTree.model().fileName(index.child(row, 0)) == "post_processed":
-                self.fileTree.setCurrentIndex(index.child(row, 0))
+            child_index = index.model().index(row, 0, index)
+            if self.fileTree.model().fileName(child_index) == "post_processed":
+                self.fileTree.setCurrentIndex(child_index)
                 QtCore.QCoreApplication.processEvents() # refresh UI
                 self.handleTreeViewClick()
                 continue

--- a/python/inertialsense/supernpp/supernpp.py
+++ b/python/inertialsense/supernpp/supernpp.py
@@ -225,10 +225,12 @@ class SuperNPP():
             build_dir_name = 'build-release'
         npp_build_folder = None
         search_dir = Path(__file__).resolve().parent
-        while search_dir != search_dir.parent:
+        while True:
             candidate = search_dir / 'cpp' / 'NavPostProcess' / build_dir_name
             if candidate.is_dir():
                 npp_build_folder = str(candidate)
+                break
+            if search_dir == search_dir.parent:
                 break
             search_dir = search_dir.parent
         if npp_build_folder is None:

--- a/python/inertialsense/supernpp/supernpp.py
+++ b/python/inertialsense/supernpp/supernpp.py
@@ -12,9 +12,10 @@ import sys
 import threading
 import yaml
 
-sys.path.insert(1, '../../SDK/python/inertialsense/logInspector')
-sys.path.insert(1, '../logInspector')
-sys.path.insert(1, '../logs')
+_supernpp_dir = Path(__file__).resolve().parent
+_inertialsense_dir = _supernpp_dir.parent
+sys.path.insert(1, str(_inertialsense_dir / 'logInspector'))
+sys.path.insert(1, str(_inertialsense_dir / 'logs'))
 
 from logReader import Log
 
@@ -216,13 +217,23 @@ class SuperNPP():
         else:
             serials = config_serials
 
-        file_path = os.path.dirname(os.path.realpath(__file__))
-        npp_build_folder = os.path.normpath(file_path + '../../../../../cpp/NavPostProcess/build')
         if os.name == 'posix':  # Linux
             exename = './navpp'
+            build_dir_name = 'build'
         else:                   # Windows
             exename = 'navpp.exe'
-            npp_build_folder += '-release'
+            build_dir_name = 'build-release'
+        npp_build_folder = None
+        search_dir = Path(__file__).resolve().parent
+        while search_dir != search_dir.parent:
+            candidate = search_dir / 'cpp' / 'NavPostProcess' / build_dir_name
+            if candidate.is_dir():
+                npp_build_folder = str(candidate)
+                break
+            search_dir = search_dir.parent
+        if npp_build_folder is None:
+            print(f"ERROR: Could not find NavPostProcess/{build_dir_name} folder searching upward from {Path(__file__).resolve()}")
+            return
         cmds = [exename + ' -d "' + folder + '" -s ' + str(s) + " -sd " + subdir + " -l " + logType for s in serials]
 
         mode_suffix = {1: ' -mode COLD', 2: ' -mode FACTORY'}.get(self.startMode, '')


### PR DESCRIPTION
This pull request improves the reliability and maintainability of path handling in the `supernpp.py` script and fixes a bug in the file tree navigation logic in `logInspector.py`. The most significant changes include making path resolution more robust and platform-independent, as well as correcting the way child indexes are handled in the file tree view.

**Path handling improvements:**

* Updated `supernpp.py` to use `Path` objects for determining and inserting module paths, making imports more robust and less dependent on the script's execution location.
* Refactored the logic for locating the `NavPostProcess` build directory in `reprocess_log` to search upwards in the directory tree, improving reliability across different setups and platforms. The code now dynamically determines whether to use `build` or `build-release` based on the OS, and prints a clear error if the directory is not found.

**Bug fix:**

* Fixed a bug in `logInspector.py` where the child index in the file tree was not being constructed correctly, potentially causing issues when selecting the `post_processed` directory in the UI. The code now properly uses the model's `index` method to obtain the child index.