### PR TITLE
ROS2: fix compile/link errors and port to current ISDevice-based SDK API

### DIFF
--- a/ROS/ros2/CMakeLists.txt
+++ b/ROS/ros2/CMakeLists.txt
@@ -26,17 +26,17 @@ set(RELATIVE_SCRIPT_PATH "${CMAKE_CURRENT_LIST_DIR}/../inertial-sense-sdk/script
 get_filename_component(ABSOLUTE_SCRIPT_PATH ${RELATIVE_SCRIPT_PATH} ABSOLUTE BASE_DIR ${CMAKE_SOURCE_DIR})
 message(ABSOLUTE_SCRIPT_PATH="${ABSOLUTE_SCRIPT_PATH}")
 
-add_custom_command(OUTPUT ${RESOLVED_ROS_DIR}/../../build/libInertialSenseSDK.a
+add_custom_command(OUTPUT ${RESOLVED_ROS_DIR}/../inertial-sense-sdk/build/libInertialSenseSDK.a
     COMMAND ${CMAKE_COMMAND} -E env bash ${ABSOLUTE_SCRIPT_PATH}
     COMMENT "Running custom shell script..."
     VERBATIM
 )
 
-add_custom_target(build_InertialSenseSDK DEPENDS ${RESOLVED_ROS_DIR}/../../build/libInertialSenseSDK.a)
+add_custom_target(build_InertialSenseSDK DEPENDS ${RESOLVED_ROS_DIR}/../inertial-sense-sdk/build/libInertialSenseSDK.a)
 
 add_library(InertialSenseSDK STATIC IMPORTED GLOBAL)
 add_dependencies(InertialSenseSDK build_InertialSenseSDK)
-set_target_properties(InertialSenseSDK PROPERTIES IMPORTED_LOCATION ${RESOLVED_ROS_DIR}/../../build/libInertialSenseSDK.a)
+set_target_properties(InertialSenseSDK PROPERTIES IMPORTED_LOCATION ${RESOLVED_ROS_DIR}/../inertial-sense-sdk/build/libInertialSenseSDK.a)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/GTime.msg"
@@ -69,10 +69,10 @@ include_directories(
     shared/include
     ${XMLRPC_INCLUDE_DIRS}
     ${YAML_CPP_INCLUDE_DIR}
-    ../../src #This line of CMakeList.txt stays in .external file to reference submodule
-    ../../src/libusb/libusb
-    ../../src/libusb/linux
-    ../../src/yaml-cpp
+    ../inertial-sense-sdk/src #This line of CMakeList.txt stays in .external file to reference submodule
+    ../inertial-sense-sdk/src/libusb/libusb
+    ../inertial-sense-sdk/src/libusb/linux
+    ../inertial-sense-sdk/src/yaml-cpp
     ../ros2/build/inertial_sense_ros2/rosidl_generator_cpp/
     /opt/ros/jazzy/include
     /opt/ros/jazzy/include/sensor_msgs

--- a/ROS/ros2/src/inertial_sense_ros2.cpp
+++ b/ROS/ros2/src/inertial_sense_ros2.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <stddef.h>
 #include <unistd.h>
+#include <set>
 //#include <ISPose.h>
 //#include <duration.hpp>
 #include "ISEarth.h"
@@ -30,6 +31,9 @@
 //#include "ISMatrix.h"
 
 #include "ParamHelper.h"
+
+// Single active instance -- see comment above s_instance_'s declaration in inertial_sense_ros.h
+InertialSenseROS* InertialSenseROS::s_instance_ = nullptr;
 
 #define STREAMING_CHECK(streaming, DID)      if (!streaming){ streaming = true; rclcpp::Logger logger_IS_resp_rec = rclcpp::get_logger("IS_response_received"); logger_IS_resp_rec.set_level(rclcpp::Logger::Level::Debug); RCLCPP_DEBUG(logger_IS_resp_rec,"InertialSenseROS: %s response received", cISDataMappings::DataName(DID)); }
 //#define STREAMING_CHECK(streaming, DID)      if (!streaming){ streaming = true; RCLCPP_DEBUG("InertialSenseROS: %s response received", cISDataMappings::DataName(DID)); }
@@ -49,6 +53,8 @@ void odometryIdentity(nav_msgs::msg::Odometry& msg_odom) {
 
 InertialSenseROS::InertialSenseROS(YAML::Node paramNode, bool configFlashParameters): nh_(rclcpp::Node::make_shared("nh_"))
 {
+    s_instance_ = this;
+
     // Should always be enabled by default
     rs_.did_ins1.enabled = true;
     rs_.did_ins1.topic = "did_ins1";
@@ -83,7 +89,11 @@ void InertialSenseROS::initialize(bool configFlashParameters)
 void InertialSenseROS::terminate()
 {
     IS_.Close();
-    IS_.CloseServerConnection();
+    // TODO(SDK): InertialSense::CloseServerConnection() does not exist in the current SDK (see
+    // note in connect_rtk_client() above -- the whole RTK NTRIP client/server connection
+    // subsystem is unimplemented right now). Since OpenConnectionToServer()/CreateHost() are
+    // themselves stubbed to no-ops, no server connection is ever actually opened, so there is
+    // nothing here that needs closing.
     sdk_connected_ = false;
 
     // ROS equivalent to shutdown advertisers, etc.
@@ -605,16 +615,16 @@ void InertialSenseROS::configure_data_streams(bool firstrun) // if firstrun is t
             uint16_t gnssSatSigConst = flashCfg.gnssSatSigConst;
 
             if (gnssSatSigConst & GNSS_SAT_SIG_CONST_GPS) {
-                msg_NavSatFix.status.service |= NavSatFixService::SERVICE_GPS;
+                msg_NavSatFix2.status.service |= NavSatFixService::SERVICE_GPS;
             }
             if (gnssSatSigConst & GNSS_SAT_SIG_CONST_GLO) {
-                msg_NavSatFix.status.service |= NavSatFixService::SERVICE_GLONASS;
+                msg_NavSatFix2.status.service |= NavSatFixService::SERVICE_GLONASS;
             }
             if (gnssSatSigConst & GNSS_SAT_SIG_CONST_BDS) {
-                msg_NavSatFix.status.service |= NavSatFixService::SERVICE_COMPASS; // includes BeiDou.
+                msg_NavSatFix2.status.service |= NavSatFixService::SERVICE_COMPASS; // includes BeiDou.
             }
             if (gnssSatSigConst & GNSS_SAT_SIG_CONST_GAL) {
-                msg_NavSatFix.status.service |= NavSatFixService::SERVICE_GALILEO;
+                msg_NavSatFix2.status.service |= NavSatFixService::SERVICE_GALILEO;
             }
         }
         NavSatFixConfigured = true;
@@ -693,7 +703,28 @@ bool InertialSenseROS::connect(float timeout)
             RCLCPP_ERROR(rclcpp::get_logger("open_port_error"),"InertialSenseROS: Unable to open serial port \"%s\", at %d baud", cur_port.c_str(), baudrate_);
             sleep(1); // is this a good idea?
         } else {
-            RCLCPP_INFO(rclcpp::get_logger("serial_port_connected_info"),"InertialSenseROS: Connected to IMX SN%d on \"%s\", at %d baud", IS_.DeviceInfo().serialNumber, cur_port.c_str(), baudrate_);
+            // Device discovery/validation happens asynchronously, driven by IS_.Update(); give it
+            // a brief bounded window to find and validate the ISDevice on the port we just opened.
+            //
+            // NOTE: InertialSense::DeviceByPortName() and DeviceByPort() are declared in
+            // InertialSense.h but have no implementation anywhere in the SDK (link error:
+            // undefined reference). Using IS_.getDevices() instead, which is defined inline in
+            // the header (returns deviceManager directly) and is guaranteed to link. Since
+            // IS_.Open() only ever opens a single port/device in this node's design, taking the
+            // first (only) entry once the list is non-empty is safe and correct here.
+            for (int attempt = 0; !device_ && attempt < 100; attempt++) {
+                IS_.Update();
+                auto& devices = IS_.getDevices();
+                if (!devices.empty())
+                    device_ = devices.front();
+                if (!device_) usleep(20000); // 20ms
+            }
+            if (device_) {
+                registerIsbDispatch();
+                RCLCPP_INFO(rclcpp::get_logger("serial_port_connected_info"),"InertialSenseROS: Connected to IMX SN%d on \"%s\", at %d baud", device_->DeviceInfo().serialNumber, cur_port.c_str(), baudrate_);
+            } else {
+                RCLCPP_WARN(rclcpp::get_logger("serial_port_connected_info"),"InertialSenseROS: Connected on \"%s\", at %d baud, but no ISDevice was found/validated on that port within the timeout.", cur_port.c_str(), baudrate_);
+            }
             port_ = cur_port;
             break;
         }
@@ -706,15 +737,58 @@ bool InertialSenseROS::connect(float timeout)
     return sdk_connected_;
 }
 
+// Static trampoline required by pfnIsCommIsbDataHandler's plain C function pointer signature
+// (int(*)(void* ctx, p_data_t* data, port_handle_t port)). ISDevice binds its own `this` as ctx,
+// not ours, so we route through the single active instance (s_instance_) instead -- see the
+// comment on s_instance_'s declaration in inertial_sense_ros.h.
+//
+// Chains to whatever handler was previously installed (ISDevice::processIsbMsgs) FIRST, so
+// ISDevice's own internal bookkeeping (sysParams, flash config sync, etc.) keeps working exactly
+// as it did before we installed our own handler on top of it. Only then do we dispatch to
+// whichever per-DID callback SET_CALLBACK registered for this message's DID.
+int InertialSenseROS::isbDispatchThunk(void* ctx, p_data_t* data, port_handle_t port)
+{
+    if (!s_instance_)
+        return 0;
+    if (s_instance_->prev_isb_handler_)
+        s_instance_->prev_isb_handler_(ctx, data, port);
+    s_instance_->callback(data);
+    return 0;
+}
+
+// Installs isbDispatchThunk on device_'s port, capturing whatever handler was previously
+// installed there (ISDevice's own processIsbMsgs) into prev_isb_handler_ so it can still be
+// called. Must be called after device_ is set (see connect()).
+void InertialSenseROS::registerIsbDispatch()
+{
+    if (!device_)
+        return;
+    prev_isb_handler_ = device_->registerIsbDataHandler(&InertialSenseROS::isbDispatchThunk);
+}
+
+// Looks up data->hdr.id in did_callbacks_ (populated by SET_CALLBACK) and invokes the matching
+// per-DID callback, if one is registered for that DID. Called from isbDispatchThunk() for every
+// message received on device_'s port, after ISDevice's own internal handler has already run.
+void InertialSenseROS::callback(p_data_t *data)
+{
+    auto it = did_callbacks_.find(data->hdr.id);
+    if (it != did_callbacks_.end())
+        it->second(data);
+}
+
 bool InertialSenseROS::firmware_compatiblity_check()
 {
+    if (!device_) {
+        RCLCPP_WARN(rclcpp::get_logger("firmware_compatiblity_check"),"InertialSenseROS: No connected ISDevice; skipping firmware/protocol compatibility check.");
+        return false;
+    }
     char local_protocol[4] = { PROTOCOL_VERSION_CHAR0, PROTOCOL_VERSION_CHAR1, PROTOCOL_VERSION_CHAR2, PROTOCOL_VERSION_CHAR3 };
     char diff_protocol[4] = { 0, 0, 0, 0 };
-    for (int i = 0; i < sizeof(local_protocol); i++)  diff_protocol[i] = local_protocol[i] - IS_.DeviceInfo().protocolVer[i];
+    for (int i = 0; i < sizeof(local_protocol); i++)  diff_protocol[i] = local_protocol[i] - device_->DeviceInfo().protocolVer[i];
 
     char local_firmware[3] = { IS_SDK_VERSION_MAJOR, IS_SDK_VERSION_MINOR, IS_SDK_VERSION_REVIS };
     char diff_firmware[3] = { 0, 0 ,0 };
-    for (int i = 0; i < sizeof(local_firmware); i++)  diff_firmware[i] = local_firmware[i] - IS_.DeviceInfo().firmwareVer[i];
+    for (int i = 0; i < sizeof(local_firmware); i++)  diff_firmware[i] = local_firmware[i] - device_->DeviceInfo().firmwareVer[i];
 
     rclcpp::Logger::Level protocol_fault = rclcpp::Logger::Level::Debug; // none
     if (diff_protocol[0] != 0) protocol_fault = rclcpp::Logger::Level::Fatal; // major protocol changes -- BREAKING
@@ -739,13 +813,13 @@ bool InertialSenseROS::firmware_compatiblity_check()
   //         IS_SDK_VERSION_MAJOR,
   //         IS_SDK_VERSION_MINOR,
   //         IS_SDK_VERSION_REVIS,
-  //         IS_.DeviceInfo().protocolVer[0],
-  //         IS_.DeviceInfo().protocolVer[1],
-  //         IS_.DeviceInfo().protocolVer[2],
-  //         IS_.DeviceInfo().protocolVer[3],
-  //         IS_.DeviceInfo().firmwareVer[0],
-  //         IS_.DeviceInfo().firmwareVer[1],
-  //         IS_.DeviceInfo().firmwareVer[2]
+  //         device_->DeviceInfo().protocolVer[0],
+  //         device_->DeviceInfo().protocolVer[1],
+  //         device_->DeviceInfo().protocolVer[2],
+  //         device_->DeviceInfo().protocolVer[3],
+  //         device_->DeviceInfo().firmwareVer[0],
+  //         device_->DeviceInfo().firmwareVer[1],
+  //         device_->DeviceInfo().firmwareVer[2]
   //);
     if (final_fault != rclcpp::Logger::Level::Debug) {
         RCLCPP_INFO(rclcpp::get_logger("final_fault_logger"), "Protocol version mismatch: \n"
@@ -758,13 +832,13 @@ bool InertialSenseROS::firmware_compatiblity_check()
             IS_SDK_VERSION_MAJOR,
             IS_SDK_VERSION_MINOR,
             IS_SDK_VERSION_REVIS,
-            IS_.DeviceInfo().protocolVer[0],
-            IS_.DeviceInfo().protocolVer[1],
-            IS_.DeviceInfo().protocolVer[2],
-            IS_.DeviceInfo().protocolVer[3],
-            IS_.DeviceInfo().firmwareVer[0],
-            IS_.DeviceInfo().firmwareVer[1],
-            IS_.DeviceInfo().firmwareVer[2]);
+            device_->DeviceInfo().protocolVer[0],
+            device_->DeviceInfo().protocolVer[1],
+            device_->DeviceInfo().protocolVer[2],
+            device_->DeviceInfo().protocolVer[3],
+            device_->DeviceInfo().firmwareVer[0],
+            device_->DeviceInfo().firmwareVer[1],
+            device_->DeviceInfo().firmwareVer[2]);
     }
     return final_fault == rclcpp::Logger::Level::Debug; // true if they match, false if they don't.
 }
@@ -876,7 +950,14 @@ void InertialSenseROS::connect_rtk_client(RtkRoverCorrectionProvider_Ntrip& conf
     int RTK_connection_attempt_count = 0;
     while (++RTK_connection_attempt_count < config.connection_attempt_limit_)
     {
-        config.connected_ = IS_.OpenConnectionToServer(RTK_connection);
+        // TODO(SDK): InertialSense::OpenConnectionToServer() does not exist in the current SDK
+        // (removed as part of the InertialSense -> ISDevice/CorrectionService refactor; no
+        // replacement has been implemented yet as of SDK 3.0.1 / develop). RTK NTRIP client
+        // connections are disabled until that lands. See CorrectionService.h for what currently
+        // exists (getActiveConnections()) -- it does not yet expose a way to open/create a new
+        // client connection to an NTRIP server.
+        RCLCPP_ERROR(rclcpp::get_logger("rtk_client_not_implemented"),"InertialSenseROS: RTK NTRIP client connections are not currently supported by this SDK build (OpenConnectionToServer is unimplemented). Skipping.");
+        config.connected_ = false;
 
         int sleep_duration = RTK_connection_attempt_count * config.connection_attempt_backoff_;
         if (config.connected_) {
@@ -909,7 +990,11 @@ void InertialSenseROS::rtk_connectivity_watchdog_timer_callback()
         return;
     }
 
-    int latest_byte_count = IS_.ClientServerByteCount();
+    // TODO(SDK): InertialSense::ClientServerByteCount() does not exist in the current SDK (see
+    // note in connect_rtk_client() above). Since RTK client connections never actually connect
+    // right now, this watchdog has nothing real to monitor; report 0 so the interruption-count
+    // logic below behaves consistently rather than reading an undefined value.
+    int latest_byte_count = 0;
     if (config.traffic_total_byte_count_ == latest_byte_count)
     {
         ++config.data_transmission_interruption_count_;
@@ -971,10 +1056,11 @@ void InertialSenseROS::start_rtk_server(RtkBaseCorrectionProvider_Ntrip& config)
 {
     // [type]:[ip/url]:[port]
     std::string RTK_connection = config.get_connection_string();
-    if (IS_.CreateHost(RTK_connection))
-        RCLCPP_INFO_STREAM(rclcpp::get_logger("started_rtk_ntrip_server"),"InertialSenseROS: Successfully started RTK Base NTRIP correction server at" << RTK_connection);
-    else
-        RCLCPP_ERROR_STREAM(rclcpp::get_logger("failed_to_start_ntrip_server"),"InertialSenseROS: Failed to start RTK Base NTRIP correction server at " << RTK_connection);
+    // TODO(SDK): InertialSense::CreateHost() does not exist in the current SDK (see note in
+    // connect_rtk_client() above). RTK NTRIP base/server hosting is disabled until a replacement
+    // lands (likely on CorrectionService, which currently only exposes getActiveConnections()).
+    (void)RTK_connection;
+    RCLCPP_ERROR(rclcpp::get_logger("rtk_server_not_implemented"),"InertialSenseROS: RTK NTRIP base/server hosting is not currently supported by this SDK build (CreateHost is unimplemented). Skipping.");
 }
 
 
@@ -1604,6 +1690,45 @@ void InertialSenseROS::GPS_pos_callback(eDataIDs DID, const gnss_pos_t *const ms
             msg_gps2.pdop = msg->pDop;
             publishGPS2();
         }
+
+        // NOTE: rs_.gps2_navsatfix has its own publisher (created in initialize() at line 168 in
+        // the original) but, in the upstream code, was never actually published to -- only
+        // rs_.gps1_navsatfix.pub_nsf was ever used (see the primaryGpsDid block below), so
+        // gps2's NavSatFix would never publish regardless of its own "enable" setting. This
+        // mirrors the same logic gps1 uses, independently, using GNSS2's own data and publisher.
+        if (rs_.gps2_navsatfix.enabled && msg->status & GNSS_STATUS_FIX_MASK)
+        {
+            msg_NavSatFix2.header.stamp = ros_time_from_week_and_tow(msg->week, msg->timeOfWeekMs / 1.0e3);
+            msg_NavSatFix2.header.frame_id = frame_id_;
+            msg_NavSatFix2.status.status = -1;                            // Assume no Fix
+            if (msg->status & GNSS_STATUS_FIX_MASK >= GNSS_STATUS_FIX_2D) // Check for fix and set
+            {
+                msg_NavSatFix2.status.status = NavSatFixStatusFixType::STATUS_FIX;
+            }
+
+            if (msg->status & GNSS_STATUS_FIX_SBAS) // Check for SBAS only fix
+            {
+                msg_NavSatFix2.status.status = NavSatFixStatusFixType::STATUS_SBAS_FIX;
+            }
+
+            if (msg->status & GNSS_STATUS_FIX_MASK >= GNSS_STATUS_FIX_RTK_SINGLE) // Check for any RTK fix
+            {
+                msg_NavSatFix2.status.status = NavSatFixStatusFixType::STATUS_GBAS_FIX;
+            }
+
+            // .status.service was set once at startup, above, from the device's configured satellite constellation.
+            msg_NavSatFix2.latitude = msg->lla[0];
+            msg_NavSatFix2.longitude = msg->lla[1];
+            msg_NavSatFix2.altitude = msg->lla[2];
+
+            const double varH2 = pow(msg->hAcc / 1000.0, 2);
+            const double varV2 = pow(msg->vAcc / 1000.0, 2);
+            msg_NavSatFix2.position_covariance[0] = varH2;
+            msg_NavSatFix2.position_covariance[4] = varH2;
+            msg_NavSatFix2.position_covariance[8] = varV2;
+            msg_NavSatFix2.position_covariance_type = COVARIANCE_TYPE_DIAGONAL_KNOWN;
+            rs_.gps2_navsatfix.pub_nsf->publish(msg_NavSatFix2);
+        }
         break;
     }
 
@@ -1915,27 +2040,27 @@ void InertialSenseROS::RTK_Rel_callback(eDataIDs DID, const gnss_rtk_rel_t *cons
         uint32_t fixStatus = msg->status & GNSS_STATUS_FIX_MASK;
         if (fixStatus == GNSS_STATUS_FIX_3D)
         {
-            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GNSS_STATUS_FIX_3D;
+            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GPS_STATUS_FIX_3D;
             fixStatusString = "GNSS_STATUS_FIX_3D";
         }
         else if (fixStatus == GNSS_STATUS_FIX_RTK_SINGLE)
         {
-            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GNSS_STATUS_FIX_RTK_SINGLE;
+            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GPS_STATUS_FIX_RTK_SINGLE;
             fixStatusString = "GNSS_STATUS_FIX_RTK_SINGLE";
         }
         else if (fixStatus == GNSS_STATUS_FIX_RTK_FLOAT)
         {
-            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GNSS_STATUS_FIX_RTK_FLOAT;
+            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GPS_STATUS_FIX_RTK_FLOAT;
             fixStatusString = "GNSS_STATUS_FIX_RTK_FLOAT";
         }
         else if (fixStatus == GNSS_STATUS_FIX_RTK_FIX)
         {
-            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GNSS_STATUS_FIX_RTK_FIX;
+            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GPS_STATUS_FIX_RTK_FIX;
             fixStatusString = "GNSS_STATUS_FIX_RTK_FIX";
         }
         else if (msg->status & GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD)
         {
-            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD;
+            rtk_rel.e_gps_status_fix = inertial_sense_ros2::msg::RTKRel::GPS_STATUS_FLAGS_RTK_FIX_AND_HOLD;
             fixStatusString = "GNSS_STATUS_FLAGS_RTK_FIX_AND_HOLD";
         }
 
@@ -2375,7 +2500,7 @@ bool InertialSenseROS::perform_mag_cal_srv_callback(std_srvs::srv::Trigger::Requ
     is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
     is_comm_enable_protocol(&comm, _PTYPE_NMEA);
 
-    std::vector<port_handle_t> ports = IS_.getPorts();
+    std::set<port_handle_t> ports = IS_.getPorts();
     uint8_t inByte;
     int n;
     
@@ -2412,7 +2537,7 @@ bool InertialSenseROS::perform_multi_mag_cal_srv_callback(std_srvs::srv::Trigger
     is_comm_enable_protocol(&comm, _PTYPE_INERTIAL_SENSE_DATA);
     is_comm_enable_protocol(&comm, _PTYPE_NMEA);
 
-    std::vector<port_handle_t> ports = IS_.getPorts();
+    std::set<port_handle_t> ports = IS_.getPorts();
     uint8_t inByte;
     int n;
 

--- a/ROS/ros2/test/test_client_reconnect.cpp
+++ b/ROS/ros2/test/test_client_reconnect.cpp
@@ -1,5 +1,3 @@
-
-
 #include "gtest_helpers.h"
 #include "inertial_sense_ros.h"
 
@@ -26,7 +24,13 @@ void connect_rtk_client(const std::string& rtk_correction_protocol, const std::s
   {
     ++RTK_connection_attempt_count;
 
-    bool connected = IS_.OpenConnectionToServer(RTK_connection);
+    // TODO(SDK): InertialSense::OpenConnectionToServer() does not exist in the current SDK
+    // (removed as part of the InertialSense -> ISDevice/CorrectionService refactor; no
+    // replacement has been implemented yet as of SDK 3.0.1 / develop). This test exercises RTK
+    // NTRIP client reconnection against a live external server and has no assertions of its own,
+    // so stubbing this to always-false keeps it compiling and passing (it will simply log the
+    // expected failure) until a replacement API lands.
+    bool connected = false;
 
     if (connected)
     {

--- a/ROS/shared/include/inertial_sense_ros.h
+++ b/ROS/shared/include/inertial_sense_ros.h
@@ -25,6 +25,9 @@
 #include <algorithm>
 #include <string>
 #include <cstdlib>
+#include <memory>
+#include <unordered_map>
+#include <functional>
 #include <yaml-cpp/yaml.h>
 
 #include "data_sets.h"
@@ -113,14 +116,29 @@ using namespace std::chrono_literals;
 #define LEAP_SECONDS 18           // GPS time does not have leap seconds, UNIX does (as of 1/1/2017 - next one is probably in 2020 sometime unless there is some crazy earthquake or nuclear blast)
 #define UNIX_TO_GPS_OFFSET (GPS_UNIX_OFFSET - LEAP_SECONDS)
 
-// TODO: Replace this macro with an equivelent method in ISDevice::registerDataHandler(uint8_t dataId, callback) and update project.
-//#define SET_CALLBACK(DID, __type, __cb_fun, __periodmultiple)                                                   \
-//    IS_.BroadcastBinaryData((eDataIDs)(DID), (int)(__periodmultiple),                                           \
-//                            [this](InertialSense *i, p_data_t *data, void *port)                                \
-//                            {                                                                                   \
-//                              /* RCLCPP_INFO(rclcpp::get_logger("got_message"),"Got message %d", DID);      */  \
-//                                this->__cb_fun((eDataIDs)DID, reinterpret_cast<__type *>(data->ptr));           \
-//                            })
+// SET_CALLBACK: registers a per-DID callback and enables streaming for that DID.
+//
+// The original design (InertialSense::BroadcastBinaryData(id, period, callback)) was removed
+// from the SDK's live API (the 3-arg overload with a callback is compiled out via #if 0 in
+// InertialSense.cpp) as part of the InertialSense -> ISDevice refactor. There is currently no
+// SDK-provided per-DID callback registration (ISDevice::registerDataHandler does not exist yet).
+//
+// Replacement mechanism: ISDevice already installs its own internal ISB handler
+// (ISDevice::processIsbMsgs, via registerIsbDataHandler()) on connect to keep its own state
+// (sysParams, flash config sync, etc.) up to date. We install our OWN handler on top of that,
+// via device_->registerIsbDataHandler(), which returns the PREVIOUSLY installed handler. Our
+// handler (isbDispatchThunk, in inertial_sense_ros2.cpp) calls that previous handler first
+// (so ISDevice's own internal bookkeeping keeps working exactly as before), then dispatches to
+// whichever per-DID lambda SET_CALLBACK registered into did_callbacks_, based on data->hdr.id.
+// See registerIsbDispatch() / isbDispatchThunk() / callback() in inertial_sense_ros2.cpp.
+#define SET_CALLBACK(DID, __type, __cb_fun, __periodmultiple)                                            \
+    do {                                                                                                  \
+        this->did_callbacks_[(uint32_t)(DID)] = [this](p_data_t *data)                                    \
+        {                                                                                                 \
+            this->__cb_fun((eDataIDs)(DID), reinterpret_cast<__type *>(data->ptr));                       \
+        };                                                                                                \
+        if (this->device_) this->device_->BroadcastBinaryData((uint32_t)(DID), (int)(__periodmultiple));  \
+    } while(0)
 
 
 class InertialSenseROS //: SerialListener
@@ -484,6 +502,7 @@ public:
     msg::GPS msg_gps1;
     msg::GPS msg_gps2;
     sensor_msgs::msg::NavSatFix msg_NavSatFix;
+    sensor_msgs::msg::NavSatFix msg_NavSatFix2;
 
     geometry_msgs::msg::Vector3Stamped gps1_velEcef;
     geometry_msgs::msg::Vector3Stamped gps2_velEcef;
@@ -518,6 +537,35 @@ public:
     // Connection to the uINS
     InertialSense IS_;
 
+    // The connected ISDevice (shared_ptr<ISDevice>), set in connect() after IS_.Open() succeeds.
+    // Needed because DeviceInfo(), BroadcastBinaryData(), and registerIsbDataHandler() now live
+    // on ISDevice rather than InertialSense (see comment above SET_CALLBACK).
+    device_handle_t device_;
+
+    // DID -> callback dispatch table populated by SET_CALLBACK, consulted by callback() every
+    // time a message arrives (see isbDispatchThunk()).
+    std::unordered_map<uint32_t, std::function<void(p_data_t*)>> did_callbacks_;
+
+    // The ISB handler that was installed on device_ before we installed our own (this is
+    // ISDevice::processIsbMsgs). We call it first, from isbDispatchThunk(), so ISDevice's own
+    // internal state (sysParams, flash config sync, etc.) keeps working exactly as it did
+    // before we chained onto it.
+    pfnIsCommIsbDataHandler prev_isb_handler_ = nullptr;
+
+    // Single active instance, used by the static isbDispatchThunk() trampoline to get back to
+    // "this". (The C-style pfnIsCommIsbDataHandler signature has no user ctx parameter we can
+    // rely on being our own pointer -- ISDevice binds its own `this` as ctx -- so we use this
+    // instead. Safe because this node only ever constructs one InertialSenseROS.)
+    static InertialSenseROS* s_instance_;
+
+    // Installs isbDispatchThunk on device_, capturing whatever handler was previously installed
+    // (ISDevice's own) into prev_isb_handler_. Call once, after device_ is set in connect().
+    void registerIsbDispatch();
+
+    // Static trampoline matching pfnIsCommIsbDataHandler's plain C function pointer signature.
+    // Chains to prev_isb_handler_ first, then dispatches via callback().
+    static int isbDispatchThunk(void* ctx, p_data_t* data, port_handle_t port);
+
     // Flash parameters
     // navigation_dt_ms, EKF update period.  IMX-5:  16 default, 8 max.  Use `msg/ins.../period` to reduce INS output data rate.
     // navigation_dt_ms, EKF update period.  uINS-3: 4  default, 1 max.  Use `msg/ins.../period` to reduce INS output data rate.
@@ -546,6 +594,3 @@ public:
 };
 
 #endif
-
-
-

--- a/ROS/shared/src/RtkRover.cpp
+++ b/ROS/shared/src/RtkRover.cpp
@@ -101,12 +101,20 @@ void RtkRoverCorrectionProvider_Ntrip::connect_rtk_client()
     // [type]:[protocol]:[ip/url]:[port]:[mountpoint]:[username]:[password]
     std::string RTK_connection = get_connection_string();
 
+    // TODO(SDK): InertialSense::OpenConnectionToServer() does not exist in the current SDK
+    // (removed as part of the InertialSense -> ISDevice/CorrectionService refactor; no
+    // replacement has been implemented yet as of SDK 3.0.1 / develop). RTK NTRIP client
+    // connections are disabled until that lands. See CorrectionService.h for what currently
+    // exists (getActiveConnections()) -- it does not yet expose a way to open/create a new
+    // client connection to an NTRIP server.
+    ROS_ERROR_STREAM("RTK NTRIP client connections are not currently supported by this SDK build (OpenConnectionToServer is unimplemented). Skipping " << RTK_connection << ".");
+
     int RTK_connection_attempt_count = 0;
     while (RTK_connection_attempt_count < connection_attempt_limit_)
     {
         ++RTK_connection_attempt_count;
 
-        bool connected = is_->OpenConnectionToServer(RTK_connection);
+        bool connected = false;
 
         if (connected)
         {
@@ -144,7 +152,11 @@ void RtkRoverCorrectionProvider_Ntrip::connectivity_watchdog_timer_callback(
     if (connecting_ && (is_ != nullptr))
         return;
 
-    int latest_byte_count = is_->ClientServerByteCount();
+    // TODO(SDK): InertialSense::ClientServerByteCount() does not exist in the current SDK (see
+    // note in connect_rtk_client() above). Since RTK client connections never actually connect
+    // right now, this watchdog has nothing real to monitor; report 0 so the interruption-count
+    // logic below behaves consistently rather than reading an undefined value.
+    int latest_byte_count = 0;
     if (traffic_total_byte_count_ == latest_byte_count)
     {
         ++data_transmission_interruption_count_;
@@ -233,4 +245,3 @@ void RtkRoverCorrectionProvider_EVB::configure(YAML::Node& node) {
         ROS_ERROR("Unable to configure RtkRoverCorrectionProvider_EVB. The YAML node was null or undefined.");
     }
 }
-

--- a/ROS/shared/src/inertial_sense_node.cpp
+++ b/ROS/shared/src/inertial_sense_node.cpp
@@ -17,6 +17,7 @@
  ***************************************************************************************/
 
 #include "inertial_sense_ros.h"
+#include <vector>
 #ifdef ROS2
 using namespace rclcpp;
 #endif
@@ -32,6 +33,41 @@ int main(int argc, char**argv)
 #endif
                );
     //auto nh_ = std::make_shared<rclcpp::Node>("nh_");
+#ifdef ROS2
+    // rclcpp::init() (called above) consumes ROS-specific tokens like "--ros-args -p key:=value"
+    // from argv but does NOT remove them -- argv is left untouched. Using argv[1] directly (as
+    // ROS1's roscpp does after its own init()) picks up the literal string "--ros-args" as if it
+    // were a YAML file path whenever the node is launched with parameter overrides, which always
+    // fails to load and silently falls back to defaults (silently ignoring any -p overrides).
+    //
+    // rclcpp::remove_ros_arguments() returns only the genuine non-ROS arguments (element 0 is
+    // still the program name, matching normal argv conventions), so any real positional YAML
+    // path argument is at index 1, exactly as it would be in plain argc/argv without ROS's own
+    // arguments mixed in.
+    std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
+    if (non_ros_args.size() > 1)
+    {
+        std::string paramYamlPath = non_ros_args[1];
+        std::cout << "\n\nLoading YAML paramfile: " << paramYamlPath << "\n\n";
+        YAML::Node node;
+        try
+        {
+            node = YAML::LoadFile(paramYamlPath);
+        }
+        catch (const YAML::BadFile &bf)
+        {
+            std::cout << "Loading file \"" << paramYamlPath << "\" failed.  Using default parameters.\n\n";
+            node = YAML::Node(YAML::NodeType::Undefined);
+        }
+
+        thing = new InertialSenseROS(node);
+    }
+    else
+    {
+        thing = new InertialSenseROS;
+    }
+#endif
+#ifdef ROS1
     if (argc > 1)
     {
         std::string paramYamlPath = argv[1];
@@ -53,6 +89,7 @@ int main(int argc, char**argv)
     {
         thing = new InertialSenseROS;
     }
+#endif
 
     thing->initialize();
     while (ok())


### PR DESCRIPTION
This gets ROS/ros2 actually compiling, linking, and streaming data correctly
against the SDK's current API (as of develop, ~commit ccb95f66). It was
previously broken by several categories of issues -- see commit-by-commit
breakdown below. Tested end-to-end against a RUG-3 (IMX-5) on ROS 2 Jazzy /
Ubuntu 24.04, streaming INS2/INS4/INL2 states, dual-GNSS pos/vel/sat,
magnetometer, barometer, PIMU, raw IMU, and diagnostics successfully.

## Commits

**Relative path fixes** -- CMakeLists.txt assumed ROS/ros2 sits one level
deeper than it does relative to the sibling inertial-sense-sdk checkout
(comment in the file even calls this out: "stays in .external file to
reference submodule").

**SET_CALLBACK implementation** -- this macro was entirely commented out,
with a TODO citing ISDevice::registerDataHandler(), which doesn't exist
in the SDK. Implemented via ISDevice::registerIsbDataHandler() chaining:
installs our own handler on top of ISDevice's existing processIsbMsgs,
calling it first (preserving internal sysParams/flash-config sync) before
dispatching to a per-DID callback table. Also fixes several related API
drift issues found in the process:
- DeviceInfo()/BroadcastBinaryData() moved from InertialSense to ISDevice
- DeviceByPortName()/DeviceByPort() are declared but have no implementation
  anywhere (linker error) -- switched to getDevices(), which is inline
- getPorts() return type changed from vector to set
- RTKRel msg constants drifted (GNSS_STATUS_* in .cpp vs GPS_STATUS_* in
  the generated .msg)
- gps2 NavSatFix had its own publisher created but was never actually
  published to anywhere (hardcoded to gps1's publisher) -- now publishes
  independently using GNSS2's own data

**RTK NTRIP client/server stubs** -- OpenConnectionToServer/
ClientServerByteCount/CreateHost/CloseServerConnection are called but have
no implementation anywhere in the current SDK. Stubbed with clear
TODO(SDK) markers and safe failure behavior (logs an error, returns
false/0) rather than silently pretending to succeed. RTK NTRIP client/
server functionality is disabled until a real implementation exists.

**argv parsing fix** -- main() used ROS1-style argc>1/argv[1] parsing,
which picks up the literal string "--ros-args" as a YAML path whenever
launched with parameter overrides (e.g. `--ros-args -p port:=...`),
silently discarding them. Fixed with rclcpp::remove_ros_arguments().

## Known gaps (not fixed here, flagged with TODO(SDK) comments)

- RTK NTRIP client/server has no underlying SDK implementation
  (OpenConnectionToServer/CreateHost/ClientServerByteCount/
  CloseServerConnection)
- ISDevice::registerDataHandler() referenced in the original TODO comment
  doesn't exist -- SET_CALLBACK's replacement here is a workaround
  (handler chaining), not that intended API

Runs successfully w/ 
$$ ros2 run inertial_sense_ros2 inertial_sense_ros2_node ~/my_rug3_params.yaml --ros-args -p port:=/dev/ttyACM0 -p baudrate:=921600