### PR TITLE
SN-8307: Accept legacy GNSS1/GNSS2 firmware target names as CXD5610 aliases

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -950,6 +950,8 @@ void ISFirmwareUpdater::cmd_SetTarget(ISFwUpdaterCmd& cmd) {
         else if (targetName == "GPX1") setTarget(fwUpdate::TARGET_GPX1);
         else if (targetName == "CXD1") setTarget(fwUpdate::TARGET_SONY_CXD5610__1);
         else if (targetName == "CXD2") setTarget(fwUpdate::TARGET_SONY_CXD5610__2);
+        else if (targetName == "GNSS1") setTarget(fwUpdate::TARGET_SONY_CXD5610__1);        // TODO: Remove this 06/30/2027 - obsoleted by CXD1
+        else if (targetName == "GNSS2") setTarget(fwUpdate::TARGET_SONY_CXD5610__2);        // TODO: Remove this 06/30/2027 - obsoleted by CXD2
         else if (targetName == "SEPT") setTarget(fwUpdate::TARGET_SEPTENTRIO);
         else {
             handleCommandError(cmd, -1, "Invalid Target specified: %s  (Valid targets are: IMX5, IMX6, GPX1, CXD1, CXD2, SEPT)", targetName.c_str());


### PR DESCRIPTION
## What

The 3.1.0 firmware manifest renames the `GNSS1`/`GNSS2` update+validate steps and targets to `CXD1`/`CXD2`. This adds backward-compatible aliases in `ISFirmwareUpdater::cmd_SetTarget` so the legacy `GNSS1`/`GNSS2` target names still resolve to `TARGET_SONY_CXD5610__1`/`__2`.

This keeps older manifests and scripts working during the transition. The aliases are marked for removal 06/30/2027.

## Why

SDK-side counterpart to the manifest changes in the tied imx PR — without it, older manifests referencing `GNSS1`/`GNSS2` targets would fail to resolve after the rename.

## Related

- Tied imx PR (firmware manifest + semver 3.1.0): inertialsense/imx#1610
- Jira: SN-8307

🤖 Generated with [Claude Code](https://claude.com/claude-code)