### PR TITLE
SN-8018: cltool -base listen URI parsing + shared utils::parseUri helper

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -1378,10 +1378,10 @@ void cltool_outputUsage()
 	cout << "            -rover=TCP:RTCM3:192.168.1.100:7777" << endl;
 	cout << "            -rover=TCP:UBLOX:192.168.1.100:7777" << endl;
 	cout << "            -rover=SERIAL:RTCM3:" << EXAMPLE_PORT << ":57600        (port, baud rate)" << endlbOn;
-	cout << "    -base=" << boldOff << "[IP]:[port]   As a Base (sever), send RTK corrections.  Examples:" << endl;
-	cout << "            -base=TCP::7777                             (IP is optional)" << endl;
-	cout << "            -base=TCP:192.168.1.43:7777" << endl;
-	cout << "            -base=SERIAL:" << EXAMPLE_PORT << ":921600" << endl;
+	cout << "    -base=" << boldOff << "TCP://[IP]:[port]   As a Base (server), send RTK corrections.  Examples:" << endl;
+	cout << "            -base=TCP://:7777                           (IP is optional)" << endl;
+	cout << "            -base=TCP://192.168.1.43:7777" << endl;
+	cout << "            -base=TCP://[::1]:7777                      (IPv6 host in brackets)" << endl;
 	cout << endlbOn;	
 	cout << "CLTool - " << boldOff << cltool_version() << endl;
 

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -47,7 +47,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "RelayPortFactory.h"
 #include "PortFactory.h"
 #include "util/natsort.h"
-#include "util/uri.hpp"
+#include "util/util.h"
 
 #include "ISBootloaderThread.h"
 #include "CorrectionService.h"
@@ -69,8 +69,7 @@ static void sendNmea(serial_port_t &port, string nmeaMsg);
 
 /// Extract the hostname portion of a canonical "http://host:port" URL for hostname-based filtering.
 static std::string hostnameFromUrl(const std::string& url) {
-    const FIX8::uri parsed{url};
-    return std::string{parsed.get_host()};
+    return utils::parseUri(url).host;
 }
 
 /// Pre-warm RelayPortFactory: register manual URLs, then pump tick() for up to 3 s so
@@ -653,8 +652,7 @@ static bool cltool_setupCommunications(InertialSense& inertialSenseInterface)
     }
     if (g_commandLineOptions.roverConnection.length() != 0)
     {
-        FIX8::uri uri(g_commandLineOptions.roverConnection);
-        if (uri.parse() && uri.has_scheme() && (std::string(uri.get_scheme()) == "ntrip")) {
+        if (utils::parseUri(g_commandLineOptions.roverConnection).scheme == "ntrip") {
             g_correctionInput = std::make_shared<NtripCorrectionService>(g_commandLineOptions.roverConnection);
         } else {
             g_correctionInput = std::make_shared<CorrectionService>(g_commandLineOptions.roverConnection);
@@ -974,8 +972,7 @@ static int cltool_createHost()
     device_handle_t srcDevice = DeviceManager::getInstance().front();
     inertialSenseInterface.StopBroadcasts();
 
-    // FIXME: Parse the rest of the "baseConnection" command-line argument for the listen address/port for incoming requests and configure the InertialSense correctionServer
-    g_correctionOutput = std::make_shared<Rtcm3CorrectionServer>(srcDevice);
+    g_correctionOutput = std::make_shared<Rtcm3CorrectionServer>(srcDevice, g_commandLineOptions.baseConnection);
     MessageStats::mul_stats_t rtcm3Stats;
     g_correctionOutput->setMessageStats(&rtcm3Stats);
 

--- a/src/ISHttpRequest.cpp
+++ b/src/ISHttpRequest.cpp
@@ -8,7 +8,7 @@
 
 #include "ISHttpRequest.h"
 #include "ISUtilities.h"
-#include "uri.hpp"
+#include "util/util.h"
 #include "TcpPortFactory.h"
 #include "core/msg_logger.h"
 
@@ -209,23 +209,18 @@ ISHttpRequest::Response ISHttpRequest::sendRequest(const std::string& url, const
 {
     Response resp;
 
-    // Parse URL
-    FIX8::basic_uri uri(url);
-    uri.parse();
+    // Parse URL; HTTP defaults to port 80 when the URL omits one
+    const utils::UriParts uri = utils::parseUri(url, "http://:80");
 
-    std::string host(uri.get_host());
-    std::string portStr(uri.get_port());
-    std::string path(uri.get_path());
-
-    if (host.empty())
+    if (!uri.hasHost())
     {
         log_error(IS_LOG_HTTP_REQUEST, "Failed to parse host from URL: %s", url.c_str());
         return resp;
     }
 
-    int port = portStr.empty() ? 80 : std::strtol(portStr.c_str(), nullptr, 10);
-    if (path.empty())
-        path = "/";
+    const std::string& host = uri.host;
+    const int port = uri.port;
+    const std::string path = uri.path.empty() ? "/" : uri.path;
 
     log_info(IS_LOG_HTTP_REQUEST, "%s %s (host=%s, port=%d, path=%s)", method.c_str(), url.c_str(), host.c_str(), port, path.c_str());
 

--- a/src/NtripCorrectionService.cpp
+++ b/src/NtripCorrectionService.cpp
@@ -8,18 +8,15 @@
 
 #include "NtripCorrectionService.h"
 
-#include "uri.hpp"
 #include "protocol_nmea.h"
 #include "TcpPortFactory.h"
+#include "util/util.h"
 
 bool NtripCorrectionService::connect(const std::string& connectUrl, std::string userAgent) {
-    FIX8::basic_uri uri(connectUrl);
-
-    // parse the URL
-    uri.parse();
-    std::string host(uri.get_host());
-    std::string portStr(uri.get_port());
-    int port = std::strtol(portStr.c_str(), NULL, 10);
+    // parse the URL; NTRIP defaults to port 2101 when the caster URL omits one
+    const utils::UriParts uri = utils::parseUri(connectUrl, "ntrip://:2101");
+    const std::string& host = uri.host;
+    const int port = uri.port;
 
     /***
      * One issue here is that connect() is not the same as portOpen(), because connect needs to do some talking
@@ -72,10 +69,10 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
     if (!source || (portOpen(source) != PORT_ERROR__NONE))
         return false;
 
-    std::string msg = "GET " + std::string(uri.get_path()) + " HTTP/1.1\r\n";
+    std::string msg = "GET " + uri.path + " HTTP/1.1\r\n";
     msg += "User-Agent: " + userAgent + "\r\n";
-    if (uri.has_userinfo()) {
-        std::string auth = std::string(uri.get_user()) + ":" + std::string(uri.get_password());
+    if (uri.hasUserinfo()) {
+        std::string auth = uri.user + ":" + uri.password;
         msg += "Authorization: Basic " + base64Encode((const unsigned char*)auth.data(), (int)auth.length()) + "\r\n";
     }
     msg += "Accept: */*\r\nConnection: close\r\n\r\n";

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -25,7 +25,6 @@
 // cpp-httplib and nlohmann/json — used only in this .cpp, not exposed via the header.
 #include "httplib.h"
 #include "json.hpp"
-#include <util/uri.hpp>
 
 using json = nlohmann::json;
 
@@ -70,17 +69,11 @@ std::string normalizeBaseUrl(const std::string& input, uint16_t defaultPort) {
         s = "http://" + s;
     }
 
-    const FIX8::uri parsed{s};
-    std::string host = std::string{parsed.get_host()};
-    std::string portStr = std::string{parsed.get_port()};
-    if (host.empty()) return {};
+    const utils::UriParts parsed = utils::parseUri(s);
+    if (!parsed.hasHost()) return {};
 
-    uint16_t port = defaultPort;
-    if (!portStr.empty()) {
-        try { port = static_cast<uint16_t>(std::stoi(portStr)); } catch (...) { return {}; }
-    }
-
-    return "http://" + host + ":" + std::to_string(port);
+    int port = parsed.hasPort() ? parsed.port : defaultPort;
+    return "http://" + parsed.host + ":" + std::to_string(port);
 }
 
 /**
@@ -91,14 +84,9 @@ std::string normalizeBaseUrl(const std::string& input, uint16_t defaultPort) {
  * @return {hostname, port}; {"", defaultPort} on failure
  */
 std::pair<std::string, int> splitBaseUrl(const std::string& baseUrl, uint16_t defaultPort) {
-    const FIX8::uri parsed{baseUrl};
-    std::string host = std::string{parsed.get_host()};
-    std::string portStr = std::string{parsed.get_port()};
-    int port = defaultPort;
-    if (!portStr.empty()) {
-        try { port = std::stoi(portStr); } catch (...) { port = defaultPort; }
-    }
-    return {host, port};
+    const utils::UriParts parsed = utils::parseUri(baseUrl);
+    int port = parsed.hasPort() ? parsed.port : defaultPort;
+    return {parsed.host, port};
 }
 
 /**
@@ -120,12 +108,10 @@ std::pair<std::string, int> splitBaseUrl(const std::string& baseUrl, uint16_t de
  */
 std::string rewriteUriHost(const std::string& uri, const std::string& newHost) {
     if (newHost.empty()) return uri;
-    const FIX8::uri parsed{uri};
-    std::string scheme{parsed.get_scheme()};
-    std::string port{parsed.get_port()};
-    if (scheme.empty()) return uri;
-    std::string out = scheme + "://" + newHost;
-    if (!port.empty()) out += ":" + port;
+    const utils::UriParts parsed = utils::parseUri(uri);
+    if (!parsed.hasScheme()) return uri;
+    std::string out = parsed.scheme + "://" + newHost;
+    if (parsed.hasPort()) out += ":" + std::to_string(parsed.port);
     return out;
 }
 

--- a/src/Rtcm3CorrectionServer.h
+++ b/src/Rtcm3CorrectionServer.h
@@ -12,11 +12,23 @@
 #include "DeviceManager.h"
 #include "CorrectionService.h"
 #include "TcpServerPortFactory.h"
+#include "util/util.h"
 
 class Rtcm3CorrectionServer : public CorrectionService, protected TcpServerPortFactory {
 public:
+    explicit Rtcm3CorrectionServer(const std::string& portUri, int max_connections = 10) : TcpServerPortFactory() {
+        // Parse the listen URI (e.g. "tcp://[IP]:port"); any omitted component falls back to the defaults.
+        const utils::UriParts uri = utils::parseUri(portUri, "tcp://127.0.0.1:7777");
+        configure(uri.port, uri.host, max_connections);
+        startListening();
+    }
+
     explicit Rtcm3CorrectionServer(int port = 7777, std::string listenAddr = "127.0.0.1", int max_connections = 10) : TcpServerPortFactory(port, listenAddr, max_connections) {
         startListening();
+    }
+
+    explicit Rtcm3CorrectionServer(const device_handle_t srcDevice, const std::string& portUri, int max_connections = 10) : Rtcm3CorrectionServer(portUri, max_connections) {
+        setSourceDevice(srcDevice);
     }
 
     explicit Rtcm3CorrectionServer(const device_handle_t srcDevice, int port = 7777, std::string listenAddr = "127.0.0.1", int max_connections = 10) : Rtcm3CorrectionServer(port, listenAddr, max_connections) {

--- a/src/TcpPortFactory.cpp
+++ b/src/TcpPortFactory.cpp
@@ -21,7 +21,6 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <util/uri.hpp>
 #include <util/util.h>
 
 #if PLATFORM_IS_WINDOWS
@@ -136,28 +135,23 @@ port_handle_t TcpPortFactory::bindPort(const std::string& pName, uint16_t pType)
     }
 
     // Parse pName for address
-    const FIX8::uri url {pName};
-    if (url.get_scheme() != "tcp" || url.get_port().empty() || url.get_host().empty()) {
+    const utils::UriParts url = utils::parseUri(pName);
+    if (url.scheme != "tcp" || !url.hasPort() || !url.hasHost()) {
         return nullptr;
     }
-    std::string uriHost {url.get_host()};
-    if (uriHost.rfind("[", 0) == 0 && uriHost.size() > 1 && uriHost[uriHost.size() - 1] == ']') {
-        uriHost = uriHost.substr(1, uriHost.size() - 2);
-    }
-    std::string uriPort {url.get_port()};
 
     // Reuse the cached resolution from validatePort() above (same host, same TTL window)
     // so we don't re-run a blocking .local getaddrinfo here. resolveHostCached fills the
     // address only; set the port from this URI.
     sockaddr_storage addr = {};
     int family = 0;
-    if (!resolveHostCached(uriHost, addr, family)) {
+    if (!resolveHostCached(url.host, addr, family)) {
         return nullptr;
     }
     if (family == AF_INET) {
-        reinterpret_cast<sockaddr_in*>(&addr)->sin_port = htons(static_cast<uint16_t>(std::stoi(uriPort)));
+        reinterpret_cast<sockaddr_in*>(&addr)->sin_port = htons(static_cast<uint16_t>(url.port));
     } else if (family == AF_INET6) {
-        reinterpret_cast<sockaddr_in6*>(&addr)->sin6_port = htons(static_cast<uint16_t>(std::stoi(uriPort)));
+        reinterpret_cast<sockaddr_in6*>(&addr)->sin6_port = htons(static_cast<uint16_t>(url.port));
     } else {
         return nullptr;
     }
@@ -195,13 +189,9 @@ bool TcpPortFactory::releasePort(port_handle_t port) {
  * @return True if port can be created, false otherwise
  */
 bool TcpPortFactory::validatePort(const std::string& pName, uint16_t pType) {
-    const FIX8::uri url {pName};
-    if (url.get_scheme() != "tcp" || url.get_port().empty() || url.get_host().empty()) {
+    const utils::UriParts url = utils::parseUri(pName);
+    if (url.scheme != "tcp" || !url.hasPort() || !url.hasHost()) {
         return false;
-    }
-    std::string uriHost {url.get_host()};
-    if (uriHost.rfind("[", 0) == 0 && uriHost.size() > 1 && uriHost[uriHost.size() - 1] == ']') {
-        uriHost = uriHost.substr(1, uriHost.size() - 2);
     }
 
     if ((pType & PORT_TYPE__TCP) != PORT_TYPE__TCP) {
@@ -212,7 +202,7 @@ bool TcpPortFactory::validatePort(const std::string& pName, uint16_t pType) {
     // resolves once per TTL window, and so bindPort() reuses this result (SN-8175).
     sockaddr_storage addr = {};
     int family = 0;
-    return resolveHostCached(uriHost, addr, family);
+    return resolveHostCached(url.host, addr, family);
 }
 
 /**

--- a/src/TcpServerPortFactory.cpp
+++ b/src/TcpServerPortFactory.cpp
@@ -11,7 +11,6 @@
 
 #include "TcpServerPortFactory.h"
 
-#include "util/uri.hpp"
 #include "util/util.h"
 
 #include "PortManager.h"
@@ -50,15 +49,10 @@ port_handle_t TcpServerPortFactory::bindPort(const std::string& pName, uint16_t 
     }
 
     // Parse pName for address
-    const FIX8::uri url {pName};
-    if (url.get_scheme() != "tcp" || url.get_port().empty() || url.get_host().empty()) {
+    const utils::UriParts url = utils::parseUri(pName);
+    if (url.scheme != "tcp" || !url.hasPort() || !url.hasHost()) {
         return nullptr;
     }
-    std::string uriHost {url.get_host()};
-    if (uriHost.rfind("[", 0) == 0 && uriHost.size() > 1 && uriHost[uriHost.size() - 1] == ']') {
-        uriHost = uriHost.substr(1, uriHost.size() - 2);
-    }
-    std::string uriPort {url.get_port()};
 
     // locate this port name in our list of known sockets
     for (auto& e : knownSockets) {
@@ -106,15 +100,12 @@ bool TcpServerPortFactory::releasePort(port_handle_t port) {
  * @return True if port can be created, false otherwise
  */
 bool TcpServerPortFactory::validatePort(const std::string& pName, uint16_t pType) {
-    const FIX8::uri url {pName};
-    if (url.get_scheme() != "tcp" || url.get_port().empty() || url.get_host().empty()) {
+    const utils::UriParts url = utils::parseUri(pName);
+    if (url.scheme != "tcp" || !url.hasPort() || !url.hasHost()) {
         return false;
     }
-    std::string uriHost {url.get_host()};
-    if (uriHost.rfind("[", 0) == 0 && uriHost.size() > 1 && uriHost[uriHost.size() - 1] == ']') {
-        uriHost = uriHost.substr(1, uriHost.size() - 2);
-    }
-    std::string uriPort {url.get_port()};
+    const std::string& uriHost = url.host;
+    const std::string uriPort = std::to_string(url.port);
 
     if ((pType & PORT_TYPE__TCP) != PORT_TYPE__TCP) {
         return false;

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -17,6 +17,7 @@
 // #include <acc_prof.h>
 
 #include "ISDataMappings.h"
+#include "util/uri.hpp"
 
 
 #ifdef PLATFORM_IS_WINDOWS
@@ -844,6 +845,60 @@ bool utils::validDomainName(const std::string& domainName) {
     static const std::regex regexp(R"(^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}\.[a-z]{2,})$)");
     std::smatch match;
     return (domainName.length() < 255) && std::regex_match(domainName, match, regexp);
+}
+
+utils::UriParts utils::parseUri(const std::string& uriStr) {
+    UriParts out;
+    const FIX8::uri uri{uriStr};
+
+    if (uri.has_scheme())
+        out.scheme.assign(uri.get_scheme());
+
+    if (uri.has_host()) {
+        std::string host{uri.get_host()};
+        // IPv6 literals are returned wrapped in brackets (e.g. "[::1]") - strip them
+        if (host.size() > 1 && host.front() == '[' && host.back() == ']')
+            host = host.substr(1, host.size() - 2);
+        out.host = std::move(host);
+    }
+
+    if (uri.has_port()) {
+        // FIX8::uri does not validate that the port is numeric, so guard against a
+        // malformed/out-of-range value (which would otherwise throw out of std::stoi).
+        try {
+            int parsed = std::stoi(std::string{uri.get_port()}, nullptr, 10);
+            if (parsed > 0 && parsed <= 65535)
+                out.port = parsed;
+        } catch (const std::exception&) {
+            // leaves out.port == -1
+        }
+    }
+
+    if (uri.has_user())
+        out.user.assign(uri.get_user());
+    if (uri.has_password())
+        out.password.assign(uri.get_password());
+    if (uri.has_path())
+        out.path.assign(uri.get_path());
+    if (uri.has_query())
+        out.query.assign(uri.get_query());
+
+    return out;
+}
+
+utils::UriParts utils::parseUri(const std::string& uriStr, const std::string& defaultsUri) {
+    UriParts out = parseUri(uriStr);
+    const UriParts def = parseUri(defaultsUri);
+
+    if (!out.hasScheme())       out.scheme = def.scheme;
+    if (!out.hasHost())         out.host = def.host;
+    if (!out.hasPort())         out.port = def.port;
+    if (out.user.empty())       out.user = def.user;
+    if (out.password.empty())   out.password = def.password;
+    if (out.path.empty())       out.path = def.path;
+    if (out.query.empty())      out.query = def.query;
+
+    return out;
 }
 
 std::string utils::encodeSTM32UID(const uint32_t uid[3]) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -284,6 +284,57 @@ namespace utils {
     bool validDomainName(const std::string& domainName);
 
     /**
+     * @brief Normalized components of a parsed URI, ready for direct use by the SDK.
+     *
+     * Wraps FIX8::uri parsing and centralizes the conventions that were previously
+     * duplicated across the port factories and correction services: IPv6 literal hosts
+     * are returned with their surrounding brackets stripped (e.g. "::1", not "[::1]"),
+     * and the port is converted to a validated integer (1..65535) rather than a raw
+     * string, with -1 indicating an absent, malformed, or out-of-range port.
+     */
+    struct UriParts {
+        std::string scheme;     //!< URI scheme as provided (e.g. "tcp", "ntrip"); empty if absent
+        std::string host;       //!< host with IPv6 brackets stripped; empty if absent
+        int         port = -1;  //!< port number 1..65535, or -1 if absent/malformed/out-of-range
+        std::string user;       //!< userinfo username; empty if absent
+        std::string password;   //!< userinfo password; empty if absent
+        std::string path;       //!< path component (e.g. an NTRIP mountpoint); empty if absent
+        std::string query;      //!< query component; empty if absent
+
+        bool hasScheme() const { return !scheme.empty(); }     //!< true if a scheme was present
+        bool hasHost() const { return !host.empty(); }         //!< true if a host was present
+        bool hasPort() const { return port >= 0; }             //!< true if a valid port was present
+        bool hasUserinfo() const { return !user.empty() || !password.empty(); } //!< true if userinfo was present
+    };
+
+    /**
+     * @brief Parse a URI string into its normalized components.
+     *
+     * This is the single, codebase-wide entry point for breaking a URI into its parts; prefer it
+     * over calling FIX8::uri directly so the IPv6-bracket and port-validation conventions stay
+     * consistent. Note that FIX8::uri requires an authority introducer ("//") for the host/port
+     * to be parsed (e.g. "tcp://host:port", not "tcp:host:port").
+     *
+     * @param uriStr the URI to parse (e.g. "tcp://[::1]:7777", "ntrip://user:pass@host:2101/MOUNT")
+     * @return a UriParts with each present component populated; absent components are left empty (port == -1)
+     */
+    UriParts parseUri(const std::string& uriStr);
+
+    /**
+     * @brief Parse a URI, falling back to a second "defaults" URI for any component the primary omits.
+     *
+     * Each component absent from @p uriStr (scheme, host, port, user, password, path, query) is filled
+     * from the corresponding component of @p defaultsUri. This lets callers express their defaults as a
+     * URI string instead of patching individual fields — e.g. parseUri(arg, "tcp://127.0.0.1:7777")
+     * yields the host/port the caller wants whenever @p uriStr leaves them out.
+     *
+     * @param uriStr      the URI to parse
+     * @param defaultsUri a URI supplying default values for any component @p uriStr omits
+     * @return a UriParts with present components from @p uriStr and the remainder from @p defaultsUri
+     */
+    UriParts parseUri(const std::string& uriStr, const std::string& defaultsUri);
+
+    /**
      * Encodes the 3x uint32_t STM32 UID registers into the UUID format required by the calibration-db API.
      * Encoding: UID registers as LE uint32_t bytes, swapped to BE for UUID fields 1 & 2,
      * field 3 = 0x8EF4, field 4 prefix = 0x99 0x6B.

--- a/tests/test_uri.cpp
+++ b/tests/test_uri.cpp
@@ -1,0 +1,160 @@
+/**
+ * @file test_uri.cpp
+ * @brief Unit tests for the utils::parseUri() URI-parsing helper.
+ *
+ * Covers the normalization conventions the helper centralizes: IPv6-bracket stripping,
+ * numeric port validation/defaulting, userinfo/path extraction, and the defaults-URI
+ * overload that fills any component the primary URI omits.
+ *
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+
+#include "util/util.h"
+
+using utils::UriParts;
+using utils::parseUri;
+
+// -------------------------------------------------------------------------------------------------
+// Basic component extraction
+// -------------------------------------------------------------------------------------------------
+
+TEST(UriParse, FullTcpUrl) {
+    const UriParts u = parseUri("tcp://192.168.1.43:7777");
+    EXPECT_EQ(u.scheme, "tcp");
+    EXPECT_EQ(u.host, "192.168.1.43");
+    EXPECT_TRUE(u.hasPort());
+    EXPECT_EQ(u.port, 7777);
+}
+
+TEST(UriParse, SchemeIsCaseSensitiveAsProvided) {
+    // The helper does not lower-case the scheme; callers compare against the expected literal.
+    EXPECT_EQ(parseUri("TCP://host:80").scheme, "TCP");
+    EXPECT_EQ(parseUri("ntrip://host:2101").scheme, "ntrip");
+}
+
+TEST(UriParse, NtripWithUserinfoAndMountpoint) {
+    const UriParts u = parseUri("ntrip://user:pass@caster.example.com:2101/MOUNT");
+    EXPECT_EQ(u.scheme, "ntrip");
+    EXPECT_EQ(u.host, "caster.example.com");
+    EXPECT_EQ(u.port, 2101);
+    EXPECT_TRUE(u.hasUserinfo());
+    EXPECT_EQ(u.user, "user");
+    EXPECT_EQ(u.password, "pass");
+    EXPECT_EQ(u.path, "/MOUNT");
+}
+
+TEST(UriParse, NoUserinfo) {
+    const UriParts u = parseUri("ntrip://caster.example.com:2101/MOUNT");
+    EXPECT_FALSE(u.hasUserinfo());
+    EXPECT_TRUE(u.user.empty());
+    EXPECT_TRUE(u.password.empty());
+}
+
+// -------------------------------------------------------------------------------------------------
+// Host handling (IPv6 bracket stripping)
+// -------------------------------------------------------------------------------------------------
+
+TEST(UriParse, Ipv6HostBracketsStripped) {
+    const UriParts u = parseUri("tcp://[::1]:7777");
+    EXPECT_EQ(u.host, "::1");
+    EXPECT_EQ(u.port, 7777);
+}
+
+TEST(UriParse, Ipv6FullHostBracketsStripped) {
+    const UriParts u = parseUri("tcp://[2001:db8::1]:1234");
+    EXPECT_EQ(u.host, "2001:db8::1");
+    EXPECT_EQ(u.port, 1234);
+}
+
+TEST(UriParse, HostOptionalWhenAuthorityHasPortOnly) {
+    const UriParts u = parseUri("tcp://:7777");
+    EXPECT_FALSE(u.hasHost());
+    EXPECT_TRUE(u.host.empty());
+    EXPECT_EQ(u.port, 7777);
+}
+
+// -------------------------------------------------------------------------------------------------
+// Port validation
+// -------------------------------------------------------------------------------------------------
+
+TEST(UriParse, MissingPortIsAbsent) {
+    const UriParts u = parseUri("tcp://host");
+    EXPECT_FALSE(u.hasPort());
+    EXPECT_EQ(u.port, -1);
+}
+
+TEST(UriParse, NonNumericPortIsRejectedNotThrown) {
+    // FIX8::uri returns the raw token "abc"; the helper must not throw out of std::stoi.
+    const UriParts u = parseUri("tcp://host:abc");
+    EXPECT_FALSE(u.hasPort());
+    EXPECT_EQ(u.port, -1);
+}
+
+TEST(UriParse, OutOfRangePortIsRejected) {
+    EXPECT_FALSE(parseUri("tcp://host:99999999999").hasPort());  // overflows int
+    EXPECT_FALSE(parseUri("tcp://host:70000").hasPort());        // > 65535
+    EXPECT_FALSE(parseUri("tcp://host:0").hasPort());            // 0 is not a valid port
+}
+
+TEST(UriParse, BoundaryPortsAccepted) {
+    EXPECT_EQ(parseUri("tcp://host:1").port, 1);
+    EXPECT_EQ(parseUri("tcp://host:65535").port, 65535);
+}
+
+// -------------------------------------------------------------------------------------------------
+// FIX8::uri requires the "//" authority introducer for host/port parsing
+// -------------------------------------------------------------------------------------------------
+
+TEST(UriParse, NoAuthorityIntroducerLeavesHostPortUnparsed) {
+    // "tcp:192.168.1.43:7777" has no "//", so the remainder is treated as an opaque path -
+    // this documents why the cltool -base help text uses the "tcp://..." form.
+    const UriParts u = parseUri("tcp:192.168.1.43:7777");
+    EXPECT_EQ(u.scheme, "tcp");
+    EXPECT_FALSE(u.hasHost());
+    EXPECT_FALSE(u.hasPort());
+}
+
+TEST(UriParse, EmptyInput) {
+    const UriParts u = parseUri("");
+    EXPECT_FALSE(u.hasScheme());
+    EXPECT_FALSE(u.hasHost());
+    EXPECT_FALSE(u.hasPort());
+}
+
+// -------------------------------------------------------------------------------------------------
+// Defaults-URI overload
+// -------------------------------------------------------------------------------------------------
+
+TEST(UriParseDefaults, FillsMissingHostAndPort) {
+    // Mirrors the Rtcm3CorrectionServer listen-URI case.
+    const UriParts u = parseUri("tcp://:9999", "tcp://127.0.0.1:7777");
+    EXPECT_EQ(u.host, "127.0.0.1");  // host omitted -> default
+    EXPECT_EQ(u.port, 9999);         // port present -> kept
+}
+
+TEST(UriParseDefaults, AllComponentsDefaultedWhenInputEmpty) {
+    const UriParts u = parseUri("", "tcp://127.0.0.1:7777");
+    EXPECT_EQ(u.scheme, "tcp");
+    EXPECT_EQ(u.host, "127.0.0.1");
+    EXPECT_EQ(u.port, 7777);
+}
+
+TEST(UriParseDefaults, PrimaryComponentsWin) {
+    const UriParts u = parseUri("tcp://10.0.0.5:1234", "tcp://127.0.0.1:7777");
+    EXPECT_EQ(u.host, "10.0.0.5");
+    EXPECT_EQ(u.port, 1234);
+}
+
+TEST(UriParseDefaults, NtripPortDefault) {
+    // Mirrors NtripCorrectionService: caster URL without a port falls back to 2101.
+    EXPECT_EQ(parseUri("ntrip://caster.example.com/MOUNT", "ntrip://:2101").port, 2101);
+    EXPECT_EQ(parseUri("ntrip://caster.example.com:2102/MOUNT", "ntrip://:2101").port, 2102);
+}
+
+TEST(UriParseDefaults, InvalidPrimaryPortFallsBackToDefault) {
+    // A malformed port in the primary is "absent", so the default applies.
+    const UriParts u = parseUri("tcp://host:abc", "tcp://127.0.0.1:7777");
+    EXPECT_EQ(u.port, 7777);
+}


### PR DESCRIPTION
## Issue (SN-8018)

The RTK base station needs to support both GPX (L1/L5) and F9P (L1/L2), which means running multiple `cltool` instances serving corrections on **configurable** ports/addresses from multiple devices. The blocker: `cltool -base=<listenUri>` could not parse its argument.

`cltool_createHost()` built the `Rtcm3CorrectionServer` with the hard-coded default `127.0.0.1:7777` and ignored the `-base` value entirely (it was left as a `// FIXME`).

## Correction

### `-base` listen-URI parsing
`Rtcm3CorrectionServer` now takes the listen URI and configures the listener accordingly. The `-base` help text was updated to the standard `tcp://[IP]:[port]` form — the underlying `FIX8::uri` parser only populates host/port when an authority introducer (`//`) is present, so the previously documented `TCP::7777` / `TCP:host:port` examples never actually parsed. The unsupported `SERIAL:` example was removed (this code path only ever creates a TCP server).

### Shared `utils::parseUri()` helper
Instead of adding another bespoke parse, this introduces one codebase-wide helper in `util/util.{h,cpp}`:

- `utils::parseUri(uri)` → normalized `UriParts { scheme, host, port, user, password, path, query }`
- `utils::parseUri(uri, defaultsUri)` → same, with any omitted component filled from a defaults URI (e.g. `parseUri(arg, "tcp://127.0.0.1:7777")`)

`UriParts` centralizes conventions previously copy-pasted across the codebase:
- IPv6 literal hosts returned with brackets stripped (`::1`, not `[::1]`)
- port is a **validated** int (1..65535), or `-1` when absent/malformed

This also **fixes a latent crash**: `TcpPortFactory::bindPort()` called `std::stoi()` directly on the raw port token, which `FIX8::uri` does not validate — a non-numeric port (`tcp://host:abc`) would throw and crash. The helper rejects it cleanly.

### Call sites refactored onto the helper
`TcpPortFactory`, `TcpServerPortFactory`, `NtripCorrectionService` (now defaults to NTRIP port 2101), `ISHttpRequest` (defaults to 80), `RelayPortFactory` (normalize/split/rewrite), `Rtcm3CorrectionServer`, and the cltool rover/ntrip + relay-hostname paths.

`ISmDnsPortFactory` is **intentionally left** on its bespoke `FIX8::uri` parse — it needs the raw port token to emit distinct error messages and to run regex path parsing, which the normalized `UriParts` deliberately abstracts away. `InertialSense::UploadImxCalibrationFromFile` is also left as-is (it uses `uri.parse()` only as a URL-vs-file-path validity check, not for component extraction).

## Tests
Adds `tests/test_uri.cpp` — 18 GoogleTest cases covering component extraction, IPv6 bracket stripping, port validation/defaulting, the no-authority case, and the defaults-URI overload. All pass.

## Verification
- SDK builds from source; `IS-SDK_unit-tests --gtest_filter='UriParse*'` → 18/18 pass
- `cltool` rebuilds + links; `-h` shows the corrected `-base` help
- EvalTool (sibling PR in `imx`) rebuilds + links against the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)