### PR TITLE
cltool: Add log replay support for -get and -list-dids options

### DIFF
--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string.h>
 #include <chrono>
 #include <ctime>
+#include <map>
 #include "ISDataMappings.h"
 #include "ISmDnsPortFactory.h"
 
@@ -680,6 +681,11 @@ bool cltool_parseCommandLine(int argc, char* argv[])
             g_commandLineOptions.list_devices = true;
             g_commandLineOptions.displayMode = cInertialSenseDisplay::DMODE_QUIET;
         }
+        else if (startsWith(a, "-list-dids"))
+        {
+            g_commandLineOptions.listLogDids = true;
+            g_commandLineOptions.replayDataLog = true;  // implies log replay
+        }
         else if (startsWith(a, "-use-mdns"))
         {
             g_commandLineOptions.useMdns = true;
@@ -1042,25 +1048,90 @@ bool cltool_replayDataLog()
         return false;
     }
 
-    cout << "Replaying log files: " << g_commandLineOptions.logPath << endl;
+    if (g_commandLineOptions.listLogDids)
+    {
+        bool multiDevice = logger.DeviceCount() > 1;
+        p_data_buf_t *data;
+        for (auto dl : logger.DeviceLogs())
+        {
+            if (multiDevice)
+                printf("Device SN%u:\n", dl->SerialNumber());
+            std::map<uint32_t, uint32_t> didCounts;
+            while ((data = logger.ReadData(dl)) != NULL)
+                didCounts[data->hdr.id]++;
+            printf("    Count  DID  Name\n");
+            for (const auto& [did, count] : didCounts)
+                printf("%9u%5u  %s\n", count, did, cISDataMappings::DataName(did));
+        }
+        return true;
+    }
+
+    bool getMode = (!g_commandLineOptions.outputOnceDid.empty() &&
+                    g_commandLineOptions.getNode &&
+                    !g_commandLineOptions.getNode.IsNull() &&
+                    g_commandLineOptions.getNode.size() > 0);
+
+    if (!getMode)
+        cout << "Replaying log files: " << g_commandLineOptions.logPath << endl;
+
+    bool multiDevice = logger.DeviceCount() > 1;
     p_data_buf_t *data;
     // for (int d=0; d<logger.DeviceCount(); d++)
     for (auto dl : logger.DeviceLogs())
     {
-        if (logger.DeviceCount() > 1)
-        {
-            printf("Device SN%d: \n", dl->SerialNumber());
-        }
+        if (multiDevice)
+            printf("Device SN%u:\n", dl->SerialNumber());
+
+        // In get mode use a per-device copy so each device is searched independently
+        std::vector<uint32_t> remainingDids = getMode ? g_commandLineOptions.outputOnceDid : std::vector<uint32_t>{};
+
         while (((data = logger.ReadData(dl)) != NULL) && !g_inertialSenseDisplay.ExitProgram())
         {
             p_data_t d = {data->hdr, data->buf};
-            g_inertialSenseDisplay.ProcessData(&d, g_commandLineOptions.replayDataLog, g_commandLineOptions.replaySpeed);
-            g_inertialSenseDisplay.PrintData();
+
+            if (getMode)
+            {
+                for (auto it = remainingDids.begin(); it != remainingDids.end(); )
+                {
+                    if (d.hdr.id == *it)
+                    {
+                        YAML::Node output;
+                        if (!cISDataMappings::DataToYaml(d.hdr.id, d.ptr, output, g_commandLineOptions.getNode))
+                        {
+                            cout << "Error parsing: " << *it << "\n";
+                        }
+                        else
+                        {
+                            YAML::Emitter out;
+                            out << output;
+                            if (out.good())
+                                std::cout << out.c_str() << std::endl;
+                            else
+                                std::cerr << "YAML emitter error: " << out.GetLastError() << std::endl;
+                        }
+                        it = remainingDids.erase(it);
+                    }
+                    else
+                    {
+                        ++it;
+                    }
+                }
+                if (remainingDids.empty())
+                    break;  // All DIDs found for this device; advance to next device
+            }
+            else
+            {
+                g_inertialSenseDisplay.ProcessData(&d, g_commandLineOptions.replayDataLog, g_commandLineOptions.replaySpeed);
+                g_inertialSenseDisplay.PrintData();
+            }
         }
     }
 
-    cout << "Done replaying log files: " << g_commandLineOptions.logPath << endl;
-    g_inertialSenseDisplay.Goodbye();
+    if (!getMode)
+    {
+        cout << "Done replaying log files: " << g_commandLineOptions.logPath << endl;
+        g_inertialSenseDisplay.Goodbye();
+    }
     return true;
 }
 
@@ -1237,11 +1308,13 @@ void cltool_outputUsage()
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -edit DID_FLASH_CONFIG" << EXAMPLE_SPACE_1 << " # edit DID_FLASH_CONFIG message" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -baud=115200 -did 5 13=10 " << " # stream at 115200 bps, GPS streamed at 10x startupGnssDtMs" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c * -baud=921600              "                    << EXAMPLE_SPACE_2 << " # 921600 bps baudrate on all serial ports" << endlbOff;
-	cout << "    " << APP_NAME << APP_EXT << " -c COM2,COM4,COM5 -did DID_INS_1    "        << EXAMPLE_SPACE_2 << " # connect to multiple ports (comma-separated)" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -c COM2,COM4,COM5 -did DID_INS_1"        << EXAMPLE_SPACE_2 << "# connect to multiple ports (comma-separated)" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -rp " <<     EXAMPLE_LOG_DIR                                              << " # replay log files from a folder" << endlbOff;
-	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -rover=RTCM3:192.168.1.100:7777:mount:user:password         # Connect to RTK NTRIP base" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -rp logs/20170117_222549 -get 12        "                                 << " # show first DID_FLASH_CONFIG value from a log" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -rp logs/20170117_222549 -list-dids     "                                 << " # list all DIDs found in log files" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -rover=RTCM3:192.168.1.100:7777:mount:user:password          # Connect to RTK NTRIP base" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get 1,4,13,DID_GNSS1_POS                                    # Return specific DIDs" << endlbOff;
-	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get \"{DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}\"   # Return portion of two DIDs" << endlbOff;
+	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -get \"{DID_INS_1: {insStatus, theta}, DID_INS_2: {qn2b}}\"    # Return portion of two DIDs" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -set \"{DID_FLASH_CONFIG: {gnss1AntOffset[1]: 0.8}}\"          # Set one value in DID array" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -set \"{DID_FLASH_CONFIG: {gnss1AntOffset: [0.8, 0.0, 1.2]}}\" # Set values in DID" << endlbOff;
 	cout << endlbOn;
@@ -1337,7 +1410,7 @@ void cltool_outputUsage()
 	cout << "    -presetGPS     " << boldOff << " Send RMC preset to enable GPS data stream" << endlbOn;
 	cout << "    -presetGPXPPD  " << boldOff << " Send RMC preset to enable GPX post processing data (PPD) stream" << endlbOn;
 	cout << endlbOn;
-	cout << "OPTIONS (Logging to file, disabled by default)" << endl;
+	cout << "OPTIONS (Logging to file)" << endl;
 	cout << "    -lon" << boldOff << "            Enable logging" << endlbOn;
 	cout << "    -lt=" << boldOff << "TYPE        Log type: raw (default), dat, sdat, kml or csv" << endlbOn;
 	cout << "    -lp " << boldOff << "PATH        Log data to path (default: ./" << CL_DEFAULT_LOGS_DIRECTORY << ")" << endlbOn;
@@ -1345,9 +1418,13 @@ void cltool_outputUsage()
 	cout << "    -lms=" << boldOff << "PERCENT    File culling: Log drive space limit in percent of total drive, 0.0 to 1.0. (default: " << CL_DEFAULT_LOG_DRIVE_USAGE_LIMIT_PERCENT << ")" << endlbOn;
 	cout << "    -lmf=" << boldOff << "BYTES      Log max file size in bytes (default: " << CL_DEFAULT_MAX_LOG_FILE_SIZE << ")" << endlbOn;
 	cout << "    -lts=" << boldOff << "0          Log sub folder, 0 or blank for none, 1 for timestamp, else use as is" << endlbOn;
+	cout << endlbOn;
+	cout << "OPTIONS (Reading from file)" << endl;
 	cout << "    -r" << boldOff << "              Replay data log from default path" << endlbOn;
 	cout << "    -rp " << boldOff << "PATH        Replay data log from PATH" << endlbOn;
 	cout << "    -rs=" << boldOff << "SPEED       Replay data log at x SPEED. SPEED=0 runs as fast as possible." << endlbOn;
+	cout << "    -list-dids  " << boldOff << "            List all DID messages found in replay log with occurrence counts (use with -rp)" << endlbOn;
+	cout << "                " << boldOff << "            Example: -rp " << EXAMPLE_LOG_DIR << " -list-dids" << endlbOn;
 	cout << endlbOn;
 	cout << "OPTIONS (READ flash config) - DEPRECATED, use `-get` instead" << endl;
 	cout << "    -imxFlashCfg" << boldOff  <<  "                                # List all \"keys\" and \"values\" in IMX" << endlbOn;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -1309,14 +1309,10 @@ void cltool_outputUsage()
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -edit DID_FLASH_CONFIG" << EXAMPLE_SPACE_1 << " # edit DID_FLASH_CONFIG message" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c "  <<     EXAMPLE_PORT << " -baud=115200 -did 5 13=10 " << " # stream at 115200 bps, GPS streamed at 10x startupGnssDtMs" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c * -baud=921600              "                    << EXAMPLE_SPACE_2 << " # 921600 bps baudrate on all serial ports" << endlbOff;
-<<<<<<< HEAD
-	cout << "    " << APP_NAME << APP_EXT << " -c COM2,COM4,COM5 -did DID_INS_1"        << EXAMPLE_SPACE_2 << "# connect to multiple ports (comma-separated)" << endlbOff;
-=======
 	cout << "    " << APP_NAME << APP_EXT << " -c COM2,COM4,COM5 -did DID_INS_1    "        << EXAMPLE_SPACE_2 << " # connect to multiple ports (comma-separated)" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c spi:///dev/spi0.0 -did DID_INS_1              "                       << " # SPI device, mode 3 default" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c spi:///dev/spi0.0[b2000000,d18] -did DID_INS_1 "                     << " # SPI: 2 MHz, data-ready on GPIO 18" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -c /dev/spi0.0[b2000000,d18] -did DID_INS_1       "                     << " # SPI: bare device path with opts" << endlbOff;
->>>>>>> origin/develop
 	cout << "    " << APP_NAME << APP_EXT << " -rp " <<     EXAMPLE_LOG_DIR                                              << " # replay log files from a folder" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -rp logs/20170117_222549 -get 12        "                                 << " # show first DID_FLASH_CONFIG value from a log" << endlbOff;
 	cout << "    " << APP_NAME << APP_EXT << " -rp logs/20170117_222549 -list-dids     "                                 << " # list all DIDs found in log files" << endlbOff;

--- a/cltool/src/cltool.cpp
+++ b/cltool/src/cltool.cpp
@@ -1410,7 +1410,7 @@ void cltool_outputUsage()
 	cout << "    -presetGPS     " << boldOff << " Send RMC preset to enable GPS data stream" << endlbOn;
 	cout << "    -presetGPXPPD  " << boldOff << " Send RMC preset to enable GPX post processing data (PPD) stream" << endlbOn;
 	cout << endlbOn;
-	cout << "OPTIONS (Logging to file)" << endl;
+	cout << "OPTIONS (Writing to data log file)" << endl;
 	cout << "    -lon" << boldOff << "            Enable logging" << endlbOn;
 	cout << "    -lt=" << boldOff << "TYPE        Log type: raw (default), dat, sdat, kml or csv" << endlbOn;
 	cout << "    -lp " << boldOff << "PATH        Log data to path (default: ./" << CL_DEFAULT_LOGS_DIRECTORY << ")" << endlbOn;
@@ -1419,12 +1419,12 @@ void cltool_outputUsage()
 	cout << "    -lmf=" << boldOff << "BYTES      Log max file size in bytes (default: " << CL_DEFAULT_MAX_LOG_FILE_SIZE << ")" << endlbOn;
 	cout << "    -lts=" << boldOff << "0          Log sub folder, 0 or blank for none, 1 for timestamp, else use as is" << endlbOn;
 	cout << endlbOn;
-	cout << "OPTIONS (Reading from file)" << endl;
+	cout << "OPTIONS (Reading from data log file)" << endl;
 	cout << "    -r" << boldOff << "              Replay data log from default path" << endlbOn;
 	cout << "    -rp " << boldOff << "PATH        Replay data log from PATH" << endlbOn;
 	cout << "    -rs=" << boldOff << "SPEED       Replay data log at x SPEED. SPEED=0 runs as fast as possible." << endlbOn;
-	cout << "    -list-dids  " << boldOff << "            List all DID messages found in replay log with occurrence counts (use with -rp)" << endlbOn;
-	cout << "                " << boldOff << "            Example: -rp " << EXAMPLE_LOG_DIR << " -list-dids" << endlbOn;
+	cout << "    -list-dids  " << boldOff << "    List all DID messages found in replay data log with occurrence counts (use with -rp)" << endlbOn;
+	cout << "                " << boldOff << "         Example: -rp logs/20170117_222549 -list-dids" << endlbOn;
 	cout << endlbOn;
 	cout << "OPTIONS (READ flash config) - DEPRECATED, use `-get` instead" << endl;
 	cout << "    -imxFlashCfg" << boldOff  <<  "                                # List all \"keys\" and \"values\" in IMX" << endlbOn;

--- a/cltool/src/cltool.h
+++ b/cltool/src/cltool.h
@@ -178,6 +178,7 @@ typedef struct cmd_options_s // we need to name this to make MSVC happy, since w
     uint32_t updateFirmwareSlot = 0;
     uint32_t runDurationMs = 0;             // Run for this many millis before exiting (0 = indefinitely)
     bool list_devices = false;              // if true, dumps results of findDevices() including port name.
+    bool listLogDids = false;              // -list-dids: scan replay log and print DID count table
     bool useMdns = false;                   // if true, registers ISmDnsPortFactory for mDNS network device discovery
     uint8_t mdnsResolvePreference = 0x07;  // bitmask of MdnsResolveFlags for address resolution preference (default: IPv4|IPv6|hostname)
     bool useRelay = false;                  // if true, registers RelayPortFactory for HTTP relay-based device discovery

--- a/cltool/src/cltool_main.cpp
+++ b/cltool/src/cltool_main.cpp
@@ -1483,7 +1483,7 @@ static int inertialSenseMain()
     if (g_commandLineOptions.replayDataLog)
     {
         // [REPLAY INSTRUCTION] 1.) Replay data log
-        return cltool_replayDataLog();
+        return cltool_replayDataLog() ? EXIT_CODE_SUCCESS : EXIT_CODE_INVALID_COMMAND_LINE;
     }
 
     // if event parsing return after completeing


### PR DESCRIPTION
This pull request adds a new feature to the `cltool` utility: the ability to list all Data IDs (DIDs) found in replay log files, along with their occurrence counts. It introduces a new command-line option, updates the usage documentation, and improves log replay handling to support this feature.

**New feature: List all DIDs in replay logs**

* Added a new command-line option `-list-dids` that scans replay log files and prints a table of all DIDs found, including their occurrence counts and names. This is useful for quickly inspecting the contents of log files. [[1]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6R684-R688) [[2]](diffhunk://#diff-78d48e85a050e8f37f9c68d1debc55c2b5547b6ec95ec7482f661246258a109dR181) [[3]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6R1051-R1134)

**Documentation improvements**

* Updated the usage output in `cltool_outputUsage()` to include documentation and examples for the new `-list-dids` option, and clarified the separation between logging and replay options. [[1]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6R1313-R1314) [[2]](diffhunk://#diff-5d5fedbb4b1d1f924cd1e01570bb96459dfc05c22c56678dd30163c48dd8e7c6L1340-R1427)

**Code and behavior adjustments**

* Improved log replay logic to support the new listing mode and to handle per-device and per-DID processing more robustly.
* Updated the main entry point to return an appropriate exit code if log replay fails.
* Added missing include for `<map>` to support the new DID counting logic.

**Example: Using -list-dids**

```
$ ./run_cltool.sh -rp ../../tests/gl_tests/goldenlogs/imx_gpx/imx6_gpx1/Compassing_Drive_GPX/20260521_122746/ -list-dids
Device SN942742854:
    Count  DID  Name
     1340    0  DID_NULL
      730    1  DID_DEV_INFO
   136632    3  DID_PIMU
     6834    5  DID_INS_2
      735   10  DID_SYS_PARAMS
       70   12  DID_FLASH_CONFIG
     3389   13  DID_GNSS1_POS
     3384   14  DID_GNSS2_POS
     3409   30  DID_GNSS1_VEL
     3396   31  DID_GNSS2_VEL
       69   35  DID_NVR_USERPAGE_G0
       66   36  DID_NVR_USERPAGE_G1
     3419   39  DID_DEBUG_ARRAY
     3420   48  DID_INL2_STATES
       60   49  DID_INL2_COVARIANCE_LD
       69   50  DID_INL2_STATUS
       69   51  DID_INL2_MISC
    34160   52  DID_MAGNETOMETER
    34162   53  DID_BAROMETER
     3420   59  DID_INL2_MAG_OBS_INFO
        1   64  DID_BIT
     7398   69  DID_GNSS1_RAW
     6388   70  DID_GNSS2_RAW
        3   79  DID_RTK_DEBUG
     3411   91  DID_GNSS2_RTK_CMP_REL
     2678   96  DID_IMUS_RAW
       70  121  DID_GPX_FLASH_CFG
     1363  123  DID_GPX_STATUS
      683  124  DID_GPX_DEBUG_ARRAY
Device SN942745909:
    Count  DID  Name
     1340    0  DID_NULL
      735    1  DID_DEV_INFO
   136553    3  DID_PIMU
     6835    5  DID_INS_2
      734   10  DID_SYS_PARAMS
       70   12  DID_FLASH_CONFIG
     3396   13  DID_GNSS1_POS
     3365   14  DID_GNSS2_POS
     3389   30  DID_GNSS1_VEL
     3363   31  DID_GNSS2_VEL
       68   35  DID_NVR_USERPAGE_G0
       60   36  DID_NVR_USERPAGE_G1
     3419   39  DID_DEBUG_ARRAY
     3419   48  DID_INL2_STATES
       50   49  DID_INL2_COVARIANCE_LD
       69   50  DID_INL2_STATUS
       69   51  DID_INL2_MISC
    34145   52  DID_MAGNETOMETER
    34149   53  DID_BAROMETER
     3420   59  DID_INL2_MAG_OBS_INFO
        1   64  DID_BIT
     7220   69  DID_GNSS1_RAW
     6446   70  DID_GNSS2_RAW
        3   79  DID_RTK_DEBUG
     3411   91  DID_GNSS2_RTK_CMP_REL
     2668   96  DID_IMUS_RAW
       70  121  DID_GPX_FLASH_CFG
     1352  123  DID_GPX_STATUS
      686  124  DID_GPX_DEBUG_ARRAY
 ```

**Example: Using -get**
```
$ ./run_cltool.sh -rp ../../tests/gl_tests/goldenlogs/imx_gpx/imx6_gpx1/Compassing_Drive_GPX/20260521_122746/ -get DID_FLASH_CONFIG
Device SN942742854:
DID_FLASH_CONFIG:
  checksum: 3716893454
  debug: 0
  dynamicModel: 8
  gnss1AntOffset: [-1.35, 0, -1.04]
  gnss2AntOffset: [-0.34999999, 0, -1.04]
  gnssCn0DynMinOffset: 20
  gnssCn0Minimum: 30
  gnssMinimumElevation: 10.0
  gnssSatSigConst: 0x13FF
  gnssTimeSyncPeriodMs: 1000
  gnssTimeUserDelay: 0.000
  imuRejectThreshGyroHigh: 3
  imuRejectThreshGyroLow: 2
  imuShockDeltaAccHighThreshold: 20
  imuShockDeltaAccLowThreshold: 3
  imuShockDeltaGyroHighThreshold: 120
  imuShockDeltaGyroLowThreshold: 12
  imuShockDetectLatencyMs: 10
  imuShockOptions: 0x03
  imuShockRejectLatchMs: 5
  insOffset: [0, 0, 0]
  insRotation: [0, 0, 0]
  ioConfig: 0x06DB8046
  ioConfig2: 0x40
  key: 36
  lastLla: [40.198367800, -111.620493800, 1359.929971078]
  lastLlaTimeOfWeekMs: 316044800
  lastLlaUpdateDistance: 1000
  lastLlaWeek: 2419
  magCalibrationQualityThreshold: 10
  magDeclination: 0.00
  magInterferenceThreshold: 3
  platformConfig: 0x0000000C
  refLla: [40.197646100, -111.620634000, 1371.189980844]
  RTKCfgBits: 0x00400004
  sensorConfig: 0x03000077
  ser0BaudRate: 921600
  ser1BaudRate: 921600
  ser2BaudRate: 921600
  size: 288
  startupGnssDtMs: 200
  startupImuDtMs: 1
  startupNavDtMs: 5
  sysCfgBits: 0x00000100
  wheelConfig.bits: 0x00000000
  wheelConfig.radius: 0
  wheelConfig.track_width: 0
  wheelConfig.transform.e_b2w: [0.00, 0.00, 0.00]
  wheelConfig.transform.e_b2w_sigma: [0.02, 0.02, 0.02]
  wheelConfig.transform.t_b2w: [0.000, 0.000, 0.000]
  wheelConfig.transform.t_b2w_sigma: [0.300, 0.300, 0.300]
  zeroVelOffset: [0, 0, 0]
  zeroVelRotation: [0, 0, 0]
Device SN942745909:
DID_FLASH_CONFIG:
  checksum: 2289115549
  debug: 0
  dynamicModel: 8
  gnss1AntOffset: [-1.35, 0, -1.04]
  gnss2AntOffset: [-0.34999999, 0, -1.04]
  gnssCn0DynMinOffset: 20
  gnssCn0Minimum: 30
  gnssMinimumElevation: 10.0
  gnssSatSigConst: 0x13FF
  gnssTimeSyncPeriodMs: 1000
  gnssTimeUserDelay: 0.000
  imuRejectThreshGyroHigh: 3
  imuRejectThreshGyroLow: 2
  imuShockDeltaAccHighThreshold: 20
  imuShockDeltaAccLowThreshold: 3
  imuShockDeltaGyroHighThreshold: 120
  imuShockDeltaGyroLowThreshold: 12
  imuShockDetectLatencyMs: 10
  imuShockOptions: 0x03
  imuShockRejectLatchMs: 5
  insOffset: [0, 0, 0]
  insRotation: [0, 0, 0]
  ioConfig: 0x06DB8046
  ioConfig2: 0x40
  key: 36
  lastLla: [40.198367500, -111.620493700, 1360.090005258]
  lastLlaTimeOfWeekMs: 316044800
  lastLlaUpdateDistance: 1000
  lastLlaWeek: 2419
  magCalibrationQualityThreshold: 10
  magDeclination: 0.00
  magInterferenceThreshold: 3
  platformConfig: 0x0000000C
  refLla: [40.197643900, -111.620633800, 1371.860024789]
  RTKCfgBits: 0x00400004
  sensorConfig: 0x03000077
  ser0BaudRate: 921600
  ser1BaudRate: 921600
  ser2BaudRate: 921600
  size: 288
  startupGnssDtMs: 200
  startupImuDtMs: 1
  startupNavDtMs: 5
  sysCfgBits: 0x00000100
  wheelConfig.bits: 0x00000000
  wheelConfig.radius: 0
  wheelConfig.track_width: 0
  wheelConfig.transform.e_b2w: [0.00, 0.00, 0.00]
  wheelConfig.transform.e_b2w_sigma: [0.02, 0.02, 0.02]
  wheelConfig.transform.t_b2w: [0.000, 0.000, 0.000]
  wheelConfig.transform.t_b2w_sigma: [0.300, 0.300, 0.300]
  zeroVelOffset: [0, 0, 0]
  zeroVelRotation: [0, 0, 0]
 ```