### PR TITLE
SN-8175/SN-8177: RelayPortFactory port lifecycle & freeze fixes

### DIFF
--- a/code-style-guide.md
+++ b/code-style-guide.md
@@ -1,0 +1,219 @@
+# Inertial Sense SDK — C++ Code Style Guide
+
+> Scope: C/C++ source in the Inertial Sense SDK and the projects that embed it
+> (EvalTool, cltool, firmware). This guide is **normative**. The key words **MUST**,
+> **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are used in the RFC 2119 sense.
+>
+> Mechanical formatting (indent, braces, column width, include grouping) is owned by
+> `.clang-format` and enforced in CI — this guide does not restate it beyond a summary.
+> When this guide and `.clang-format` disagree, `.clang-format` wins for formatting.
+
+---
+
+## 1. Formatting (owned by `.clang-format`)
+
+The SDK's `.clang-format` is the source of truth. For reference, it currently sets:
+
+- `BasedOnStyle: Google`
+- `IndentWidth: 4`, `UseTab: Never` — **4 spaces, never tabs**
+- `ColumnLimit: 200`
+- `IncludeBlocks: Regroup` — includes are grouped and sorted automatically
+- `InsertNewlineAtEOF: true`
+
+You **MUST** run `clang-format` (or the IDE equivalent) before committing. Do not
+hand-format against the tool.
+
+---
+
+## 2. Documentation — Doxygen
+
+Reference: <https://www.doxygen.nl/manual/docblocks.html>. Doxygen accepts several
+comment styles; this project standardizes on **two** of them and forbids the rest so
+that documentation is consistent and greppable.
+
+### 2.1 The two allowed forms
+
+| Purpose | Form | Position |
+|---|---|---|
+| Document the item that **follows** (file, class, struct, enum, function, standalone) | `/** … */` block | **before** the declaration |
+| Document the item to its **left** (a member variable, enumerator, or parameter) | `//!< …` | **trailing**, same line |
+
+That is the whole rule: **preceding documentation uses `/** */`; trailing
+member/enumerator/parameter documentation uses `//!<`.**
+
+### 2.2 Forbidden forms
+
+You **MUST NOT** use:
+
+- `///` or `///<` — the triple-slash forms (this is the most common mistake).
+- `//!` as a *preceding* single-line block — use a `/** */` block instead.
+- `/*! */` Qt-style blocks — use `/** */` (JavaDoc style) for consistency.
+
+> Why `//!<` and not `///<` for trailing docs? Both are valid Doxygen, but the project
+> standard pairs the JavaDoc preceding block (`/** */`) with the `//!<` trailing marker
+> so the two roles are visually distinct and a simple search for `///` reliably finds
+> style violations.
+
+### 2.3 Preceding blocks — `/** */`
+
+Every line begins with ` * `. Start with a one-line brief; a blank line separates the
+brief from the detailed description (or use `@brief` explicitly).
+
+```cpp
+/**
+ * Enable or disable a known relay host.
+ *
+ * Disabled hosts remain listed by getRelayHosts() but contribute no ports. Enabling
+ * spawns the SSE worker; disabling tears it down and evicts the host's ports.
+ *
+ * @param url      canonical or raw relay URL (normalized internally)
+ * @param enabled  true to start contributing ports, false to stop
+ */
+void setRelayHostEnabled(const std::string& url, bool enabled);
+```
+
+Single-line briefs are fine for simple members/functions:
+
+```cpp
+/** Returns the number of ports currently managed. */
+size_t getPortCount() const;
+```
+
+### 2.4 Trailing member / enumerator / parameter docs — `//!<`
+
+The `<` tells Doxygen the comment documents the item **to its left**. Per the Doxygen
+manual these trailing blocks document **members and parameters only** — never the
+struct/enum/class itself (that gets a preceding `/** */`).
+
+```cpp
+/** Active transport in use for a relay host. */
+enum class RelayFeedType : uint8_t {
+    Auto    = 0,  //!< negotiating; not yet connected via any transport
+    SSE     = 1,  //!< push-based /api/events/devices stream is connected
+    Polling = 2,  //!< polling fallback (SSE unavailable or failed)
+};
+
+struct RelayHostStatus {
+    std::string  url;            //!< canonical "http://host:port" (no path)
+    bool         enabled;        //!< true iff this host contributes ports
+    size_t       deviceCount;    //!< number of devices reported by this host
+};
+```
+
+If a trailing description needs more than one line, promote it to a preceding
+`/** */` block above the member rather than wrapping a `//!<`.
+
+Parameter docs **MAY** use the trailing form inline in a signature, but the `@param`
+form in the function's preceding block (2.3) is preferred for readability.
+
+### 2.5 File headers
+
+Every translation unit and header **MUST** open with a file block. `@file` and
+`@brief` document the file itself, so they live in a preceding `/** */` block:
+
+```cpp
+/**
+ * @file RelayPortFactory.h
+ * @brief Discovers IS device ports through remote HTTP-based relay hosts.
+ *
+ * @author <name> on <date>
+ * @copyright Copyright (c) <year> Inertial Sense, Inc. All rights reserved.
+ */
+```
+
+### 2.6 Common commands
+
+Use `@`-prefixed commands (not `\`). The vocabulary in regular use:
+
+`@file` `@brief` `@param` `@param[in]` `@param[out]` `@param[in,out]` `@return`
+`@retval` `@tparam` `@note` `@warning` `@see` `@code`/`@endcode` `@deprecated` `@todo`.
+
+### 2.7 What to document
+
+- Public API (anything in a header that callers use): **MUST** be documented.
+- Non-obvious private functions, invariants, ownership, threading/locking
+  assumptions, and units: **SHOULD** be documented.
+- When you change a function's signature, you **MUST** update its doc block in the
+  same change (params added/removed/renamed, return semantics, ownership).
+- Trivial getters/setters and self-evident code: a doc comment is optional; do not
+  add noise that merely restates the signature.
+
+---
+
+## 3. Naming
+
+These reflect the prevailing SDK conventions. Match the **surrounding file** first; use
+the following for new files and new symbols.
+
+| Kind | Convention | Example |
+|---|---|---|
+| Type (class/struct/enum) | `PascalCase` | `RelayPortFactory`, `RelayHostStatus` |
+| `enum class` enumerators | `PascalCase` | `RelayFeedType::Polling` |
+| Function / method | `camelCase` | `discoverPorts()`, `bindPort()` |
+| Local variable / parameter | `camelCase` | `portUrl`, `relayHost` |
+| Private data member | `camelCase` with trailing `_` | `relayHosts_`, `pollInterval_` |
+| Plain-struct public field | `camelCase`, no underscore | `RelayHostStatus::deviceCount` |
+| Constant / `constexpr` / macro | `UPPER_SNAKE_CASE` | `DEFAULT_HTTP_PORT`, `MDNS_QUERY_INTERVAL_MS` |
+
+Notes:
+- The private-member trailing `_` is used by newer code (e.g. `RelayPortFactory`) but is
+  **not** universal across the SDK. Do **not** mass-rename existing members; follow the
+  file you are in, and prefer the trailing `_` in new code.
+- **Do not** prefix interface/abstract types with `I` (no `IFoo`). Name the abstraction
+  for what it is. Defer introducing abstractions until a second concrete case exists,
+  and keep the class count low — prefer a singleton concrete factory over an interface
+  hierarchy when there is one implementation.
+
+---
+
+## 4. Language & best practices (C++17)
+
+**Const-correctness.** Mark methods `const` when they don't mutate observable state.
+Pass read-only objects by `const&`. Prefer `const`/`constexpr` for values that don't change.
+
+**References vs pointers.** Use a reference for a required, non-null argument; use a
+pointer only when null is meaningful (optional/out param). Never return a raw owning pointer.
+
+**Ownership & RAII.** Express ownership with `std::unique_ptr` (sole owner) or
+`std::shared_ptr` (shared). Raw pointers/references are non-owning observers. Acquire
+locks with `std::lock_guard`/`std::unique_lock`, never bare `lock()`/`unlock()`. Every
+resource (socket, thread, file, mutex) **MUST** be released on every path, including
+exceptions and early returns.
+
+**`enum class`.** Prefer scoped enums over plain `enum`. Give them an explicit underlying
+type when the width matters on the wire (`enum class … : uint8_t`).
+
+**Modern keywords.** Use `nullptr` (not `NULL`/`0`), `override` on every overriding
+method, `= default` / `= delete` for special members, `auto` where it aids readability.
+Delete copy/move on non-copyable types (e.g. types owning a `std::thread`).
+
+**Includes (IWYU).** Include what you use; don't lean on transitive includes. Keep the
+public header's includes minimal — prefer forward declarations and push heavy includes
+(`httplib.h`, `json.hpp`) into the `.cpp`. `IncludeBlocks: Regroup` will order them.
+
+**Anonymous namespace.** Give internal (TU-local) helpers internal linkage via an
+unnamed `namespace { … }` rather than `static` on each symbol.
+
+**Error handling.** The SDK core avoids throwing across module boundaries. Prefer status
+returns (`bool`, an out-param, or an enum/`std::optional`) for expected failures; reserve
+exceptions for truly exceptional conditions and never let one escape a C ABI boundary or
+a callback invoked by C code.
+
+**Threading & locking.** Document which mutex guards what, and the lock order. Two rules
+that have bitten this codebase specifically:
+- **Do not hold a lock across a callback or blocking I/O.** Snapshot the data you need
+  under the lock, release it, then invoke the callback / do the network/DNS work. Holding
+  a factory mutex across `bindPort()`/`getaddrinfo()` froze the UI (SN-8175).
+- **Never do network, DNS, or port I/O on the GUI thread.** Marshal it to the worker/IO
+  thread (e.g. `QMetaObject::invokeMethod(obj, "slot", Qt::QueuedConnection)`).
+
+**Magic numbers.** Name timeouts, intervals, retry counts, and buffer sizes as
+`constexpr` (e.g. `OFFLINE_EVICT_MS`) rather than embedding literals at the call site.
+
+---
+
+## 5. References
+
+- Doxygen — Documenting the code: <https://www.doxygen.nl/manual/docblocks.html>
+- Doxygen — Special commands: <https://www.doxygen.nl/manual/commands.html>
+- `.clang-format` in this directory (mechanical formatting, CI-enforced)

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -31,7 +31,12 @@ using json = nlohmann::json;
 
 namespace {
 
-/// Map bridgeboard's module "state" string to a full encoded is_hardware_t (type + major + minor).
+/**
+ * Map bridgeboard's module "state" string to a full encoded is_hardware_t (type + major + minor).
+ *
+ * @param state  bridgeboard module state ("imx5", "imx6", "gpx", "isbl", ...)
+ * @return the encoded hardware id, or IS_HARDWARE_NONE if unrecognized
+ */
 is_hardware_t stateToHardwareId(const std::string& state) {
     if (state == "imx5") return IS_HARDWARE_IMX_5_0;
     if (state == "imx6") return IS_HARDWARE_IMX_6_0;
@@ -40,17 +45,21 @@ is_hardware_t stateToHardwareId(const std::string& state) {
     return IS_HARDWARE_NONE;
 }
 
-/// Canonicalize any relay input (bare hostname, IP, full URL, URL-with-path) into
-/// the factory's storage key form: "http://<host>:<port>" with no trailing slash and no path.
-///
-/// Examples:
-///   "http://host.local:8080/api/status"   -> "http://host.local:8080"
-///   "http://host.local:9090/"             -> "http://host.local:9090"
-///   "http://host.local"                   -> "http://host.local:8080"   (default port applied)
-///   "host.local:9090"                     -> "http://host.local:9090"   (scheme defaulted)
-///   "10.1.2.3"                            -> "http://10.1.2.3:8080"
-///
-/// Returns an empty string on unparseable input.
+/**
+ * Canonicalize any relay input (bare hostname, IP, full URL, URL-with-path) into
+ * the factory's storage key form: "http://<host>:<port>" with no trailing slash and no path.
+ *
+ * Examples:
+ *   "http://host.local:8080/api/status"   -> "http://host.local:8080"
+ *   "http://host.local:9090/"             -> "http://host.local:9090"
+ *   "http://host.local"                   -> "http://host.local:8080"   (default port applied)
+ *   "host.local:9090"                     -> "http://host.local:9090"   (scheme defaulted)
+ *   "10.1.2.3"                            -> "http://10.1.2.3:8080"
+ *
+ * @param input        relay address in any of the accepted forms
+ * @param defaultPort  port to apply when the input omits one
+ * @return the canonical "http://host:port", or an empty string on unparseable input
+ */
 std::string normalizeBaseUrl(const std::string& input, uint16_t defaultPort) {
     std::string s = input;
     while (!s.empty() && std::isspace(static_cast<unsigned char>(s.front()))) s.erase(s.begin());
@@ -74,7 +83,13 @@ std::string normalizeBaseUrl(const std::string& input, uint16_t defaultPort) {
     return "http://" + host + ":" + std::to_string(port);
 }
 
-/// Split a canonical "http://host:port" URL into hostname + port. Returns {"", defaultPort} on failure.
+/**
+ * Split a canonical "http://host:port" URL into hostname + port.
+ *
+ * @param baseUrl      canonical relay base URL
+ * @param defaultPort  port returned when the URL omits or has an invalid port
+ * @return {hostname, port}; {"", defaultPort} on failure
+ */
 std::pair<std::string, int> splitBaseUrl(const std::string& baseUrl, uint16_t defaultPort) {
     const FIX8::uri parsed{baseUrl};
     std::string host = std::string{parsed.get_host()};
@@ -86,18 +101,23 @@ std::pair<std::string, int> splitBaseUrl(const std::string& baseUrl, uint16_t de
     return {host, port};
 }
 
-/// Rewrite the host component of a device URI to `newHost`, preserving scheme + port.
-///
-/// A bridgeboard relays its OWN locally-attached devices, so every device URI it reports
-/// is on the same host we already connected to for the relay's HTTP/SSE API. The relayed
-/// URIs, however, frequently use the bridgeboard's mDNS `.local` name, which is only
-/// resolvable on the bridgeboard's own link. A client reaching the relay over routed/VPN
-/// transport (e.g. Tailscale) connected via the relay's configured host but cannot resolve
-/// the `.local` form at all — so binding those ports blocks in nss-mdns and then fails,
-/// and no ports ever surface (SN-8175). Substituting the relay's known-reachable host (the
-/// one normalizeBaseUrl already validated and the SSE/poll client connected to) makes the
-/// device ports resolvable exactly the way the relay itself was reached. Returns the input
-/// unchanged if it can't be parsed or newHost is empty.
+/**
+ * Rewrite the host component of a device URI to @p newHost, preserving scheme + port.
+ *
+ * A bridgeboard relays its OWN locally-attached devices, so every device URI it reports
+ * is on the same host we already connected to for the relay's HTTP/SSE API. The relayed
+ * URIs, however, frequently use the bridgeboard's mDNS `.local` name, which is only
+ * resolvable on the bridgeboard's own link. A client reaching the relay over routed/VPN
+ * transport (e.g. Tailscale) connected via the relay's configured host but cannot resolve
+ * the `.local` form at all — so binding those ports blocks in nss-mdns and then fails,
+ * and no ports ever surface (SN-8175). Substituting the relay's known-reachable host (the
+ * one normalizeBaseUrl already validated and the SSE/poll client connected to) makes the
+ * device ports resolvable exactly the way the relay itself was reached.
+ *
+ * @param uri      the relayed device URI (e.g. "tcp://host.local:34663")
+ * @param newHost  the relay's reachable host to substitute in
+ * @return the rewritten URI, or @p uri unchanged if it can't be parsed or @p newHost is empty
+ */
 std::string rewriteUriHost(const std::string& uri, const std::string& newHost) {
     if (newHost.empty()) return uri;
     const FIX8::uri parsed{uri};
@@ -109,19 +129,26 @@ std::string rewriteUriHost(const std::string& uri, const std::string& newHost) {
     return out;
 }
 
-/// HTTP timeouts (seconds)
-/// SN-8177: keep the connect timeout short — a dead/unreachable relay must not block the
-/// IO thread for long per attempt (a powered-off host over VPN won't RST; it just hangs).
+/**
+ * HTTP timeouts (seconds).
+ * SN-8177: keep the connect timeout short — a dead/unreachable relay must not block the
+ * IO thread for long per attempt (a powered-off host over VPN won't RST; it just hangs).
+ */
 static constexpr int HTTP_CONNECT_TIMEOUT_S = 2;
 static constexpr int HTTP_READ_TIMEOUT_S    = 5;
-/// SSE read timeout — generous enough to outlive server keepalive (15 s per SN-7804)
+/** SSE read timeout — generous enough to outlive server keepalive (15 s per SN-7804) */
 static constexpr int SSE_READ_TIMEOUT_S     = 30;
-/// SSE reconnect backoff (ms) — bounded exponential
+/** SSE reconnect backoff (ms) — bounded exponential */
 static constexpr int SSE_RECONNECT_INITIAL_MS = 250;
 static constexpr int SSE_RECONNECT_MAX_MS     = 2000;
 
-/// Parse a "YYYY-MM-DD HH:MM:SS" timestamp (as bridgeboard's build_date field) into
-/// the dev_info_t date/time byte fields. Missing or malformed input leaves everything zero.
+/**
+ * Parse a "YYYY-MM-DD HH:MM:SS" timestamp (as bridgeboard's build_date field) into
+ * the dev_info_t date/time byte fields. Missing or malformed input leaves everything zero.
+ *
+ * @param s          the build_date string
+ * @param[out] hint  dev_info_t whose build* fields are populated
+ */
 void parseBuildDate(const std::string& s, dev_info_t& hint) {
     int y = 0, mo = 0, d = 0, h = 0, mi = 0, se = 0;
     if (std::sscanf(s.c_str(), "%d-%d-%d %d:%d:%d", &y, &mo, &d, &h, &mi, &se) < 3)
@@ -134,20 +161,33 @@ void parseBuildDate(const std::string& s, dev_info_t& hint) {
     if (se >= 0 && se < 60) hint.buildSecond = static_cast<uint8_t>(se);
 }
 
-/// Parse the first hex word of bridgeboard's firmware_commit ("deadbeef abc123.0") into
-/// repoRevision. Non-hex input leaves it zero.
+/**
+ * Parse the first hex word of bridgeboard's firmware_commit ("deadbeef abc123.0") into
+ * repoRevision. Non-hex input leaves it zero.
+ *
+ * @param s          the firmware_commit string
+ * @param[out] hint  dev_info_t whose repoRevision is populated
+ */
 void parseRepoRevision(const std::string& s, dev_info_t& hint) {
     try {
         hint.repoRevision = static_cast<uint32_t>(std::stoul(s, nullptr, 16));
     } catch (...) {}
 }
 
-/// Parse a single device entry from the SN-7804 `/api/availableDevices` schema
-/// (or from a `device.added` / `device.changed` SSE event payload — same shape).
-///
-/// Populates every dev_info_t field the relay can supply so consumers don't need to
-/// issue a follow-up DID_DEV_INFO query: hardwareType/Ver, serialNumber, full
-/// protocolVer[], firmwareVer, manufacturer, build date/time, repo revision.
+/**
+ * Parse a single device entry from the SN-7804 `/api/availableDevices` schema
+ * (or from a `device.added` / `device.changed` SSE event payload — same shape).
+ *
+ * Populates every dev_info_t field the relay can supply so consumers don't need to
+ * issue a follow-up DID_DEV_INFO query: hardwareType/Ver, serialNumber, full
+ * protocolVer[], firmwareVer, manufacturer, build date/time, repo revision.
+ *
+ * @param dev        the JSON device object to parse
+ * @param[out] out   the populated DeviceRecord; its portUrl is rebased onto @p relayHost
+ * @param relayHost  the relay's reachable host, substituted for the device URI's (often
+ *                   `.local`) host so the port resolves off-link (see rewriteUriHost / SN-8175)
+ * @return true if the entry is a usable device, false if it should be skipped
+ */
 bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out, const std::string& relayHost) {
     if (!dev.is_object()) return false;
 
@@ -203,15 +243,26 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out, const
     return true;
 }
 
-/// Parse the SN-7804 snapshot envelope (shared between `/api/availableDevices` HTTP response
-/// and SSE `snapshot` event payload). Expected shape:
-/// `{ "server_instance_id": "...", "snapshot_id": N, "devices": [ ... ] }`
+/**
+ * Parsed form of the SN-7804 snapshot envelope (shared between the `/api/availableDevices`
+ * HTTP response and the SSE `snapshot` event payload). Expected shape:
+ * `{ "server_instance_id": "...", "snapshot_id": N, "devices": [ ... ] }`
+ */
 struct SnapshotResult {
     std::string serverInstanceId;
     uint64_t    snapshotId = 0;
     std::vector<RelayPortFactory::DeviceRecord> devices;
 };
 
+/**
+ * Parse the SN-7804 snapshot envelope into a SnapshotResult.
+ *
+ * @param doc        the snapshot JSON (HTTP response body or SSE `snapshot` payload)
+ * @param[out] out   the parsed envelope: server instance id, snapshot id, and devices
+ * @param relayHost  the relay's reachable host, propagated to each device's portUrl
+ *                   (see parseDeviceJson / SN-8175)
+ * @return true if the envelope was well-formed (had a `devices` array), false otherwise
+ */
 bool parseSnapshotJson(const json& doc, SnapshotResult& out, const std::string& relayHost) {
     if (!doc.is_object()) return false;
 
@@ -231,8 +282,12 @@ bool parseSnapshotJson(const json& doc, SnapshotResult& out, const std::string& 
     return true;
 }
 
-/// Split a composite SSE id "<instance_uuid>:<snapshot_id>" into its parts.
-/// Returns {instance, snapshotId}; instance is empty and snapshotId is 0 on malformed input.
+/**
+ * Split a composite SSE id "<instance_uuid>:<snapshot_id>" into its parts.
+ *
+ * @param id  the composite event id
+ * @return {instance, snapshotId}; {"", 0} on malformed input
+ */
 std::pair<std::string, uint64_t> splitEventId(const std::string& id) {
     auto colon = id.find(':');
     if (colon == std::string::npos) return {"", 0};
@@ -242,11 +297,11 @@ std::pair<std::string, uint64_t> splitEventId(const std::string& id) {
     return {std::move(inst), snap};
 }
 
-/// HTTP paths on a relay host (appended to the stored base URL).
+/** HTTP paths on a relay host (appended to the stored base URL). */
 static constexpr const char* PATH_AVAILABLE_DEVICES = "/api/availableDevices";
 static constexpr const char* PATH_EVENTS_DEVICES    = "/api/events/devices";
 
-/// SSE event type names emitted by bridgeboard per SN-7804.
+/** SSE event type names emitted by bridgeboard per SN-7804. */
 static constexpr const char* EVT_SNAPSHOT        = "snapshot";
 static constexpr const char* EVT_DEVICE_ADDED    = "device.added";
 static constexpr const char* EVT_DEVICE_CHANGED  = "device.changed";

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -86,8 +86,33 @@ std::pair<std::string, int> splitBaseUrl(const std::string& baseUrl, uint16_t de
     return {host, port};
 }
 
+/// Rewrite the host component of a device URI to `newHost`, preserving scheme + port.
+///
+/// A bridgeboard relays its OWN locally-attached devices, so every device URI it reports
+/// is on the same host we already connected to for the relay's HTTP/SSE API. The relayed
+/// URIs, however, frequently use the bridgeboard's mDNS `.local` name, which is only
+/// resolvable on the bridgeboard's own link. A client reaching the relay over routed/VPN
+/// transport (e.g. Tailscale) connected via the relay's configured host but cannot resolve
+/// the `.local` form at all — so binding those ports blocks in nss-mdns and then fails,
+/// and no ports ever surface (SN-8175). Substituting the relay's known-reachable host (the
+/// one normalizeBaseUrl already validated and the SSE/poll client connected to) makes the
+/// device ports resolvable exactly the way the relay itself was reached. Returns the input
+/// unchanged if it can't be parsed or newHost is empty.
+std::string rewriteUriHost(const std::string& uri, const std::string& newHost) {
+    if (newHost.empty()) return uri;
+    const FIX8::uri parsed{uri};
+    std::string scheme{parsed.get_scheme()};
+    std::string port{parsed.get_port()};
+    if (scheme.empty()) return uri;
+    std::string out = scheme + "://" + newHost;
+    if (!port.empty()) out += ":" + port;
+    return out;
+}
+
 /// HTTP timeouts (seconds)
-static constexpr int HTTP_CONNECT_TIMEOUT_S = 3;
+/// SN-8177: keep the connect timeout short — a dead/unreachable relay must not block the
+/// IO thread for long per attempt (a powered-off host over VPN won't RST; it just hangs).
+static constexpr int HTTP_CONNECT_TIMEOUT_S = 2;
 static constexpr int HTTP_READ_TIMEOUT_S    = 5;
 /// SSE read timeout — generous enough to outlive server keepalive (15 s per SN-7804)
 static constexpr int SSE_READ_TIMEOUT_S     = 30;
@@ -123,7 +148,7 @@ void parseRepoRevision(const std::string& s, dev_info_t& hint) {
 /// Populates every dev_info_t field the relay can supply so consumers don't need to
 /// issue a follow-up DID_DEV_INFO query: hardwareType/Ver, serialNumber, full
 /// protocolVer[], firmwareVer, manufacturer, build date/time, repo revision.
-bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
+bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out, const std::string& relayHost) {
     if (!dev.is_object()) return false;
 
     std::string state = dev.value("state", "none");
@@ -171,7 +196,9 @@ bool parseDeviceJson(const json& dev, RelayPortFactory::DeviceRecord& out) {
     // so we hard-code a sane default. This matches what real devices report.
     std::strncpy(hint.manufacturer, "Inertial Sense", sizeof(hint.manufacturer) - 1);
 
-    out.portUrl = std::move(uri);
+    // Device URIs from the relay often carry the bridgeboard's .local host, which a
+    // routed/VPN client can't resolve. Rebind to the relay's reachable host (SN-8175).
+    out.portUrl = rewriteUriHost(uri, relayHost);
     out.hint = hint;
     return true;
 }
@@ -185,7 +212,7 @@ struct SnapshotResult {
     std::vector<RelayPortFactory::DeviceRecord> devices;
 };
 
-bool parseSnapshotJson(const json& doc, SnapshotResult& out) {
+bool parseSnapshotJson(const json& doc, SnapshotResult& out, const std::string& relayHost) {
     if (!doc.is_object()) return false;
 
     out.serverInstanceId = doc.value("server_instance_id", "");
@@ -198,7 +225,7 @@ bool parseSnapshotJson(const json& doc, SnapshotResult& out) {
     out.devices.reserve(doc["devices"].size());
     for (const auto& dev : doc["devices"]) {
         RelayPortFactory::DeviceRecord rec;
-        if (parseDeviceJson(dev, rec))
+        if (parseDeviceJson(dev, rec, relayHost))
             out.devices.push_back(std::move(rec));
     }
     return true;
@@ -323,6 +350,10 @@ void RelayPortFactory::setRelayHostEnabled(const std::string& url, bool enabled)
             host.activeTransport = RelayFeedType::Auto;
             host.sseConsecutiveFailures = 0;
             host.consecutiveFailures = 0;
+            // Start the offline-eviction / backoff clock now: an enabled host that never
+            // makes contact begins its grace period here (SN-8177).
+            host.lastContact = std::chrono::steady_clock::now();
+            host.lastAttemptTime = {};
             host.stopRequested.store(false);
             startSseWorker(host);
         } else {
@@ -375,7 +406,6 @@ std::vector<RelayPortFactory::RelayHostStatus> RelayPortFactory::getRelayHosts()
 void RelayPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback,
                                     const std::string& pattern, uint16_t pType) {
     tick();
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     std::regex regexPattern;
     try {
@@ -384,15 +414,29 @@ void RelayPortFactory::locatePorts(std::function<void(PortFactory*, uint16_t, st
         return;
     }
 
-    for (const auto& [url, hostPtr] : relayHosts_) {
-        const RelayHost& host = *hostPtr;
-        if (!host.enabled)
-            continue;
-        for (const auto& portUrl : host.knownPortUrls) {
-            if (std::regex_match(portUrl, regexPattern)) {
-                portCallback(this, PORT_TYPE__TCP | PORT_TYPE__COMM | pType, portUrl);
+    // Snapshot the matching port URLs under mutex_, then invoke portCallback OUTSIDE the
+    // lock. portCallback -> PortManager::portHandler -> bindPort -> TcpPortFactory resolves
+    // the port's host via getaddrinfo(); for a relay serving .local device URIs that drops
+    // into nss-mdns and can block for seconds. Holding mutex_ across that starves the UI
+    // thread's getRelayHosts() and freezes the Port Options dialog (SN-8175). Same
+    // "collect under lock, act outside" pattern used by the dtor and setRelayHostEnabled.
+    std::vector<std::string> toEmit;
+    {
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
+        for (const auto& [url, hostPtr] : relayHosts_) {
+            const RelayHost& host = *hostPtr;
+            if (!host.enabled)
+                continue;
+            for (const auto& portUrl : host.knownPortUrls) {
+                if (std::regex_match(portUrl, regexPattern)) {
+                    toEmit.push_back(portUrl);
+                }
             }
         }
+    }
+
+    for (const auto& portUrl : toEmit) {
+        portCallback(this, PORT_TYPE__TCP | PORT_TYPE__COMM | pType, portUrl);
     }
 }
 
@@ -453,36 +497,92 @@ bool RelayPortFactory::releasePort(port_handle_t port) {
 
 void RelayPortFactory::tick() {
     auto& self = getInstance();
-    std::lock_guard<std::recursive_mutex> lock(self.mutex_);
 
-    auto now = std::chrono::steady_clock::now();
-    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - self.lastMdnsQueryTime_);
-    if (elapsed.count() > MDNS_QUERY_INTERVAL_MS) {
-        mdns::sendQuery(MDNS_RECORDTYPE_PTR, "_inertialsense-discovery._tcp.local");
-        self.lastMdnsQueryTime_ = now;
-    }
-    mdns::tick();
+    // Teardown collected under the lock, executed OUTSIDE it: reaped mDNS hosts (whose
+    // announcements aged out) keep their RelayHost alive in `reaped` until their SSE worker
+    // is joined, so a worker currently blocked acquiring mutex_ can finish first. Mirrors
+    // the dtor / removeRelayHost pattern; joining under the lock would deadlock (SN-8177).
+    std::vector<std::unique_ptr<RelayHost>> reaped;
+    std::vector<std::function<void()>> abortHooks;
 
-    self.discoverRelayHostsViaMdns();
+    {
+        std::lock_guard<std::recursive_mutex> lock(self.mutex_);
 
-    // Only poll hosts that have fallen back to Polling transport.
-    // SSE hosts drive their own state via the worker thread.
-    for (auto& [url, hostPtr] : self.relayHosts_) {
-        RelayHost& host = *hostPtr;
-        if (!host.enabled) continue;
-        if (host.activeTransport != RelayFeedType::Polling) continue;
-        auto sincePoll = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastPollTime);
-        if (sincePoll >= self.pollInterval_ || host.lastPollTime == std::chrono::steady_clock::time_point{}) {
-            self.pollRelayHost(host);
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - self.lastMdnsQueryTime_);
+        if (elapsed.count() > MDNS_QUERY_INTERVAL_MS) {
+            mdns::sendQuery(MDNS_RECORDTYPE_PTR, "_inertialsense-discovery._tcp.local");
+            self.lastMdnsQueryTime_ = now;
+        }
+        mdns::tick();
+
+        self.discoverRelayHostsViaMdns(reaped, abortHooks);
+
+        // SN-8177: evict ports for any enabled host gone silent past the grace window
+        // (no SSE bytes incl. keepalive, no successful poll). Clearing devices +
+        // knownPortUrls makes validatePort() fail for those ports, so PortManager's next
+        // sweep removes them and closes their sockets — including ports the user had open.
+        // They reappear from the next snapshot if the host comes back.
+        for (auto& [url, hostPtr] : self.relayHosts_) {
+            RelayHost& host = *hostPtr;
+            if (!host.enabled) continue;
+            auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
+            if (silentMs > OFFLINE_EVICT_MS && (!host.devices.empty() || !host.knownPortUrls.empty())) {
+                log_warn(IS_LOG_PORT_FACTORY,
+                         "RelayPortFactory: relay '%s' silent %lldms; evicting %zu port(s)",
+                         host.url.c_str(), (long long)silentMs, host.knownPortUrls.size());
+                host.devices.clear();
+                host.knownPortUrls.clear();
+                if (host.lastError.empty()) host.lastError = "relay offline; ports evicted";
+            }
+        }
+
+        // Poll hosts on the Polling transport, gated by an escalating backoff while lost
+        // (SN-8177) so a dead host isn't hammered. SSE hosts drive their own reconnect on
+        // the worker thread; the eviction pass above still drops their ports when silent.
+        for (auto& [url, hostPtr] : self.relayHosts_) {
+            RelayHost& host = *hostPtr;
+            if (!host.enabled) continue;
+            if (host.activeTransport != RelayFeedType::Polling) continue;
+            auto interval = self.reconnectInterval(host, now);
+            auto sinceAttempt = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastAttemptTime);
+            if (host.lastAttemptTime == std::chrono::steady_clock::time_point{} || sinceAttempt >= interval) {
+                self.pollRelayHost(host);
+            }
         }
     }
+
+    // Signal + join reaped mDNS workers outside the lock.
+    for (auto& hook : abortHooks) if (hook) hook();
+    for (auto& host : reaped) {
+        if (host && host->streamThread && host->streamThread->joinable())
+            host->streamThread->join();
+    }
+}
+
+// Escalating reconnect/poll cadence for a host based on how long it's been silent.
+std::chrono::milliseconds RelayPortFactory::reconnectInterval(
+        const RelayHost& host, std::chrono::steady_clock::time_point now) const {
+    auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
+    // Healthy / recently-lost (still inside the eviction grace): normal cadence so a brief
+    // blip recovers quickly.
+    if (silentMs < OFFLINE_EVICT_MS) {
+        return pollInterval_;
+    }
+    // Lost: grow ~ one step per minute, capped at LOST_BACKOFF_MAX_MS (reached by ~10 min).
+    int64_t minutesLost = silentMs / 60000;
+    int64_t backoffMs = 6000 * (minutesLost + 1);   // 6s, 12s, ... -> 60s
+    if (backoffMs > LOST_BACKOFF_MAX_MS) backoffMs = LOST_BACKOFF_MAX_MS;
+    return std::chrono::milliseconds(backoffMs);
 }
 
 // ============================================================
 // mDNS relay-host discovery (honors SN-7804 http_port TXT key)
 // ============================================================
 
-void RelayPortFactory::discoverRelayHostsViaMdns() {
+void RelayPortFactory::discoverRelayHostsViaMdns(
+        std::vector<std::unique_ptr<RelayHost>>& reaped,
+        std::vector<std::function<void()>>& abortHooks) {
     // mutex_ is already held by tick()
 
     auto ptrRecords = mdns::getRecords([](const mdns::mdns_record_cpp_t& r) {
@@ -490,6 +590,7 @@ void RelayPortFactory::discoverRelayHostsViaMdns() {
     });
 
     std::set<std::string> seenHostnames;
+    std::set<std::string> advertisedUrls;   // canonical URLs currently announced via mDNS
     for (const auto& ptr : ptrRecords) {
         auto srvRecords = mdns::getRecords([&ptr](const mdns::mdns_record_cpp_t& r) {
             return r.type == MDNS_RECORDTYPE_SRV && r.name == ptr.data.ptr.name;
@@ -519,6 +620,7 @@ void RelayPortFactory::discoverRelayHostsViaMdns() {
         }
 
         std::string url = "http://" + hostname + ":" + std::to_string(httpPort);
+        advertisedUrls.insert(url);
         if (relayHosts_.find(url) == relayHosts_.end()) {
             auto host = std::make_unique<RelayHost>();
             host->url = url;
@@ -526,6 +628,33 @@ void RelayPortFactory::discoverRelayHostsViaMdns() {
             host->viaMdns = true;
             relayHosts_[url] = std::move(host);
             log_info(IS_LOG_PORT_FACTORY, "RelayPortFactory: discovered relay host via mDNS: '%s'", url.c_str());
+        }
+    }
+
+    // SN-8177: reap mDNS-discovered hosts whose announcement has aged out of the cache.
+    // mDNS is link-local, so a vanished announcement means the host is genuinely gone —
+    // drop it and stop reconnecting (it re-adds itself if it reappears). Guards:
+    //   * only viaMdns hosts (manual hosts persist and keep retrying with backoff);
+    //   * not while a stream is still connected (reachable by IP despite no mDNS) —
+    //     let it be reaped when the connection also drops, not kill a live link;
+    //   * only once it's also been silent past the eviction grace, so a transient mDNS
+    //     cache gap can't wipe a host that's still in contact.
+    // Reaped hosts are moved out (kept alive) and joined OUTSIDE mutex_ by the caller.
+    auto now = std::chrono::steady_clock::now();
+    for (auto it = relayHosts_.begin(); it != relayHosts_.end(); ) {
+        RelayHost& host = *it->second;
+        const bool recordGone = host.viaMdns && advertisedUrls.find(host.url) == advertisedUrls.end();
+        auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
+        if (recordGone && !host.streamConnected.load() && silentMs > OFFLINE_EVICT_MS) {
+            log_info(IS_LOG_PORT_FACTORY,
+                     "RelayPortFactory: mDNS relay host '%s' announcement expired; dropping (%zu port(s))",
+                     host.url.c_str(), host.knownPortUrls.size());
+            host.stopRequested.store(true);
+            if (host.sseAbortHook) abortHooks.push_back(host.sseAbortHook);
+            if (host.streamThread) reaped.push_back(std::move(it->second));
+            it = relayHosts_.erase(it);
+        } else {
+            ++it;
         }
     }
 }
@@ -536,6 +665,9 @@ void RelayPortFactory::discoverRelayHostsViaMdns() {
 
 void RelayPortFactory::pollRelayHost(RelayHost& host) {
     // mutex_ is held by tick() (caller).
+    // Stamp the attempt time up front (success or fail) so the backoff cadence in tick()
+    // advances even when the host is unreachable (SN-8177).
+    host.lastAttemptTime = std::chrono::steady_clock::now();
     auto [hostname, port] = splitBaseUrl(host.url, DEFAULT_HTTP_PORT);
 
     httplib::Client client(hostname, port);
@@ -565,7 +697,7 @@ void RelayPortFactory::pollRelayHost(RelayHost& host) {
     }
 
     SnapshotResult snap;
-    if (!parseSnapshotJson(doc, snap)) {
+    if (!parseSnapshotJson(doc, snap, hostname)) {
         host.consecutiveFailures++;
         host.lastError = "Expected SN-7804 availableDevices envelope (missing 'devices' array)";
         return;
@@ -584,6 +716,7 @@ void RelayPortFactory::pollRelayHost(RelayHost& host) {
 
     host.devices = std::move(snap.devices);
     host.lastPollTime = std::chrono::steady_clock::now();
+    host.lastContact = host.lastPollTime;   // successful poll counts as contact (SN-8177)
     host.lastError.clear();
     host.consecutiveFailures = 0;
 
@@ -670,6 +803,10 @@ void RelayPortFactory::sseWorkerLoop(RelayHost& host) {
 
             std::lock_guard<std::recursive_mutex> lock(mutex_);
 
+            // Relay-reachable host for rewriting device URIs off their (possibly unresolvable)
+            // .local form — see rewriteUriHost / SN-8175. host.url is fixed at creation.
+            const std::string relayHost = splitBaseUrl(host.url, DEFAULT_HTTP_PORT).first;
+
             // server_instance_id change → force fresh snapshot state on all events
             if (!evtInstance.empty() && !host.serverInstanceId.empty() &&
                 evtInstance != host.serverInstanceId) {
@@ -682,13 +819,14 @@ void RelayPortFactory::sseWorkerLoop(RelayHost& host) {
             if (!evtInstance.empty())      host.serverInstanceId = evtInstance;
             if (evtSnapshotId > host.lastSnapshotId) host.lastSnapshotId = evtSnapshotId;
             host.lastEventTime = std::chrono::steady_clock::now();
+            host.lastContact = host.lastEventTime;   // event = contact (SN-8177)
             host.lastError.clear();
             // First byte received → SSE connection confirmed
             host.activeTransport = RelayFeedType::SSE;
 
             if (evt == EVT_SNAPSHOT) {
                 SnapshotResult snap;
-                if (parseSnapshotJson(payload, snap)) {
+                if (parseSnapshotJson(payload, snap, relayHost)) {
                     // Replace devices; rebuild knownPortUrls from snapshot (authoritative resync)
                     host.knownPortUrls.clear();
                     host.devices = std::move(snap.devices);
@@ -696,7 +834,7 @@ void RelayPortFactory::sseWorkerLoop(RelayHost& host) {
                 }
             } else if (evt == EVT_DEVICE_ADDED || evt == EVT_DEVICE_CHANGED) {
                 DeviceRecord rec;
-                if (parseDeviceJson(payload, rec)) {
+                if (parseDeviceJson(payload, rec, relayHost)) {
                     // Replace any prior record for the same URI (device.changed), then upsert.
                     auto it = std::find_if(host.devices.begin(), host.devices.end(),
                         [&](const DeviceRecord& d) { return d.portUrl == rec.portUrl; });
@@ -716,6 +854,8 @@ void RelayPortFactory::sseWorkerLoop(RelayHost& host) {
                 }
             } else if (evt == EVT_DEVICE_REMOVED) {
                 std::string uri = payload.is_object() ? payload.value("uri", std::string{}) : std::string{};
+                // Rewrite to match the stored (relay-host-rebound) portUrls — see SN-8175.
+                uri = rewriteUriHost(uri, relayHost);
                 if (!uri.empty()) {
                     host.devices.erase(std::remove_if(host.devices.begin(), host.devices.end(),
                                         [&](const DeviceRecord& d) { return d.portUrl == uri; }),
@@ -733,6 +873,13 @@ void RelayPortFactory::sseWorkerLoop(RelayHost& host) {
             if (firstChunk) {
                 log_debug(IS_LOG_PORT_FACTORY, "RelayPortFactory: SSE stream connected to '%s' (%zu bytes first chunk)",
                           host.url.c_str(), size);
+            }
+
+            // Any bytes — including SSE `:` keepalive comments that never reach applyFrame —
+            // count as contact, so a healthy idle stream isn't falsely evicted (SN-8177).
+            {
+                std::lock_guard<std::recursive_mutex> lock(mutex_);
+                host.lastContact = std::chrono::steady_clock::now();
             }
 
             buffer.append(data, size);

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -167,6 +167,16 @@ public:
     /// the host falls back to polling transport for the remainder of its enabled lifetime.
     static constexpr uint32_t DEFAULT_MAX_SSE_RETRIES = 3;
 
+    /// SN-8177: a host with no contact (no SSE bytes incl. keepalive, no successful poll)
+    /// for this long is considered offline — its ports are evicted (PortManager closes +
+    /// removes them on its next sweep). Ports reappear from the next snapshot if it returns.
+    static constexpr int64_t OFFLINE_EVICT_MS = 30000;
+
+    /// SN-8177: escalating reconnect backoff for a "lost" manually-configured host. The probe
+    /// interval grows roughly each minute the host has been silent, capping here (~10 min in).
+    /// Keeps a dead-but-maybe-returning relay from being hammered (and blocking the IO thread).
+    static constexpr int64_t LOST_BACKOFF_MAX_MS = 60000;
+
     /// mDNS query interval (ms) — matches ISmDnsPortFactory's rate
     static constexpr int64_t MDNS_QUERY_INTERVAL_MS = 200;
 
@@ -186,6 +196,10 @@ private:
                                                                     ///< survive device resets (WaitRecover keeps the listener open).
         std::chrono::steady_clock::time_point lastPollTime = {};    ///< last successful poll (Polling mode)
         std::chrono::steady_clock::time_point lastEventTime = {};   ///< last SSE event received (SSE mode)
+        std::chrono::steady_clock::time_point lastContact = {};     ///< last contact of ANY kind: SSE bytes (incl. keepalive) or a
+                                                                    ///< successful poll. Drives offline port eviction + reconnect backoff.
+                                                                    ///< Seeded to "now" on enable so a never-reachable host starts its grace then.
+        std::chrono::steady_clock::time_point lastAttemptTime = {}; ///< last poll ATTEMPT (success or failure) — gates the backoff cadence.
         std::string  lastError;
         uint32_t     consecutiveFailures = 0;                       ///< polling failure counter (resets on success)
 
@@ -217,8 +231,20 @@ private:
     std::chrono::milliseconds pollInterval_ = std::chrono::seconds(1);
     std::chrono::steady_clock::time_point lastMdnsQueryTime_ = {}; ///< rate-limit mDNS queries
 
-    /// Rate-limited mDNS host discovery (reads from shared mdns:: cache).
-    void discoverRelayHostsViaMdns();
+    /// Rate-limited mDNS host discovery (reads from shared mdns:: cache). Adds newly-seen
+    /// hosts and reaps viaMdns hosts whose announcement has aged out of the cache. Reaped
+    /// hosts are moved into @p reaped (kept alive until their worker is joined) with their
+    /// abort hooks pushed to @p abortHooks; the caller signals + joins OUTSIDE mutex_ so a
+    /// worker blocked acquiring mutex_ can make progress (see SN-8177 / the dtor pattern).
+    /// Call with mutex_ held.
+    void discoverRelayHostsViaMdns(std::vector<std::unique_ptr<RelayHost>>& reaped,
+                                   std::vector<std::function<void()>>& abortHooks);
+
+    /// Compute the next reconnect/poll interval for a host based on how long it's been silent:
+    /// the normal poll interval while healthy/recently-lost, escalating toward LOST_BACKOFF_MAX_MS
+    /// the longer it stays lost. Call with mutex_ held.
+    std::chrono::milliseconds reconnectInterval(const RelayHost& host,
+                                                std::chrono::steady_clock::time_point now) const;
 
     /// Poll a single relay host's /api/availableDevices endpoint (fallback transport).
     void pollRelayHost(RelayHost& host);

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -71,30 +71,32 @@ public:
 
     // -- Per-device record parsed from the relay's HTTP response --
     struct DeviceRecord {
-        std::string  portUrl;       ///< tcp://host:port — the actual port to bind/connect
-        dev_info_t   hint = {};     ///< bridgeboard-authoritative device info for seedDeviceHint()
+        std::string  portUrl;       //!< tcp://host:port — the actual port to bind/connect
+        dev_info_t   hint = {};     //!< bridgeboard-authoritative device info for seedDeviceHint()
     };
 
-    /// Active transport in use for a given relay host. Exposed via RelayHostStatus
-    /// so UIs can render a badge (and so tests can assert fallback behavior).
+    /**
+     * Active transport in use for a given relay host. Exposed via RelayHostStatus
+     * so UIs can render a badge (and so tests can assert fallback behavior).
+     */
     enum class RelayFeedType : uint8_t {
-        Auto    = 0, ///< initial / negotiating — not yet connected via any transport
-        SSE     = 1, ///< push-based /api/events/devices stream is connected
-        Polling = 2, ///< one-shot polling of /api/availableDevices (SSE unavailable or failed)
+        Auto    = 0, //!< initial / negotiating — not yet connected via any transport
+        SSE     = 1, //!< push-based /api/events/devices stream is connected
+        Polling = 2, //!< one-shot polling of /api/availableDevices (SSE unavailable or failed)
     };
 
     // -- Per-host status snapshot (returned by getRelayHosts()) --
     struct RelayHostStatus {
-        std::string  url;                                           ///< http://host:port (canonical base URL; no path)
-        bool         enabled = false;                               ///< whether this host contributes ports
-        bool         viaMdns = false;                               ///< true if discovered via mDNS, false if manually added
-        std::chrono::steady_clock::time_point lastPollTime = {};    ///< time of last successful poll (Polling mode)
-        std::chrono::steady_clock::time_point lastEventTime = {};   ///< time of last SSE event received (SSE mode)
-        std::string  lastError;                                     ///< empty on success; descriptive string on failure
-        uint32_t     consecutiveFailures = 0;                       ///< reset to 0 on each successful poll/event
-        size_t       deviceCount = 0;                               ///< number of devices reported by this host
-        RelayFeedType feedType = RelayFeedType::Auto;               ///< active transport in use
-        bool         streamConnected = false;                       ///< true iff an SSE stream is currently open
+        std::string  url;                                           //!< http://host:port (canonical base URL; no path)
+        bool         enabled = false;                               //!< whether this host contributes ports
+        bool         viaMdns = false;                               //!< true if discovered via mDNS, false if manually added
+        std::chrono::steady_clock::time_point lastPollTime = {};    //!< time of last successful poll (Polling mode)
+        std::chrono::steady_clock::time_point lastEventTime = {};   //!< time of last SSE event received (SSE mode)
+        std::string  lastError;                                     //!< empty on success; descriptive string on failure
+        uint32_t     consecutiveFailures = 0;                       //!< reset to 0 on each successful poll/event
+        size_t       deviceCount = 0;                               //!< number of devices reported by this host
+        RelayFeedType feedType = RelayFeedType::Auto;               //!< active transport in use
+        bool         streamConnected = false;                       //!< true iff an SSE stream is currently open
     };
 
     // -- Service-style management API --
@@ -102,42 +104,96 @@ public:
     /**
      * Manually register a relay host URL (e.g., "http://192.168.1.50:8080/api/status").
      * Hosts added this way are marked viaMdns=false and start enabled=false.
+     *
+     * @param url  relay URL in any accepted form (bare host, host:port, or full URL);
+     *             normalized internally to the canonical "http://host:port" key
      */
     void addRelayHost(const std::string& url);
 
     /**
-     * Remove a relay host (manual or mDNS-discovered). Returns true if the host was found and removed.
+     * Remove a relay host (manual or mDNS-discovered) and tear down its SSE worker.
+     *
+     * @param url  relay URL identifying the host (normalized internally)
+     * @return true if the host was found and removed, false if it was not known
      */
     bool removeRelayHost(const std::string& url);
 
     /**
-     * Enable or disable a known relay host. Disabled hosts are still listed by getRelayHosts()
-     * but do not contribute ports to PortManager.
+     * Enable or disable a known relay host. Disabled hosts are still listed by
+     * getRelayHosts() but do not contribute ports to PortManager.
+     *
+     * @param url      relay URL identifying the host (normalized internally)
+     * @param enabled  true to start contributing ports (spawns the SSE worker),
+     *                 false to stop and release the host's ports
      */
     void setRelayHostEnabled(const std::string& url, bool enabled);
 
     /**
-     * Returns the current set of known relay hosts (mDNS-discovered + manually added) with per-host status.
-     * Thread-safe (snapshot under mutex).
+     * Returns the current set of known relay hosts (mDNS-discovered + manually added)
+     * with per-host status. Thread-safe (snapshot taken under the factory mutex).
+     *
+     * @return a RelayHostStatus snapshot for every known relay host
      */
     std::vector<RelayHostStatus> getRelayHosts() const;
 
-    // -- PortFactory interface --
+    // ============================================================
+    // PortFactory interface
+    // ============================================================
+
+    /**
+     * Emit every port known from enabled relay hosts whose URL matches @p pattern.
+     *
+     * @param portCallback  invoked once per matching port (factory, type flags, tcp:// URL)
+     * @param pattern       regex matched against each known relay port URL
+     * @param pType         caller's requested port-type flags, OR'd into the emitted type
+     */
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
+
+    /**
+     * @param pName  candidate tcp:// port URL
+     * @param pType  port-type flags; must include PORT_TYPE__TCP
+     * @return true if @p pName is a TCP port currently known to an enabled relay host
+     */
     bool validatePort(const std::string& pName, uint16_t pType = 0) override;
+
+    /**
+     * Bind a relay-known TCP port (delegated to TcpPortFactory) and seed its device hint.
+     *
+     * @param pName  tcp:// port URL to bind
+     * @param pType  port-type flags
+     * @return the bound port handle, or nullptr if validation or binding failed
+     */
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
+
+    /**
+     * Release a port previously returned by bindPort().
+     *
+     * @param port  the port handle to release
+     * @return true on success
+     */
     bool releasePort(port_handle_t port) override;
 
-    /// PortManager calls this when our locatePorts() emit was deduped against an existing
-    /// port (typically TcpPortFactory got there first for a relay-known tcp:// URL). The
-    /// existing port handle is fine; we just need to seed our device hint into
-    /// DeviceManager so beginValidation can use it. Does NOT create a new port.
+    /**
+     * PortManager calls this when our locatePorts() emit was deduped against an existing
+     * port (typically TcpPortFactory got there first for a relay-known tcp:// URL). The
+     * existing port handle is fine; we just need to seed our device hint into
+     * DeviceManager so beginValidation can use it. Does NOT create a new port.
+     *
+     * @param existing  the already-bound port handle our emitted URL aliased onto
+     * @param pName     the tcp:// URL we emitted (matches an enabled host's device)
+     * @param pType     port-type flags (unused; the alias target's type is authoritative)
+     */
     void onPortAlias(port_handle_t existing, const std::string& pName, uint16_t pType) override;
 
 private:
-    /// Internal helper: if @p portUrl appears in any enabled relay host's device list,
-    /// seed that device's hint into DeviceManager keyed by @p port. Shared by
-    /// bindPort() and onPortAlias().
+    /**
+     * Internal helper: if @p portUrl appears in any enabled relay host's device list,
+     * seed that device's hint into DeviceManager keyed by @p port. Shared by
+     * bindPort() and onPortAlias().
+     *
+     * @param port     the bound port handle to associate the hint with
+     * @param portUrl  the tcp:// URL whose relay device hint should be seeded
+     */
     void seedHintForPortIfKnown(port_handle_t port, const std::string& portUrl);
 
 public:
@@ -157,27 +213,33 @@ public:
     void setPollInterval(std::chrono::milliseconds interval) { pollInterval_ = interval; }
     std::chrono::milliseconds getPollInterval() const { return pollInterval_; }
 
-    /// Default HTTP port assumed for mDNS-discovered hosts (bridgeboard default).
+    /** Default HTTP port assumed for mDNS-discovered hosts (bridgeboard default). */
     static constexpr uint16_t DEFAULT_HTTP_PORT = 8080;
 
-    /// Default number of consecutive failures before logging a warning (ports are retained).
+    /** Default number of consecutive failures before logging a warning (ports are retained). */
     static constexpr uint32_t DEFAULT_FAILURE_GRACE_COUNT = 3;
 
-    /// Default SSE retry budget — after this many consecutive connect/read failures,
-    /// the host falls back to polling transport for the remainder of its enabled lifetime.
+    /**
+     * Default SSE retry budget — after this many consecutive connect/read failures,
+     * the host falls back to polling transport for the remainder of its enabled lifetime.
+     */
     static constexpr uint32_t DEFAULT_MAX_SSE_RETRIES = 3;
 
-    /// SN-8177: a host with no contact (no SSE bytes incl. keepalive, no successful poll)
-    /// for this long is considered offline — its ports are evicted (PortManager closes +
-    /// removes them on its next sweep). Ports reappear from the next snapshot if it returns.
+    /**
+     * SN-8177: a host with no contact (no SSE bytes incl. keepalive, no successful poll)
+     * for this long is considered offline — its ports are evicted (PortManager closes +
+     * removes them on its next sweep). Ports reappear from the next snapshot if it returns.
+     */
     static constexpr int64_t OFFLINE_EVICT_MS = 30000;
 
-    /// SN-8177: escalating reconnect backoff for a "lost" manually-configured host. The probe
-    /// interval grows roughly each minute the host has been silent, capping here (~10 min in).
-    /// Keeps a dead-but-maybe-returning relay from being hammered (and blocking the IO thread).
+    /**
+     * SN-8177: escalating reconnect backoff for a "lost" manually-configured host. The probe
+     * interval grows roughly each minute the host has been silent, capping here (~10 min in).
+     * Keeps a dead-but-maybe-returning relay from being hammered (and blocking the IO thread).
+     */
     static constexpr int64_t LOST_BACKOFF_MAX_MS = 60000;
 
-    /// mDNS query interval (ms) — matches ISmDnsPortFactory's rate
+    /** mDNS query interval (ms) — matches ISmDnsPortFactory's rate */
     static constexpr int64_t MDNS_QUERY_INTERVAL_MS = 200;
 
 private:
@@ -186,31 +248,31 @@ private:
 
     // -- Internal per-host state --
     struct RelayHost {
-        std::string  url;                                           ///< canonical "http://host:port" (no path)
+        std::string  url;                                           //!< canonical "http://host:port" (no path)
         bool         enabled = false;
         bool         viaMdns = false;
-        std::vector<DeviceRecord> devices;                          ///< latest poll/snapshot result (metadata + hints)
-        std::set<std::string> knownPortUrls;                        ///< high-water mark of tcp:// URLs ever seen from this host.
-                                                                    ///< Only cleared on host disable/remove. Ports persist across
-                                                                    ///< device reboots because bridgeboard's slot-based TCP sockets
-                                                                    ///< survive device resets (WaitRecover keeps the listener open).
-        std::chrono::steady_clock::time_point lastPollTime = {};    ///< last successful poll (Polling mode)
-        std::chrono::steady_clock::time_point lastEventTime = {};   ///< last SSE event received (SSE mode)
-        std::chrono::steady_clock::time_point lastContact = {};     ///< last contact of ANY kind: SSE bytes (incl. keepalive) or a
-                                                                    ///< successful poll. Drives offline port eviction + reconnect backoff.
-                                                                    ///< Seeded to "now" on enable so a never-reachable host starts its grace then.
-        std::chrono::steady_clock::time_point lastAttemptTime = {}; ///< last poll ATTEMPT (success or failure) — gates the backoff cadence.
+        std::vector<DeviceRecord> devices;                          //!< latest poll/snapshot result (metadata + hints)
+        std::set<std::string> knownPortUrls;                        //!< high-water mark of tcp:// URLs ever seen from this host.
+                                                                    //!< Only cleared on host disable/remove. Ports persist across
+                                                                    //!< device reboots because bridgeboard's slot-based TCP sockets
+                                                                    //!< survive device resets (WaitRecover keeps the listener open).
+        std::chrono::steady_clock::time_point lastPollTime = {};    //!< last successful poll (Polling mode)
+        std::chrono::steady_clock::time_point lastEventTime = {};   //!< last SSE event received (SSE mode)
+        std::chrono::steady_clock::time_point lastContact = {};     //!< last contact of ANY kind: SSE bytes (incl. keepalive) or a
+                                                                    //!< successful poll. Drives offline port eviction + reconnect backoff.
+                                                                    //!< Seeded to "now" on enable so a never-reachable host starts its grace then.
+        std::chrono::steady_clock::time_point lastAttemptTime = {}; //!< last poll ATTEMPT (success or failure) — gates the backoff cadence.
         std::string  lastError;
-        uint32_t     consecutiveFailures = 0;                       ///< polling failure counter (resets on success)
+        uint32_t     consecutiveFailures = 0;                       //!< polling failure counter (resets on success)
 
         // -- SSE worker state (populated while feedType == SSE) --
-        std::string  serverInstanceId;                              ///< remote bridgeboard's UUID (restart detection)
-        uint64_t     lastSnapshotId = 0;                            ///< numeric half of <instance_id>:<snapshot_id> for Last-Event-ID
-        std::unique_ptr<std::thread> streamThread;                  ///< worker running the /api/events/devices reader
-        std::atomic<bool> stopRequested{false};                     ///< asks the SSE worker to exit cleanly
-        std::function<void()> sseAbortHook;                         ///< set by worker; aborts the current httplib request (unblocks recv)
-        std::atomic<bool> streamConnected{false};                   ///< true while the SSE stream is open
-        uint32_t     sseConsecutiveFailures = 0;                    ///< drives fallback to Polling after DEFAULT_MAX_SSE_RETRIES
+        std::string  serverInstanceId;                              //!< remote bridgeboard's UUID (restart detection)
+        uint64_t     lastSnapshotId = 0;                            //!< numeric half of <instance_id>:<snapshot_id> for Last-Event-ID
+        std::unique_ptr<std::thread> streamThread;                  //!< worker running the /api/events/devices reader
+        std::atomic<bool> stopRequested{false};                     //!< asks the SSE worker to exit cleanly
+        std::function<void()> sseAbortHook;                         //!< set by worker; aborts the current httplib request (unblocks recv)
+        std::atomic<bool> streamConnected{false};                   //!< true while the SSE stream is open
+        uint32_t     sseConsecutiveFailures = 0;                    //!< drives fallback to Polling after DEFAULT_MAX_SSE_RETRIES
 
         // -- Transport mode --
         RelayFeedType activeTransport = RelayFeedType::Auto;
@@ -223,39 +285,68 @@ private:
         RelayHost& operator=(RelayHost&&) = delete;
     };
 
-    /// Hosts are keyed by canonical URL. std::map gives stable iterator/reference semantics,
-    /// which matters because the SSE worker holds a reference to its RelayHost for the
-    /// lifetime of the stream. unique_ptr keeps RelayHost move-stable on container growth.
+    /**
+     * Hosts are keyed by canonical URL. std::map gives stable iterator/reference semantics,
+     * which matters because the SSE worker holds a reference to its RelayHost for the
+     * lifetime of the stream. unique_ptr keeps RelayHost move-stable on container growth.
+     */
     std::map<std::string, std::unique_ptr<RelayHost>> relayHosts_;
     mutable std::recursive_mutex mutex_;
     std::chrono::milliseconds pollInterval_ = std::chrono::seconds(1);
-    std::chrono::steady_clock::time_point lastMdnsQueryTime_ = {}; ///< rate-limit mDNS queries
+    std::chrono::steady_clock::time_point lastMdnsQueryTime_ = {}; //!< rate-limit mDNS queries
 
-    /// Rate-limited mDNS host discovery (reads from shared mdns:: cache). Adds newly-seen
-    /// hosts and reaps viaMdns hosts whose announcement has aged out of the cache. Reaped
-    /// hosts are moved into @p reaped (kept alive until their worker is joined) with their
-    /// abort hooks pushed to @p abortHooks; the caller signals + joins OUTSIDE mutex_ so a
-    /// worker blocked acquiring mutex_ can make progress (see SN-8177 / the dtor pattern).
-    /// Call with mutex_ held.
+    /**
+     * Rate-limited mDNS host discovery (reads from shared mdns:: cache). Adds newly-seen
+     * hosts and reaps viaMdns hosts whose announcement has aged out of the cache. Reaped
+     * hosts are moved into @p reaped (kept alive until their worker is joined) with their
+     * abort hooks pushed to @p abortHooks; the caller signals + joins OUTSIDE mutex_ so a
+     * worker blocked acquiring mutex_ can make progress (see SN-8177 / the dtor pattern).
+     * Call with mutex_ held.
+     *
+     * @param[out] reaped      hosts removed this pass, moved here so they outlive their join
+     * @param[out] abortHooks  abort hooks for the reaped hosts' workers, fired before joining
+     */
     void discoverRelayHostsViaMdns(std::vector<std::unique_ptr<RelayHost>>& reaped,
                                    std::vector<std::function<void()>>& abortHooks);
 
-    /// Compute the next reconnect/poll interval for a host based on how long it's been silent:
-    /// the normal poll interval while healthy/recently-lost, escalating toward LOST_BACKOFF_MAX_MS
-    /// the longer it stays lost. Call with mutex_ held.
+    /**
+     * Compute the next reconnect/poll interval for a host based on how long it's been silent:
+     * the normal poll interval while healthy/recently-lost, escalating toward LOST_BACKOFF_MAX_MS
+     * the longer it stays lost. Call with mutex_ held.
+     *
+     * @param host  the host whose cadence to compute
+     * @param now   the current steady_clock time
+     * @return the interval to wait before the next poll/reconnect attempt
+     */
     std::chrono::milliseconds reconnectInterval(const RelayHost& host,
                                                 std::chrono::steady_clock::time_point now) const;
 
-    /// Poll a single relay host's /api/availableDevices endpoint (fallback transport).
+    /**
+     * Poll a single relay host's /api/availableDevices endpoint (fallback transport).
+     *
+     * @param host  the host to poll; updated in place with results or failure state
+     */
     void pollRelayHost(RelayHost& host);
 
-    /// Start the SSE worker thread for a host (call with mutex_ held; releases during I/O).
+    /**
+     * Start the SSE worker thread for a host (call with mutex_ held; releases during I/O).
+     *
+     * @param host  the host to start streaming
+     */
     void startSseWorker(RelayHost& host);
 
-    /// Ask the SSE worker to stop and join it. Safe to call with mutex_ held.
+    /**
+     * Ask the SSE worker to stop and join it. Safe to call with mutex_ held.
+     *
+     * @param host  the host whose worker to stop
+     */
     void stopSseWorker(RelayHost& host);
 
-    /// SSE worker body — runs on host.streamThread. Owns its own I/O and respects stopRequested.
+    /**
+     * SSE worker body — runs on host.streamThread. Owns its own I/O and respects stopRequested.
+     *
+     * @param host  the host this worker streams for
+     */
     void sseWorkerLoop(RelayHost& host);
 };
 

--- a/src/TcpPortFactory.cpp
+++ b/src/TcpPortFactory.cpp
@@ -17,6 +17,10 @@
 #include "TcpPortFactory.h"
 #include "PortManager.h"
 #include <iostream>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 #include <util/uri.hpp>
 #include <util/util.h>
 
@@ -26,6 +30,89 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #endif
+
+namespace {
+
+/// Cache host -> resolved address (port intentionally left zero) with a short TTL.
+///
+/// A relay host serving many device ports hands out URIs that all share one hostname
+/// (e.g. tcp://golden-planet-ce38.local:34663, :34664, ...). Resolving a `.local` name
+/// goes through nss-mdns and blocks on a socket read. Without caching, validatePort and
+/// bindPort each resolve, and every one of N same-host ports re-resolves every discovery
+/// pass — tens of blocking syscalls per pass. Collapsing those to one resolve per host
+/// per TTL keeps discovery responsive (SN-8175). Numeric literals bypass the cache.
+struct ResolvedHost {
+    sockaddr_storage addr;   ///< family + address; sin_port / sin6_port left zero
+    int              family;
+    std::chrono::steady_clock::time_point when;
+};
+
+std::mutex                                  g_resolveCacheMutex;
+std::unordered_map<std::string, ResolvedHost> g_resolveCache;
+constexpr auto                              RESOLVE_CACHE_TTL = std::chrono::seconds(30);
+
+/// Resolve `host` (no service/port) into `out` (family + address only; caller sets the
+/// port). Returns true on success. Thread-safe; numeric addresses skip getaddrinfo.
+bool resolveHostCached(const std::string& host, sockaddr_storage& out, int& family) {
+    sockaddr_storage tmp = {};
+    if (inet_pton(AF_INET, host.c_str(), &reinterpret_cast<sockaddr_in*>(&tmp)->sin_addr) == 1) {
+        out = {};
+        out.ss_family = AF_INET;
+        reinterpret_cast<sockaddr_in*>(&out)->sin_addr = reinterpret_cast<sockaddr_in*>(&tmp)->sin_addr;
+        family = AF_INET;
+        return true;
+    }
+    if (inet_pton(AF_INET6, host.c_str(), &reinterpret_cast<sockaddr_in6*>(&tmp)->sin6_addr) == 1) {
+        out = {};
+        out.ss_family = AF_INET6;
+        reinterpret_cast<sockaddr_in6*>(&out)->sin6_addr = reinterpret_cast<sockaddr_in6*>(&tmp)->sin6_addr;
+        family = AF_INET6;
+        return true;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard<std::mutex> lock(g_resolveCacheMutex);
+        auto it = g_resolveCache.find(host);
+        if (it != g_resolveCache.end() && (now - it->second.when) < RESOLVE_CACHE_TTL) {
+            out    = it->second.addr;
+            family = it->second.family;
+            return true;
+        }
+    }
+
+    struct addrinfo hints = {}, *dns_addr = nullptr;
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    if (getaddrinfo(host.c_str(), nullptr, &hints, &dns_addr) != 0 || !dns_addr) {
+        return false;
+    }
+
+    sockaddr_storage resolved = {};
+    resolved.ss_family = dns_addr->ai_family;
+    if (dns_addr->ai_family == AF_INET) {
+        *reinterpret_cast<sockaddr_in*>(&resolved)  = *reinterpret_cast<sockaddr_in*>(dns_addr->ai_addr);
+        reinterpret_cast<sockaddr_in*>(&resolved)->sin_port = 0;
+    } else if (dns_addr->ai_family == AF_INET6) {
+        *reinterpret_cast<sockaddr_in6*>(&resolved) = *reinterpret_cast<sockaddr_in6*>(dns_addr->ai_addr);
+        reinterpret_cast<sockaddr_in6*>(&resolved)->sin6_port = 0;
+    } else {
+        freeaddrinfo(dns_addr);
+        return false;
+    }
+    family = dns_addr->ai_family;
+    freeaddrinfo(dns_addr);
+
+    {
+        std::lock_guard<std::mutex> lock(g_resolveCacheMutex);
+        g_resolveCache[host] = ResolvedHost{resolved, family, now};
+    }
+    out = resolved;
+    return true;
+}
+
+} // namespace
 
 /**
  * This function parses and creates a new port_handle_t repersenting a TCP Port
@@ -50,40 +137,18 @@ port_handle_t TcpPortFactory::bindPort(const std::string& pName, uint16_t pType)
     }
     std::string uriPort {url.get_port()};
 
+    // Reuse the cached resolution from validatePort() above (same host, same TTL window)
+    // so we don't re-run a blocking .local getaddrinfo here. resolveHostCached fills the
+    // address only; set the port from this URI.
     sockaddr_storage addr = {};
-    sockaddr_storage ipaddr = {};
-    struct addrinfo hints = {}, *dns_addr;
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
-    if (inet_pton(AF_INET, uriHost.c_str(), &ipaddr)) {
-        addr.ss_family = AF_INET;
-        auto* ipv4 = reinterpret_cast<sockaddr_in*>(&addr);
-        ipv4->sin_port = htons(std::stoi(uriPort));
-        ipv4->sin_addr = *reinterpret_cast<in_addr*>(&ipaddr);
-    } else if (inet_pton(AF_INET6, uriHost.c_str(), &ipaddr)) {
-        addr.ss_family = AF_INET6;
-        auto* ipv6 = reinterpret_cast<sockaddr_in6*>(&addr);
-        ipv6->sin6_port = htons(std::stoi(uriPort));
-        ipv6->sin6_addr = *reinterpret_cast<in6_addr*>(&ipaddr);
-    } else if (getaddrinfo(uriHost.c_str(), uriPort.c_str(), &hints, &dns_addr) == 0) {
-        addr.ss_family = dns_addr->ai_family;
-        if (addr.ss_family == AF_INET) {
-            auto* ipv4 = reinterpret_cast<sockaddr_in*>(&addr);
-            auto* ipv4_from_dns = reinterpret_cast<sockaddr_in*>(dns_addr->ai_addr);
-            ipv4->sin_family = ipv4_from_dns->sin_family;
-            ipv4->sin_port = ipv4_from_dns->sin_port;
-            ipv4->sin_addr = ipv4_from_dns->sin_addr;
-        } else if (addr.ss_family == AF_INET6) {
-            auto* ipv6 = reinterpret_cast<sockaddr_in6*>(&addr);
-            auto* ipv6_from_dns = reinterpret_cast<sockaddr_in6*>(dns_addr->ai_addr);
-            ipv6->sin6_family = ipv6_from_dns->sin6_family;
-            ipv6->sin6_port = ipv6_from_dns->sin6_port;
-            ipv6->sin6_flowinfo = ipv6_from_dns->sin6_flowinfo;
-            ipv6->sin6_addr = ipv6_from_dns->sin6_addr;
-            ipv6->sin6_scope_id = ipv6_from_dns->sin6_scope_id;
-        }
-        freeaddrinfo(dns_addr);
+    int family = 0;
+    if (!resolveHostCached(uriHost, addr, family)) {
+        return nullptr;
+    }
+    if (family == AF_INET) {
+        reinterpret_cast<sockaddr_in*>(&addr)->sin_port = htons(static_cast<uint16_t>(std::stoi(uriPort)));
+    } else if (family == AF_INET6) {
+        reinterpret_cast<sockaddr_in6*>(&addr)->sin6_port = htons(static_cast<uint16_t>(std::stoi(uriPort)));
     } else {
         return nullptr;
     }
@@ -129,28 +194,16 @@ bool TcpPortFactory::validatePort(const std::string& pName, uint16_t pType) {
     if (uriHost.rfind("[", 0) == 0 && uriHost.size() > 1 && uriHost[uriHost.size() - 1] == ']') {
         uriHost = uriHost.substr(1, uriHost.size() - 2);
     }
-    std::string uriPort {url.get_port()};
 
     if ((pType & PORT_TYPE__TCP) != PORT_TYPE__TCP) {
         return false;
     }
 
+    // Resolvability is the validation. Cached so a host shared by many device ports
+    // resolves once per TTL window, and so bindPort() reuses this result (SN-8175).
     sockaddr_storage addr = {};
-    if (inet_pton(AF_INET, uriHost.c_str(), &addr)) {
-        return true;
-    }
-    if (inet_pton(AF_INET6, uriHost.c_str(), &addr)) {
-        return true;
-    }
-    struct addrinfo hints = {}, *dns_addr;
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = IPPROTO_TCP;
-    if (getaddrinfo(uriHost.c_str(), uriPort.c_str(), &hints, &dns_addr) == 0) {
-        return true;
-    }
-
-    return false;
+    int family = 0;
+    return resolveHostCached(uriHost, addr, family);
 }
 
 /**

--- a/src/TcpPortFactory.cpp
+++ b/src/TcpPortFactory.cpp
@@ -33,16 +33,18 @@
 
 namespace {
 
-/// Cache host -> resolved address (port intentionally left zero) with a short TTL.
-///
-/// A relay host serving many device ports hands out URIs that all share one hostname
-/// (e.g. tcp://golden-planet-ce38.local:34663, :34664, ...). Resolving a `.local` name
-/// goes through nss-mdns and blocks on a socket read. Without caching, validatePort and
-/// bindPort each resolve, and every one of N same-host ports re-resolves every discovery
-/// pass — tens of blocking syscalls per pass. Collapsing those to one resolve per host
-/// per TTL keeps discovery responsive (SN-8175). Numeric literals bypass the cache.
+/**
+ * Cache host -> resolved address (port intentionally left zero) with a short TTL.
+ *
+ * A relay host serving many device ports hands out URIs that all share one hostname
+ * (e.g. tcp://golden-planet-ce38.local:34663, :34664, ...). Resolving a `.local` name
+ * goes through nss-mdns and blocks on a socket read. Without caching, validatePort and
+ * bindPort each resolve, and every one of N same-host ports re-resolves every discovery
+ * pass — tens of blocking syscalls per pass. Collapsing those to one resolve per host
+ * per TTL keeps discovery responsive (SN-8175). Numeric literals bypass the cache.
+ */
 struct ResolvedHost {
-    sockaddr_storage addr;   ///< family + address; sin_port / sin6_port left zero
+    sockaddr_storage addr;   //!< family + address; sin_port / sin6_port left zero
     int              family;
     std::chrono::steady_clock::time_point when;
 };
@@ -51,8 +53,15 @@ std::mutex                                  g_resolveCacheMutex;
 std::unordered_map<std::string, ResolvedHost> g_resolveCache;
 constexpr auto                              RESOLVE_CACHE_TTL = std::chrono::seconds(30);
 
-/// Resolve `host` (no service/port) into `out` (family + address only; caller sets the
-/// port). Returns true on success. Thread-safe; numeric addresses skip getaddrinfo.
+/**
+ * Resolve @p host (no service/port) into @p out (family + address only; caller sets the
+ * port). Thread-safe; numeric addresses skip getaddrinfo and the cache.
+ *
+ * @param host        hostname or numeric IP literal to resolve
+ * @param[out] out     filled with the resolved address (port left zero)
+ * @param[out] family  the resolved address family (AF_INET / AF_INET6)
+ * @return true on success, false if the host could not be resolved
+ */
 bool resolveHostCached(const std::string& host, sockaddr_storage& out, int& family) {
     sockaddr_storage tmp = {};
     if (inet_pton(AF_INET, host.c_str(), &reinterpret_cast<sockaddr_in*>(&tmp)->sin_addr) == 1) {


### PR DESCRIPTION
## Summary

Fixes two field-found defects in the SN-7805 relay-discovery feature, diagnosed with live gdb thread dumps against EvalTool.

### SN-8175 — Port Options freeze + unresolvable `.local` device URIs
- `RelayPortFactory::locatePorts` now snapshots matching port URLs under `mutex_` and invokes `portCallback` **outside** the lock. Previously it held the factory mutex across `portCallback → bindPort → TcpPortFactory → getaddrinfo`, so a blocking `.local` DNS lookup froze EvalTool's Port Options dialog (the UI thread blocked in `getRelayHosts()`).
- Relay device URIs are rewritten to the relay's **reachable base-URL host** instead of the relayed mDNS `.local` name — which a routed/VPN (Tailscale) client cannot resolve. Since a bridgeboard relays its own devices, they share its host.
- `TcpPortFactory`: host-keyed resolution cache (30s TTL) + removal of the redundant second `getaddrinfo` in `bindPort`.

### SN-8177 — relay endpoint goes offline
- Per-host `lastContact` tracking (any SSE bytes incl. keepalive comments, or a successful poll). `tick()` evicts a host's ports after **30s** of silence — clears `devices`/`knownPortUrls` so PortManager's sweep closes & removes the ports (including open ones). They repopulate from the next snapshot if the relay returns.
- Escalating reconnect backoff for lost **manual** hosts (grows ~per-minute, capped at **60s**); **mDNS** hosts whose announcement ages out are dropped and not retried (torn down outside the lock).
- Relay connect timeout **3s → 2s** so a dead host can't block the IO thread.

## Notes
- Known limitation: after SSE falls back to polling, a recovered relay's ports repopulate via polling (SSE push isn't auto-resumed) — noted on SN-8177.
- Related review (SN-8177 comment): `TcpPort` should self-detect a dropped peer and invalidate independently of factory cleanup — likely a follow-up. (A hard power-loss sends no FIN/RST, so the client socket needs TCP keepalive or a failed write to notice.)

Jira: SN-8175, SN-8177 (linked to SN-7805)

🤖 Generated with [Claude Code](https://claude.com/claude-code)