### PR TITLE
SN-8215: fix SEGV from dangling listener on singleton DeviceManager/PortManager

### DIFF
--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -19,8 +19,10 @@
 
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <functional>
+#include <unordered_set>
 
 #include "core/msg_logger.h"
 
@@ -33,6 +35,7 @@ typedef device_handle_t(*pfnOnNewDeviceHandler)(port_handle_t port, const dev_in
 typedef device_handle_t(*pfnOnCloneDeviceHandler)(const ISDevice& orig);
 
 typedef std::function<void(uint8_t, device_handle_t)> device_listener;
+typedef std::shared_ptr<device_listener> device_listener_handle_t;
 
 // typedef void(*pfnStepLogFunction)(void* ctx, const p_data_t* data, port_handle_t port);
 typedef std::function<void(void* ctx, p_data_t* data, port_handle_t port)> pfnHandleBinaryData;
@@ -191,17 +194,21 @@ public:
      * @param handler a function pointer to be called when a new device is discovered
      * @return the previously registered handler, if any
      */
-    void addDeviceListener(const device_listener& listener) { std::lock_guard<std::recursive_mutex> lock(mutex); listeners.push_back(listener); }
+    device_listener_handle_t addDeviceListener(const device_listener& listener) {
+        std::lock_guard<std::recursive_mutex> lock(mutex);
+        device_listener_handle_t listenerPtr = std::make_shared<device_listener>(listener);
+        listeners.insert(listenerPtr);
+        return listenerPtr;
+    }
 
     /**
      * Removes a previously registered device listener.
-     * @param handler a function pointer to be called when a new device is discovered
-     * @return the previously registered handler, if any
+     * @param listener the handle returned by addDeviceListener()
+     * @return true if the listener was found and removed, otherwise false
      */
-    bool removeDeviceListener(const device_listener& listener) {
-        (void)listener; // Suppress unused parameter warning
-        // TODO: locate the listener, and remove it if found and return true, otherwise return false
-        return false;
+    bool removeDeviceListener(const device_listener_handle_t& listener) {
+        std::lock_guard<std::recursive_mutex> lock(mutex);
+        return (listeners.erase(listener) != 0);
     }
 
     /**
@@ -239,12 +246,12 @@ public:
      * helpers that already take the same mutex.
      */
     void notifyListeners(device_handle_t device, uint8_t event) {
-        std::vector<device_listener> snapshot;
+        std::vector<device_listener_handle_t> snapshot;
         {
             std::lock_guard<std::recursive_mutex> lock(mutex);
-            snapshot = listeners;
+            snapshot.assign(listeners.begin(), listeners.end());
         }
-        for (auto& l : snapshot) l(event, device);
+        for (auto& l : snapshot) if (l) (*l)(event, device);
     }
 
 
@@ -400,7 +407,7 @@ private:
     PortManager& portManager = PortManager::getInstance();
 
     std::vector<DeviceFactory*> factories;                              //!< list of device factories responsible for detecting, allocating and freeing ports of different types. -- Note that DeviceFactories should always be static singletons, DO NOT FREE/DELETE the factory!
-    std::vector<device_listener> listeners;                             //!< list of listeners who should be notified when new devices are discovered, lost, opened, closed, etc
+    std::unordered_set<device_listener_handle_t> listeners;             //!< list of listeners who should be notified when new devices are discovered, lost, opened, closed, etc
     std::vector<device_entry_t> knownDevices;                           //!< vector of previously discovered devices, by factory & hdwid (bits 47-63) + serial (bits 0-31) - different than actual, allocated devices
     std::map<port_handle_t, device_handle_t> portToDeviceMap;           //!< map of port handles to device handles for fast lookups
 

--- a/src/InertialSense.cpp
+++ b/src/InertialSense.cpp
@@ -133,7 +133,7 @@ InertialSense::InertialSense(std::vector<PortFactory*> pFactories, std::vector<D
     } else {
         for (auto f: dFactories) deviceManager.addDeviceFactory(f);
     }
-    deviceManager.addDeviceListener([this](auto && PH1, auto && PH2) { deviceManagerHandler(PH1, PH2); });
+    m_deviceListenerHandle = deviceManager.addDeviceListener([this](auto && PH1, auto && PH2) { deviceManagerHandler(PH1, PH2); });
 
     if (pFactories.empty()) {
         SerialPortFactory& spf = SerialPortFactory::getInstance();
@@ -149,7 +149,7 @@ InertialSense::InertialSense(std::vector<PortFactory*> pFactories, std::vector<D
     } else {
         for (auto f : pFactories) portManager.addPortFactory(f);
     }
-    portManager.addPortListener([this](auto && PH1, auto && PH2, auto && PH3, auto && PH4, auto && PH5) { portManagerHandler(PH1, PH2, PH3, PH4, PH5); });
+    m_portListenerHandle = portManager.addPortListener([this](auto && PH1, auto && PH2, auto && PH3, auto && PH4, auto && PH5) { portManagerHandler(PH1, PH2, PH3, PH4, PH5); });
 
 
     for (int i=0; i<int(sizeof(m_comManagerState.binaryCallback)/sizeof(pfnHandleBinaryData)); i++)
@@ -203,10 +203,10 @@ InertialSense::InertialSense(
     m_disableBroadcastsOnClose = false;  // For Intel.
 
     deviceManager.addDeviceFactory((DeviceFactory*)&ImxDeviceFactory::getInstance());
-    deviceManager.addDeviceListener([this](auto && PH1, auto && PH2) { deviceManagerHandler(PH1, PH2); });
+    m_deviceListenerHandle = deviceManager.addDeviceListener([this](auto && PH1, auto && PH2) { deviceManagerHandler(PH1, PH2); });
 
     SetNetworkPortDiscovery();
-    portManager.addPortListener([this](auto && PH1, auto && PH2, auto && PH3, auto && PH4, auto && PH5) { portManagerHandler(PH1, PH2, PH3, PH4, PH5); });
+    m_portListenerHandle = portManager.addPortListener([this](auto && PH1, auto && PH2, auto && PH3, auto && PH4, auto && PH5) { portManagerHandler(PH1, PH2, PH3, PH4, PH5); });
 
     for (int i=0; i<int(sizeof(m_comManagerState.binaryCallback)/sizeof(pfnHandleBinaryData)); i++)
     {
@@ -238,6 +238,13 @@ InertialSense::InertialSense(
 
 InertialSense::~InertialSense()
 {
+    // Remove our singleton-manager listeners FIRST: these were registered in the constructor
+    // capturing `this`. If they outlive the instance (e.g. a transient InertialSense used only
+    // to resolve a -sn target, as cltool does), a later device/port event invokes the lambda
+    // against freed memory -> SEGV in deviceManagerHandler.
+    deviceManager.removeDeviceListener(m_deviceListenerHandle);
+    portManager.removePortListener(m_portListenerHandle);
+
     Close();
     DisableLogging();
     s_is = nullptr;

--- a/src/InertialSense.h
+++ b/src/InertialSense.h
@@ -661,6 +661,9 @@ private:
 
     std::set<port_handle_t> portsToValidate;    //!< ports which were discovered but have not been validated as an ISDevice
 
+    device_listener_handle_t                m_deviceListenerHandle;  //!< handle for the deviceManagerHandler listener registered on the singleton DeviceManager; removed in ~InertialSense() so a destroyed instance never leaves a dangling listener
+    PortManager::port_listener_handle_t     m_portListenerHandle;    //!< handle for the portManagerHandler listener registered on the singleton PortManager; removed in ~InertialSense()
+
 
     // returns false if logger failed to open
     bool UpdateServer();


### PR DESCRIPTION
## Summary
Fixes **SN-8215**: a second concurrent cltool (or any second SDK client) process reliably segfaults inside `InertialSense::deviceManagerHandler()` at `portsToValidate.find(device->port)`. A single instance is stable.

## Root cause
A **dangling listener on a process singleton** — not a data race, not cross-process memory.

`DeviceManager`/`PortManager` are singletons (`getInstance()`). `InertialSense`'s constructor registers listeners on both capturing `this`, but `~InertialSense()` never removed them (and `DeviceManager::removeDeviceListener()` was a no-op stub). cltool builds a **transient** `InertialSense` in `cltool_resolveDeviceTarget()` just to resolve `-sn`, then destroys it — leaving its listener (capturing the freed stack `this`) registered. A later `DEVICE_ADDED` → `notifyListeners` walks **both** listeners → the dead one dereferences reclaimed memory → SEGV.

### Evidence (gdb)
- `DeviceManager::getInstance().listeners.size() == 2` but only one live `InertialSense`.
- Handler `this = 0x…a2f0` ≠ running `OpenPorts` `this = 0x…a300`.
- Dead object's set tree node = `0x314d4341` = ASCII `"ACM1"` (the `/dev/ttyACM1` string reclaimed that freed stack); `_M_node_count` = garbage.
- Single thread; the two processes even targeted different devices — no shared memory.

## Fix
Mirror `PortManager`'s existing handle-based listener lifecycle in `DeviceManager`:
- `addDeviceListener()` returns a `device_listener_handle_t` (`shared_ptr<device_listener>`); `listeners` becomes `unordered_set<handle>`; `removeDeviceListener(handle)` actually erases; `notifyListeners` dereferences the handles.
- `InertialSense` stores `m_deviceListenerHandle`/`m_portListenerHandle` and removes both **first** in `~InertialSense()`.

Backward-compatible: all callers ignored the old `void` return; EvalTool's IOManager/Devices listeners are on long-lived singletons (unaffected).

## Verification
Rebuilt cltool, re-ran the exact repro under gdb against a running first instance: the second instance ran stably (40s+) where it previously segfaulted instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
