### PR TITLE
SN-8308: add Welford online variance/stddev to ChronoStat + unit tests

### DIFF
--- a/src/ChronoStat.h
+++ b/src/ChronoStat.h
@@ -46,6 +46,7 @@ private:
     double timeLast = NAN;                  //!< the last time that a sample was taken
     std::chrono::high_resolution_clock::time_point localTimeTs;     // this should initialize to the clocks epoch
     std::string label;
+    double dtM2 = 0;                        //!< Welford's algorithm running sum of squared differences from the mean, used to derive dtVariance
 
 public:
     double dt = 0;                          //!< the delta in time between the previous 2 samples, in seconds,
@@ -54,6 +55,7 @@ public:
     double dtMinTime = 0;                   //!< the sample time of the lowest dt
     double dtMaxTime = 0;                   //!< the sample time of the largest dt
     double dtAvg = 0;                       //!< the average dt across all samples (in seconds)
+    double dtVariance = 0;                  //!< the (population) variance of dt across all samples, computed online via Welford's algorithm
     int dtCnt = 0;                          //!< the number of dt samples (should always be cnt - 1)
     double duration = 0;                    //!< the sum of all dt's - effectively the total time between the first and last sample.
 
@@ -142,6 +144,8 @@ public:
         dtMinTime = 0;
         dtMaxTime = 0;
         dtAvg = 0;
+        dtVariance = 0;
+        dtM2 = 0;
         dtCnt = 0;
         duration = 0;
 
@@ -185,7 +189,11 @@ public:
             dt = time - timeLast;
             double alpha = 1.0 / (1.0 + dtCnt);
             double beta = 1.0 - alpha;
+            double dtDelta = dt - dtAvg;              // dtAvg is still the mean of the previous dtCnt samples here
             dtAvg = beta * dtAvg + alpha * dt;
+            double dtDelta2 = dt - dtAvg;              // dtAvg is now the updated mean
+            dtM2 += dtDelta * dtDelta2;                 // Welford's algorithm running sum of squares
+            dtVariance = dtM2 / (dtCnt + 1);            // population variance over all dt samples so far
             dtCnt++;
             duration += dt;
 
@@ -217,6 +225,11 @@ public:
         END_DEBUG_MSG(log_more_debug);
     };
 
+
+    /**
+     * @returns the (population) standard deviation of dt across all samples, in the same units as dt.
+     */
+    inline double dtStdDev() { return std::sqrt(dtVariance); }
 
     /**
      * @brief a utility function to generate a summary of the stat values

--- a/tests/test_chrono_stat.cpp
+++ b/tests/test_chrono_stat.cpp
@@ -1,0 +1,135 @@
+// D-10-adjacent / SN-8308: unit tests for ChronoStat, covering the
+// existing dt/ddt tracking plus the Welford online variance/stddev
+// added for the EvalTool GNSS dt-guard work, and the clear()+sample()
+// reset pattern that the guarded wrapper (EvalTool-side) relies on to
+// rebase after a backwards/absurd time jump.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "ChronoStat.h"
+
+TEST(ChronoStat, InitialStateHasNoData) {
+    ChronoStat stat;
+    EXPECT_EQ(stat.count(), 0);
+    EXPECT_FALSE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 0);
+    EXPECT_EQ(stat.dtVariance, 0);
+}
+
+TEST(ChronoStat, FirstSampleProducesNoDt) {
+    ChronoStat stat;
+    stat.sample(10.0);
+    EXPECT_EQ(stat.count(), 1);
+    // A single sample can't produce a dt yet.
+    EXPECT_FALSE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 0);
+    EXPECT_EQ(stat.dtMin, 0);
+    EXPECT_EQ(stat.dtMax, 0);
+}
+
+TEST(ChronoStat, MinMaxTrackAcrossSamples) {
+    ChronoStat stat;
+    stat.sample(0.0);
+    stat.sample(1.0);   // dt = 1.0
+    stat.sample(1.5);   // dt = 0.5
+    stat.sample(3.5);   // dt = 2.0
+
+    EXPECT_TRUE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 3);
+    EXPECT_DOUBLE_EQ(stat.dtMin, 0.5);
+    EXPECT_DOUBLE_EQ(stat.dtMax, 2.0);
+}
+
+TEST(ChronoStat, AverageMatchesSimpleMean) {
+    ChronoStat stat;
+    // dt sequence: 1, 3, 5 -> mean 3
+    stat.sample(0.0);
+    stat.sample(1.0);
+    stat.sample(4.0);
+    stat.sample(9.0);
+
+    EXPECT_EQ(stat.dtCnt, 3);
+    EXPECT_NEAR(stat.dtAvg, 3.0, 1e-9);
+}
+
+TEST(ChronoStat, VarianceMatchesReferenceCalculation) {
+    ChronoStat stat;
+    // dt sequence chosen to have an easy-to-verify population variance.
+    // times: 0, 2, 5, 6 -> dts: 2, 3, 1 ; mean = 2 ; population variance = ((0)^2+(1)^2+(-1)^2)/3 = 2/3
+    stat.sample(0.0);
+    stat.sample(2.0);
+    stat.sample(5.0);
+    stat.sample(6.0);
+
+    EXPECT_EQ(stat.dtCnt, 3);
+    EXPECT_NEAR(stat.dtAvg, 2.0, 1e-9);
+    EXPECT_NEAR(stat.dtVariance, 2.0 / 3.0, 1e-9);
+    EXPECT_NEAR(stat.dtStdDev(), std::sqrt(2.0 / 3.0), 1e-9);
+}
+
+TEST(ChronoStat, VarianceIsZeroForConstantDt) {
+    ChronoStat stat;
+    stat.sample(0.0);
+    stat.sample(1.0);
+    stat.sample(2.0);
+    stat.sample(3.0);
+
+    EXPECT_NEAR(stat.dtVariance, 0.0, 1e-12);
+    EXPECT_NEAR(stat.dtStdDev(), 0.0, 1e-12);
+}
+
+TEST(ChronoStat, ClearResetsAllDtStats) {
+    ChronoStat stat;
+    stat.sample(0.0);
+    stat.sample(1.0);
+    stat.sample(3.0);
+    ASSERT_TRUE(stat.hasData());
+    ASSERT_GT(stat.dtVariance, 0.0);
+
+    stat.clear();
+
+    EXPECT_EQ(stat.count(), 0);
+    EXPECT_FALSE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 0);
+    EXPECT_EQ(stat.dtMin, 0);
+    EXPECT_EQ(stat.dtMax, 0);
+    EXPECT_EQ(stat.dtAvg, 0);
+    EXPECT_EQ(stat.dtVariance, 0);
+}
+
+// This is the pattern the EvalTool-side guarded wrapper relies on: on a
+// backwards/absurd jump, call clear() and re-baseline with the new
+// timestamp as if it were the first sample ever seen, rather than
+// recording a bogus dt into min/max/avg/variance.
+TEST(ChronoStat, ClearThenResampleBehavesAsFreshStart) {
+    ChronoStat stat;
+    stat.sample(0.0);
+    stat.sample(1.0);   // dt = 1.0 -- establishes a baseline
+    stat.sample(2.0);   // dt = 1.0
+
+    // Simulate a GPS-week wraparound / backwards jump: the guarded
+    // wrapper detects this externally and rebases instead of sampling
+    // the raw (huge negative) delta.
+    stat.clear();
+    stat.sample(0.05);  // new baseline post-wrap; still no dt yet
+    EXPECT_FALSE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 0);
+
+    stat.sample(0.15);  // dt = 0.10, first "real" dt after the rebase
+    EXPECT_TRUE(stat.hasData());
+    EXPECT_EQ(stat.dtCnt, 1);
+    EXPECT_NEAR(stat.dtMin, 0.10, 1e-9);
+    EXPECT_NEAR(stat.dtMax, 0.10, 1e-9);
+    EXPECT_NEAR(stat.dtAvg, 0.10, 1e-9);
+    EXPECT_NEAR(stat.dtVariance, 0.0, 1e-12);
+}
+
+TEST(ChronoStat, LabelRoundTrips) {
+    ChronoStat stat;
+    EXPECT_FALSE(stat.hasLabel());
+    stat.setLabel("DID_GNSS1_POS");
+    EXPECT_TRUE(stat.hasLabel());
+    EXPECT_EQ(stat.getLabel(), "DID_GNSS1_POS");
+}

--- a/tests/test_message_stats.cpp
+++ b/tests/test_message_stats.cpp
@@ -1,0 +1,110 @@
+// SN-8308: unit tests for MessageStats, covering the counting/dt
+// bookkeeping shared by EvalTool's Log Summary and cltool's stream
+// stats display. Exercises MessageStats::append() directly against
+// non-ISB protocol types (NMEA/RTCM3/ACK/parse-error) so the tests
+// don't depend on cISDataMappings being initialized -- only the ISB
+// path (DID lookups) needs that, and it's not what's under test here.
+
+#include <gtest/gtest.h>
+
+#include "message_stats.h"
+#include "ISComm.h"
+
+TEST(MessageStats, InitialStateIsEmpty) {
+    MessageStats::mul_stats_t stats;
+    EXPECT_TRUE(stats.isb.empty());
+    EXPECT_TRUE(stats.nmea.empty());
+    EXPECT_TRUE(stats.ublox.empty());
+    EXPECT_TRUE(stats.rtcm3.empty());
+    EXPECT_EQ(stats.ack.count, 0);
+    EXPECT_EQ(stats.parseError.count, 0);
+}
+
+TEST(MessageStats, FirstAppendCreatesEntryWithCountOne) {
+    MessageStats::mul_stats_t stats;
+    MessageStats::append("", stats, _PTYPE_NMEA, /*id=*/1234, /*bytes=*/50, /*timeMs=*/1000);
+
+    ASSERT_EQ(stats.nmea.count(1234), 1u);
+    const MessageStats::stats_t &s = stats.nmea.at(1234);
+    EXPECT_EQ(s.count, 1);
+    EXPECT_EQ(s.timeMs, 1000u);
+    EXPECT_EQ(s.prevTimeMs, 1000u);   // first sample: prev == current, so dt reads as 0
+    EXPECT_EQ(s.bytes, 50u);
+}
+
+TEST(MessageStats, RepeatedAppendsIncrementCountAndTrackDt) {
+    MessageStats::mul_stats_t stats;
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 1000);
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 1500);
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 2100);
+
+    const MessageStats::stats_t &s = stats.nmea.at(1234);
+    EXPECT_EQ(s.count, 3);
+    // dt is derived by callers (e.g. MessageStats::summary()) as timeMs - prevTimeMs.
+    EXPECT_EQ(s.timeMs, 2100u);
+    EXPECT_EQ(s.prevTimeMs, 1500u);
+    EXPECT_EQ(s.timeMs - s.prevTimeMs, 600u);
+}
+
+TEST(MessageStats, BytesPerSecondResetsOnceWindowElapses) {
+    MessageStats::mul_stats_t stats;
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 1000);   // startTimeMs := 1000
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 1500);   // dtMs=500 <1000s window: no rate update yet
+
+    {
+        const MessageStats::stats_t &s = stats.nmea.at(1234);
+        EXPECT_EQ(s.bytesPerSec, 0);
+        EXPECT_EQ(s.bytes, 100u);   // accumulating, not yet flushed
+    }
+
+    MessageStats::append("", stats, _PTYPE_NMEA, 1234, 50, 2100);   // dtMs=1100 >=1000: flush window
+
+    const MessageStats::stats_t &s = stats.nmea.at(1234);
+    EXPECT_EQ(s.bytesPerSec, (1000 * 150) / 1100);
+    EXPECT_EQ(s.bytes, 0u);   // reset after computing the rate
+}
+
+TEST(MessageStats, DifferentIdsGetIndependentEntries) {
+    MessageStats::mul_stats_t stats;
+    MessageStats::append("", stats, _PTYPE_NMEA, 1111, 10, 1000);
+    MessageStats::append("", stats, _PTYPE_NMEA, 2222, 20, 1000);
+
+    ASSERT_EQ(stats.nmea.size(), 2u);
+    EXPECT_EQ(stats.nmea.at(1111).count, 1);
+    EXPECT_EQ(stats.nmea.at(2222).count, 1);
+    EXPECT_EQ(stats.nmea.at(1111).bytes, 10u);
+    EXPECT_EQ(stats.nmea.at(2222).bytes, 20u);
+}
+
+TEST(MessageStats, ProtocolTypesAreTrackedInSeparateBuckets) {
+    MessageStats::mul_stats_t stats;
+    MessageStats::append("", stats, _PTYPE_NMEA, 1, 10, 1000);
+    MessageStats::append("", stats, _PTYPE_RTCM3, 1005, 20, 1000);
+    MessageStats::append("", stats, _PTYPE_INERTIAL_SENSE_ACK, 0, 5, 1000);
+    MessageStats::append("", stats, _PTYPE_PARSE_ERROR, 0, 1, 1000);
+
+    EXPECT_EQ(stats.nmea.size(), 1u);
+    EXPECT_EQ(stats.rtcm3.size(), 1u);
+    EXPECT_EQ(stats.ack.count, 1);
+    EXPECT_EQ(stats.parseError.count, 1);
+
+    // Buckets are independent: touching one doesn't perturb the others.
+    EXPECT_TRUE(stats.ublox.empty());
+}
+
+TEST(MessageStats, ClearResetsAllBucketsAndHistory) {
+    MessageStats ms;
+    ms.history.push_back("some event");
+    MessageStats::append("", ms.stats, _PTYPE_NMEA, 1, 10, 1000);
+    MessageStats::append("", ms.stats, _PTYPE_RTCM3, 1005, 20, 1000);
+    ms.update = true;
+
+    ms.clear();
+
+    EXPECT_TRUE(ms.stats.isb.empty());
+    EXPECT_TRUE(ms.stats.nmea.empty());
+    EXPECT_TRUE(ms.stats.rtcm3.empty());
+    EXPECT_TRUE(ms.history.empty());
+    EXPECT_FALSE(ms.update);
+    EXPECT_FALSE(ms.historyPaused);
+}


### PR DESCRIPTION
## Summary

Part 1 of 2 for [SN-8308](https://inertialsense.atlassian.net/browse/SN-8308) (EvalTool Log Summary shows garbage dt min/max for GNSS DIDs). The companion `imx`/EvalTool PR is inertialsense/imx#<TBD>.

- `ChronoStat` gains `dtVariance` / `dtStdDev()`, computed incrementally via Welford's algorithm alongside the existing running `dtAvg`. Header-only, purely additive — no signature changes, so existing consumers (EvalTool's `ChronoStatGraph`, `is-imx`'s ci_hdw tests, `ISDevice`) are unaffected.
- This is prep for the `imx`-side change, which migrates EvalTool's `sParcelDevice` dt-tracking onto `ChronoStat` (with a guard against GPS-week wraparound / pre-lock-zero / absurd jumps), so `ChronoStat` needs to be a proper superset of `sParcelDevice`'s own stats (which already had a bespoke dt-sigma).
- Adds `tests/test_chrono_stat.cpp` (init, first-sample, min/max, avg, variance, `clear()`+resample reset pattern) and `tests/test_message_stats.cpp` (init, per-ID counts, dt, bytes/sec windowing) — neither class had test coverage before.

## Test plan

- [x] `./scripts/build_unit_tests.sh --no-build --test` (ran via a Ninja-generator workaround for a Unix-Makefiles relative/absolute out-of-tree-subdirectory quirk hit in this sandbox — unrelated to this change, reproduces on a clean `develop` checkout too)
- [x] Full suite: 410 passed / 3 skipped (pre-existing hardware-fixture skips) / 0 failed
- [x] New tests: 16/16 passed (`ChronoStat.*`, `MessageStats.*`)

[SN-8308]: https://inertialsense.atlassian.net/browse/SN-8308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ