### PR TITLE
SN-8307: Fix DID_CANFD_CONFIG mapping under-covering can_config_t

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1998,6 +1998,13 @@ static void PopulateMapCanFdConfig(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember2("can_fd_transmit_address[FDCID_GNSS2_POS]",         offsetof(can_config_t, can_transmit_address) + sizeof(uint32_t) * FDCID_GNSS2_POS,         DATA_TYPE_UINT32, "", "FD transmit address for GNSS2 position",            DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember2("can_fd_transmit_address[FDCID_GNSS1_RTK_POS_REL]", offsetof(can_config_t, can_transmit_address) + sizeof(uint32_t) * FDCID_GNSS1_RTK_POS_REL, DATA_TYPE_UINT32, "", "FD transmit address for GNSS1 RTK relative",       DATA_FLAGS_DISPLAY_HEX);
     mapper.AddMember2("can_fd_transmit_address[FDCID_GNSS2_RTK_CMP_REL]", offsetof(can_config_t, can_transmit_address) + sizeof(uint32_t) * FDCID_GNSS2_RTK_CMP_REL, DATA_TYPE_UINT32, "", "FD transmit address for GNSS2 RTK compassing relative", DATA_FLAGS_DISPLAY_HEX);
+
+    // can_config_t is shared with DID_CAN_CONFIG, whose arrays are sized NUM_CIDS (27). CAN-FD
+    // only uses the first NUM_FDCIDS (10) slots of each array, so the mappings above cover just
+    // that subset. The DataMapper invariant requires the mapped fields to span the whole struct,
+    // so account for the FD-unused tail of both arrays as reserved regions.
+    mapper.AddMember2("can_fd_period_mult_reserved",      offsetof(can_config_t, can_period_mult)      + sizeof(uint16_t) * NUM_FDCIDS, DATA_TYPE_BINARY, "", "Reserved (classic-CAN period-mult slots unused in FD mode)",      DATA_FLAGS_READ_ONLY, 1.0, (uint32_t)(sizeof(uint16_t) * (NUM_CIDS - NUM_FDCIDS)));
+    mapper.AddMember2("can_fd_transmit_address_reserved", offsetof(can_config_t, can_transmit_address) + sizeof(uint32_t) * NUM_FDCIDS, DATA_TYPE_BINARY, "", "Reserved (classic-CAN transmit-address slots unused in FD mode)", DATA_FLAGS_READ_ONLY, 1.0, (uint32_t)(sizeof(uint32_t) * (NUM_CIDS - NUM_FDCIDS)));
 }
 
 static void PopulateMapDiagMsg(data_set_t data_set[DID_COUNT], uint32_t did)


### PR DESCRIPTION
## Problem

The EvalTool debug build aborts during static initialization (SIGABRT) before the GUI appears:

```
DataMapper ERROR [12can_config_t]: mapped size 66 != struct size 168 (diff 102 bytes)
Assertion `false && "Size of mapped fields does not match struct size"' failed. (ISDataMappings.h:242)
```

## Root cause

`can_config_t` is **168 bytes** — its two arrays are sized `NUM_CIDS` (27): `can_period_mult[27]` (54B) + `can_transmit_address[27]` (108B) + `can_setting` (2B) + `can_receive_address` (4B).

`PopulateMapCanFdConfig` (DID_CANFD_CONFIG) maps only the CAN-FD subset — the first `NUM_FDCIDS` (10) slots of each shared array — summing to **66 bytes** (22 members). The `DataMapper` destructor requires mapped fields to span the whole struct (`totalSize == sizeof(struct)`), so `66 != 168` aborts startup in debug builds.

SN-8301 fixed the classic `PopulateMapCanConfig` (DID_CAN_CONFIG) mapper to fully cover all 27 slots, but left the FD mapper under-covering the shared struct.

## Fix

Add reserved `DATA_TYPE_BINARY` filler mappings for the FD-unused tail of both arrays (indices `NUM_FDCIDS..NUM_CIDS-1`), keyed off `NUM_FDCIDS`/`NUM_CIDS`. The FD mapping now spans the full 168 bytes (66 + 102 = 168).

## Validation

EvalTool debug build (develop) starts cleanly — no `DataMapper ERROR`, no assertion, no segfault, graceful shutdown.

Jira: SN-8307

🤖 Generated with [Claude Code](https://claude.com/claude-code)