### PR TITLE
Update Windows install_build_tools.bat

### DIFF
--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -309,7 +309,10 @@ class BuildTestManager:
                 # print(f"  DEBUG:: {command}")
 
                 candidate_vcvars_paths = [
+                    r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat",
+                    r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat",
                     r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat",
+                    r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat",
                     r"C:\Program Files\Microsoft Visual Studio\2022\VC\Auxiliary\Build\vcvarsall.bat",
                 ]
                 vcvarsall_path = next((p for p in candidate_vcvars_paths if os.path.exists(p)), None)

--- a/scripts/build_manager.py
+++ b/scripts/build_manager.py
@@ -308,12 +308,19 @@ class BuildTestManager:
                 print("No Visual Studio installations found using vswhere.exe. Trying fallback methods.")
                 # print(f"  DEBUG:: {command}")
 
+                candidate_roots = [
+                    os.environ.get("ProgramFiles", r"C:\Program Files"),
+                    os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+                ]
+                candidate_editions = ["BuildTools", "Community", "Professional", "Enterprise", None]
                 candidate_vcvars_paths = [
-                    r"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat",
-                    r"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat",
-                    r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat",
-                    r"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat",
-                    r"C:\Program Files\Microsoft Visual Studio\2022\VC\Auxiliary\Build\vcvarsall.bat",
+                    (
+                        os.path.join(root, "Microsoft Visual Studio", "2022", edition, "VC", "Auxiliary", "Build", "vcvarsall.bat")
+                        if edition
+                        else os.path.join(root, "Microsoft Visual Studio", "2022", "VC", "Auxiliary", "Build", "vcvarsall.bat")
+                    )
+                    for root in candidate_roots
+                    for edition in candidate_editions
                 ]
                 vcvarsall_path = next((p for p in candidate_vcvars_paths if os.path.exists(p)), None)
                 if not vcvarsall_path:

--- a/scripts/windows/build_tools.cmd
+++ b/scripts/windows/build_tools.cmd
@@ -19,9 +19,13 @@
 	:: Locate MSBuild.exe
 	call :locate_executable_multi "MSBuild.exe" ^
 		"C:\Program Files\Microsoft Visual Studio\2022\Professional\Msbuild\Current\Bin\MSBuild.exe" ^
+		"C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional\Msbuild\Current\Bin\MSBuild.exe" ^
 		"C:\Program Files\Microsoft Visual Studio\2022\Community\Msbuild\Current\Bin\MSBuild.exe" ^
-		"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Current\Bin\MSBuild.exe" ^
-		"C:\Program Files\Microsoft Visual Studio\2022\Msbuild\Current\Bin\MSBuild.exe"
+		"C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\Msbuild\Current\Bin\MSBuild.exe" ^
+		"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" ^
+		"C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" ^
+		"C:\Program Files\Microsoft Visual Studio\2022\Msbuild\Current\Bin\MSBuild.exe" ^
+		"C:\Program Files (x86)\Microsoft Visual Studio\2022\Msbuild\Current\Bin\MSBuild.exe"
 
 	if not defined FOUND_EXECUTABLE (
 		echo Failed to locate MSBuild.exe!!!
@@ -29,19 +33,38 @@
 		exit /b 1
 	)
 	set "MSBUILD_EXECUTABLE=%FOUND_EXECUTABLE%"
-	echo Found MSBuild.exe at "%MSBUILD_EXECUTABLE%"
 
 	:: Locate latest nmake.exe
 	set "VC_ROOT_BUILDTOOLS=C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
+	set "VC_ROOT_BUILDTOOLS_X86=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
 	set "VC_ROOT_COMMUNITY=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC"
+	set "VC_ROOT_COMMUNITY_X86=C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC"
 	set "VC_ROOT_PROFESSIONAL=C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC"
+	set "VC_ROOT_PROFESSIONAL_X86=C:\Program Files (x86)\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC"
 	set "VC_ROOT_ENTERPRISE=C:\Program Files\Microsoft Visual Studio\2022\VC\Tools\MSVC"
+	set "VC_ROOT_ENTERPRISE_X86=C:\Program Files (x86)\Microsoft Visual Studio\2022\VC\Tools\MSVC"
 	set "FOUND_EXECUTABLE="
+
+	if exist "%VC_ROOT_BUILDTOOLS_X86%" (
+		for /f "delims=" %%D in ('dir "%VC_ROOT_BUILDTOOLS_X86%" /b /ad-h /o-n') do (
+			call :locate_executable_multi "nmake.exe" ^
+				"%VC_ROOT_BUILDTOOLS_X86%\%%D\bin\Hostx64\x64\nmake.exe"
+			if defined FOUND_EXECUTABLE goto :found_nmake
+		)
+	)
 
 	if exist "%VC_ROOT_BUILDTOOLS%" (
 		for /f "delims=" %%D in ('dir "%VC_ROOT_BUILDTOOLS%" /b /ad-h /o-n') do (
 			call :locate_executable_multi "nmake.exe" ^
 				"%VC_ROOT_BUILDTOOLS%\%%D\bin\Hostx64\x64\nmake.exe"
+			if defined FOUND_EXECUTABLE goto :found_nmake
+		)
+	)
+
+	if exist "%VC_ROOT_COMMUNITY_X86%" (
+		for /f "delims=" %%D in ('dir "%VC_ROOT_COMMUNITY_X86%" /b /ad-h /o-n') do (
+			call :locate_executable_multi "nmake.exe" ^
+				"%VC_ROOT_COMMUNITY_X86%\%%D\bin\Hostx64\x64\nmake.exe"
 			if defined FOUND_EXECUTABLE goto :found_nmake
 		)
 	)
@@ -54,10 +77,26 @@
 		)
 	)
 
+	if exist "%VC_ROOT_PROFESSIONAL_X86%" (
+		for /f "delims=" %%D in ('dir "%VC_ROOT_PROFESSIONAL_X86%" /b /ad-h /o-n') do (
+			call :locate_executable_multi "nmake.exe" ^
+				"%VC_ROOT_PROFESSIONAL_X86%\%%D\bin\Hostx64\x64\nmake.exe"
+			if defined FOUND_EXECUTABLE goto :found_nmake
+		)
+	)
+
 	if exist "%VC_ROOT_PROFESSIONAL%" (
 		for /f "delims=" %%D in ('dir "%VC_ROOT_PROFESSIONAL%" /b /ad-h /o-n') do (
 			call :locate_executable_multi "nmake.exe" ^
 				"%VC_ROOT_PROFESSIONAL%\%%D\bin\Hostx64\x64\nmake.exe"
+			if defined FOUND_EXECUTABLE goto :found_nmake
+		)
+	)
+
+	if exist "%VC_ROOT_ENTERPRISE_X86%" (
+		for /f "delims=" %%D in ('dir "%VC_ROOT_ENTERPRISE_X86%" /b /ad-h /o-n') do (
+			call :locate_executable_multi "nmake.exe" ^
+				"%VC_ROOT_ENTERPRISE_X86%\%%D\bin\Hostx64\x64\nmake.exe"
 			if defined FOUND_EXECUTABLE goto :found_nmake
 		)
 	)
@@ -79,7 +118,6 @@
 
 :found_nmake
 	set "NMAKE_EXECUTABLE=%FOUND_EXECUTABLE%"
-	echo Found nmake.exe at "%NMAKE_EXECUTABLE%"
 
 
     REM set MSBUILD_OPTIONS=/maxcpucount:7 /p:MP=7 /t:Build /p:Configuration=Release /p:Platform=x64


### PR DESCRIPTION
This pull request updates the logic for finding the `vcvarsall.bat` file in the `find_vcvarsall()` function to improve compatibility with different Visual Studio 2022 installations. The main change is the addition of more possible paths to cover both `BuildTools` and `Community` editions in both `Program Files` and `Program Files (x86)` directories.

Improvements to Visual Studio environment detection:

* Added additional candidate paths for `vcvarsall.bat` to include both `BuildTools` and `Community` editions in `Program Files` and `Program Files (x86)`, increasing the robustness of Visual Studio 2022 environment detection.