### PR TITLE
SN-8177: offline eviction + backoff unit tests; configurable eviction timeout

### DIFF
--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -610,9 +610,12 @@ std::chrono::milliseconds RelayPortFactory::reconnectInterval(
     if (silentMs < offlineEvictMs_) {
         return pollInterval_;
     }
-    // Lost: grow ~ one step per minute, capped at LOST_BACKOFF_MAX_MS (reached by ~10 min).
+    // Lost: grow ~ one step per minute, capped at LOST_BACKOFF_MAX_MS (60s). With the default
+    // lostBackoffBaseMs_ (6000ms): 6s, 12s, ... -> 60s cap, reached by ~10 min lost. Tests may
+    // override the base via setLostBackoffBaseMs() for a faster cadence; the cap and the
+    // one-step-per-minute growth shape are unaffected.
     int64_t minutesLost = silentMs / 60000;
-    int64_t backoffMs = lostBackoffBaseMs_ * (minutesLost + 1);   // 6s, 12s, ... -> 60s
+    int64_t backoffMs = lostBackoffBaseMs_ * (minutesLost + 1);
     if (backoffMs > LOST_BACKOFF_MAX_MS) backoffMs = LOST_BACKOFF_MAX_MS;
     return std::chrono::milliseconds(backoffMs);
 }

--- a/src/RelayPortFactory.cpp
+++ b/src/RelayPortFactory.cpp
@@ -568,7 +568,7 @@ void RelayPortFactory::tick() {
             RelayHost& host = *hostPtr;
             if (!host.enabled) continue;
             auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
-            if (silentMs > OFFLINE_EVICT_MS && (!host.devices.empty() || !host.knownPortUrls.empty())) {
+            if (silentMs > self.offlineEvictMs_ && (!host.devices.empty() || !host.knownPortUrls.empty())) {
                 log_warn(IS_LOG_PORT_FACTORY,
                          "RelayPortFactory: relay '%s' silent %lldms; evicting %zu port(s)",
                          host.url.c_str(), (long long)silentMs, host.knownPortUrls.size());
@@ -607,12 +607,12 @@ std::chrono::milliseconds RelayPortFactory::reconnectInterval(
     auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
     // Healthy / recently-lost (still inside the eviction grace): normal cadence so a brief
     // blip recovers quickly.
-    if (silentMs < OFFLINE_EVICT_MS) {
+    if (silentMs < offlineEvictMs_) {
         return pollInterval_;
     }
     // Lost: grow ~ one step per minute, capped at LOST_BACKOFF_MAX_MS (reached by ~10 min).
     int64_t minutesLost = silentMs / 60000;
-    int64_t backoffMs = 6000 * (minutesLost + 1);   // 6s, 12s, ... -> 60s
+    int64_t backoffMs = lostBackoffBaseMs_ * (minutesLost + 1);   // 6s, 12s, ... -> 60s
     if (backoffMs > LOST_BACKOFF_MAX_MS) backoffMs = LOST_BACKOFF_MAX_MS;
     return std::chrono::milliseconds(backoffMs);
 }
@@ -686,7 +686,7 @@ void RelayPortFactory::discoverRelayHostsViaMdns(
         RelayHost& host = *it->second;
         const bool recordGone = host.viaMdns && advertisedUrls.find(host.url) == advertisedUrls.end();
         auto silentMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - host.lastContact).count();
-        if (recordGone && !host.streamConnected.load() && silentMs > OFFLINE_EVICT_MS) {
+        if (recordGone && !host.streamConnected.load() && silentMs > offlineEvictMs_) {
             log_info(IS_LOG_PORT_FACTORY,
                      "RelayPortFactory: mDNS relay host '%s' announcement expired; dropping (%zu port(s))",
                      host.url.c_str(), host.knownPortUrls.size());

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -233,6 +233,21 @@ public:
     static constexpr int64_t OFFLINE_EVICT_MS = 30000;
 
     /**
+     * Override the offline eviction threshold at runtime. The default is OFFLINE_EVICT_MS (30 s).
+     * Intended for unit tests that need a short timeout to avoid long waits; not for production use.
+     * @param ms  new threshold in milliseconds
+     */
+    void setOfflineEvictMs(int64_t ms) { offlineEvictMs_ = ms; }
+
+    /**
+     * Override the per-step base for the escalating reconnect backoff. The default is 6000 ms
+     * (so the first step past the eviction window is 6 s). Intended for unit tests only.
+     * In production the value is tuned so the cadence reaches LOST_BACKOFF_MAX_MS (~10 min).
+     * @param ms  new per-step base in milliseconds
+     */
+    void setLostBackoffBaseMs(int64_t ms) { lostBackoffBaseMs_ = ms; }
+
+    /**
      * SN-8177: escalating reconnect backoff for a "lost" manually-configured host. The probe
      * interval grows roughly each minute the host has been silent, capping here (~10 min in).
      * Keeps a dead-but-maybe-returning relay from being hammered (and blocking the IO thread).
@@ -293,6 +308,8 @@ private:
     std::map<std::string, std::unique_ptr<RelayHost>> relayHosts_;
     mutable std::recursive_mutex mutex_;
     std::chrono::milliseconds pollInterval_ = std::chrono::seconds(1);
+    int64_t offlineEvictMs_ = OFFLINE_EVICT_MS;    //!< mutable threshold used by tick() and reconnectInterval(); override via setOfflineEvictMs()
+    int64_t lostBackoffBaseMs_ = 6000;             //!< per-step multiplier for escalating backoff; override via setLostBackoffBaseMs()
     std::chrono::steady_clock::time_point lastMdnsQueryTime_ = {}; //!< rate-limit mDNS queries
 
     /**

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -242,15 +242,18 @@ public:
     /**
      * Override the per-step base for the escalating reconnect backoff. The default is 6000 ms
      * (so the first step past the eviction window is 6 s). Intended for unit tests only.
-     * In production the value is tuned so the cadence reaches LOST_BACKOFF_MAX_MS (~10 min).
+     * In production, with this default, the interval reaches the LOST_BACKOFF_MAX_MS cap after
+     * ~10 minutes of being lost.
      * @param ms  new per-step base in milliseconds
      */
     void setLostBackoffBaseMs(int64_t ms) { lostBackoffBaseMs_ = ms; }
 
     /**
-     * SN-8177: escalating reconnect backoff for a "lost" manually-configured host. The probe
-     * interval grows roughly each minute the host has been silent, capping here (~10 min in).
-     * Keeps a dead-but-maybe-returning relay from being hammered (and blocking the IO thread).
+     * SN-8177: ceiling on the escalating reconnect backoff interval for a "lost"
+     * manually-configured host — 60 s. With the default lostBackoffBaseMs_ (6000 ms), the
+     * probe interval grows roughly one step per minute the host has been silent (6 s, 12 s,
+     * ...), reaching this 60 s cap after ~10 minutes lost. Keeps a dead-but-maybe-returning
+     * relay from being hammered (and blocking the IO thread).
      */
     static constexpr int64_t LOST_BACKOFF_MAX_MS = 60000;
 

--- a/tests/test_RelayPortFactory.cpp
+++ b/tests/test_RelayPortFactory.cpp
@@ -83,16 +83,29 @@ public:
                 res.set_content("{\"error\":\"offline\"}", "application/json");
                 return;
             }
-            json body = {
-                {"host", "fake.local"},
-                {"server_instance_id", instanceId_},
-                {"snapshot_id", snapshotId_.load()},
-                {"devices", snapshotDevices()},
-            };
+            json body;
+            {
+                // instanceId_/devices_ are mutated under mutex_ by emitAdded/emitRemoved/restart;
+                // take the lock here too so this handler doesn't race them.
+                std::lock_guard<std::mutex> lock(mutex_);
+                body = {
+                    {"host", "fake.local"},
+                    {"server_instance_id", instanceId_},
+                    {"snapshot_id", snapshotId_.load()},
+                    {"devices", snapshotDevices()},
+                };
+            }
             res.set_content(body.dump(), "application/json");
         });
 
         server_.Get("/api/events/devices", [this](const httplib::Request& req, httplib::Response& res) {
+            if (offline_.load()) {
+                // Reject new connection attempts outright (503) — matches the polling endpoint's
+                // offline behavior. An already-open stream is handled separately in handleStream().
+                res.status = 503;
+                res.set_content("{\"error\":\"offline\"}", "application/json");
+                return;
+            }
             const std::string lastId = req.get_header_value("Last-Event-ID");
             res.set_chunked_content_provider("text/event-stream",
                 [this, lastId](size_t /*offset*/, httplib::DataSink& sink) {
@@ -160,8 +173,11 @@ public:
     /// Override: serve SSE with a 500 status so transport-fallback tests can force retries.
     void setFailSse(bool fail) { failSse_ = fail; }
 
-    /// Simulate a complete relay outage: both HTTP and SSE endpoints return 503. Thread-safe.
-    /// Call setOffline(false) to restore normal operation.
+    /// Simulate a complete relay outage: new /api/availableDevices requests and new SSE
+    /// connection attempts both get an HTTP 503. An already-open SSE stream is NOT forcibly
+    /// closed by this call — it just goes silent (no further bytes) — mirroring a real relay's
+    /// hard power loss, where the peer sends no FIN/RST and the socket looks alive but idle.
+    /// Thread-safe. Call setOffline(false) to restore normal operation.
     void setOffline(bool offline) {
         offline_.store(offline);
         if (offline) {

--- a/tests/test_RelayPortFactory.cpp
+++ b/tests/test_RelayPortFactory.cpp
@@ -78,6 +78,11 @@ public:
         if (port_ <= 0) return 0;
 
         server_.Get("/api/availableDevices", [this](const httplib::Request&, httplib::Response& res) {
+            if (offline_.load()) {
+                res.status = 503;
+                res.set_content("{\"error\":\"offline\"}", "application/json");
+                return;
+            }
             json body = {
                 {"host", "fake.local"},
                 {"server_instance_id", instanceId_},
@@ -155,6 +160,17 @@ public:
     /// Override: serve SSE with a 500 status so transport-fallback tests can force retries.
     void setFailSse(bool fail) { failSse_ = fail; }
 
+    /// Simulate a complete relay outage: both HTTP and SSE endpoints return 503. Thread-safe.
+    /// Call setOffline(false) to restore normal operation.
+    void setOffline(bool offline) {
+        offline_.store(offline);
+        if (offline) {
+            // Wake SSE handlers so they observe the offline flag and close their sinks.
+            std::lock_guard<std::mutex> lock(mutex_);
+            cv_.notify_all();
+        }
+    }
+
     int port() const { return port_; }
     std::string instanceId() const { std::lock_guard<std::mutex> lock(mutex_); return instanceId_; }
 
@@ -162,7 +178,7 @@ private:
     struct Event { std::string type; uint64_t id; std::string data; };
 
     void handleStream(const std::string& lastId, httplib::DataSink& sink) {
-        if (failSse_.load()) {
+        if (failSse_.load() || offline_.load()) {
             // Emulate a server error — write nothing and let the client time out / retry.
             sink.done();
             return;
@@ -256,6 +272,7 @@ private:
     size_t ringSize_ = 256;
     uint64_t ringBase_ = 1;        // snapshot_ids >= this are in the ring
     std::atomic<bool> failSse_{false};
+    std::atomic<bool> offline_{false};
     std::atomic<bool> stopping_{false};
 };
 
@@ -269,6 +286,10 @@ void resetFactory() {
     for (const auto& h : rpf.getRelayHosts()) {
         rpf.removeRelayHost(h.url);
     }
+    // Reset test-only overrides to production defaults.
+    rpf.setOfflineEvictMs(RelayPortFactory::OFFLINE_EVICT_MS);
+    rpf.setLostBackoffBaseMs(6000);
+    rpf.setPollInterval(std::chrono::seconds(1));
 }
 
 /// Spin-wait with timeout, running tick() periodically to drive the factory.
@@ -482,5 +503,205 @@ TEST(test_RelayPortFactory, pollingFallbackAfterSseFailures) {
 
     rpf.setRelayHostEnabled(url, false);
     resetFactory();
+    fake.stop();
+}
+
+// ============================================================
+// SN-8177: offline eviction, reconnect backoff, recovery
+// ============================================================
+
+// Plan A: when a relay goes silent past the eviction window, tick() clears its devices
+// and knownPortUrls so PortManager evicts the ports on its next sweep.
+TEST(test_RelayPortFactory, offlineEviction_sse_clearsPorts) {
+    FakeBridgeboard fake;
+    fake.emitAdded(makeDevice(1, 0, "tcp://127.0.0.1:55400", 400));
+    ASSERT_GT(fake.start(), 0);
+
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+    rpf.setOfflineEvictMs(500);   // short for test speed
+    std::string url = "http://127.0.0.1:" + std::to_string(fake.port());
+    rpf.addRelayHost(url);
+    rpf.setRelayHostEnabled(url, true);
+
+    // Wait for SSE to deliver the initial snapshot.
+    ASSERT_TRUE(waitFor([&]() {
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 1 && h.streamConnected) return true;
+        return false;
+    }, 2s)) << "initial SSE snapshot did not arrive";
+
+    // Take the relay offline: no more bytes from the server.
+    fake.setOffline(true);
+
+    // Tick repeatedly; once the silence exceeds offlineEvictMs (500 ms) the eviction fires.
+    EXPECT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 0) return true;
+        return false;
+    }, 4s)) << "ports not evicted after relay went silent";
+
+    // validatePort must also return false so PortManager sweeps are correct.
+    EXPECT_FALSE(rpf.validatePort("tcp://127.0.0.1:55400", PORT_TYPE__TCP | PORT_TYPE__COMM));
+
+    rpf.setRelayHostEnabled(url, false);
+    resetFactory();
+    fake.setOffline(false);
+    fake.stop();
+}
+
+// Plan A (polling transport): same eviction via the polling code path.
+TEST(test_RelayPortFactory, offlineEviction_polling_clearsPorts) {
+    FakeBridgeboard fake;
+    fake.setFailSse(true);   // force polling mode from the start
+    fake.emitAdded(makeDevice(1, 0, "tcp://127.0.0.1:55401", 401));
+    ASSERT_GT(fake.start(), 0);
+
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+    rpf.setOfflineEvictMs(500);
+    rpf.setLostBackoffBaseMs(50);    // fast reconnect cadence so ticks fire quickly
+    rpf.setPollInterval(std::chrono::milliseconds(50));
+
+    std::string url = "http://127.0.0.1:" + std::to_string(fake.port());
+    rpf.addRelayHost(url);
+    rpf.setRelayHostEnabled(url, true);
+
+    // Wait for polling fallback and initial sync.
+    ASSERT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.feedType == RelayPortFactory::RelayFeedType::Polling && h.deviceCount == 1) return true;
+        return false;
+    }, 5s)) << "polling fallback + initial device not reached";
+
+    // Silence the relay.
+    fake.setOffline(true);
+
+    // Tick until eviction fires.
+    EXPECT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 0) return true;
+        return false;
+    }, 4s)) << "ports not evicted (polling) after relay went silent";
+
+    rpf.setRelayHostEnabled(url, false);
+    resetFactory();
+    fake.setOffline(false);
+    fake.stop();
+}
+
+// Plan A + recovery: after eviction, when the relay returns, tick() repopulates its ports.
+TEST(test_RelayPortFactory, offlineEviction_recovery_portsRepopulate) {
+    FakeBridgeboard fake;
+    fake.setFailSse(true);   // use polling so recovery is driven by tick() alone
+    fake.emitAdded(makeDevice(1, 0, "tcp://127.0.0.1:55402", 402));
+    ASSERT_GT(fake.start(), 0);
+
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+    rpf.setOfflineEvictMs(300);
+    rpf.setLostBackoffBaseMs(100);   // backoff base: 100 ms (first step = 100 ms) for fast recovery
+    rpf.setPollInterval(std::chrono::milliseconds(50));
+
+    std::string url = "http://127.0.0.1:" + std::to_string(fake.port());
+    rpf.addRelayHost(url);
+    rpf.setRelayHostEnabled(url, true);
+
+    ASSERT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.feedType == RelayPortFactory::RelayFeedType::Polling && h.deviceCount == 1) return true;
+        return false;
+    }, 5s)) << "polling + initial device not reached before going offline";
+
+    // Go offline — should evict within ~300 ms.
+    fake.setOffline(true);
+    ASSERT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 0) return true;
+        return false;
+    }, 3s)) << "eviction did not happen";
+
+    // Bring the relay back.
+    fake.setOffline(false);
+
+    // After the backoff interval elapses, tick() polls again and repopulates.
+    EXPECT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 1) return true;
+        return false;
+    }, 5s)) << "ports did not repopulate after relay returned";
+
+    rpf.setRelayHostEnabled(url, false);
+    resetFactory();
+    fake.stop();
+}
+
+// Plan B (backoff): once a polling host is past the eviction window, tick() uses an
+// escalating interval instead of hammering at pollInterval_ cadence.
+TEST(test_RelayPortFactory, reconnectBackoff_escalatesAfterEviction) {
+    FakeBridgeboard fake;
+    fake.setFailSse(true);
+    fake.emitAdded(makeDevice(1, 0, "tcp://127.0.0.1:55403", 403));
+    ASSERT_GT(fake.start(), 0);
+
+    auto& rpf = RelayPortFactory::getInstance();
+    resetFactory();
+    rpf.setOfflineEvictMs(200);
+    rpf.setLostBackoffBaseMs(500);  // first backoff step = 500 ms (much longer than poll interval)
+    rpf.setPollInterval(std::chrono::milliseconds(30));
+
+    std::string url = "http://127.0.0.1:" + std::to_string(fake.port());
+    rpf.addRelayHost(url);
+    rpf.setRelayHostEnabled(url, true);
+
+    ASSERT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.feedType == RelayPortFactory::RelayFeedType::Polling && h.deviceCount == 1) return true;
+        return false;
+    }, 5s)) << "initial polling + device not reached";
+
+    // Silence the relay and wait past the eviction window.
+    fake.setOffline(true);
+    ASSERT_TRUE(waitFor([&]() {
+        RelayPortFactory::tick();
+        for (const auto& h : rpf.getRelayHosts())
+            if (h.url == url && h.deviceCount == 0) return true;
+        return false;
+    }, 3s)) << "eviction did not happen";
+
+    // Sample consecutiveFailures just after entering the backoff zone.
+    uint32_t failuresAtEntry = 0;
+    for (const auto& h : rpf.getRelayHosts())
+        if (h.url == url) { failuresAtEntry = h.consecutiveFailures; break; }
+
+    // Drive tick() for 300 ms. With a 500 ms first-step backoff, at most 1 new poll
+    // attempt should occur in this window.
+    auto t0 = std::chrono::steady_clock::now();
+    while (std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - t0).count() < 300) {
+        RelayPortFactory::tick();
+        std::this_thread::sleep_for(20ms);
+    }
+
+    uint32_t failuresAfter = 0;
+    for (const auto& h : rpf.getRelayHosts())
+        if (h.url == url) { failuresAfter = h.consecutiveFailures; break; }
+
+    // At 30 ms poll interval with no backoff, 300 ms would produce ~10 attempts.
+    // With backoff first-step = 500 ms, at most 1 attempt should occur.
+    EXPECT_LE(failuresAfter - failuresAtEntry, 1u)
+        << "expected backoff to suppress most poll attempts; got "
+        << (failuresAfter - failuresAtEntry) << " new failure(s) in 300 ms";
+
+    rpf.setRelayHostEnabled(url, false);
+    resetFactory();
+    fake.setOffline(false);
     fake.stop();
 }


### PR DESCRIPTION
## Summary

- Adds the unit tests that were planned in SN-8177 but omitted from the June PR (#1188).
- Makes `OFFLINE_EVICT_MS` and the reconnect backoff base configurable at runtime (test-only setters; production defaults unchanged) so tests run in seconds rather than minutes.
- Adds `FakeBridgeboard::setOffline()` to simulate a powered-off relay cleanly in tests.

**New tests (all passing):**
- `offlineEviction_sse_clearsPorts` — relay goes silent via SSE path; `tick()` evicts ports within the configurable timeout (Plan A)
- `offlineEviction_polling_clearsPorts` — same via polling fallback path (Plan A)
- `offlineEviction_recovery_portsRepopulate` — relay returns after eviction; polling repopulates ports (Plan A + B recovery)
- `reconnectBackoff_escalatesAfterEviction` — confirms `tick()` uses the escalating interval after the host enters the backoff zone, not the fast poll cadence (Plan B)

No production behavior changes — only the addition of two public setter overrides and the refactoring of `OFFLINE_EVICT_MS` / the backoff step constant to use mutable members.

## Test plan

- [x] All 10 `test_RelayPortFactory.*` tests pass locally
- [x] Full SDK unit test suite: 260/261 pass (1 GPS fixture skip — unrelated)
- [x] CI green

Jira: SN-8177

🤖 Generated with [Claude Code](https://claude.com/claude-code)