### PR TITLE
SN-8294: Doxygen documentation for supplemental data structures and math

### DIFF
--- a/src/ISEarth.h
+++ b/src/ISEarth.h
@@ -91,24 +91,24 @@ void lla2ecef(const double *LLA, double *Pe);
 
 /**
  * @brief Find NED (north, east, down) offset from llaRef to lla, single precision.
- * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
- * @param lla    Target latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param lla    Target latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param result Output: NED offset (meters) from llaRef to lla.
  */
 void lla2ned(ixVector3 llaRef, ixVector3 lla, ixVector3 result);
 
 /**
  * @brief Find NED (north, east, down) offset from llaRef to lla, double precision.
- * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
- * @param lla    Target latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param lla    Target latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param result Output: NED offset (meters) from llaRef to lla.
  */
 void lla2ned_d(double llaRef[3], double lla[3], ixVector3 result);
 
 /**
  * @brief Find NED (north, east, down) offset from llaRef to lla, double precision, degrees input.
- * @param llaRef Reference latitude (degrees), longitude (degrees), MSL altitude (m).
- * @param lla    Target latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param llaRef Reference latitude (degrees), longitude (degrees), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param lla    Target latitude (degrees), longitude (degrees), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param result Output: NED offset (meters) from llaRef to lla.
  */
 void llaDeg2ned_d(double llaRef[3], double lla[3], ixVector3 result);
@@ -116,31 +116,31 @@ void llaDeg2ned_d(double llaRef[3], double lla[3], ixVector3 result);
 /**
  * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, single precision.
  * @param ned    NED offset (meters) from llaRef.
- * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
- * @param result Output: latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param result Output: latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  */
 void ned2lla(ixVector3 ned, ixVector3 llaRef, ixVector3 result);
 
 /**
  * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, double precision.
  * @param ned    NED offset (meters) from llaRef.
- * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
- * @param result Output: latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param result Output: latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  */
 void ned2lla_d(ixVector3 ned, double llaRef[3], double result[3]);
 
 /**
  * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, double precision, degrees output (WGS-84 standard).
  * @param ned    NED offset (meters) from llaRef.
- * @param llaRef Reference latitude (degrees), longitude (degrees), MSL altitude (m).
- * @param result Output: latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param llaRef Reference latitude (degrees), longitude (degrees), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
+ * @param result Output: latitude (degrees), longitude (degrees), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  */
 void ned2llaDeg_d(ixVector3 ned, double llaRef[3], double result[3]);
 
 /**
  * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, single precision.
  * @param ned     NED offset (meters) from llaRef.
- * @param llaRef  Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef  Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param deltaLLA Output: delta latitude (rad), delta longitude (rad), delta altitude (m).
  */
 void ned2DeltaLla(ixVector3 ned, ixVector3 llaRef, ixVector3 deltaLLA);
@@ -148,7 +148,7 @@ void ned2DeltaLla(ixVector3 ned, ixVector3 llaRef, ixVector3 deltaLLA);
 /**
  * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, double precision.
  * @param ned     NED offset (meters) from llaRef.
- * @param llaRef  Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param llaRef  Reference latitude (rad), longitude (rad), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param deltaLLA Output: delta latitude (rad), delta longitude (rad), delta altitude (m).
  */
 void ned2DeltaLla_d(ixVector3 ned, double llaRef[3], double deltaLLA[3]);
@@ -156,7 +156,7 @@ void ned2DeltaLla_d(ixVector3 ned, double llaRef[3], double deltaLLA[3]);
 /**
  * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, double precision, degrees output.
  * @param ned     NED offset (meters) from llaRef.
- * @param llaRef  Reference latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param llaRef  Reference latitude (degrees), longitude (degrees), altitude (m; MSL or WGS-84, any datum consistent between llaRef and lla/result).
  * @param deltaLLA Output: delta latitude (degrees), delta longitude (degrees), delta altitude (m).
  */
 void ned2DeltaLlaDeg_d(ixVector3 ned, double llaRef[3], double deltaLLA[3]);

--- a/src/ISEarth.h
+++ b/src/ISEarth.h
@@ -10,6 +10,19 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT, IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISEarth.h
+ * @brief Earth-relative coordinate transformations: ECEF/LLA/NED conversions, range/bearing,
+ * radius-of-curvature, gravity model, and GPS time helpers (gtime_t).
+ *
+ * Unless otherwise noted: angles are in radians (functions with a "Deg" in their name take/return
+ * degrees instead), distances/altitudes are in meters, and LLA is (latitude, longitude, altitude).
+ * ECEF is earth-centered earth-fixed; NED is North-East-Down relative to a reference LLA.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef ISEARTH_H_
 #define ISEARTH_H_
 
@@ -22,14 +35,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 extern "C" {
 #endif
 
-#define DEG2RAD_EARTH_RADIUS_F      111120.0f                    // = DEG2RAD * earth_radius_in_meters
-#define INV_DEG2RAD_EARTH_RADIUS_F  8.99928005759539236861e-6f    // = 1 / (DEG2RAD * earth_radius_in_meters)
+#define DEG2RAD_EARTH_RADIUS_F      111120.0f                    //!< = DEG2RAD * earth_radius_in_meters
+#define INV_DEG2RAD_EARTH_RADIUS_F  8.99928005759539236861e-6f    //!< = 1 / (DEG2RAD * earth_radius_in_meters)
 
-#define EARTH_RADIUS_F              6366707.01949371f                // = earth_radius_in_meters
-#define INV_EARTH_RADIUS_F          1.5706706731410E-07f                // = 1 / earth_radius_in_meters
+#define EARTH_RADIUS_F              6366707.01949371f                //!< = earth_radius_in_meters
+#define INV_EARTH_RADIUS_F          1.5706706731410E-07f                //!< = 1 / earth_radius_in_meters
 
 #ifndef MAX
-#define MAX(a,b)    (((a) > (b)) ? (a) : (b))
+#define MAX(a,b)    (((a) > (b)) ? (a) : (b))    //!< Standard two-argument maximum, defined here if not already available
 #endif
 
 #if 0
@@ -47,7 +60,7 @@ typedef ixMatrix4     ixMatrix4;
 
 
 #if (!defined (__cplusplus) && (!defined (inline)))
-#       define inline __inline          // allow "inline" keyword to work in windows w/ c program
+#       define inline __inline          //!< Allow the "inline" keyword to work in Windows w/ a C (non-C++) program
 #endif
 
 
@@ -55,122 +68,185 @@ typedef ixMatrix4     ixMatrix4;
 
 //_____ P R O T O T Y P E S ________________________________________________
 
-/* 
- * Coordinate transformation from ECEF coordinates to latitude/longitude/altitude (rad,rad,m)
+/**
+ * @brief Convert ECEF coordinates to latitude/longitude/altitude, double precision.
+ * @param Pe  ECEF position (X, Y, Z), meters.
+ * @param LLA Output: latitude (rad), longitude (rad), altitude (m).
  */
 void ecef2lla(const double *Pe, double *LLA);
+
+/**
+ * @brief Convert ECEF coordinates to latitude/longitude/altitude, single precision.
+ * @param Pe  ECEF position (X, Y, Z), meters.
+ * @param LLA Output: latitude (rad), longitude (rad), altitude (m).
+ */
 void ecef2lla_f(const float *Pe, float *LLA);
 
-/*
- * Coordinate transformation from latitude/longitude/altitude (rad,rad,m) to ECEF coordinates
+/**
+ * @brief Convert latitude/longitude/altitude to ECEF coordinates.
+ * @param LLA Latitude (rad), longitude (rad), altitude (m).
+ * @param Pe  Output: ECEF position (X, Y, Z), meters.
  */
 void lla2ecef(const double *LLA, double *Pe);
 
-/*
- *  Find NED (north, east, down) from LLAref to LLA
- *
- *  lla[0] = latitude (rad)
- *  lla[1] = longitude (rad)
- *  lla[2] = msl altitude (m)
+/**
+ * @brief Find NED (north, east, down) offset from llaRef to lla, single precision.
+ * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param lla    Target latitude (rad), longitude (rad), MSL altitude (m).
+ * @param result Output: NED offset (meters) from llaRef to lla.
  */
 void lla2ned(ixVector3 llaRef, ixVector3 lla, ixVector3 result);
-void lla2ned_d(double llaRef[3], double lla[3], ixVector3 result);     // double precision
 
-/*
- *  Find NED (north, east, down) from LLAref to LLA
- *
- *  lla[0] = latitude (degrees)
- *  lla[1] = longitude (degrees)
- *  lla[2] = msl altitude (m)
+/**
+ * @brief Find NED (north, east, down) offset from llaRef to lla, double precision.
+ * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param lla    Target latitude (rad), longitude (rad), MSL altitude (m).
+ * @param result Output: NED offset (meters) from llaRef to lla.
+ */
+void lla2ned_d(double llaRef[3], double lla[3], ixVector3 result);
+
+/**
+ * @brief Find NED (north, east, down) offset from llaRef to lla, double precision, degrees input.
+ * @param llaRef Reference latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param lla    Target latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param result Output: NED offset (meters) from llaRef to lla.
  */
 void llaDeg2ned_d(double llaRef[3], double lla[3], ixVector3 result);
 
-/*
- *  Find LLA of NED (north, east, down) from LLAref
- *
- *  lla[0] = latitude (rad)
- *  lla[1] = longitude (rad)
- *  lla[2] = msl altitude (m)
+/**
+ * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, single precision.
+ * @param ned    NED offset (meters) from llaRef.
+ * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param result Output: latitude (rad), longitude (rad), MSL altitude (m).
  */
 void ned2lla(ixVector3 ned, ixVector3 llaRef, ixVector3 result);
-void ned2lla_d(ixVector3 ned, double llaRef[3], double result[3]);     // double precision
 
-/*
-*  Find LLA of NED (north, east, down) from LLAref (WGS-84 standard)
-*
-*  lla[0] = latitude (degrees)
-*  lla[1] = longitude (degrees)
-*  lla[2] = msl altitude (m)
-*/
+/**
+ * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, double precision.
+ * @param ned    NED offset (meters) from llaRef.
+ * @param llaRef Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param result Output: latitude (rad), longitude (rad), MSL altitude (m).
+ */
+void ned2lla_d(ixVector3 ned, double llaRef[3], double result[3]);
+
+/**
+ * @brief Find LLA from an NED (north, east, down) offset relative to llaRef, double precision, degrees output (WGS-84 standard).
+ * @param ned    NED offset (meters) from llaRef.
+ * @param llaRef Reference latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param result Output: latitude (degrees), longitude (degrees), MSL altitude (m).
+ */
 void ned2llaDeg_d(ixVector3 ned, double llaRef[3], double result[3]);
 
-/*
- *  Find Delta LLA of NED (north, east, down) from LLAref
- *
- *  lla[0] = latitude (rad)
- *  lla[1] = longitude (rad)
- *  lla[2] = msl altitude (m)
+/**
+ * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, single precision.
+ * @param ned     NED offset (meters) from llaRef.
+ * @param llaRef  Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param deltaLLA Output: delta latitude (rad), delta longitude (rad), delta altitude (m).
  */
 void ned2DeltaLla(ixVector3 ned, ixVector3 llaRef, ixVector3 deltaLLA);
+
+/**
+ * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, double precision.
+ * @param ned     NED offset (meters) from llaRef.
+ * @param llaRef  Reference latitude (rad), longitude (rad), MSL altitude (m).
+ * @param deltaLLA Output: delta latitude (rad), delta longitude (rad), delta altitude (m).
+ */
 void ned2DeltaLla_d(ixVector3 ned, double llaRef[3], double deltaLLA[3]);
 
-/*
-*  Find Delta LLA of NED (north, east, down) from LLAref
-*
-*  lla[0] = latitude (degrees)
-*  lla[1] = longitude (degrees)
-*  lla[2] = msl altitude (m)
-*/
+/**
+ * @brief Find the delta-LLA equivalent of an NED (north, east, down) offset relative to llaRef, double precision, degrees output.
+ * @param ned     NED offset (meters) from llaRef.
+ * @param llaRef  Reference latitude (degrees), longitude (degrees), MSL altitude (m).
+ * @param deltaLLA Output: delta latitude (degrees), delta longitude (degrees), delta altitude (m).
+ */
 void ned2DeltaLlaDeg_d(ixVector3 ned, double llaRef[3], double deltaLLA[3]);
 
-// Convert LLA from radians to degrees
+/**
+ * @brief Convert LLA from radians to degrees (altitude is passed through unchanged).
+ * @param result Output: latitude (degrees), longitude (degrees), altitude (m).
+ * @param lla    Input: latitude (rad), longitude (rad), altitude (m).
+ */
 void lla_Rad2Deg_d(double result[3], double lla[3]);
 
-// Convert LLA from degrees to radians
+/**
+ * @brief Convert LLA from degrees to radians (altitude is passed through unchanged).
+ * @param result Output: latitude (rad), longitude (rad), altitude (m).
+ * @param lla    Input: latitude (degrees), longitude (degrees), altitude (m).
+ */
 void lla_Deg2Rad_d(double result[3], double lla[3]);
+
+/**
+ * @brief Convert individual lat/lon/alt from degrees to radians (altitude is passed through unchanged).
+ * @param result Output: latitude (rad), longitude (rad), altitude (m).
+ * @param lat    Input latitude (degrees).
+ * @param lon    Input longitude (degrees).
+ * @param alt    Input altitude (m).
+ */
 void lla_Deg2Rad_d2(double result[3], double lat, double lon, double alt);
 
-/*
- *  Find msl altitude based on barometric pressure
- *  https://en.wikipedia.org/wiki/Atmospheric_pressure
- *
- *  baroKPa = (kPa) barometric pressure in kilopascals
- *  return = (m) MSL altitude in meters
+/**
+ * @brief Find MSL altitude based on barometric pressure. See https://en.wikipedia.org/wiki/Atmospheric_pressure
+ * @param pKPa Barometric pressure (kPa).
+ * @return MSL altitude (m).
  */
 f_t baro2msl(f_t pKPa);
 
-/*
- *  Find linear distance between lat,lon,alt (rad,rad,m) coordinates.
- *
- *  return = (m) distance in meters
+/**
+ * @brief Find the linear (great-circle-adjacent, ECEF-based) distance between two lat/lon/alt coordinates, radians input.
+ * @param lla1 First coordinate: latitude (rad), longitude (rad), altitude (m).
+ * @param lla2 Second coordinate: latitude (rad), longitude (rad), altitude (m).
+ * @return Distance (m).
  */
 f_t llaRadDistance(double lla1[3], double lla2[3]);
+
+/**
+ * @brief Find the linear (great-circle-adjacent, ECEF-based) distance between two lat/lon/alt coordinates, degrees input.
+ * @param lla1 First coordinate: latitude (degrees), longitude (degrees), altitude (m).
+ * @param lla2 Second coordinate: latitude (degrees), longitude (degrees), altitude (m).
+ * @return Distance (m).
+ */
 f_t llaDegDistance(double lla1[3], double lla2[3]);
 
-/*
- *  Check if lat,lon,alt (deg,deg,m) coordinates are valid.
- *
- *  return 0 on success, -1 on failure.
+/**
+ * @brief Check whether lat/lon/alt coordinates (degrees) are within valid ranges.
+ * @param lla Latitude (degrees), longitude (degrees), altitude (m).
+ * @return 0 on success (valid), -1 on failure (invalid).
  */
 int llaDegValid(double lla[3]);
 
-/* 
- * IGF-80 gravity model with WGS-84 ellipsoid refinement 
-*/
+/**
+ * @brief IGF-80 gravity model with WGS-84 ellipsoid refinement.
+ * @param lat Latitude (rad).
+ * @param alt Altitude (m).
+ * @return Local gravitational acceleration (m/s^2).
+ */
 float gravity_igf80(float lat, float alt);
 
-/*
- * Quaternion rotation to NED with respect to ECEF at specified LLA
- */
+// Quaternion rotation to NED with respect to ECEF at specified LLA
 // void quatEcef2Ned(ixVector4 Qe2n, const ixVector3d lla);
 
-/* Attitude quaternion for NED frame in ECEF */
+/**
+ * @brief Compute the attitude quaternion for the NED frame, expressed in ECEF, at a given latitude/longitude.
+ * @param lat  Latitude (rad).
+ * @param lon  Longitude (rad).
+ * @param qe2n Output: quaternion rotation from ECEF to NED (W, X, Y, Z).
+ */
 void quat_ecef2ned(float lat, float lon, float *qe2n);
 
-/*
-* Convert ECEF quaternion to NED euler at specified ECEF
-*/
+/**
+ * @brief Convert an ECEF body-rotation quaternion to NED Euler angles at a specified ECEF position.
+ * @param theta Output: Euler angles (roll, pitch, yaw), radians, w.r.t. NED.
+ * @param qe2b  Input: quaternion body rotation w.r.t. ECEF (W, X, Y, Z).
+ * @param ecef  Input: ECEF position (X, Y, Z), meters, used to determine the local NED frame.
+ */
 void qe2b2EulerNedEcef(ixVector3 theta, const ixVector4 qe2b, const ixVector3d ecef);
+
+/**
+ * @brief Convert an ECEF body-rotation quaternion to NED Euler angles at a specified LLA position.
+ * @param eul  Output: Euler angles (roll, pitch, yaw), radians, w.r.t. NED.
+ * @param qe2b Input: quaternion body rotation w.r.t. ECEF (W, X, Y, Z).
+ * @param lla  Input: latitude (rad), longitude (rad), altitude (m), used to determine the local NED frame.
+ */
 void qe2b2EulerNedLLA(ixVector3 eul, const ixVector4 qe2b, const ixVector3d lla);
 
 /**
@@ -219,7 +295,7 @@ void gndSpeedToVelEcef(const float gndSpeed, const float hdg, const float vertVe
 /**
  * @brief Convert week and tow in gps time to gtime_t struct
  *
- * @param weel                  week number in gps time
+ * @param week                  week number in gps time
  * @param sec                   time of week in gps time (s)
  * @return                      gtime_t struct
  */
@@ -243,7 +319,8 @@ gtime_t IStimeadd(gtime_t t, double sec);
 
 /**
  * @brief Difference between gtime_t structs
- * @param t1, t2                gtime_t structs
+ * @param t1                    gtime_t struct (minuend)
+ * @param t2                    gtime_t struct (subtrahend)
  * @return                      time difference (t1-t2) (s)
  */
 double IStimediff(gtime_t t1, gtime_t t2);
@@ -257,7 +334,7 @@ gtime_t ISepoch2time(const double *ep);
 
 /**
  * @brief convert utc to gpstime considering leap seconds
- * @param args                  time expressed in utc
+ * @param t                     time expressed in utc
  * @return                      time expressed in gpstime
  */
 gtime_t ISutc2gpst(gtime_t t);

--- a/src/ISGnss.h
+++ b/src/ISGnss.h
@@ -1,11 +1,39 @@
+/**
+ * @file ISGnss.h
+ * @brief GNSS constellation and signal ID -> human-readable name/prefix helpers.
+ *
+ * Converts the numeric gnssId/sigId values used in satellite-tracking structures (e.g. @ref
+ * gnss_sat_t, @ref gnss_sig_t) into display strings, for UI and log-summary use.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
 
 #ifndef IS_GNSS_H_
 #define IS_GNSS_H_
 
+#include <string>
 
-
+/**
+ * @brief Convert a GNSS constellation ID to its human-readable name.
+ * @param gnssId Constellation ID (see SAT_SV_GNSS_ID_* in data_sets.h).
+ * @return Constellation name (e.g. "GPS", "GLONASS"), or the numeric ID as a string if unrecognized.
+ */
 std::string gnssIdToGnssName(int gnssId);
+
+/**
+ * @brief Convert a GNSS constellation ID to its single-character prefix, as used in satellite ID strings.
+ * @param gnssId Constellation ID (see SAT_SV_GNSS_ID_* in data_sets.h).
+ * @return Constellation prefix character (e.g. 'G' for GPS, 'R' for GLONASS), or ' ' if unrecognized.
+ */
 char gnssIdToGnssPrefix(int gnssId);
+
+/**
+ * @brief Convert a GNSS constellation ID + signal ID pair to its human-readable signal name.
+ * @param gnssId Constellation ID (see SAT_SV_GNSS_ID_* in data_sets.h).
+ * @param sigId  Signal ID within that constellation (see SAT_SV_SIG_ID_* in data_sets.h).
+ * @return Signal name (e.g. "L1CA", "E5aI"), or an empty string if the gnssId/sigId pair is unrecognized.
+ */
 std::string gnssIdSigIdToSignalName(int gnssId, int sigId);
 
 

--- a/src/ISMatrix.h
+++ b/src/ISMatrix.h
@@ -96,7 +96,7 @@ extern "C" {
 #define SET_VEC3_X(v,x)                     { (v[0])=(x); (v[1])=(x); (v[2])=(x); }
 #define SET_VEC4_X(v,x)                     { (v[0])=(x); (v[1])=(x); (v[2])=(x); (v[3])=(x); }
 
-/** Zero-order (single-pole) low-pass filter state for a 3-vector; see @ref LPFO0_init_Vec3 / @ref LPFO0_Vec3. */
+/** Single-pole ("O0") low-pass filter state for a 3-vector (usually called a 1st-order LPF); see @ref LPFO0_init_Vec3 / @ref LPFO0_Vec3. */
 typedef struct
 {
     ixVector3               v;      //!< Filter output / running value
@@ -943,7 +943,8 @@ int isAllMoreThanX_array(f_t *a, f_t x, int size);
 int isAllAbsLessThanX_array(f_t *a, f_t x, int size);
 
 /**
- * @brief Initialize a zero-order low-pass filter's alpha/beta gains and initial value.
+ * @brief Initialize a single-pole ("O0" -- tracks no extra derivative state, as opposed to O1 below)
+ * low-pass filter's alpha/beta gains and initial value. Usually called a 1st-order LPF.
  * @param lpf          Filter state to initialize.
  * @param dt           Expected update period (seconds).
  * @param cornerFreqHz Low-pass filter corner frequency (Hz).
@@ -952,14 +953,16 @@ int isAllAbsLessThanX_array(f_t *a, f_t x, int size);
 void LPFO0_init_Vec3(sLpfO0 *lpf, f_t dt, f_t cornerFreqHz, const ixVector3 initVal);
 
 /**
- * @brief Update a zero-order low-pass filter with a new sample: v[n+1] = beta*v[n] + alpha*input.
+ * @brief Update a single-pole ("O0") low-pass filter with a new sample (usually called a 1st-order
+ * LPF): v[n+1] = beta*v[n] + alpha*input.
  * @param lpf   Filter state; updated in place.
  * @param input New input sample.
  */
 void LPFO0_Vec3(sLpfO0 *lpf, const ixVector3 input);
 
 /**
- * @brief Zero-order (single-pole) low-pass filter update, standalone (no sLpfO0 state struct needed): result = beta*result + alpha*input.
+ * @brief Single-pole ("O0") low-pass filter update, standalone (no sLpfO0 state struct needed;
+ * usually called a 1st-order LPF): result = beta*result + alpha*input.
  * @param result Filter output and running state; updated in place.
  * @param input  New input sample.
  * @param alph   Filter alpha parameter (input gain).
@@ -977,12 +980,17 @@ static __inline void O0_LPF_Vec3(ixVector3 result, const ixVector3 input, f_t al
 
 
 /**
- * @brief First-order low-pass filter update with an explicit model-coefficient state (for larger dt).
+ * @brief Not a traditional low-pass filter despite the name -- this is a fused kinematic tracker
+ * with LPF smoothing, useful when dt is large enough that a plain single-pole LPF (O0, above)
+ * would lag noticeably behind a changing input. Each update: (1) estimates the derivative as
+ * (input - result) / dt; (2) low-pass filters that derivative estimate into the c1 state via
+ * O0_LPF_Vec3(); (3) integrates c1*dt onto the previous result to predict the current state;
+ * (4) blends that prediction with the new raw input via another O0_LPF_Vec3() stage.
  * @param result Filter output and running state; updated in place.
  * @param input  New input sample.
- * @param c1     Model-coefficient state; updated in place.
- * @param alph   Filter alpha parameter (input gain).
- * @param beta   Filter beta parameter (memory gain).
+ * @param c1     Model-coefficient (filtered derivative) state; updated in place.
+ * @param alph   Filter alpha parameter (input gain), used for both internal LPF stages.
+ * @param beta   Filter beta parameter (memory gain), used for both internal LPF stages.
  * @param dt     Time since the last update (seconds).
  */
 static __inline void O1_LPF_Vec3(ixVector3 result, const ixVector3 input, ixVector3 c1, f_t alph, f_t beta, f_t dt)

--- a/src/ISMatrix.h
+++ b/src/ISMatrix.h
@@ -10,6 +10,23 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISMatrix.h
+ * @brief Vector/matrix math for 2/3/4-element vectors and 2x2/3x3/4x4/NxM matrices: dot/cross
+ * products, magnitude/normalization, transpose/inverse, element-wise arithmetic, comparisons, and
+ * low-pass filtering.
+ *
+ * Naming convention: an operation on vectors/matrices of dimension N is suffixed _VecN / _MatN
+ * (e.g. add_Vec3_Vec3, mul_Mat3x3_Vec3x1); a trailing "d" (e.g. Vec3d) means double precision,
+ * otherwise types are f_t (float, unless the SDK is built for double precision). Macro variants of
+ * the simplest operations (DOT_VEC3, MAG_VEC3, etc.) are provided as faster inline alternatives to
+ * their function equivalents (e.g. dot_Vec3()), at the cost of evaluating their argument multiple
+ * times -- prefer the function form when the argument expression has side effects.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef MATRIX_H_
 #define MATRIX_H_
 
@@ -24,13 +41,12 @@ extern "C" {
 
 //_____ M A C R O S ________________________________________________________
 
-// Magnitude Squared or Dot Product of vector w/ itself
-// Inline macros (faster).  Call functions (i.e. dot_Vec3()) for slower but better memory usage.
+/** Magnitude squared (dot product of a vector with itself). Inline macros (faster); call the equivalent dot_VecN() function instead for slower but better memory usage, or if v has side effects. */
 #define DOT_VEC2(v)     ((v)[0]*(v)[0] + (v)[1]*(v)[1])
 #define DOT_VEC3(v)     ((v)[0]*(v)[0] + (v)[1]*(v)[1] + (v)[2]*(v)[2])
 #define DOT_VEC4(v)     ((v)[0]*(v)[0] + (v)[1]*(v)[1] + (v)[2]*(v)[2] + (v)[3]*(v)[3])
 
-// Magnitude or Norm 
+/** Magnitude (norm) of a vector, single precision (F) or double precision (D). */
 #define MAG_VEC2(v)     (_SQRT(DOT_VEC2(v)))
 #define MAG_VEC3(v)     (_SQRT(DOT_VEC3(v)))
 #define MAG_VEC4(v)     (_SQRT(DOT_VEC4(v)))
@@ -38,22 +54,26 @@ extern "C" {
 #define MAG_VEC3D(v)    (sqrt(DOT_VEC3(v)))
 #define MAG_VEC4D(v)    (sqrt(DOT_VEC4(v)))
 
-#define EPSF32 (1.0e-16f)  // Smallest number for safe division
-#define EPSF64 (1.0e-16l)  // Smallest number for safe division
+#define EPSF32 (1.0e-16f)  //!< Smallest number for safe division, single precision
+#define EPSF64 (1.0e-16l)  //!< Smallest number for safe division, double precision
 
+/** Reciprocal of a vector's magnitude, clamped away from zero by EPSF32/EPSF64 for safe division (e.g. when normalizing). */
 #define RECIPNORM_VEC2(v)   (1.0f/_MAX(MAG_VEC2(v),  EPSF32))
 #define RECIPNORM_VEC3(v)   (1.0f/_MAX(MAG_VEC3(v),  EPSF32))
 #define RECIPNORM_VEC4(v)   (1.0f/_MAX(MAG_VEC4(v),  EPSF32))
 #define RECIPNORM_VEC3D(v)  (1.0l/_MAX(MAG_VEC3D(v), EPSF64))
 #define RECIPNORM_VEC4D(v)  (1.0l/_MAX(MAG_VEC4D(v), EPSF64))
 
+/** Unwrap each element of a 3-vector of radian angles into the canonical +-pi range (see UNWRAP_RAD_F32). */
 #define UNWRAP_VEC3(v)          {UNWRAP_RAD_F32(v[0]); UNWRAP_RAD_F32(v[1]); UNWRAP_RAD_F32(v[2]) }
 
+/** Type-correct zero literal for x's type (float/double/long double/int), used by the VEC3_*_ZERO macros below. */
 #ifdef __cplusplus
 #define ZERO_OF(x)                          static_cast<std::remove_reference_t<decltype(x)>>(0)
 #else
 #define ZERO_OF(x)                          _Generic((x), float: 0.0f, double: 0.0, long double: 0.0l, default: 0)
 #endif
+/** Per-element threshold comparisons over a 3-vector: true if any/all element(s) are less/greater than x (plain or absolute value). */
 #define VEC3_ANY_LESS_THAN_X(v,x)           ( (((v)[0])<(x)) || (((v)[1])<(x)) || (((v)[2])<(x)) )
 #define VEC3_ANY_GRTR_THAN_X(v,x)           ( (((v)[0])>(x)) || (((v)[1])>(x)) || (((v)[2])>(x)) )
 #define VEC3_ALL_LESS_THAN_X(v,x)           ( (((v)[0])<(x)) && (((v)[1])<(x)) && (((v)[2])<(x)) )
@@ -62,43 +82,45 @@ extern "C" {
 #define VEC3_ABS_ALL_GRTR_THAN_X(v,x)       ( (fabs((v)[0])>(x)) && (fabs((v)[1])>(x)) && (fabs((v)[2])>(x)) )
 #define VEC3_ABSF_ALL_LESS_THAN_X(v,x)      ( (fabsf((v)[0])<(x)) && (fabsf((v)[1])<(x)) && (fabsf((v)[2])<(x)) )
 #define VEC3_ABSF_ALL_GRTR_THAN_X(v,x)      ( (fabsf((v)[0])>(x)) && (fabsf((v)[1])>(x)) && (fabsf((v)[2])>(x)) )
+/** Zero/non-zero tests over a 3-vector: true if all/any/none of its elements are (not) zero, or if any element is NaN. */
 #define VEC3_ALL_ZERO(v)                    ( (((v)[0]) == ZERO_OF((v)[0])) && (((v)[1]) == ZERO_OF((v)[1])) && (((v)[2]) == ZERO_OF((v)[2])) )
 #define VEC3_ANY_ZERO(v)                    ( (((v)[0]) == ZERO_OF((v)[0])) || (((v)[1]) == ZERO_OF((v)[1])) || (((v)[2]) == ZERO_OF((v)[2])) )
 #define VEC3_ANY_NOT_ZERO(v)                ( (((v)[0]) != ZERO_OF((v)[0])) || (((v)[1]) != ZERO_OF((v)[1])) || (((v)[2]) != ZERO_OF((v)[2])) )
-#define VEC3_ANY_NAN(v)                     ( (is_nan_f((v)[0])) || (is_nan_f((v)[1])) || (is_nan_f((v)[2])) )  
+#define VEC3_ANY_NAN(v)                     ( (is_nan_f((v)[0])) || (is_nan_f((v)[1])) || (is_nan_f((v)[2])) )
 #define VEC3_NO_NAN(v)                      ( !VEC3_ANY_NAN(v) )
 
+/** True if any element of an integer 3-vector is non-zero. */
 #define INT3_ANY_NOT_ZERO(v)                ( ((v[0])!=(0)) || ((v[1])!=(0)) || ((v[2])!=(0)) )
 
+/** Set every element of a 3- or 4-vector to the scalar x. */
 #define SET_VEC3_X(v,x)                     { (v[0])=(x); (v[1])=(x); (v[2])=(x); }
 #define SET_VEC4_X(v,x)                     { (v[0])=(x); (v[1])=(x); (v[2])=(x); (v[3])=(x); }
 
-// Zero order low-pass filter 
+/** Zero-order (single-pole) low-pass filter state for a 3-vector; see @ref LPFO0_init_Vec3 / @ref LPFO0_Vec3. */
 typedef struct
 {
-    ixVector3               v;
-    f_t                   alpha;  // alpha gain
-    f_t                   beta;   // beta  gain
+    ixVector3               v;      //!< Filter output / running value
+    f_t                   alpha;    //!< Alpha gain (input weight)
+    f_t                   beta;     //!< Beta gain (memory weight)
 } sLpfO0;
 
-// First order low-pass filter
+/** First-order low-pass filter state for a 3-vector, with an explicit model-coefficient state (see O1_LPF_Vec3()). */
 typedef struct
 {
-    ixVector3               v;
-    ixVector3               c1;
-    f_t                   alpha;  // alpha gain
-    f_t                   beta;   // beta  gain
+    ixVector3               v;      //!< Filter output / running value
+    ixVector3               c1;     //!< Model-coefficient state
+    f_t                   alpha;    //!< Alpha gain (input weight)
+    f_t                   beta;     //!< Beta gain (memory weight)
 } sLpfO1;
 
 //_____ G L O B A L S ______________________________________________________
 
 //_____ P R O T O T Y P E S ________________________________________________
 
-/*
- * We can avoid expensive floating point operations if one of the
- * values in question is zero.  This provides an easy way to check
- * to see if it is actually a zero without using any floating point
- * code.
+/**
+ * @brief Check whether a float is exactly zero via its raw bit pattern, avoiding a floating-point comparison.
+ * @param f Pointer to the float to check.
+ * @return 1 if *f is exactly zero, 0 otherwise.
  */
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -114,153 +136,122 @@ static __inline char is_zero(const f_t * f)
 #endif
 
 
-/*
- * Perform the matrix multiplication A[m,n] * B[n,p], storing the
- * result in result[m,p].
- *
- * If transpose_B is set, B is assumed to be a [p,n] matrix that is
- * transversed in column major order instead of row major.  This
- * has the effect of transposing B during the computation.
- *
- * If add == 0, OUT  = A * B.
- * If add >  0, OUT += A * B.
- * If add <  0, OUT -= A * B.
+/**
+ * @brief General matrix multiplication: result[m,p] = A[m,n] * B[n,p] (or +=/-= per add).
+ * @param result      Output: result[m,p].
+ * @param A_ptr       Input matrix A[m,n], row-major.
+ * @param B_ptr       Input matrix B[n,p], row-major (or [p,n] if transpose_B is set).
+ * @param m           Row count of A (and result).
+ * @param n           Column count of A / row count of B.
+ * @param p           Column count of B (and result).
+ * @param transpose_A Non-zero to treat A_ptr as an [n,m] matrix, transposed during the computation.
+ * @param transpose_B Non-zero to treat B_ptr as a [p,n] matrix (traversed column-major instead of
+ *                    row-major), transposing B during the computation.
+ * @param add         0: result = A*B. >0: result += A*B. <0: result -= A*B.
  */
 void mul_MatMxN(f_t *result, const f_t *A_ptr, const f_t *B_ptr, i_t m, i_t n, i_t p, char transpose_A, char transpose_B, char add);
 
-/* Initialize square matrix as identity (0's with 1's in the diagonal)
-* result(nxn) = eye(nxn)
-*/
+/**
+ * @brief Initialize an nxn matrix as the identity matrix (0s with 1s on the diagonal).
+ * @param A Output: nxn identity matrix.
+ * @param n Matrix dimension.
+ */
 void eye_MatN(f_t *A, i_t n);
 
-/* Matrix Inverse
-* result(nxn) = M(nxn)^-1
-*/
+/**
+ * @brief Invert an nxn matrix: result = M^-1.
+ * @param result Output: nxn inverse matrix.
+ * @param M      Input nxn matrix.
+ * @param n      Matrix dimension.
+ * @return 0 on success, non-zero on numerical error (e.g. singular matrix).
+ */
 char inv_MatN(f_t *result, const f_t *M, i_t n);
 
 
-/* Matrix Transpose:  M[m x n] -> result[n x m]
-*/
+/**
+ * @brief Matrix transpose: M[m x n] -> result[n x m].
+ * @param result Output: transposed matrix.
+ * @param M      Input matrix.
+ * @param m      Row count of M.
+ * @param n      Column count of M.
+ */
 void trans_MatMxN(f_t *result, const f_t *M, int m, int n);
 
 
-/* Matrix Multiply
- * result(3x3) = m1(3x3) * m2(3x3)
- */
+/** @brief Matrix multiply: result(3x3) = m1(3x3) * m2(3x3), single/double precision. */
 void mul_Mat3x3_Mat3x3(ixMatrix3 result, const ixMatrix3 m1, const ixMatrix3 m2);
 void mul_Mat3x3_Mat3x3_d(ixMatrix3d result, const ixMatrix3d m1, const ixMatrix3d m2);
 
-/* Matrix Multiply w/ Transpose
- * result(3x3) = m1.T(3x3) * m2(3x3)
- */
+/** @brief Matrix multiply with transpose: result(3x3) = m1.T(3x3) * m2(3x3), single/double precision. */
 void mul_Mat3x3_Trans_Mat3x3(ixMatrix3 result, const ixMatrix3 m1, const ixMatrix3 m2);
 void mul_Mat3x3_Trans_Mat3x3_d(ixMatrix3d result, const ixMatrix3d m1, const ixMatrix3d m2);
 
-/* Matrix Multiply w/ Transpose
- * result(3x3) = m1(3x3) * m2.T(3x3)
- */
+/** @brief Matrix multiply with transpose: result(3x3) = m1(3x3) * m2.T(3x3), single/double precision. */
 void mul_Mat3x3_Mat3x3_Trans(ixMatrix3 result, const ixMatrix3 m1, const ixMatrix3 m2);
 void mul_Mat3x3_Mat3x3_Trans_d(ixMatrix3d result, const ixMatrix3d m1, const ixMatrix3d m2);
 
-/* Matrix addition
- * result(3x3) = m1(3x3) + m2(3x3)
- */
+/** @brief Matrix addition: result(3x3) = m1(3x3) + m2(3x3). */
 void add_Mat3x3_Mat3x3(ixMatrix3 result, const ixMatrix3 m1, const ixMatrix3 m2);
 
-/* Matrix subtraction
- * result(3x3) = m1(3x3) - m2(3x3)
- */
+/** @brief Matrix subtraction: result(3x3) = m1(3x3) - m2(3x3). */
 void sub_Mat3x3_Mat3x3(ixMatrix3 result, const ixMatrix3 m1, const ixMatrix3 m2);
 
-/* Matrix Multiply
- * result(1x2) = m(2x2) * v(2x1)
- */
+/** @brief Matrix-vector multiply: result(2x1) = m(2x2) * v(2x1). */
 void mul_Mat2x2_Vec2x1(ixVector2 result, const ixMatrix2 m, const ixVector2 v);
 
-/* Matrix Multiply w/ Transpose
- * result(1x2) = m(2x2).T * v(2x1)
- */
+/** @brief Matrix-vector multiply with transpose: result(2x1) = m(2x2).T * v(2x1). */
 void mul_Mat2x2_Trans_Vec2x1(ixVector2 result, const ixMatrix2 m, const ixVector2 v);
 
-/* Matrix Multiply
- * result(1x3) = m(3x3) * v(3x1)
- * (9 multiplies, 6 adds)
- */
+/** @brief Matrix-vector multiply: result(3x1) = m(3x3) * v(3x1). (9 multiplies, 6 adds) */
 void mul_Mat3x3_Vec3x1(ixVector3 result, const ixMatrix3 m, const ixVector3 v);
 
-/* Matrix Multiply w/ Transpose
- * result(1x3) = m(3x3).T * v(3x1)
- */
+/** @brief Matrix-vector multiply with transpose: result(3x1) = m(3x3).T * v(3x1). */
 void mul_Mat3x3_Trans_Vec3x1(ixVector3 result, const ixMatrix3 m, const ixVector3 v);
 
-/* Matrix Multiply
- * result(1x4) = m(4x4) * v(4x1)
- */
+/** @brief Matrix-vector multiply: result(4x1) = m(4x4) * v(4x1). */
 void mul_Mat4x4_Vec4x1(ixVector4 result, const ixMatrix4 m, const ixVector4 v);
 
-/* Matrix Multiply w/ Transpose
- * result(1x4) = m(4x4).T * v(4x1)
- */
+/** @brief Matrix-vector multiply with transpose: result(4x1) = m(4x4).T * v(4x1). */
 void mul_Mat4x4_Trans_Vec4x1(ixVector4 result, const ixMatrix4 m, const ixVector4 v);
 
-/* Negate 
-*/
+/** @brief Negate a 3x3 matrix: result = -m. */
 void neg_Mat3x3(ixMatrix3 result, const ixMatrix3 m);
 
-/* Multiply
- * result(3x3) = m(3x3) .* x
- */
+/** @brief Scalar multiply: result(3x3) = m(3x3) .* x. */
 void mul_Mat3x3_X(ixMatrix3 result, const ixMatrix3 m, const f_t x);
 
-/* Divide
- * result(3x3) = m(3x3) ./ x
- */
+/** @brief Scalar divide: result(3x3) = m(3x3) ./ x. */
 void div_Mat3x3_X(ixMatrix3 result, const ixMatrix3 m, const f_t x);
 
-/* Multiply
- * result(3x3) = v1(3x1) * v2(1x3)
- */
+/** @brief Outer product: result(3x3) = v1(3x1) * v2(1x3). */
 void mul_Vec3x1_Vec1x3(ixMatrix3 result, const ixVector3 v1, const ixVector3 v2);
 
-/* Multiply
- * result(2) = v1(2) * v2(2)
- */
+/** @brief Element-wise multiply: result(2) = v1(2) .* v2(2). */
 void mul_Vec2_Vec2(ixVector2 result, const ixVector2 v1, const ixVector2 v2);
 
-/* Multiply
- * result(3) = v1(3) * v2(3)
- */
+/** @brief Element-wise multiply: result(3) = v1(3) .* v2(3). */
 void mul_Vec3_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 
-/* Multiply
- * result(4) = v1(4) .* v2(4)
- */
+/** @brief Element-wise multiply: result(4) = v1(4) .* v2(4). */
 void mul_Vec4_Vec4(ixVector4 result, const ixVector4 v1, const ixVector4 v2);
 
-/* Square Root
- * result(3) = .sqrt(v(3))
- */
+/** @brief Element-wise square root: result(3) = sqrt(v(3)). */
 void sqrt_Vec3(ixVector3 result, const ixVector3 v);
 
-/* Square Root
- * result(4) = .sqrt(v(4))
- */
+/** @brief Element-wise square root: result(4) = sqrt(v(4)). */
 void sqrt_Vec4(ixVector4 result, const ixVector4 v);
 
-/* Absolute Value
- * result(n) = .abs(v(n))
- */
+/** @brief Element-wise absolute value: result(n) = abs(v(n)), single precision. */
 void abs_Vec2(ixVector2 result, const ixVector2 v);
 void abs_Vec3(ixVector3 result, const ixVector3 v);
 void abs_Vec4(ixVector4 result, const ixVector4 v);
 
+/** @brief Element-wise absolute value: result(n) = abs(v(n)), double precision. */
 void abs_Vec2d(ixVector2d result, const ixVector2d v);
 void abs_Vec3d(ixVector3d result, const ixVector3d v);
 void abs_Vec4d(ixVector4d result, const ixVector4d v);
 
-/* Dot product
- * result = v(n) dot v(n)
- */
+/** @brief Dot product of a vector with itself: result = v(n) dot v(n), single/double precision. */
 f_t dot_Vec2(const ixVector2 v);
 f_t dot_Vec3(const ixVector3 v);
 f_t dot_Vec4(const ixVector4 v);
@@ -268,9 +259,7 @@ double dot_Vec2d(const ixVector2d v);
 double dot_Vec3d(const ixVector3d v);
 double dot_Vec4d(const ixVector4d v);
 
-/* Dot product
- * result = v1(n) dot v2(n)
- */
+/** @brief Dot product: result = v1(n) dot v2(n), single/double precision. */
 f_t dot_Vec2_Vec2(const ixVector2 v1, const ixVector2 v2);
 f_t dot_Vec3_Vec3(const ixVector3 v1, const ixVector3 v2);
 f_t dot_Vec4_Vec4(const ixVector4 v1, const ixVector4 v2);
@@ -278,16 +267,12 @@ double dot_Vec2d_Vec2d(const ixVector2d v1, const ixVector2d v2);
 double dot_Vec3d_Vec3d(const ixVector3d v1, const ixVector3d v2);
 double dot_Vec4d_Vec4d(const ixVector4d v1, const ixVector4d v2);
 
-/* Vector magnitude
- * result = sqrt(v(n) dot v(n))
- */
+/** @brief Vector magnitude: result = sqrt(v(n) dot v(n)). */
 f_t mag_Vec2(const ixVector2 v);
 f_t mag_Vec3(const ixVector3 v);
 f_t mag_Vec4(const ixVector4 v);
 
-/* Cross product
- * result(3) = v1(3) x v2(3)
- */
+/** @brief Cross product: result(3) = v1(3) x v2(3), single-precision inputs, single- or double-precision output. */
 void cross_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 void crossd_Vec3(ixVector3d result, const ixVector3 v1, const ixVector3 v2);
 
@@ -296,97 +281,69 @@ void crossd_Vec3(ixVector3d result, const ixVector3 v1, const ixVector3 v2);
 //  */
 // f_t length_Vec3(ixVector3 v);
 
-/* Multiply
- * result(2x1) = v(2) .* x
- */
+/** @brief Scalar multiply: result(2x1) = v(2) .* x, single/double precision. */
 void mul_Vec2_X(ixVector2 result, const ixVector2 v, const f_t x);
 void mul_Vec2d_X(ixVector2d result, const ixVector2d v, const double x);
 
-/* Multiply
- * result(3x1) = v(3) .* x
- */
+/** @brief Scalar multiply: result(3x1) = v(3) .* x, single/double precision. */
 void mul_Vec3_X(ixVector3 result, const ixVector3 v, const  f_t x);
 void mul_Vec3d_X(ixVector3d result, const ixVector3d v, const double x);
 
-/* Multiply
- * result(4x1) = v(4) .* x
- */
+/** @brief Scalar multiply: result(4x1) = v(4) .* x, single/double precision. */
 void mul_Vec4_X(ixVector4 result, const ixVector4 v, const f_t x);
 void mul_Vec4d_X(ixVector4d result, const ixVector4d v, const double x);
 
-/* Divide
- * result(3x1) = v(3) ./ x
- */
+/** @brief Scalar divide: result(3x1) = v(3) ./ x, single/double precision. */
 void div_Vec3_X(ixVector3 result, const ixVector3 v, const f_t x);
 void div_Vec3d_X(ixVector3d result, const ixVector3d v, const double x);
 
-/* Divide
- * result(4x1) = v(4) ./ x
- */
+/** @brief Scalar divide: result(4x1) = v(4) ./ x, single/double precision. */
 void div_Vec4_X(ixVector4 result, const ixVector4 v, const f_t x);
 void div_Vec4d_X(ixVector4d result, const ixVector4d v, const double x);
 
 
-/* Add
- * result(2) = v1(2) + v2(2)
- */
+/** @brief Vector add: result(2) = v1(2) + v2(2). */
 void add_Vec2_Vec2(ixVector2 result, const ixVector2 v1, const ixVector2 v2);
 
-/* Add
- * result(3) = v1(3) + v2(3)
- */
+/** @brief Vector add: result(3) = v1(3) + v2(3), single/double precision. */
 void add_Vec3_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 void add_Vec3d_Vec3d(ixVector3d result, const ixVector3d v1, const ixVector3d v2);
 
-/* Add
- * result(3) = k1*v1(3) + k2*v2(3)
- */
+/** @brief Weighted vector add: result(3) = k1*v1(3) + k2*v2(3). */
 void add_K1Vec3_K2Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2, float k1, float k2);
 
-/* Add
- * result(4) = v1(4) + v2(4)
- */
+/** @brief Vector add: result(4) = v1(4) + v2(4), single/double precision. */
 void add_Vec4_Vec4(ixVector4 result, const ixVector4 v1, const ixVector4 v2);
 void add_Vec4d_Vec4d(ixVector4d result, const ixVector4d v1, const ixVector4d v2);
 
-/* Subtract
- * result(3) = v1(3) - v2(3)
- */
+/** @brief Vector subtract: result(3) = v1(3) - v2(3), single/double precision. */
 void sub_Vec3_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 void sub_Vec3d_Vec3d(ixVector3d result, const ixVector3d v1, const ixVector3d v2);
 
-/* Subtract
- * result(2) = v1(2) - v2(2)
- */
+/** @brief Vector subtract: result(2) = v1(2) - v2(2). */
 void sub_Vec2_Vec2(ixVector2 result, const ixVector2 v1, const ixVector2 v2);
 
-/* Subtract
- * result(4) = v1(4) +- v2(4)
- */
+/** @brief Vector subtract: result(4) = v1(4) - v2(4). */
 void sub_Vec4_Vec4(ixVector4 result, const ixVector4 v1, const ixVector4 v2);
 
-/* Divide
- * result(3) = v1(3) ./ v2(3)
- */
+/** @brief Element-wise divide: result(3) = v1(3) ./ v2(3). */
 void div_Vec3_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 
-/* Divide
- * result(4) = v1(4) ./ v2(4)
- */
+/** @brief Element-wise divide: result(4) = v1(4) ./ v2(4). */
 void div_Vec4_Vec4(ixVector4 result, const ixVector4 v1, const ixVector4 v2);
 
-/* Negate*/
+/** @brief Negate: result(3) = -v(3). */
 void neg_Vec3(ixVector3 result, const ixVector3 v);
 
-/* Average
- * result(3) = (v1(3) + v2(3)) * 0.5
- */
+/** @brief Average: result(3) = (v1(3) + v2(3)) * 0.5, single/double precision. */
 void mean_Vec3_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2);
 void mean_Vec3d_Vec3d(ixVector3d result, const ixVector3d v1, const ixVector3d v2);
 
 
-/* Min of vector elements
- * = min(v[0], v[1], v[2])
+/**
+ * @brief Minimum of a 3-vector's elements: min(v[0], v[1], v[2]).
+ * @param v Input vector.
+ * @return Minimum element value.
  */
 static __inline f_t min_Vec3_X(const ixVector3 v)
 {
@@ -401,8 +358,10 @@ static __inline f_t min_Vec3_X(const ixVector3 v)
     return val;
 }
 
-/* Max of vector elements
- * = max(v[0], v[1], v[2])
+/**
+ * @brief Maximum of a 3-vector's elements: max(v[0], v[1], v[2]).
+ * @param v Input vector.
+ * @return Maximum element value.
  */
 static __inline f_t max_Vec3_X(const ixVector3 v)
 {
@@ -417,8 +376,10 @@ static __inline f_t max_Vec3_X(const ixVector3 v)
     return val;
 }
 
-/* Max of vector elements
- * = max(fabsf(v[0]), fabsf(v[1]), fabsf(v[2]))
+/**
+ * @brief Maximum of a 3-vector's absolute-value elements: max(fabsf(v[0]), fabsf(v[1]), fabsf(v[2])).
+ * @param v Input vector.
+ * @return Maximum absolute element value.
  */
 static __inline f_t abs_Vec3_X(const ixVector3 v)
 {
@@ -435,8 +396,11 @@ static __inline f_t abs_Vec3_X(const ixVector3 v)
     return result;
 }
 
-/* Max of vector elements
- * = max(v1, v[1], v[2] }
+/**
+ * @brief Element-wise minimum of two 3-vectors: result[i] = min(v1[i], v2[i]).
+ * @param result Output: element-wise minimum.
+ * @param v1     First input vector.
+ * @param v2     Second input vector.
  */
 static __inline void min_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2)
 {
@@ -445,8 +409,11 @@ static __inline void min_Vec3(ixVector3 result, const ixVector3 v1, const ixVect
     result[2] = _MIN(v1[2], v2[2]);
 }
 
-/* Max of vector elements
- * = max(v1, v[1], v[2] }
+/**
+ * @brief Element-wise maximum of two 3-vectors: result[i] = max(v1[i], v2[i]).
+ * @param result Output: element-wise maximum.
+ * @param v1     First input vector.
+ * @param v2     Second input vector.
  */
 static __inline void max_Vec3(ixVector3 result, const ixVector3 v1, const ixVector3 v2)
 {
@@ -455,9 +422,7 @@ static __inline void max_Vec3(ixVector3 result, const ixVector3 v1, const ixVect
     result[2] = _MAX(v1[2], v2[2]);
 }
 
-/* Zero vector
- * v(2) = { 0, 0 }
- */
+/** @brief Zero a 2-vector: v(2) = {0, 0}, single/double precision. */
 static __inline void zero_Vec2(ixVector2 v)
 {
     v[0] = 0.0f;
@@ -469,9 +434,7 @@ static __inline void zero_Vec2d(ixVector2d v)
     v[1] = 0.0;
 }
 
-/* Zero vector
- * v(3) = { 0, 0, 0 }
- */
+/** @brief Zero a 3-vector: v(3) = {0, 0, 0}, single/double precision. */
 static __inline void zero_Vec3(ixVector3 v)
 {
     v[0] = 0.0f;
@@ -485,9 +448,7 @@ static __inline void zero_Vec3d(ixVector3d v)
     v[2] = 0.0;
 }
 
-/* Zero vector
- * v(4) = { 0, 0, 0 }
- */
+/** @brief Zero a 4-vector: v(4) = {0, 0, 0, 0}, single/double precision. */
 static __inline void zero_Vec4(ixVector4 v)
 {
     v[0] = 0.0f;
@@ -503,9 +464,11 @@ static __inline void zero_Vec4d(ixVector4d v)
     v[3] = 0.0;
 }
 
-/* Zero vector
-* v(n) = { 0, ..., 0 }
-*/
+/**
+ * @brief Zero an n-vector: v(n) = {0, ..., 0}.
+ * @param v Vector to zero.
+ * @param n Number of elements.
+ */
 static __inline void zero_VecN(f_t *v, i_t n)
 {
     for (int i=0; i<n; i++)
@@ -514,9 +477,12 @@ static __inline void zero_VecN(f_t *v, i_t n)
     }
 }
 
-/* Zero matrix
-* m(m,n) = { 0, ..., 0 }
-*/
+/**
+ * @brief Zero an mxn matrix.
+ * @param M Matrix to zero.
+ * @param m Row count.
+ * @param n Column count.
+ */
 static __inline void zero_MatMxN(f_t *M, i_t m, i_t n)
 {
     for (int i=0; i<(m*n); i++)
@@ -526,13 +492,13 @@ static __inline void zero_MatMxN(f_t *M, i_t m, i_t n)
 }
 
 /**
- * Return 1 if 3x3 matrix is an identity, 0 if not.
+ * @brief Check whether a 3x3 matrix is the identity matrix.
+ * @param m Input 3x3 matrix.
+ * @return 1 if m is an identity matrix, 0 otherwise.
  */
 int mat3x3_IsIdentity(const f_t m[]);
 
-/* Copy vector
- * result(3) = v(3)
- */
+/** @brief Copy a 3-vector: result(3) = v(3). Also converts between single/double precision. */
 static __inline void cpy_Vec3_Vec3(ixVector3 result, const ixVector3 v)
 {
     result[0] = v[0];
@@ -558,9 +524,7 @@ static __inline void cpy_Vec3_Vec3d(ixVector3 result, const ixVector3d v)
     result[2] = (f_t)v[2];
 }
 
-/* Copy vector
- * result(4) = v(4)
- */
+/** @brief Copy a 4-vector: result(4) = v(4). Also converts between single/double precision. */
 static __inline void cpy_Vec4_Vec4(ixVector4 result, const ixVector4 v)
 {
     result[0] = v[0];
@@ -590,9 +554,12 @@ static __inline void cpy_Vec4_Vec4d(ixVector4 result, const ixVector4d v)
     result[3] = (f_t)v[3];
 }
 
-/* Copy vector
-* result(n) = v(n)
-*/
+/**
+ * @brief Copy an n-vector: result(n) = v(n).
+ * @param result Output vector.
+ * @param v      Input vector.
+ * @param n      Number of elements.
+ */
 static __inline void cpy_VecN_VecN(f_t *result, const f_t *v, i_t n)
 {
     for (int i=0; i<n; i++)
@@ -601,9 +568,13 @@ static __inline void cpy_VecN_VecN(f_t *result, const f_t *v, i_t n)
     }
 }
 
-/* Copy matrix
-* result(mxn) = M(mxn)
-*/
+/**
+ * @brief Copy an mxn matrix: result(mxn) = M(mxn).
+ * @param result Output matrix.
+ * @param M      Input matrix.
+ * @param m      Row count.
+ * @param n      Column count.
+ */
 static __inline void cpy_MatMxN(f_t *result, const f_t *M, i_t m, i_t n)
 {
     for (int i=0; i<(m*n); i++)
@@ -612,46 +583,57 @@ static __inline void cpy_MatMxN(f_t *result, const f_t *M, i_t m, i_t n)
     }
 }
 
-/* Copy matrix A(mxn) into result(rxc) matrix, starting at offset_r, offset_c.  Matrix A must fit inside result matrix dimensions.
-* result(rxc) <= A(mxn)
-*/
+/**
+ * @brief Copy matrix A(mxn) into a sub-block of matrix result(rxc), starting at (r_offset, c_offset).
+ * A must fit inside result's dimensions at that offset.
+ * @param result   Output matrix, r rows by c columns.
+ * @param r        Row count of result.
+ * @param c        Column count of result.
+ * @param r_offset Row offset within result at which to place A.
+ * @param c_offset Column offset within result at which to place A.
+ * @param A        Input matrix, m rows by n columns.
+ * @param m        Row count of A.
+ * @param n        Column count of A.
+ */
 void cpy_MatRxC_MatMxN(f_t *result, i_t r, i_t c, i_t r_offset, i_t c_offset, f_t *A, i_t m, i_t n);
 
 
-/* Matrix Transpose
- * result(2x2) = m(2x2)'
- */
+/** @brief Matrix transpose: result(2x2) = m(2x2)'. */
 void transpose_Mat2(ixMatrix2 result, const ixMatrix2 m);
 
-/* Matrix Transpose
- * result(3x3) = m(3x3)'
- */
+/** @brief Matrix transpose: result(3x3) = m(3x3)'. */
 void transpose_Mat3(ixMatrix3 result, const ixMatrix3 m);
 
-/* Matrix Transpose
- * result(4x4) = m(4x4)'
- */
+/** @brief Matrix transpose: result(4x4) = m(4x4)'. */
 void transpose_Mat4(ixMatrix4 result, const ixMatrix4 m);
 
-/*
- * Invert a 2x2 matrix.
+/**
+ * @brief Invert a 2x2 matrix: result = m^-1.
+ * @param result Output: 2x2 inverse matrix.
+ * @param m      Input 2x2 matrix.
+ * @return 0 on success, non-zero on numerical error (e.g. singular matrix).
  */
 char inv_Mat2(ixMatrix2 result, ixMatrix2 m);
 
-/* Matrix Inverse
- * result(3x3) = m(3x3)^-1
- * return 0 on success, -1 on numerical error
+/**
+ * @brief Invert a 3x3 matrix: result = m^-1.
+ * @param result Output: 3x3 inverse matrix.
+ * @param m      Input 3x3 matrix.
+ * @return 0 on success, -1 on numerical error.
  */
 char inv_Mat3(ixMatrix3 result, const ixMatrix3 m);
 
-/* Matrix Inverse
- * result(4x4) = m(4x4)^-1
- * return 0 on success, -1 on numerical error
+/**
+ * @brief Invert a 4x4 matrix: result = m^-1.
+ * @param result Output: 4x4 inverse matrix.
+ * @param m      Input 4x4 matrix.
+ * @return 0 on success, -1 on numerical error.
  */
 char inv_Mat4(ixMatrix4 result, const ixMatrix4 m);
 
-/*
- * Normalize 2 dimensional vector
+/**
+ * @brief Normalize a 2-dimensional vector in place.
+ * @param v Vector to normalize; updated in place.
  */
 static __inline void normalize_Vec2(ixVector2 v)
 {
@@ -659,8 +641,10 @@ static __inline void normalize_Vec2(ixVector2 v)
     mul_Vec2_X(v, v, RECIPNORM_VEC2(v));
 }
 
-/*
- * Normalize 3 dimensional vector
+/**
+ * @brief Normalize a 3-dimensional vector.
+ * @param result Output: normalized vector.
+ * @param v      Input vector.
  */
 static __inline void normalize_Vec3(ixVector3 result, const ixVector3 v)
 {
@@ -668,23 +652,33 @@ static __inline void normalize_Vec3(ixVector3 result, const ixVector3 v)
     mul_Vec3_X(result, v, RECIPNORM_VEC3(v));
 }
 
-/*
- * Normalize 4 dimensional vector
+/**
+ * @brief Normalize a 4-dimensional vector, single precision.
+ * @param result Output: normalized vector.
+ * @param v      Input vector.
  */
 static __inline void normalize_Vec4(ixVector4 result, const ixVector4 v)
 {
     // Normalize vector
     mul_Vec4_X(result, v, RECIPNORM_VEC4(v));
 }
+/**
+ * @brief Normalize a 4-dimensional vector, double precision.
+ * @param result Output: normalized vector.
+ * @param v      Input vector.
+ */
 static __inline void normalize_Vec4d(ixVector4d result, const ixVector4d v)
 {
     // Normalize vector
     mul_Vec4d_X(result, v, RECIPNORM_VEC4D(v));
 }
 
-/*
-* Check if 2 dimensional vectors are equal
-*/
+/**
+ * @brief Check whether two 2-dimensional vectors are equal.
+ * @param v1 First vector.
+ * @param v2 Second vector.
+ * @return Non-zero if v1 == v2 element-wise, 0 otherwise.
+ */
 static __inline int is_equal_Vec2(const ixVector2 v1, const ixVector2 v2)
 {
     return
@@ -692,9 +686,12 @@ static __inline int is_equal_Vec2(const ixVector2 v1, const ixVector2 v2)
         (v1[1] == v2[1]);
 }
 
-/*
-* Check if 3 dimensional vectors are equal
-*/
+/**
+ * @brief Check whether two 3-dimensional vectors are equal.
+ * @param v1 First vector.
+ * @param v2 Second vector.
+ * @return Non-zero if v1 == v2 element-wise, 0 otherwise.
+ */
 static __inline int is_equal_Vec3(const ixVector3 v1, const ixVector3 v2)
 {
     return
@@ -703,9 +700,12 @@ static __inline int is_equal_Vec3(const ixVector3 v1, const ixVector3 v2)
         (v1[2] == v2[2]);
 }
 
-/*
-* Check if 4 dimensional vectors are equal
-*/
+/**
+ * @brief Check whether two 4-dimensional vectors are equal.
+ * @param v1 First vector.
+ * @param v2 Second vector.
+ * @return Non-zero if v1 == v2 element-wise, 0 otherwise.
+ */
 static __inline int is_equal_Vec4(const ixVector4 v1, const ixVector4 v2)
 {
     return
@@ -715,19 +715,24 @@ static __inline int is_equal_Vec4(const ixVector4 v1, const ixVector4 v2)
         (v1[3] == v2[3]);
 }
 
-/*
-* Limit 3 dimensional vector to +- specified limit
-*/
+/**
+ * @brief Limit a 3-dimensional vector's elements to +-limit, in place.
+ * @param v     Vector to limit; updated in place.
+ * @param limit Symmetric limit magnitude.
+ */
 static __inline void limit_Vec3(ixVector3 v, f_t limit)
-{     
+{
     _LIMIT(v[0], limit);
     _LIMIT(v[1], limit);
     _LIMIT(v[2], limit);
 }
 
-/*
-* Limit 3 dimensional vector to min and max values
-*/
+/**
+ * @brief Limit a 3-dimensional vector's elements to [min, max], in place.
+ * @param v   Vector to limit; updated in place.
+ * @param min Lower limit.
+ * @param max Upper limit.
+ */
 static __inline void limit2_Vec3(ixVector3 v, f_t min, f_t max)
 {
     _LIMIT2(v[0], min, max);
@@ -735,36 +740,59 @@ static __inline void limit2_Vec3(ixVector3 v, f_t min, f_t max)
     _LIMIT2(v[2], min, max);
 }
 
+/**
+ * @brief Check whether any element of a single-precision 3-vector is NaN.
+ * @param v Input vector.
+ * @return Non-zero if any element is NaN, 0 otherwise.
+ */
 static inline int is_nan_vec3_f(float v[3])
 {
-    return  is_nan_f(v[0]) || 
-            is_nan_f(v[1]) || 
+    return  is_nan_f(v[0]) ||
+            is_nan_f(v[1]) ||
             is_nan_f(v[2]);
 }
 
+/**
+ * @brief Check whether any element of a double-precision 3-vector is NaN.
+ * @param v Input vector.
+ * @return Non-zero if any element is NaN, 0 otherwise.
+ */
 static inline int is_nan_vec3(double v[3])
 {
-    return  is_nan(v[0]) || 
-            is_nan(v[1]) || 
+    return  is_nan(v[0]) ||
+            is_nan(v[1]) ||
             is_nan(v[2]);
 }
 
+/**
+ * @brief Check whether every element of a single-precision 3-vector is finite (not NaN or infinite).
+ * @param v Input vector.
+ * @return Non-zero if all elements are finite, 0 otherwise.
+ */
 static inline int is_valid_vec3_f(float v[3])
 {
-    return  is_finite_f(v[0]) && 
-            is_finite_f(v[1]) && 
+    return  is_finite_f(v[0]) &&
+            is_finite_f(v[1]) &&
             is_finite_f(v[2]);
 }
 
+/**
+ * @brief Check whether every element of a double-precision 3-vector is finite (not NaN or infinite).
+ * @param v Input vector.
+ * @return Non-zero if all elements are finite, 0 otherwise.
+ */
 static inline int is_valid_vec3(double v[3])
 {
-    return  is_finite(v[0]) && 
-            is_finite(v[1]) && 
+    return  is_finite(v[0]) &&
+            is_finite(v[1]) &&
             is_finite(v[2]);
 }
 
-/* Array contains NAN
- * return 1 if NAN found in array, 0 if not
+/**
+ * @brief Check whether an array contains NaN, single precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if any element is NaN, 0 otherwise.
  */
 static __inline int isNan_array(f_t *a, int size)
 {
@@ -779,8 +807,11 @@ static __inline int isNan_array(f_t *a, int size)
     return 0;
 }
 
-/* Array contains NAN
- * return 1 if NAN found in double array, 0 if not
+/**
+ * @brief Check whether an array contains NaN, double precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if any element is NaN, 0 otherwise.
  */
 static __inline int isNan_array_d(double *a, int size)
 {
@@ -800,8 +831,11 @@ static __inline int isNan_array_d(double *a, int size)
 #pragma warning(disable : 4723)
 #endif
 
-/* Array contains INF
- * return 1 if INF found in array, 0 if not
+/**
+ * @brief Check whether an array contains infinity, single precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if any element is infinite, 0 otherwise.
  */
 static __inline int isInf_array(f_t *a, int size)
 {
@@ -820,9 +854,12 @@ static __inline int isInf_array(f_t *a, int size)
 }
 
 
-/* Array contains INF
-* return 1 if INF found in double array, 0 if not
-*/
+/**
+ * @brief Check whether an array contains infinity, double precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if any element is infinite, 0 otherwise.
+ */
 static __inline int isInf_array_d(double *a, int size)
 {
     int i;
@@ -843,8 +880,11 @@ static __inline int isInf_array_d(double *a, int size)
 #pragma warning(pop) 
 #endif
 
-/* Array does not contain NAN or INF
- * return 0 if NAN or INF found in array, 1 if not
+/**
+ * @brief Check whether every element of an array is finite (no NaN or infinity), single precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if no element is NaN or infinite, 0 otherwise.
  */
 static __inline int isFinite_array(f_t *a, int size)
 {
@@ -858,9 +898,12 @@ static __inline int isFinite_array(f_t *a, int size)
 }
 
 
-/* Array does not contain NAN or INF
-* return 0 if NAN or INF found in double array, 1 if not
-*/
+/**
+ * @brief Check whether every element of an array is finite (no NaN or infinity), double precision.
+ * @param a    Input array.
+ * @param size Number of elements in a.
+ * @return 1 if no element is NaN or infinite, 0 otherwise.
+ */
 static __inline int isFinite_array_d(double *a, int size)
 {
     if (isNan_array_d(a, size))
@@ -872,16 +915,56 @@ static __inline int isFinite_array_d(double *a, int size)
     return 1;
 }
 
+/**
+ * @brief Check whether every element of an array is strictly less than x.
+ * @param a    Input array.
+ * @param x    Threshold.
+ * @param size Number of elements in a.
+ * @return 1 if all elements are < x, 0 otherwise.
+ */
 int isAllLessThanX_array(f_t *a, f_t x, int size);
+
+/**
+ * @brief Check whether every element of an array is strictly greater than x.
+ * @param a    Input array.
+ * @param x    Threshold.
+ * @param size Number of elements in a.
+ * @return 1 if all elements are > x, 0 otherwise.
+ */
 int isAllMoreThanX_array(f_t *a, f_t x, int size);
+
+/**
+ * @brief Check whether every element's absolute value is strictly less than x.
+ * @param a    Input array.
+ * @param x    Threshold.
+ * @param size Number of elements in a.
+ * @return 1 if all elements' absolute values are < x, 0 otherwise.
+ */
 int isAllAbsLessThanX_array(f_t *a, f_t x, int size);
 
-// Low-Pass Alpha Filter
+/**
+ * @brief Initialize a zero-order low-pass filter's alpha/beta gains and initial value.
+ * @param lpf          Filter state to initialize.
+ * @param dt           Expected update period (seconds).
+ * @param cornerFreqHz Low-pass filter corner frequency (Hz).
+ * @param initVal      Initial value for the filter's running output.
+ */
 void LPFO0_init_Vec3(sLpfO0 *lpf, f_t dt, f_t cornerFreqHz, const ixVector3 initVal);
-// output[n+1] = beta*output[n] + alpha*input
+
+/**
+ * @brief Update a zero-order low-pass filter with a new sample: v[n+1] = beta*v[n] + alpha*input.
+ * @param lpf   Filter state; updated in place.
+ * @param input New input sample.
+ */
 void LPFO0_Vec3(sLpfO0 *lpf, const ixVector3 input);
 
-// Zero order Low-Pass Filter
+/**
+ * @brief Zero-order (single-pole) low-pass filter update, standalone (no sLpfO0 state struct needed): result = beta*result + alpha*input.
+ * @param result Filter output and running state; updated in place.
+ * @param input  New input sample.
+ * @param alph   Filter alpha parameter (input gain).
+ * @param beta   Filter beta parameter (memory gain).
+ */
 static __inline void O0_LPF_Vec3(ixVector3 result, const ixVector3 input, f_t alph, f_t beta)
 {
     ixVector3 tmp3;
@@ -893,7 +976,15 @@ static __inline void O0_LPF_Vec3(ixVector3 result, const ixVector3 input, f_t al
 }
 
 
-// First order Low-Pass Filter
+/**
+ * @brief First-order low-pass filter update with an explicit model-coefficient state (for larger dt).
+ * @param result Filter output and running state; updated in place.
+ * @param input  New input sample.
+ * @param c1     Model-coefficient state; updated in place.
+ * @param alph   Filter alpha parameter (input gain).
+ * @param beta   Filter beta parameter (memory gain).
+ * @param dt     Time since the last update (seconds).
+ */
 static __inline void O1_LPF_Vec3(ixVector3 result, const ixVector3 input, ixVector3 c1, f_t alph, f_t beta, f_t dt)
 {
     ixVector3 tmp3;

--- a/src/ISPolynomial.h
+++ b/src/ISPolynomial.h
@@ -10,6 +10,14 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISPolynomial.h
+ * @brief Least-squares polynomial curve fitting and Horner's-method polynomial evaluation.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef IS_POLYNOMIAL_H_
 #define IS_POLYNOMIAL_H_
 
@@ -19,47 +27,50 @@ extern "C" {
 #endif
 
 
-/** ixPolyFit() polynomial curve fit
-n = number of samples
-x = input data array
-y = output data array
-coef = polynomial coefficients
-num_coef = 1 + the highest degree (or order) of the monomials with non-zero coefficients
-
-    2nd Order Example:
-        y    =     A       c
-    [ y1 ] = [ x1  1 ] [ c0 ]
-    [ y2 ]   [ X2  1 ] [ c1 ]
-    [ yn ]   [ x2  1 ]
-    (n x 1)   (n x 2)  (2 x 1)
-
-    c = inv(At A) At y
-
-    3rd Order Example:
-        y    =        A          c
-    [ y1 ] = [ x1^2  x1  1 ] [ c0 ]
-    [ y2 ]   [ x2^2  X2  1 ] [ c1 ]
-    [ yn ]   [ xn^2  x2  1 ] [ c2 ]
-    (n x 1)      (n x 3)     (3 x 1)
-
-    c = inv(At A) At y
-
-@return 0 on success, -1 on failure
-*/
+/**
+ * @brief Fit a polynomial of the given order to a set of (x, y) samples via least squares.
+ *
+ * Solves c = inv(At A) At y, where A is the Vandermonde-like design matrix built from x. For
+ * example, for a 2nd-order fit (num_coefs = 2):
+ *
+ *     y    =     A       c
+ * [ y1 ] = [ x1  1 ] [ c0 ]
+ * [ y2 ]   [ x2  1 ] [ c1 ]
+ * [ yn ]   [ xn  1 ]
+ * (n x 1)   (n x 2)  (2 x 1)
+ *
+ * and for a 3rd-order fit (num_coefs = 3):
+ *
+ *     y    =        A          c
+ * [ y1 ] = [ x1^2  x1  1 ] [ c0 ]
+ * [ y2 ]   [ x2^2  x2  1 ] [ c1 ]
+ * [ yn ]   [ xn^2  xn  1 ] [ c2 ]
+ * (n x 1)      (n x 3)     (3 x 1)
+ *
+ * @param n         Number of samples in x and y.
+ * @param x         Input data array (independent variable), length n.
+ * @param y         Input data array (dependent variable), length n.
+ * @param coef      Output: polynomial coefficients, length num_coefs.
+ * @param num_coefs 1 + the highest degree (order) of the monomials with non-zero coefficients.
+ * @return 0 on success, -1 on failure.
+ */
 char ixPolyFit(const int n, const float x[], const float y[], float coef[], const int num_coefs);
 
-// ----------------------------------------------------------------------------
-//  y = horner(degree, coef, x) evaluates a polynomial y = f(x) at x.  The polynomial has
-//                    degree = n-1.  The coefficients of the polynomial are stored
-//                    in the 1-D array c, which has n elements.
-//
-//  NOTE:  The polynomial coefficients are multipliers of monomial terms of
-//         decreasing order.  In other words, the polynomial is assumed to be
-//         written in the form
-//
-//            y(x) = coef[0]*x^n + coef[1]*x^(n-1) + ... + coef[n-1]*x + coef[n]
-//
-//         where n is the order (coef_size-1) of the polynomial and the largest index in coef is n.
+/**
+ * @brief Evaluate a polynomial y = f(x) at x using Horner's method.
+ *
+ * The polynomial has degree = coef_size-1. The coefficients are multipliers of monomial terms of
+ * decreasing order, i.e. the polynomial is assumed to be written in the form:
+ *
+ *     y(x) = coef[0]*x^n + coef[1]*x^(n-1) + ... + coef[n-1]*x + coef[n]
+ *
+ * where n is the order (coef_size-1) of the polynomial and the largest index in coef is n.
+ *
+ * @param coef_size Number of elements in coef (degree + 1).
+ * @param coef      Polynomial coefficients, highest-order term first, length coef_size.
+ * @param x         Value at which to evaluate the polynomial.
+ * @return y = f(x), the evaluated polynomial value.
+ */
 float ixPolyHorner(const int coef_size, const float coef[], const float x);
 
 

--- a/src/ISPose.h
+++ b/src/ISPose.h
@@ -10,6 +10,19 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISPose.h
+ * @brief Attitude/pose math: quaternion algebra, quaternion<->Euler<->DCM conversions, and
+ * body<->reference frame vector/Euler rotations.
+ *
+ * Unless otherwise noted: quaternions are (W, X, Y, Z); Euler angles are (phi, theta, psi) =
+ * (roll, pitch, yaw) in radians; DCMs (direction cosine matrices) rotate NED to body frame
+ * (body = DCM * NED) in the standard [phi][theta][psi] rotation sequence.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef POSE_H_
 #define POSE_H_
 
@@ -21,245 +34,293 @@ extern "C" {
 #endif
 
 #if (!defined (__cplusplus) && (!defined (inline)))
-#       define inline __inline          // allow "inline" keyword to work in windows w/ c program
+#       define inline __inline          //!< Allow the "inline" keyword to work in Windows w/ a C (non-C++) program
 #endif
 
 
 /**
- * Initialize Quaternion q = [w, x, y, z]
+ * @brief Initialize a quaternion to identity, q = [1, 0, 0, 0].
+ * @param q Output: quaternion (W, X, Y, Z) to initialize.
  */
 void quat_init(ixQuat q);
 
 /**
- * Quaternion Conjugate: q* = [ w, -x, -y, -z ] of quaterion q = [ w, x, y, z ]
- * Rotation in opposite direction.
+ * @brief Quaternion conjugate: q* = [w, -x, -y, -z] of quaternion q = [w, x, y, z]. Rotation in the opposite direction.
+ * @param result Output: conjugate of q.
+ * @param q      Input quaternion (W, X, Y, Z).
  */
 void quatConj(ixQuat result, const ixQuat q);
 
 /**
-* Product of two Quaternions.  Order of q1 and q2 matters (same as applying two successive DCMs)!!!  
-* Combines two quaternion rotations into one rotation.
-* result = q1 * q2. 
-* Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
-*/
+ * @brief Product of two quaternions: result = q1 * q2. Order of q1 and q2 matters (same as applying
+ * two successive DCMs)! Combines two quaternion rotations into one rotation.
+ * Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
+ * @param result Output: q1 * q2.
+ * @param q1     First quaternion (W, X, Y, Z).
+ * @param q2     Second quaternion (W, X, Y, Z).
+ */
 void mul_Quat_Quat(ixQuat result, const ixQuat q1, const ixQuat q2);
 
 /**
-* Product of two Quaternions.  Order of q1 and q2 matters (same as applying two successive DCMs)!!!
-* Combines two quaternion rotations into one rotation.
-* result = quatConj(q1) * q2.
-* Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
-*/
+ * @brief Product of two quaternions: result = quatConj(qc) * q2. Order matters (same as applying
+ * two successive DCMs)! Combines two quaternion rotations into one rotation.
+ * Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
+ * @param result Output: quatConj(qc) * q2.
+ * @param qc     Quaternion (W, X, Y, Z) to conjugate before multiplying.
+ * @param q2     Second quaternion (W, X, Y, Z).
+ */
 void mul_ConjQuat_Quat(ixQuat result, const ixQuat qc, const ixQuat q2);
 
 /**
-* Product of two Quaternions.  Order of q1 and q2 matters (same as applying two successive DCMs)!!!
-* Combines two quaternion rotations into one rotation.
-* result = q1 * quatConj(q2)
-* Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
-*/
+ * @brief Product of two quaternions: result = q1 * quatConj(qc). Order matters (same as applying
+ * two successive DCMs)! Combines two quaternion rotations into one rotation.
+ * Reference: http://www.mathworks.com/help/aeroblks/quaternionmultiplication.html
+ * @param result Output: q1 * quatConj(qc).
+ * @param q1     First quaternion (W, X, Y, Z).
+ * @param qc     Quaternion (W, X, Y, Z) to conjugate before multiplying.
+ */
 void mul_Quat_ConjQuat(ixQuat result, const ixQuat q1, const ixQuat qc);
 
 /**
- * Division of two Quaternions.  Order matters!!!
- * result = q1 / q2. 
+ * @brief Division of two quaternions: result = q1 / q2. Order matters!
  * Reference: http://www.mathworks.com/help/aeroblks/quaterniondivision.html
+ * @param result Output: q1 / q2.
+ * @param q1     Numerator quaternion (W, X, Y, Z).
+ * @param q2     Denominator quaternion (W, X, Y, Z).
  */
 void div_Quat_Quat(ixQuat result, const ixQuat q1, const ixQuat q2);
 
 /**
- * Quaternion rotation from vector v1 to vector v2.
+ * @brief Compute the quaternion rotation from vector v1 to vector v2.
+ * @param result Output: quaternion (W, X, Y, Z) rotating v1 onto v2.
+ * @param v1     Source vector.
+ * @param v2     Target vector.
  */
 void quat_Vec3_Vec3(ixQuat result, const ixVector3 v1, const ixVector3 v2);
 
 /**
- * Computationally simple means to apply quaternion rotation to a vector.
- * Requires quaternion be normalized first.  
- * If quaternion describes current attitude, then rotation is body frame -> reference frame.
+ * @brief Computationally simple means to apply a quaternion rotation to a vector. Requires the
+ * quaternion be normalized first. If the quaternion describes the current attitude, this rotates
+ * body frame -> reference frame.
+ * @param result Output: rotated vector.
+ * @param q      Normalized quaternion (W, X, Y, Z) to rotate by.
+ * @param v      Vector to rotate.
  */
 void quatRot(ixVector3 result, const ixQuat q, const ixVector3 v);
 
 /**
- * Computationally simple means to apply quaternion conjugate (opposite) rotation to a vector
- * Requires quaternion be normalized first
- * If quaternion describes current attitude, then rotation is reference frame -> body frame.
+ * @brief Computationally simple means to apply a quaternion's conjugate (opposite) rotation to a
+ * vector. Requires the quaternion be normalized first. If the quaternion describes the current
+ * attitude, this rotates reference frame -> body frame.
+ * @param result Output: rotated vector.
+ * @param q      Normalized quaternion (W, X, Y, Z) whose conjugate rotation is applied.
+ * @param v      Vector to rotate.
  */
 void quatConjRot(ixVector3 result, const ixQuat q, const ixVector3 v);
 
 /**
- * This will convert from quaternions to euler angles
- * q(W,X,Y,Z) -> euler(phi,theta,psi) (rad)
- *
+ * @brief Convert from quaternion to Euler angles: q(W,X,Y,Z) -> euler(phi,theta,psi), radians.
  * Reference: http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+ * @param q     Input quaternion (W, X, Y, Z).
+ * @param theta Output: Euler angles (phi, theta, psi), radians.
  */
 void quat2euler(const ixQuat q, ixEuler theta);
+
+/**
+ * @brief Extract just the phi (roll) and theta (pitch) Euler angles from a quaternion.
+ * @param q     Input quaternion (W, X, Y, Z).
+ * @param phi   Output: phi (roll) angle, radians.
+ * @param theta Output: theta (pitch) angle, radians.
+ */
 void quat2phiTheta(const ixQuat q, f_t *phi, f_t *theta);
+
+/**
+ * @brief Extract just the psi (yaw) Euler angle from a quaternion.
+ * @param q   Input quaternion (W, X, Y, Z).
+ * @param psi Output: psi (yaw) angle, radians.
+ */
 void quat2psi(const ixQuat q, f_t *psi);
 
 /**
- * This will convert from euler angles to quaternion vector
- * euler(phi,theta,psi) (rad) -> q(W,X,Y,Z)
+ * @brief Convert from Euler angles to a quaternion: euler(phi,theta,psi) (rad) -> q(W,X,Y,Z).
+ * @param euler Input Euler angles (phi, theta, psi), radians.
+ * @param q     Output: quaternion (W, X, Y, Z).
  */
 void euler2quat(const ixEuler euler, ixQuat q);
 
 
 
 /**
- * This will construct a direction cosine matrix from
- * the psi angle - rotates from NE to body frame
- *
- * body = tBL(2,2)*NE
- *
+ * @brief Construct a 2x2 direction cosine matrix from the psi (yaw) angle: rotates from NE to body frame (body = m*NE).
+ * @param psi Yaw angle, radians.
+ * @param m   Output: 2x2 DCM.
  */
 void psiDCM(const f_t psi, ixMatrix2 m);
 
 /**
-* This will extract the psi euler angle from a direction cosine matrix in the
-* standard rotation sequence, for either a 2x2 or 3x3 DCM matrix.
-* [phi][theta][psi] from NED to body frame
-*
-* body = tBL(2,2)*NE
-* body = tBL(3,3)*NED
-*
-* reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
-*/
+ * @brief Extract the psi Euler angle from a direction cosine matrix in the standard rotation
+ * sequence, for either a 2x2 (body = m*NE) or 3x3 (body = m*NED) DCM.
+ * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param m Input DCM (2x2 or 3x3, row-major).
+ * @return Psi (yaw) angle, radians.
+ */
 f_t DCMpsi(const f_t *m);
 
 /**
- * This will construct a direction cosine matrix from
- * euler angles in the standard rotation sequence
- * [phi][theta][psi] from NED to body frame
- *
- * body = tBL(3,3)*NED
- *
+ * @brief Construct a 3x3 direction cosine matrix from Euler angles in the standard rotation
+ * sequence [phi][theta][psi] from NED to body frame (body = m*NED).
  * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param euler Input Euler angles (phi, theta, psi), radians.
+ * @param m     Output: 3x3 DCM.
  */
 //const Matrix<3,3> eulerDCM(const Vector<3> & euler)
 void eulerDCM(const ixEuler euler, ixMatrix3 m);
-// Only use phi and theta (exclude psi) in rotation
+
+/**
+ * @brief Same as @ref eulerDCM, but using only phi and theta (psi is excluded from the rotation).
+ * @param euler Input Euler angles (phi, theta used; psi ignored), radians.
+ * @param m     Output: 3x3 DCM.
+ */
 void phiThetaDCM(const ixEuler euler, ixMatrix3 m);
 
 /**
- * This will construct the transpose matrix of
- * the direction cosine matrix from
- * euler angles in the standard rotation sequence
- * [phi][theta][psi] from NED to body frame
- *
- * body = tBL(3,3)*NED
- *
- * reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @brief Construct the transpose of the direction cosine matrix from Euler angles in the standard
+ * rotation sequence [phi][theta][psi] from NED to body frame (body = m*NED, before transposing).
+ * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param euler Input Euler angles (phi, theta, psi), radians.
+ * @param m     Output: transpose of the 3x3 DCM.
  */
 void eulerDCM_Trans(const ixEuler euler, ixMatrix3 m);
 
 /**
- * This will extract euler angles from a direction cosine matrix in the
- * standard rotation sequence.
- * [phi][theta][psi] from NED to body frame
- *
- * body = tBL(3,3)*NED
- *
+ * @brief Extract Euler angles from a direction cosine matrix in the standard rotation sequence
+ * [phi][theta][psi] from NED to body frame (body = m*NED).
  * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param m     Input 3x3 DCM.
+ * @param euler Output: Euler angles (phi, theta, psi), radians.
  */
 void DCMeuler(const ixMatrix3 m, ixEuler euler);
 
 
 /**
- * This will construct a direction cosine matrix from
- * quaternions in the standard rotation  sequence
- * [phi][theta][psi] from NED to body frame
- *
- * body = tBL(3,3)*NED
- * q(4,1)
- *
+ * @brief Construct a 3x3 direction cosine matrix from a quaternion, in the standard rotation
+ * sequence [phi][theta][psi] from NED to body frame (body = mat*NED), single precision.
  * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param q   Input quaternion (W, X, Y, Z).
+ * @param mat Output: 3x3 DCM.
  */
 void quatDCM(const ixQuat q, ixMatrix3 mat);
+
+/**
+ * @brief Same as @ref quatDCM, double-precision quaternion input.
+ * @param q   Input quaternion (W, X, Y, Z), double precision.
+ * @param mat Output: 3x3 DCM.
+ */
 void quatdDCM(const ixVector4d q, ixMatrix3 mat);
 
 /**
- * This will construct a quaternion from direction 
- * cosine matrix in the standard rotation sequence
- * [phi][theta][psi] from NED to body frame
- *
- * body = tBL(3,3)*NED
- * q(4,1)
- *
+ * @brief Construct a quaternion from a direction cosine matrix in the standard rotation sequence
+ * [phi][theta][psi] from NED to body frame (body = mat*NED).
  * Reference: http://en.wikipedia.org/wiki/Rotation_representation_%28mathematics%29
+ * @param mat Input 3x3 DCM.
+ * @param q   Output: quaternion (W, X, Y, Z).
  */
 void DCMquat(const ixMatrix3 mat, ixQuat q);
 
 /**
- * This will construct the euler omega-cross matrix
- * wx(3,3)
- * p, q, r (rad/sec)
+ * @brief Construct the Euler omega-cross matrix wx(3,3) from body angular rates.
+ * @param euler Body angular rates p, q, r (rad/sec), packed into an ixEuler-shaped vector.
+ * @param mat   Output: 3x3 omega-cross matrix.
  */
 void eulerWx(const ixEuler euler, ixMatrix3 mat);
 
 /**
- * This will construct the quaternion omega matrix
- * W(4,4)
- * p, q, r (rad/sec)
+ * @brief Construct the quaternion omega matrix W(4,4) from body angular rates.
+ * @param euler Body angular rates p, q, r (rad/sec), packed into an ixEuler-shaped vector.
+ * @param mat   Output: 4x4 quaternion omega matrix.
  */
 void quatW(const ixEuler euler, ixMatrix4 mat);
 
 /**
-*   Convert quaternion to rotation axis (and angle).  Quaternion must be normalized.
-*/
+ * @brief Convert a quaternion to a rotation axis (and implicitly, angle). Quaternion must be normalized.
+ * @param q   Input normalized quaternion (W, X, Y, Z).
+ * @param pqr Output: rotation axis vector, scaled by the rotation angle.
+ */
 void quatRotAxis(const ixQuat q, ixVector3 pqr);
 
 /**
- *  Compute the derivative of the ixEuler angle psi with respect
- * to the quaternion Q.  The result is a row vector
- *
- * d(psi)/d(q0)
- * d(psi)/d(q1)
- * d(psi)/d(q2)
- * d(psi)/d(q3)
+ * @brief Compute the derivative of the Euler angle psi with respect to the quaternion q. The
+ * result is a row vector: d(psi)/d(q0), d(psi)/d(q1), d(psi)/d(q2), d(psi)/d(q3).
+ * @param q  Input quaternion (W, X, Y, Z).
+ * @param dq Output: derivative row vector, packed into an ixQuat-shaped array.
  */
 void dpsi_dq(const ixQuat q, ixQuat dq);
 
 /**
- * NED to ixEuler
+ * @brief Convert an NED vector to its equivalent ixEuler-shaped representation (no rotation; a repacking helper).
+ * @param ned Input NED vector.
+ * @param e   Output: same values, packed into an ixEuler-shaped array.
  */
 void nedEuler(const ixVector3 ned, ixEuler e);
 
 /**
- * ixEuler to NED
+ * @brief Convert an ixEuler-shaped vector to its equivalent NED representation (no rotation; a repacking helper).
+ * @param e   Input, packed into an ixEuler-shaped array.
+ * @param ned Output: same values as an NED vector.
  */
 void eulerNed(const ixEuler e, ixVector3 ned);
 
 /**
- * Rotate theta eulers from body frame to reference frame by eulers, in order: phi, theta, psi
+ * @brief Rotate Euler angles from body frame to reference frame by a rotation given as Euler angles, in order: phi, theta, psi.
+ * @param e      Input Euler angles (body frame), radians.
+ * @param rot    Rotation to apply, as Euler angles (phi, theta, psi), radians.
+ * @param result Output: rotated Euler angles (reference frame), radians.
  */
 void eulerBodyToReference(const  ixEuler e, const  ixEuler rot, ixEuler result);
 
 /**
- * Rotate theta eulers from reference frame to body frame by eulers, in order: psi, theta, phi
+ * @brief Rotate Euler angles from reference frame to body frame by a rotation given as Euler angles, in order: psi, theta, phi.
+ * @param e      Input Euler angles (reference frame), radians.
+ * @param rot    Rotation to apply, as Euler angles (phi, theta, psi), radians.
+ * @param result Output: rotated Euler angles (body frame), radians.
  */
 void eulerReferenceToBody(const  ixEuler e, const ixEuler rot, ixEuler result);
 
 /**
- * Rotate vector from body frame to reference frame by euler angles, in order: phi, theta, psi
+ * @brief Rotate a vector from body frame to reference frame by Euler angles, in order: phi, theta, psi.
+ * @param v      Input vector (body frame).
+ * @param rot    Rotation to apply, as Euler angles (phi, theta, psi), radians.
+ * @param result Output: rotated vector (reference frame).
  */
 void vectorBodyToReference(const  ixVector3 v, const ixEuler rot, ixVector3 result);
 
 /**
- * Rotate vector from reference frame to body frame by euler angles, in order: psi, theta, phi
+ * @brief Rotate a vector from reference frame to body frame by Euler angles, in order: psi, theta, phi.
+ * @param v      Input vector (reference frame).
+ * @param rot    Rotation to apply, as Euler angles (phi, theta, psi), radians.
+ * @param result Output: rotated vector (body frame).
  */
 void vectorReferenceToBody(const  ixVector3 v, const ixEuler rot, ixVector3 result);
 
 /**
- * Vector to euler roll angle
+ * @brief Compute the Euler roll angle implied by a vector's direction.
+ * @param v Input vector.
+ * @return Roll angle, radians.
  */
 float vectorToRoll(const ixVector3 v);
 
 /**
- * Vector to euler pitch angle
+ * @brief Compute the Euler pitch angle implied by a vector's direction.
+ * @param v Input vector.
+ * @return Pitch angle, radians.
  */
 float vectorToPitch(const ixVector3 v);
 
 /**
- * Returns the pitch angle of the vector selected axis.
+ * @brief Compute the pitch angle of a vector about a selected axis.
+ * @param v         Input vector.
+ * @param pitchAxis Axis index (0=X, 1=Y, 2=Z) to compute the pitch angle about.
+ * @return Pitch angle, radians.
  */
 float vectorSelectedAxisToPitch(const ixVector3 v, int pitchAxis);
 

--- a/src/IS_calibration.h
+++ b/src/IS_calibration.h
@@ -1,3 +1,18 @@
+/**
+ * @file IS_calibration.h
+ * @brief On-device sensor calibration data structures: temperature compensation (TCAL) and motion
+ * calibration (MCAL), in the two currently-supported layout versions (v1.3, v1.4).
+ *
+ * v1.3 (3x IMU + 2x Mag) is used natively on IMX-5 hardware; v1.4 (5x IMU + 1x Mag) is used natively
+ * on IMX-6 and the host SDK. sensor_tcal_group_t/sensor_mcal_group_t/sensor_cal_data_t/sensor_cal_t
+ * resolve to whichever version is native for the current build target (see the typedefs below); use
+ * IS_calibration_convert.h's convert_*_v1p3_to_v1p4()/convert_*_v1p4_to_v1p3() to convert between
+ * versions, e.g. when a v1.3 calibration record is read from an IMX-5 device on a v1.4-native host.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef IS_CALIBRATION_H
 #define IS_CALIBRATION_H
 
@@ -11,253 +26,280 @@ extern "C" {
 
 //_____ D E F I N I T I O N S ______________________________________________
 
-#define TCAL_MAX_NUM_POINTS     20      // Maximum number of calibration points allowable
-#define TCAL_MAX_TEMPERATURE    85      // Maximum temperature for temperature calibration
+#define TCAL_MAX_NUM_POINTS     20      //!< Maximum number of calibration points allowable
+#define TCAL_MAX_TEMPERATURE    85      //!< Maximum temperature for temperature calibration
 
-// 1.2.0 = 2x IMU, 1.3.0 = 3x IMU + 2x Mag, 1.4.0 = 5x IMU + 1x Mag
+/** Sensor calibration layout version: 1.2.0 = 2x IMU, 1.3.0 = 3x IMU + 2x Mag, 1.4.0 = 5x IMU + 1x Mag. Selected by build target. */
 #if defined(IMX_5)
-#define SENSOR_CAL_VER0     1
-#define SENSOR_CAL_VER1     3
-#define SENSOR_CAL_VER2     0
+#define SENSOR_CAL_VER0     1      //!< Major version
+#define SENSOR_CAL_VER1     3      //!< Minor version (IMX-5: v1.3, 3x IMU + 2x Mag)
+#define SENSOR_CAL_VER2     0      //!< Patch version
 #else // IMX-6 and host SDK
-#define SENSOR_CAL_VER0     1
-#define SENSOR_CAL_VER1     4
-#define SENSOR_CAL_VER2     0
+#define SENSOR_CAL_VER0     1      //!< Major version
+#define SENSOR_CAL_VER1     4      //!< Minor version (IMX-6/host: v1.4, 5x IMU + 1x Mag)
+#define SENSOR_CAL_VER2     0      //!< Patch version
 #endif
 
+/** Sensor compensation/calibration state machine states, stepping through temperature calibration (TCAL) and motion calibration (MCAL) sampling. */
 enum eScompCalState
 {
-    SC_RUNTIME                      = 0,   // Calibration off
-    SC_TCAL_MONITOR_TEMP            = 1,
-    SC_TCAL_INIT                    = 2,
-    SC_TCAL_STARTUP_MEAN_LSB        = 3,
-    SC_TCAL_STARTUP_DELAY           = 4,
-    SC_TCAL_READY_TO_RUN            = 5,
-    SC_TCAL_RUNNING                 = 6,
-    SC_TCAL_STOP                    = 7,
-    SC_TCAL_DONE                    = 8,
-    SC_ACCEL_ALIGN_CHECK            = 9,
-    SC_MCAL_SAMPLE_INIT             = 10,
-    SC_MCAL_SAMPLE_MEAN_UCAL        = 11,    // Uncalibrated sensor
-    SC_MCAL_SAMPLE_MEAN_TCAL        = 12,    // Temperature compensated sensor 
-    SC_MCAL_SAMPLE_MEAN_MCAL        = 13,    // Motion calibrated + compensated sensor 
-    SC_MCAL_SAMPLE_STOP             = 14,
-    SC_LPF_SAMPLE                   = 15,
-    SC_LPF_SAMPLE_FAST              = 16,
-    SC_DONE                         = 17,
-    SC_LINEARITY_MEAN_TCAL          = 18,    // Like SC_MCAL_SAMPLE_MEAN_TCAL, but goes back to SC_RUNTIME after some samples
+    SC_RUNTIME                      = 0,    //!< Calibration off
+    SC_TCAL_MONITOR_TEMP            = 1,    //!< Monitoring temperature for a calibration-worthy change
+    SC_TCAL_INIT                    = 2,    //!< Initializing temperature calibration
+    SC_TCAL_STARTUP_MEAN_LSB        = 3,    //!< Averaging raw ADC LSB at startup
+    SC_TCAL_STARTUP_DELAY           = 4,    //!< Waiting for sensor to stabilize before sampling
+    SC_TCAL_READY_TO_RUN            = 5,    //!< Ready to begin temperature calibration sampling
+    SC_TCAL_RUNNING                 = 6,    //!< Temperature calibration sampling in progress
+    SC_TCAL_STOP                    = 7,    //!< Stopping temperature calibration sampling
+    SC_TCAL_DONE                    = 8,    //!< Temperature calibration complete
+    SC_ACCEL_ALIGN_CHECK            = 9,    //!< Checking accelerometer alignment
+    SC_MCAL_SAMPLE_INIT             = 10,   //!< Initializing motion calibration sampling
+    SC_MCAL_SAMPLE_MEAN_UCAL        = 11,   //!< Sampling uncalibrated sensor mean
+    SC_MCAL_SAMPLE_MEAN_TCAL        = 12,   //!< Sampling temperature-compensated sensor mean
+    SC_MCAL_SAMPLE_MEAN_MCAL        = 13,   //!< Sampling motion-calibrated + compensated sensor mean
+    SC_MCAL_SAMPLE_STOP             = 14,   //!< Stopping motion calibration sampling
+    SC_LPF_SAMPLE                   = 15,   //!< Low-pass-filtered sampling
+    SC_LPF_SAMPLE_FAST              = 16,   //!< Low-pass-filtered sampling, fast corner frequency
+    SC_DONE                         = 17,   //!< Calibration sequence complete
+    SC_LINEARITY_MEAN_TCAL          = 18,   //!< Like SC_MCAL_SAMPLE_MEAN_TCAL, but returns to SC_RUNTIME after some samples
 };
 
+/** Status bits for the sensor compensation/calibration subsystem. */
 enum eScompStatus
 {
-    SC_STATUS_ALIGNMENT_MASK        = 0x0000000F,
-    SC_STATUS_ALIGNMENT_OFF         = 0x00000000,
-    SC_STATUS_ALIGNMENT_GOOD        = 0x00000001,
-    SC_STATUS_ALIGNMENT_BAD         = 0x00000002,
-    SC_STATUS_SAMPLE_VALID_MASK     = 0x00000F00,
-    SC_STATUS_SAMPLE_VALID_GYR      = 0x00000100,
-    SC_STATUS_SAMPLE_VALID_ACC      = 0x00000200,
-    SC_STATUS_SAMPLE_VALID_MAG      = 0x00000400,
-    SC_STATUS_REFERENCE_IMU_VALID   = 0x00010000,
-    SC_STATUS_REFERENCE_MAG_VALID   = 0x00020000,
-    SC_STATUS_USING_INFERRED_IMU    = 0x00040000,
-    SC_STATUS_USING_INFERRED_MAG    = 0x00080000,
-    SC_STATUS_TEMPERATURE_CAL_VALID = 0x00100000,
-    SC_STATUS_MOTION_CAL_VALID_MASK = 0x00600000,
-    SC_STATUS_MOTION_CAL_VALID_OFFSET = 21,
-    SC_STATUS_MOTION_CAL_VALID_IMU  = 0x00200000,
-    SC_STATUS_MOTION_CAL_VALID_MAG  = 0x00400000,
+    SC_STATUS_ALIGNMENT_MASK        = 0x0000000F,   //!< Mask isolating the alignment-status field
+    SC_STATUS_ALIGNMENT_OFF         = 0x00000000,    //!< Alignment check not performed
+    SC_STATUS_ALIGNMENT_GOOD        = 0x00000001,    //!< Alignment check passed
+    SC_STATUS_ALIGNMENT_BAD         = 0x00000002,    //!< Alignment check failed
+    SC_STATUS_SAMPLE_VALID_MASK     = 0x00000F00,    //!< Mask of all per-sensor sample-valid bits
+    SC_STATUS_SAMPLE_VALID_GYR      = 0x00000100,    //!< Gyro sample is valid
+    SC_STATUS_SAMPLE_VALID_ACC      = 0x00000200,    //!< Accelerometer sample is valid
+    SC_STATUS_SAMPLE_VALID_MAG      = 0x00000400,    //!< Magnetometer sample is valid
+    SC_STATUS_REFERENCE_IMU_VALID   = 0x00010000,    //!< Reference (truth) IMU is present and valid
+    SC_STATUS_REFERENCE_MAG_VALID   = 0x00020000,    //!< Reference (truth) magnetometer is present and valid
+    SC_STATUS_USING_INFERRED_IMU    = 0x00040000,    //!< IMU reference is inferred (no physical reference IMU available)
+    SC_STATUS_USING_INFERRED_MAG    = 0x00080000,    //!< Magnetometer reference is inferred (no physical reference magnetometer available)
+    SC_STATUS_TEMPERATURE_CAL_VALID = 0x00100000,    //!< Temperature calibration data is valid
+    SC_STATUS_MOTION_CAL_VALID_MASK = 0x00600000,    //!< Mask isolating the motion-cal-valid field (see SC_STATUS_MOTION_CAL_VALID_OFFSET)
+    SC_STATUS_MOTION_CAL_VALID_OFFSET = 21,          //!< Bit offset of the motion-cal-valid field
+    SC_STATUS_MOTION_CAL_VALID_IMU  = 0x00200000,    //!< IMU motion calibration is valid
+    SC_STATUS_MOTION_CAL_VALID_MAG  = 0x00400000,    //!< Magnetometer motion calibration is valid
 };
+
+/** Calibration record header: version/date/serial-number identification, common to all calibration layout versions. */
 typedef struct PACKED
 {
-    uint32_t                size;                               // Size of this struct
-    uint32_t                checksum;                           // XOR of all bytes in this struct excluding size and checksum
-    uint8_t                 version[4];                         // Sensor calibration version: [0] = major, [1] = mid, [2] = minor, [3] = unused
-    uint8_t                 calDate[4];                         // Sensor calibration date, little endian order: [0] = year-2000, [1] = month, [2] = day, [3] = unused  */
-    uint8_t                 calTime[4];                         // Sensor calibration date, little endian order: [0] = hour, [1] = minute, [2] = second, [3] = unused */
-    uint32_t                devSerialNum;                       // Device serial number
+    uint32_t                size;                               //!< Size of this struct
+    uint32_t                checksum;                           //!< XOR of all bytes in this struct excluding size and checksum
+    uint8_t                 version[4];                         //!< Sensor calibration version: [0] = major, [1] = mid, [2] = minor, [3] = unused
+    uint8_t                 calDate[4];                         //!< Sensor calibration date, little endian order: [0] = year-2000, [1] = month, [2] = day, [3] = unused
+    uint8_t                 calTime[4];                         //!< Sensor calibration time, little endian order: [0] = hour, [1] = minute, [2] = second, [3] = unused
+    uint32_t                devSerialNum;                       //!< Device serial number
 } sensor_cal_info_t;
 
+/** Size/checksum header for the calibration data payload (see sensor_cal_v1p3_data_t / sensor_cal_v1p4_data_t). */
 typedef struct PACKED
 {
-    uint32_t                size;                               // Size of this struct
-    uint32_t                checksum;                           // XOR of all bytes in this struct excluding size and checksum
+    uint32_t                size;                               //!< Size of this struct
+    uint32_t                checksum;                           //!< XOR of all bytes in this struct excluding size and checksum
 } sensor_data_info_t;
 
 ////////////////////////////////////////////////
 // TCAL v1.2
+/** Single temperature-calibration point, v1.2 layout: per-axis steady-state value and slope to the next point, for gyro/accel/mag. */
 typedef struct PACKED
 {
-    float                   temp;           // temperature of calibration point
-    float                   gyrS[3];        // gyro - tc point steady state ADC LSB point
-    float                   gyrK[3];        // gyro - tc point slope between current and next ADC point
-    float                   accS[3];        // acc  - tc point steady state ADC LSB point
-    float                   accK[3];        // acc  - tc point slope between current and next ADC point
-    float                   magS[3];        // mag  - tc point steady state ADC LSB point
-    float                   magK[3];        // mag  - tc point slope between current and next ADC point
+    float                   temp;           //!< Temperature of calibration point
+    float                   gyrS[3];        //!< Gyro: tc point steady-state ADC LSB value
+    float                   gyrK[3];        //!< Gyro: tc point slope between current and next ADC point
+    float                   accS[3];        //!< Accel: tc point steady-state ADC LSB value
+    float                   accK[3];        //!< Accel: tc point slope between current and next ADC point
+    float                   magS[3];        //!< Mag: tc point steady-state ADC LSB value
+    float                   magK[3];        //!< Mag: tc point slope between current and next ADC point
 } sensor_tcal_pt_t;
 
+/** Temperature calibration curve, v1.2 layout: a set of calibration points for one sensor. */
 typedef struct PACKED
 {
-    uint32_t                numPts;                             // Number of temperature calibration points
-    sensor_tcal_pt_t        pt[TCAL_MAX_NUM_POINTS];            // Sensor temperature calibration
+    uint32_t                numPts;                             //!< Number of temperature calibration points
+    sensor_tcal_pt_t        pt[TCAL_MAX_NUM_POINTS];            //!< Sensor temperature calibration points
 } nvm_sensor_tcal_t;
 
 ////////////////////////////////////////////////
 // TCAL v1.3
+/** Single temperature-calibration point, v1.3+ layout: per-axis steady-state value only (slope is derived from adjacent points). */
 typedef struct PACKED
 {
-    float                   temp;           // temperature of calibration point
-    float                   ss[3];          // tc point steady state ADC LSB point
+    float                   temp;           //!< Temperature of calibration point
+    float                   ss[3];          //!< Per-axis (X/Y/Z) tc point steady-state ADC LSB value
 } sensor_tcal_3axis_pt_t;
 
+/** Temperature calibration curve, v1.3+ layout: a set of calibration points for one 3-axis sensor. */
 typedef struct PACKED
 {
-    uint32_t                numPts;                             // Number of temperature calibration points
-    sensor_tcal_3axis_pt_t  pt[TCAL_MAX_NUM_POINTS];            // Sensor temperature calibration
+    uint32_t                numPts;                             //!< Number of temperature calibration points
+    sensor_tcal_3axis_pt_t  pt[TCAL_MAX_NUM_POINTS];            //!< Sensor temperature calibration points
 } nvm_sensor_tcal_3axis_t;
 
+/** Temperature calibration for every sensor, v1.3 layout (IMX-5 native: 3x IMU + 2x Mag). */
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P3];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P3];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P3];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P3];          //!< Gyro temperature calibration, one per IMU
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P3];          //!< Accel temperature calibration, one per IMU
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P3];          //!< Mag temperature calibration, one per magnetometer
 } sensor_tcal_group_v1p3_t;
 
+/** Temperature calibration for every sensor, v1.4 layout (IMX-6/host native: 5x IMU + 1x Mag). */
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P4];          // Gyro temperature calibration
-    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P4];          // Accel temperature calibration
-    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P4];          // Mag temperature calibration
+    nvm_sensor_tcal_3axis_t gyr[NUM_IMU_DEVICES_V1P4];          //!< Gyro temperature calibration, one per IMU
+    nvm_sensor_tcal_3axis_t acc[NUM_IMU_DEVICES_V1P4];          //!< Accel temperature calibration, one per IMU
+    nvm_sensor_tcal_3axis_t mag[NUM_MAG_DEVICES_V1P4];          //!< Mag temperature calibration, one per magnetometer
 } sensor_tcal_group_v1p4_t;
 
-// 1/3 of sensor_tcal_group_t used for uploading calibration
+/** Gyro temperature calibration for all IMUs; 1/3 of sensor_tcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
+    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            //!< Per-IMU gyro temperature calibration
 } sensor_tcal_gyr_group_t;
 
+/** Accel temperature calibration for all IMUs; 1/3 of sensor_tcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            // temperature calibration
+    nvm_sensor_tcal_3axis_t sensor[MAX_IMU_DEVICES];            //!< Per-IMU accel temperature calibration
 } sensor_tcal_acc_group_t;
 
+/** Mag temperature calibration for all magnetometers; 1/3 of sensor_tcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    nvm_sensor_tcal_3axis_t sensor[MAX_MAG_DEVICES];            // temperature calibration
+    nvm_sensor_tcal_3axis_t sensor[MAX_MAG_DEVICES];            //!< Per-magnetometer temperature calibration
 } sensor_tcal_mag_group_t;
 
 ////////////////////////////////////////////////
 // MCAL v1.3
+/** Single sensor's motion calibration: cross-axis/scale-factor ortho-normalization matrix plus bias. */
 typedef struct PACKED
 {
-    float                   orth[9];        // Ortho-normalization matrices (cross-axis and scale factor)
-    float                   bias[3];        // Bias
+    float                   orth[9];        //!< Ortho-normalization matrix (cross-axis and scale factor), row-major 3x3
+    float                   bias[3];        //!< Per-axis (X/Y/Z) bias
 } sensor_motion_cal_t;
 
-// 1/3 of sensor_mcal_group_t used for uploading calibration
+/** Gyro motion calibration for all IMUs; 1/3 of sensor_mcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // gyro motion calibration
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                //!< Per-IMU gyro motion calibration
 } sensor_mcal_gyr_group_t;
 
+/** Accel motion calibration for all IMUs; 1/3 of sensor_mcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                // accel motion calibration
+    sensor_motion_cal_t sensor[MAX_IMU_DEVICES];                //!< Per-IMU accel motion calibration
 } sensor_mcal_acc_group_t;
 
+/** Mag motion calibration for all magnetometers; 1/3 of sensor_mcal_group_t, used for uploading calibration one sensor type at a time. */
 typedef struct PACKED
 {
-    sensor_motion_cal_t sensor[MAX_MAG_DEVICES];                // mag motion calibration
+    sensor_motion_cal_t sensor[MAX_MAG_DEVICES];                //!< Per-magnetometer motion calibration
 } sensor_mcal_mag_group_t;
 
+/** Motion calibration for every sensor, v1.3 layout (IMX-5 native: 3x IMU + 2x Mag). */
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P3];          // Gyros (x3 IMUs)
-    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P3];          // Accelerometers (x3 IMUs)
-    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P3];          // Magnetometers
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P3];          //!< Gyros (x3 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P3];          //!< Accelerometers (x3 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P3];          //!< Magnetometers
 } sensor_mcal_group_v1p3_t;
 
+/** Motion calibration for every sensor, v1.4 layout (IMX-6/host native: 5x IMU + 1x Mag). */
 typedef struct PACKED
 {
-    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P4];          // Gyros (x5 IMUs)
-    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P4];          // Accelerometers (x5 IMUs)
-    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P4];          // Magnetometers
+    sensor_motion_cal_t     pqr[NUM_IMU_DEVICES_V1P4];          //!< Gyros (x5 IMUs)
+    sensor_motion_cal_t     acc[NUM_IMU_DEVICES_V1P4];          //!< Accelerometers (x5 IMUs)
+    sensor_motion_cal_t     mag[NUM_MAG_DEVICES_V1P4];          //!< Magnetometers
 } sensor_mcal_group_v1p4_t;
 
 ////////////////////////////////////////////////
 // v1.3
+/** Calibration data payload (temperature + motion calibration), v1.3 layout. */
 typedef struct PACKED
 {
-    sensor_data_info_t          dinfo;                      // Size and checksum
-    sensor_tcal_group_v1p3_t    tcal;                       // Temperature compensation
-    sensor_mcal_group_v1p3_t    mcal;                       // Motion calibration
+    sensor_data_info_t          dinfo;                      //!< Size and checksum
+    sensor_tcal_group_v1p3_t    tcal;                       //!< Temperature compensation
+    sensor_mcal_group_v1p3_t    mcal;                       //!< Motion calibration
 } sensor_cal_v1p3_data_t;
 
+/** Full calibration record (header + data payload), v1.3 layout. */
 typedef struct PACKED
 {
-    sensor_cal_info_t           info;                       // Hardware IMX-5 and later have info before data to support various versions of calibration without hardware detection
-    sensor_cal_v1p3_data_t      data;
+    sensor_cal_info_t           info;                       //!< Calibration record header. Hardware IMX-5 and later have info before data to support various versions of calibration without hardware detection.
+    sensor_cal_v1p3_data_t      data;                       //!< Calibration data payload
 } sensor_cal_v1p3_t;
 
 ////////////////////////////////////////////////
 // v1.4
+/** Calibration data payload (temperature + motion calibration), v1.4 layout. */
 typedef struct PACKED
 {
-    sensor_data_info_t          dinfo;                      // Size and checksum
-    sensor_tcal_group_v1p4_t    tcal;                       // Temperature compensation
-    sensor_mcal_group_v1p4_t    mcal;                       // Motion calibration
+    sensor_data_info_t          dinfo;                      //!< Size and checksum
+    sensor_tcal_group_v1p4_t    tcal;                       //!< Temperature compensation
+    sensor_mcal_group_v1p4_t    mcal;                       //!< Motion calibration
 } sensor_cal_v1p4_data_t;
 
+/** Full calibration record (header + data payload), v1.4 layout. */
 typedef struct PACKED
 {
-    sensor_cal_info_t           info;
-    sensor_cal_v1p4_data_t      data;
+    sensor_cal_info_t           info;                       //!< Calibration record header
+    sensor_cal_v1p4_data_t      data;                       //!< Calibration data payload
 } sensor_cal_v1p4_t;
 
-// Per-build-target native calibration types. SN-7966: IMX-5 hardware is permanently Cal v1.3,
-// IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) sees v1.4 so
-// ISDeviceCal etc. continue to operate on the v1.4 in-memory representation.
+/**
+ * Per-build-target native calibration types. SN-7966: IMX-5 hardware is permanently Cal v1.3,
+ * IMX-6 (and host SDK) is permanently Cal v1.4. Host code (no IMX_5/IMX_6 define) sees v1.4 so
+ * ISDeviceCal etc. continue to operate on the v1.4 in-memory representation.
+ */
 #if defined(IMX_5)
-typedef sensor_tcal_group_v1p3_t    sensor_tcal_group_t;
-typedef sensor_mcal_group_v1p3_t    sensor_mcal_group_t;
-typedef sensor_cal_v1p3_data_t      sensor_cal_data_t;
-typedef sensor_cal_v1p3_t           sensor_cal_t;
+typedef sensor_tcal_group_v1p3_t    sensor_tcal_group_t;   //!< Native temperature calibration group type for this build target (v1.3 on IMX-5)
+typedef sensor_mcal_group_v1p3_t    sensor_mcal_group_t;   //!< Native motion calibration group type for this build target (v1.3 on IMX-5)
+typedef sensor_cal_v1p3_data_t      sensor_cal_data_t;     //!< Native calibration data payload type for this build target (v1.3 on IMX-5)
+typedef sensor_cal_v1p3_t           sensor_cal_t;          //!< Native full calibration record type for this build target (v1.3 on IMX-5)
 #else
-typedef sensor_tcal_group_v1p4_t    sensor_tcal_group_t;
-typedef sensor_mcal_group_v1p4_t    sensor_mcal_group_t;
-typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;
-typedef sensor_cal_v1p4_t           sensor_cal_t;
+typedef sensor_tcal_group_v1p4_t    sensor_tcal_group_t;   //!< Native temperature calibration group type for this build target (v1.4 on IMX-6/host)
+typedef sensor_mcal_group_v1p4_t    sensor_mcal_group_t;   //!< Native motion calibration group type for this build target (v1.4 on IMX-6/host)
+typedef sensor_cal_v1p4_data_t      sensor_cal_data_t;     //!< Native calibration data payload type for this build target (v1.4 on IMX-6/host)
+typedef sensor_cal_v1p4_t           sensor_cal_t;          //!< Native full calibration record type for this build target (v1.4 on IMX-6/host)
 #endif
 
-#define SIZE_OF_SENSOR_TCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_MCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(sensor_motion_cal_t))
+/** Byte sizes of each v1.3 calibration sub-group, for allocation/copy sizing. */
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.3 gyro temperature calibration group
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.3 accel temperature calibration group
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.3 mag temperature calibration group
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))       //!< Size of the v1.3 gyro motion calibration group
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P3    (NUM_IMU_DEVICES_V1P3*sizeof(sensor_motion_cal_t))       //!< Size of the v1.3 accel motion calibration group
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P3    (NUM_MAG_DEVICES_V1P3*sizeof(sensor_motion_cal_t))       //!< Size of the v1.3 mag motion calibration group
 
-#define SIZE_OF_SENSOR_TCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_TCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))
-#define SIZE_OF_SENSOR_MCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
-#define SIZE_OF_SENSOR_MCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))
+/** Byte sizes of each v1.4 calibration sub-group, for allocation/copy sizing. */
+#define SIZE_OF_SENSOR_TCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.4 gyro temperature calibration group
+#define SIZE_OF_SENSOR_TCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.4 accel temperature calibration group
+#define SIZE_OF_SENSOR_TCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(nvm_sensor_tcal_3axis_t))   //!< Size of the v1.4 mag temperature calibration group
+#define SIZE_OF_SENSOR_MCAL_GYR_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))       //!< Size of the v1.4 gyro motion calibration group
+#define SIZE_OF_SENSOR_MCAL_ACC_V1P4    (NUM_IMU_DEVICES_V1P4*sizeof(sensor_motion_cal_t))       //!< Size of the v1.4 accel motion calibration group
+#define SIZE_OF_SENSOR_MCAL_MAG_V1P4    (NUM_MAG_DEVICES_V1P4*sizeof(sensor_motion_cal_t))       //!< Size of the v1.4 mag motion calibration group
 
+/** Byte sizes of each calibration sub-group for the current build target's native version (v1.3 on IMX-5, v1.4 otherwise). */
 #if defined(IMX_5)
-#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P3
-#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P3
-#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P3
-#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P3
-#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P3
-#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P3
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P3   //!< Native gyro temperature calibration group size
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P3   //!< Native accel temperature calibration group size
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P3   //!< Native mag temperature calibration group size
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P3   //!< Native gyro motion calibration group size
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P3   //!< Native accel motion calibration group size
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P3   //!< Native mag motion calibration group size
 #else
-#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P4
-#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P4
-#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P4
-#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P4
-#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P4
-#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P4
+#define SIZE_OF_SENSOR_TCAL_GYR         SIZE_OF_SENSOR_TCAL_GYR_V1P4   //!< Native gyro temperature calibration group size
+#define SIZE_OF_SENSOR_TCAL_ACC         SIZE_OF_SENSOR_TCAL_ACC_V1P4   //!< Native accel temperature calibration group size
+#define SIZE_OF_SENSOR_TCAL_MAG         SIZE_OF_SENSOR_TCAL_MAG_V1P4   //!< Native mag temperature calibration group size
+#define SIZE_OF_SENSOR_MCAL_GYR         SIZE_OF_SENSOR_MCAL_GYR_V1P4   //!< Native gyro motion calibration group size
+#define SIZE_OF_SENSOR_MCAL_ACC         SIZE_OF_SENSOR_MCAL_ACC_V1P4   //!< Native accel motion calibration group size
+#define SIZE_OF_SENSOR_MCAL_MAG         SIZE_OF_SENSOR_MCAL_MAG_V1P4   //!< Native mag motion calibration group size
 #endif
 
 #ifdef __cplusplus

--- a/src/IS_calibration_convert.h
+++ b/src/IS_calibration_convert.h
@@ -1,3 +1,17 @@
+/**
+ * @file IS_calibration_convert.h
+ * @brief Default-initialization and v1.3 <-> v1.4 conversion helpers for the sensor calibration
+ * structures defined in IS_calibration.h.
+ *
+ * The set_sensor_*_defaults() functions (without a _v1pN suffix) resolve to the build target's
+ * native version (v1.3 on IMX-5, v1.4 elsewhere) via @ref sensor_cal_data_t; use the explicit _v1p3
+ * / _v1p4 conversion functions when translating a calibration record between versions, e.g. when a
+ * v1.3 record read from an IMX-5 device needs to be consumed by v1.4-native host code.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef IS_CALIBRATION_CONVERT_H
 #define IS_CALIBRATION_CONVERT_H
 
@@ -7,12 +21,35 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Initialize a v1.3 calibration data payload's temperature-calibration fields to defaults.
+ * @param data Calibration data payload to initialize.
+ */
 void set_sensor_cal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data);
+
+/**
+ * @brief Initialize a v1.4 calibration data payload's temperature-calibration fields to defaults.
+ * @param data Calibration data payload to initialize.
+ */
 void set_sensor_cal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data);
+
+/**
+ * @brief Initialize a v1.3 calibration data payload's motion-calibration fields to defaults.
+ * @param data Calibration data payload to initialize.
+ */
 void set_sensor_mcal_data_defaults_v1p3(sensor_cal_v1p3_data_t *data);
+
+/**
+ * @brief Initialize a v1.4 calibration data payload's motion-calibration fields to defaults.
+ * @param data Calibration data payload to initialize.
+ */
 void set_sensor_mcal_data_defaults_v1p4(sensor_cal_v1p4_data_t *data);
 
-// Native (build-target) defaults init. Resolves to _v1p3 under IMX_5, _v1p4 elsewhere.
+/**
+ * @brief Initialize a calibration data payload's temperature-calibration fields to defaults, using
+ * the build target's native version (v1.3 on IMX_5, v1.4 elsewhere).
+ * @param data Calibration data payload to initialize.
+ */
 static inline void set_sensor_cal_data_defaults(sensor_cal_data_t *data)
 {
 #if defined(IMX_5)
@@ -22,7 +59,11 @@ static inline void set_sensor_cal_data_defaults(sensor_cal_data_t *data)
 #endif
 }
 
-// Native (build-target) defaults init. Resolves to _v1p3 under IMX_5, _v1p4 elsewhere.
+/**
+ * @brief Initialize a calibration data payload's motion-calibration fields to defaults, using
+ * the build target's native version (v1.3 on IMX_5, v1.4 elsewhere).
+ * @param data Calibration data payload to initialize.
+ */
 static inline void set_sensor_motion_cal_data_defaults(sensor_cal_data_t *data)
 {
 #if defined(IMX_5)
@@ -32,14 +73,60 @@ static inline void set_sensor_motion_cal_data_defaults(sensor_cal_data_t *data)
 #endif
 }
 
+/**
+ * @brief Convert a v1.3 temperature calibration group (3x IMU + 2x Mag) to v1.4 layout (5x IMU + 1x Mag).
+ * @param v1p3 Source v1.3 temperature calibration group.
+ * @param v1p4 Output: v1.4 temperature calibration group.
+ */
 void convert_tcal_v1p3_to_v1p4(const sensor_tcal_group_v1p3_t *v1p3, sensor_tcal_group_v1p4_t *v1p4);
+
+/**
+ * @brief Convert a v1.3 motion calibration group (3x IMU + 2x Mag) to v1.4 layout (5x IMU + 1x Mag).
+ * @param v1p3 Source v1.3 motion calibration group.
+ * @param v1p4 Output: v1.4 motion calibration group.
+ */
 void convert_mcal_v1p3_to_v1p4(const sensor_mcal_group_v1p3_t *v1p3, sensor_mcal_group_v1p4_t *v1p4);
+
+/**
+ * @brief Convert a full v1.3 calibration record (header + temperature + motion calibration) to v1.4 layout.
+ * @param v1p3 Source v1.3 calibration record.
+ * @param v1p4 Output: v1.4 calibration record.
+ */
 void convert_sensor_cal_v1p3_to_v1p4(const sensor_cal_v1p3_t *v1p3, sensor_cal_v1p4_t *v1p4);
+
+/**
+ * @brief Convert v1.3 sensor compensation data to v1.4 layout.
+ * @param v1p3 Source v1.3 sensor compensation data.
+ * @param v1p4 Output: v1.4 sensor compensation data.
+ */
 void convert_scomp_v1p3_to_v1p4(const sensor_compensation_v1p3_t *v1p3, sensor_compensation_v1p4_t *v1p4);
 
+/**
+ * @brief Convert a v1.4 temperature calibration group (5x IMU + 1x Mag) to v1.3 layout (3x IMU + 2x Mag).
+ * @param v1p4 Source v1.4 temperature calibration group.
+ * @param v1p3 Output: v1.3 temperature calibration group.
+ */
 void convert_tcal_v1p4_to_v1p3(const sensor_tcal_group_v1p4_t *v1p4, sensor_tcal_group_v1p3_t *v1p3);
+
+/**
+ * @brief Convert a v1.4 motion calibration group (5x IMU + 1x Mag) to v1.3 layout (3x IMU + 2x Mag).
+ * @param v1p4 Source v1.4 motion calibration group.
+ * @param v1p3 Output: v1.3 motion calibration group.
+ */
 void convert_mcal_v1p4_to_v1p3(const sensor_mcal_group_v1p4_t *v1p4, sensor_mcal_group_v1p3_t *v1p3);
+
+/**
+ * @brief Convert a full v1.4 calibration record (header + temperature + motion calibration) to v1.3 layout.
+ * @param v1p4 Source v1.4 calibration record.
+ * @param v1p3 Output: v1.3 calibration record.
+ */
 void convert_sensor_cal_v1p4_to_v1p3(const sensor_cal_v1p4_t *v1p4, sensor_cal_v1p3_t *v1p3);
+
+/**
+ * @brief Convert v1.4 sensor compensation data to v1.3 layout.
+ * @param v1p4 Source v1.4 sensor compensation data.
+ * @param v1p3 Output: v1.3 sensor compensation data.
+ */
 void convert_scomp_v1p4_to_v1p3(const sensor_compensation_v1p4_t *v1p4, sensor_compensation_v1p3_t *v1p3);
 
 #ifdef __cplusplus

--- a/src/convert_ins.h
+++ b/src/convert_ins.h
@@ -48,7 +48,7 @@ void convertIns1ToIns2(ins_1_t* ins1, ins_2_t* result);
 void convertIns2ToIns1(ins_2_t *ins2, ins_1_t *result, double *refLla=NULL);
 
 /**
- * @brief Convert ins_3_t (quaternion/NED, ECEF position) to ins_1_t (Euler/NED, LLA position).
+ * @brief Convert ins_3_t (quaternion/NED, LLA position) to ins_1_t (Euler/NED, LLA position).
  * @param ins3   Source INS-3 solution (quaternion body rotation w.r.t. NED, LLA position).
  * @param result Output INS-1 solution: Euler angles w.r.t. NED, same LLA position, and NED offset
  *               from refLla (if provided).

--- a/src/convert_ins.h
+++ b/src/convert_ins.h
@@ -10,14 +10,62 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file convert_ins.h
+ * @brief Conversions between the four INS output data sets (ins_1_t, ins_2_t, ins_3_t, ins_4_t).
+ *
+ * The INS DIDs all carry the same navigation solution (time, status, velocity, position) but differ
+ * in attitude representation (Euler angles vs. quaternion) and reference frame (NED-relative vs.
+ * ECEF). These helpers convert between them so callers only need to work with one representation.
+ * All rotations are in radians; velocities in meters/second; ins_1_t/ins_2_t/ins_3_t positions are
+ * WGS84 latitude/longitude (degrees) + ellipsoid altitude (meters) with an optional NED offset from
+ * a caller-supplied reference LLA, while ins_4_t uses ECEF position (meters) directly.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef IS_SDK_CONVERT_INS_H_
 #define IS_SDK_CONVERT_INS_H_
 
 #include "data_sets.h"
 
+/**
+ * @brief Convert ins_1_t (Euler/NED) to ins_2_t (quaternion/NED).
+ * @param ins1   Source INS-1 solution (Euler angles w.r.t. NED, LLA position).
+ * @param result Output INS-2 solution: quaternion body rotation w.r.t. NED (qn2b), same LLA position.
+ */
 void convertIns1ToIns2(ins_1_t* ins1, ins_2_t* result);
+
+/**
+ * @brief Convert ins_2_t (quaternion/NED) to ins_1_t (Euler/NED).
+ * @param ins2   Source INS-2 solution (quaternion body rotation w.r.t. NED, LLA position).
+ * @param result Output INS-1 solution: Euler angles w.r.t. NED, same LLA position, and NED offset
+ *               from refLla (if provided).
+ * @param refLla Optional reference WGS84 latitude/longitude/altitude (degrees, degrees, meters)
+ *               used to compute result->ned. If NULL, result->ned is zeroed.
+ */
 void convertIns2ToIns1(ins_2_t *ins2, ins_1_t *result, double *refLla=NULL);
+
+/**
+ * @brief Convert ins_3_t (quaternion/NED, ECEF position) to ins_1_t (Euler/NED, LLA position).
+ * @param ins3   Source INS-3 solution (quaternion body rotation w.r.t. NED, LLA position).
+ * @param result Output INS-1 solution: Euler angles w.r.t. NED, same LLA position, and NED offset
+ *               from refLla (if provided).
+ * @param refLla Optional reference WGS84 latitude/longitude/altitude (degrees, degrees, meters)
+ *               used to compute result->ned. If NULL, result->ned is zeroed.
+ */
 void convertIns3ToIns1(ins_3_t *ins3, ins_1_t *result, double *refLla=NULL);
+
+/**
+ * @brief Convert ins_4_t (quaternion/ECEF) to ins_1_t (Euler/NED, LLA position).
+ * @param ins4   Source INS-4 solution (quaternion body rotation w.r.t. ECEF, ECEF position/velocity).
+ * @param result Output INS-1 solution: body-frame velocity (derived by rotating ECEF velocity into
+ *               the body frame), Euler angles w.r.t. NED, WGS84 LLA position (converted from ECEF),
+ *               and NED offset from refLla (if provided).
+ * @param refLla Optional reference WGS84 latitude/longitude/altitude (degrees, degrees, meters)
+ *               used to compute result->ned. If NULL, result->ned is zeroed.
+ */
 void convertIns4ToIns1(ins_4_t *ins4, ins_1_t *result, double *refLla=NULL);
 
 #endif //IS_SDK_CONVERT_INS_H_

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -10,6 +10,27 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT, IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file data_sets_canbus.h
+ * @brief CAN-bus payload structures for classic CAN (8-byte) and CAN FD (up to 64-byte) frames.
+ *
+ * Each struct here is the payload of exactly one CAN (or CAN FD) frame, addressed by a CAN ID
+ * from @ref can_cid_t (classic CAN) or the corresponding FDCID_* macro (CAN FD); see data_sets.h
+ * and can_config_t for the broadcast configuration that maps DIDs to CAN addresses. Classic-CAN payloads (is_can_*)
+ * pack multiple scaled-integer fields into 8 bytes to fit the CAN 2.0 frame limit; CAN FD payloads
+ * (is_canfd_*) carry the same information at native float/double precision since CAN FD supports
+ * larger frames (valid CAN FD payload sizes are 0-8, 12, 16, 20, 24, 32, 48, or 64 bytes -- structs
+ * that don't land on a valid boundary are padded by the driver).
+ *
+ * Unless otherwise noted: angles are in radians, velocities are in meters/second, and positions
+ * given as ECEF are in meters. INS Euler/quaternion fields are body rotation with respect to NED
+ * or ECEF as named in the type. Classic-CAN scaled-integer fields state their scale factor and
+ * decimal-place precision in their inline comment.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef CAN_COMM_H_
 #define CAN_COMM_H_
 #ifdef __cplusplus
@@ -19,261 +40,220 @@ extern "C" {
 
 PUSH_PACK_1
 
-/*GMT information*/
+/** GMT week and time-of-week, classic-CAN native precision. */
 typedef struct PACKED
 {
-    /** Weeks since January 6th, 1980 */
-    uint32_t        week;                                //4 bytes
-    
-    /** Time of week (since Sunday morning) in milliseconds, GMT */
-    float           timeOfWeekMs;                        //4 bytes
-    
+    uint32_t        week;                                //!< Weeks since January 6th, 1980
+    float           timeOfWeekMs;                        //!< Time of week (since Sunday morning) in milliseconds, GMT
 } is_can_time;
 
-/*Status Information*/
+/** INS/hardware status flags, copied from DID_SYS_PARAMS. */
 typedef struct PACKED
 {
-    /** INS status flags (eInsStatusFlags). Copy of DID_SYS_PARAMS.insStatus */
-    uint32_t        insStatus;                            //4 bytes
-
-    /** Hardware status flags (eHdwStatusFlags). Copy of DID_SYS_PARAMS.hdwStatus */
-    uint32_t        hdwStatus;                            //4 bytes
-    
+    uint32_t        insStatus;                            //!< INS status flags (eInsStatusFlags). Copy of DID_SYS_PARAMS.insStatus
+    uint32_t        hdwStatus;                            //!< Hardware status flags (eHdwStatusFlags). Copy of DID_SYS_PARAMS.hdwStatus
 } is_can_ins_status;
 
-/*Euler Angles*/
+/** Euler angles: roll, pitch, yaw with respect to NED, scaled by 10000 (4 decimal places precision) for 2-byte transport. */
 typedef struct PACKED
 {
-    /** Euler angles: roll, pitch, yaw in radians with respect to NED (scaled by 10000)*/
-    int16_t                 theta1;                                //2 bytes (4 decimal places precision)
-    int16_t                 theta2;                                //2 bytes
-    int16_t                 theta3;                                //2 bytes
+    int16_t                 theta1;                                //!< Roll (radians, scaled by 10000)
+    int16_t                 theta2;                                //!< Pitch (radians, scaled by 10000)
+    int16_t                 theta3;                                //!< Yaw (radians, scaled by 10000)
     //int16_t                    reserved;
 } is_can_ins_euler;
 
-/*Quaternion*/
+/** Quaternion body rotation with respect to NED, scaled by 10000 (4 decimal places precision) for 2-byte transport. */
 typedef struct PACKED
 {
-    /** Quaternion body rotation with respect to NED: W, X, Y, Z (scaled by 10000)*/
-    int16_t                 qn2b1;                                //2 bytes (4 decimal places precision)
-    int16_t                 qn2b2;                                //2 bytes
-    int16_t                 qn2b3;                                //2 bytes
-    int16_t                 qn2b4;                                //2 bytes
+    int16_t                 qn2b1;                                //!< Quaternion W component (scaled by 10000)
+    int16_t                 qn2b2;                                //!< Quaternion X component (scaled by 10000)
+    int16_t                 qn2b3;                                //!< Quaternion Y component (scaled by 10000)
+    int16_t                 qn2b4;                                //!< Quaternion Z component (scaled by 10000)
 } is_can_ins_quatn2b;
 
-/*Quaternion*/
+/** Quaternion body rotation with respect to ECEF, scaled by 10000 (4 decimal places precision) for 2-byte transport. */
 typedef struct PACKED
 {
-    /** Quaternion body rotation with respect to ECEF: W, X, Y, Z (scaled by 10000)*/
-    int16_t                 qe2b1;                                //2 bytes (4 decimal places precision)
-    int16_t                 qe2b2;                                //2 bytes
-    int16_t                 qe2b3;                                //2 bytes
-    int16_t                 qe2b4;                                //2 bytes
+    int16_t                 qe2b1;                                //!< Quaternion W component (scaled by 10000)
+    int16_t                 qe2b2;                                //!< Quaternion X component (scaled by 10000)
+    int16_t                 qe2b3;                                //!< Quaternion Y component (scaled by 10000)
+    int16_t                 qe2b4;                                //!< Quaternion Z component (scaled by 10000)
 } is_can_ins_quate2b;
 
-/*velocity in body frame*/
+/** Velocity in the body frame, scaled by 100 (2 decimal places precision, max absolute value 327.67 m/s) for 2-byte transport. Convert to NED velocity using vectorBodyToReference(uvw, theta, vel_ned). */
 typedef struct PACKED
 {
-    /** Velocity U, V, W in meters per second (scaled by 100).  Convert to NED velocity using "vectorBodyToReference(uvw, theta, vel_ned)". */
-    int16_t                 uvw1;                                //2 bytes (2 decimal places precision, max absolute value 327.67)
-    int16_t                 uvw2;                                //2 bytes
-    int16_t                 uvw3;                                //2 bytes
+    int16_t                 uvw1;                                //!< Body-frame U (forward) velocity, m/s (scaled by 100)
+    int16_t                 uvw2;                                //!< Body-frame V (right) velocity, m/s (scaled by 100)
+    int16_t                 uvw3;                                //!< Body-frame W (down) velocity, m/s (scaled by 100)
 } is_can_uvw;
 
-/** Velocity in ECEF */
+/** Velocity in ECEF (earth-centered earth-fixed) frame, scaled by 100 (2 decimal places precision, max absolute value 327.67 m/s) for 2-byte transport. */
 typedef struct PACKED
 {
-    /** Velocity in ECEF (earth-centered earth-fixed) (scaled by 100) frame in meters per second */
-    int16_t                 ve1;                                //2 bytes (2 decimal places precision, max absolute value 327.67)
-    int16_t                 ve2;                                //2 bytes
-    int16_t                 ve3;                                //2 bytes
-    
+    int16_t                 ve1;                                //!< ECEF X velocity, m/s (scaled by 100)
+    int16_t                 ve2;                                //!< ECEF Y velocity, m/s (scaled by 100)
+    int16_t                 ve3;                                //!< ECEF Z velocity, m/s (scaled by 100)
 } is_can_ve;
 
-/** WGS84 latitude (degrees) */
+/** WGS84 latitude, native double precision. */
 typedef struct PACKED
 {
-    /** WGS84 latitude (degrees) */
-    double                  lat;                                //8 bytes (more than 8 decimal places precision)
-    
+    double                  lat;                                //!< WGS84 latitude (degrees)
 } is_can_ins_lat;
 
-/** WGS84 longitude (degrees) */
+/** WGS84 longitude, native double precision. */
 typedef struct PACKED
 {
-    /** WGS84 longitude (degrees) */
-    double                  lon;                                //8 bytes (more than 8 decimal places precision)
+    double                  lon;                                //!< WGS84 longitude (degrees)
 } is_can_ins_lon;
 
-/** WGS84 height above ellipsoid (meters) */
+/** WGS84 height above ellipsoid plus GNSS fix status. */
 typedef struct PACKED
 {
-    /** WGS84 height above ellipsoid (meters) */
-    float                   alt;                                //4 bytes (more than 8 decimal places precision)    
-    /** (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags */
-    uint32_t                status;
+    float                   alt;                                //!< WGS84 height above ellipsoid (meters)
+    uint32_t                status;                             //!< (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags
 } is_can_ins_alt;
 
-/** North offset from reference LLA */
+/** North and East offset from a reference LLA. */
 typedef struct PACKED
 {
-    /** North offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude */
-    float                   ned1;                                //4 bytes
-    /** East offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude */
-    float                   ned2;                                //4 bytes
-    
+    float                   ned1;                                //!< North offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude (meters)
+    float                   ned2;                                //!< East offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude (meters)
 } is_can_north_east;
 
-/** Down offset from reference LLA */
+/** Down offset from a reference LLA, plus INS status. */
 typedef struct PACKED
 {
-    /** Down offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude */
-    float                   ned3;                                //4 bytes
-    /** INS status flags (eInsStatusFlags). Copy of DID_SYS_PARAMS.insStatus */
-    uint32_t                insStatus;                            //4 bytes
-    
+    float                   ned3;                                //!< Down offset from reference latitude, longitude, and altitude to current latitude, longitude, and altitude (meters)
+    uint32_t                insStatus;                            //!< INS status flags (eInsStatusFlags). Copy of DID_SYS_PARAMS.insStatus
 } is_can_down;
 
-/** X Position in ECEF (earth-centered earth-fixed) frame in meters */
+/** X position in ECEF (earth-centered earth-fixed) frame, native double precision. */
 typedef struct PACKED
 {
-    /** X Position in ECEF (earth-centered earth-fixed) frame in meters */
-    double                  ecef1;                                //8 bytes
-    
+    double                  ecef1;                                //!< X position in ECEF frame (meters)
 } is_can_ecef_x;
 
-/** Y Position in ECEF (earth-centered earth-fixed) frame in meters */
+/** Y position in ECEF (earth-centered earth-fixed) frame, native double precision. */
 typedef struct PACKED
 {
-    /** Y Position in ECEF (earth-centered earth-fixed) frame in meters */
-    double                  ecef2;                                //8 bytes
-    
+    double                  ecef2;                                //!< Y position in ECEF frame (meters)
 } is_can_ecef_y;
 
-/** Z Position in ECEF (earth-centered earth-fixed) frame in meters */
+/** Z position in ECEF (earth-centered earth-fixed) frame, native double precision. */
 typedef struct PACKED
 {
-    /** Z Position in ECEF (earth-centered earth-fixed) frame in meters */
-    double                  ecef3;                                //8 bytes
-    
+    double                  ecef3;                                //!< Z position in ECEF frame (meters)
 } is_can_ecef_z;
 
-/** Height above Mean Sea Level */
+/** Height above Mean Sea Level, native float precision. */
 typedef struct PACKED
 {
-    /** Height above mean sea level (MSL) in meters */
-    float                   msl;                                //4 bytes
+    float                   msl;                                //!< Height above mean sea level (MSL) in meters
 } is_can_msl;
 
-/**Preintegrated IMU values delta theta and delta velocity (X axis), and Integral period in body/IMU frame of accelerometer 0.**/
+/** Preintegrated IMU delta theta/velocity (X axis) and integral period, body/IMU frame, accelerometer 0. */
 typedef struct PACKED
 {
-    int16_t                 theta0;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel0;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** Integral period in seconds for delta theta and delta velocity (scaled by 1000).*/
-    uint16_t                dt;                                        //2 bytes
+    int16_t                 theta0;                                    //!< Delta theta, X axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel0;                                    //!< Delta velocity, X axis, m/s (scaled by 100, 2 decimal places precision)
+    uint16_t                dt;                                        //!< Integral period in seconds for delta theta and delta velocity (scaled by 1000)
 } is_can_preint_imu_px;
 
-/**Preintegrated IMU values delta theta and delta velocity (Y axis), and Integral period in body/IMU frame of accelerometer 0.**/
+/** Preintegrated IMU delta theta/velocity (Y axis) and integral period, body/IMU frame, accelerometer 0. */
 typedef struct PACKED
 {
-    int16_t                 theta1;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel1;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** Integral period in seconds for delta theta and delta velocity (scaled by 1000).*/
-    uint16_t                dt;                                        //2 bytes
-    
+    int16_t                 theta1;                                    //!< Delta theta, Y axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel1;                                    //!< Delta velocity, Y axis, m/s (scaled by 100, 2 decimal places precision)
+    uint16_t                dt;                                        //!< Integral period in seconds for delta theta and delta velocity (scaled by 1000)
 } is_can_preint_imu_qy;
 
-/**Preintegrated IMU values delta theta and delta velocity (Z axis), and Integral period in body/IMU frame of accelerometer 0.**/
+/** Preintegrated IMU delta theta/velocity (Z axis) and integral period, body/IMU frame, accelerometer 0. */
 typedef struct PACKED
 {
-    int16_t                 theta2;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel2;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** Integral period in seconds for delta theta and delta velocity (scaled by 1000).*/
-    uint16_t                dt;                                        //2 bytes
+    int16_t                 theta2;                                    //!< Delta theta, Z axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel2;                                    //!< Delta velocity, Z axis, m/s (scaled by 100, 2 decimal places precision)
+    uint16_t                dt;                                        //!< Integral period in seconds for delta theta and delta velocity (scaled by 1000)
 } is_can_preint_imu_rz;
 
+/** Dual-rate IMU delta theta/velocity (X axis) and status. */
 typedef struct PACKED
 {
-    int16_t                 theta0;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel0;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** IMU Status (eImuStatus) */
-    uint32_t                status;                                    //4 bytes
+    int16_t                 theta0;                                    //!< Delta theta, X axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel0;                                    //!< Delta velocity, X axis, m/s (scaled by 100, 2 decimal places precision)
+    uint32_t                status;                                    //!< IMU Status (eImuStatus)
 } is_can_dual_imu_px;
 
+/** Dual-rate IMU delta theta/velocity (Y axis) and status. */
 typedef struct PACKED
 {
-    int16_t                 theta1;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel1;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** IMU Status (eImuStatus) */
-    uint32_t                status;                                    //4 bytes
-    
+    int16_t                 theta1;                                    //!< Delta theta, Y axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel1;                                    //!< Delta velocity, Y axis, m/s (scaled by 100, 2 decimal places precision)
+    uint32_t                status;                                    //!< IMU Status (eImuStatus)
 } is_can_dual_imu_qy;
 
+/** Dual-rate IMU delta theta/velocity (Z axis) and status. */
 typedef struct PACKED
 {
-    int16_t                 theta2;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-    int16_t                 vel2;                                    //2 bytes (scaled by 100 2 decimal places precision)
-    /** IMU Status (eImuStatus) */
-    uint32_t                status;                                    //4 bytes
+    int16_t                 theta2;                                    //!< Delta theta, Z axis, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 vel2;                                    //!< Delta velocity, Z axis, m/s (scaled by 100, 2 decimal places precision)
+    uint32_t                status;                                    //!< IMU Status (eImuStatus)
 } is_can_dual_imu_rz;
 
+/** GNSS position fix status and mean signal quality. */
 typedef struct PACKED
 {
-    /** (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags */
-    uint32_t                status;                                    //4 bytes
-    /** Average of all satellite carrier to noise ratios (signal strengths) that non-zero in dBHz */
-    uint32_t                cnoMean;                                //4 byte
+    uint32_t                status;                                    //!< (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags
+    uint32_t                cnoMean;                                //!< Average of all satellite carrier to noise ratios (signal strengths) that are non-zero, in dBHz
 } is_can_gnss_pos_status;
 
+/** RTK relative-positioning quality metrics. */
 typedef struct PACKED
 {
-    /** Ambiguity resolution ratio factor for validation */
-    uint8_t                 arRatio;                                //1 byte
-    /** Age of differential (seconds) */
-    uint8_t                 differentialAge;                        //1 byte
-    /** Distance to Base (m) */
-    float                   distanceToBase;                            //4 bytes
-    /** Angle from north to vectorToBase in local tangent plane. (rad) */
-    int16_t                 headingToBase;                            //2 bytes (scaled by 1000 3 decimal places precision)
+    uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
+    uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
+    float                   distanceToBase;                            //!< Distance to base station (meters)
+    int16_t                 headingToBase;                            //!< Angle from north to vectorToBase in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
 } is_can_gnss_rtk_rel;
 
+/** INS roll and per-IMU roll rates. */
 typedef struct PACKED
 {
-        /** Euler roll, roll rates from each IMU(DID_IMU)**/
-        int16_t             insRoll;                                //2 bytes (scaled by 10000 4 decimal places precision)
-        int16_t             pImu1;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-        int16_t             pImu2;                                    //2 bytes (scaled by 1000 3 decimal places precision)
-        
+        int16_t             insRoll;                                //!< INS Euler roll, radians (scaled by 10000, 4 decimal places precision)
+        int16_t             pImu1;                                    //!< IMU 1 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
+        int16_t             pImu2;                                    //!< IMU 2 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
 } is_can_roll_rollRate;
 
+/** Union of all classic-CAN (8-byte) payload types; the active member is selected by the frame's CAN ID. */
 typedef union PACKED
 {
-    is_can_time time;
-    is_can_ins_status insstatus;
-    is_can_ins_euler euler;
-    is_can_ins_quatn2b quatn2b;
-    is_can_ins_quate2b quate2b;
-    is_can_uvw uvw;
-    is_can_ve ve;
-    is_can_ins_lat lat;
-    is_can_ins_lon lon;
-    is_can_ins_alt alt;
-    is_can_north_east ne;
-    is_can_down down;
-    is_can_ecef_x ecefx;
-    is_can_ecef_y ecefy;
-    is_can_ecef_z ecefz;
-    is_can_msl msl;
-    is_can_preint_imu_px pimupx;
-    is_can_preint_imu_qy pimuqy;
-    is_can_preint_imu_rz pimurz;
-    is_can_dual_imu_px dimupx;
-    is_can_dual_imu_qy dimuqy;
-    is_can_dual_imu_rz dimurz;
-    is_can_gnss_pos_status gnsspos;
-    is_can_gnss_rtk_rel rtkrel;
-    is_can_roll_rollRate rollrollrate;    
+    is_can_time time;                          //!< GMT week/time-of-week
+    is_can_ins_status insstatus;               //!< INS/hardware status flags
+    is_can_ins_euler euler;                    //!< Euler angles (NED)
+    is_can_ins_quatn2b quatn2b;                //!< Quaternion body rotation (NED)
+    is_can_ins_quate2b quate2b;                //!< Quaternion body rotation (ECEF)
+    is_can_uvw uvw;                            //!< Body-frame velocity
+    is_can_ve ve;                              //!< ECEF velocity
+    is_can_ins_lat lat;                        //!< WGS84 latitude
+    is_can_ins_lon lon;                        //!< WGS84 longitude
+    is_can_ins_alt alt;                        //!< WGS84 altitude + GNSS status
+    is_can_north_east ne;                      //!< North/East offset from reference LLA
+    is_can_down down;                          //!< Down offset from reference LLA + INS status
+    is_can_ecef_x ecefx;                       //!< ECEF X position
+    is_can_ecef_y ecefy;                       //!< ECEF Y position
+    is_can_ecef_z ecefz;                       //!< ECEF Z position
+    is_can_msl msl;                            //!< Height above mean sea level
+    is_can_preint_imu_px pimupx;               //!< Preintegrated IMU, X axis
+    is_can_preint_imu_qy pimuqy;                //!< Preintegrated IMU, Y axis
+    is_can_preint_imu_rz pimurz;                //!< Preintegrated IMU, Z axis
+    is_can_dual_imu_px dimupx;                  //!< Dual-rate IMU, X axis
+    is_can_dual_imu_qy dimuqy;                  //!< Dual-rate IMU, Y axis
+    is_can_dual_imu_rz dimurz;                  //!< Dual-rate IMU, Z axis
+    is_can_gnss_pos_status gnsspos;             //!< GNSS position fix status
+    is_can_gnss_rtk_rel rtkrel;                 //!< RTK relative-positioning quality metrics
+    is_can_roll_rollRate rollrollrate;          //!< INS roll + per-IMU roll rates
 } is_can_payload;
 
 
@@ -287,83 +267,84 @@ POP_PACK
 // ============================================================================
 PUSH_PACK_1
 
-/** FDCID_INS_1: key INS-1 fields in 64 bytes (exact FD DLC) */
+/** FDCID_INS_1: key INS-1 fields in native float/double precision, 64 bytes (exact FD DLC). */
 typedef struct PACKED
 {
-    uint32_t    week;           // 4
-    double      timeOfWeek;     // 8
-    uint32_t    insStatus;      // 4
-    uint32_t    hdwStatus;      // 4
-    float       theta[3];       // 12
-    float       uvw[3];         // 12
-    double      lat;            // 8
-    double      lon;            // 8
-    float       alt;            // 4
-} is_canfd_ins1;                // 64 bytes
+    uint32_t    week;           //!< Weeks since January 6th, 1980
+    double      timeOfWeek;     //!< Time of week (seconds)
+    uint32_t    insStatus;      //!< INS status flags (eInsStatusFlags)
+    uint32_t    hdwStatus;      //!< Hardware status flags (eHdwStatusFlags)
+    float       theta[3];       //!< Euler angles roll/pitch/yaw w.r.t. NED (radians)
+    float       uvw[3];         //!< Body-frame velocity U/V/W (m/s)
+    double      lat;            //!< WGS84 latitude (degrees)
+    double      lon;            //!< WGS84 longitude (degrees)
+    float       alt;            //!< WGS84 height above ellipsoid (meters)
+} is_canfd_ins1;                //!< 64 bytes total
 
-/** FDCID_INS_2: native-precision NED quaternion */
+/** FDCID_INS_2: native-precision NED quaternion. */
 typedef struct PACKED
 {
-    float       qn2b[4];        // 16
-} is_canfd_ins2;                // 16 bytes
+    float       qn2b[4];        //!< Quaternion body rotation w.r.t. NED: W, X, Y, Z
+} is_canfd_ins2;                //!< 16 bytes total
 
-/** FDCID_INS_3: MSL altitude */
+/** FDCID_INS_3: MSL altitude. */
 typedef struct PACKED
 {
-    float       msl;            // 4
-} is_canfd_ins3;                // 4 bytes
+    float       msl;            //!< Height above mean sea level (meters)
+} is_canfd_ins3;                //!< 4 bytes total
 
-/** FDCID_INS_4: ECEF quaternion, ECEF velocity, ECEF position (52 bytes → 64-byte FD frame) */
+/** FDCID_INS_4: ECEF quaternion, ECEF velocity, ECEF position (52 bytes -> padded to a 64-byte FD frame). */
 typedef struct PACKED
 {
-    float       qe2b[4];        // 16
-    float       ve[3];          // 12
-    double      ecef[3];        // 24
-} is_canfd_ins4;                // 52 bytes
+    float       qe2b[4];        //!< Quaternion body rotation w.r.t. ECEF: W, X, Y, Z
+    float       ve[3];          //!< ECEF velocity X/Y/Z (m/s)
+    double      ecef[3];        //!< ECEF position X/Y/Z (meters)
+} is_canfd_ins4;                //!< 52 bytes total
 
-/** FDCID_PIMU: preintegrated IMU in native float (32 bytes exact FD DLC) */
+/** FDCID_PIMU: preintegrated IMU in native float (32 bytes, exact FD DLC). */
 typedef struct PACKED
 {
-    float       theta[3];       // 12
-    float       vel[3];         // 12
-    float       dt;             // 4
-    uint32_t    status;         // 4
-} is_canfd_pimu;                // 32 bytes
+    float       theta[3];       //!< Delta theta X/Y/Z, body/IMU frame (radians)
+    float       vel[3];         //!< Delta velocity X/Y/Z, body/IMU frame (m/s)
+    float       dt;             //!< Integral period for delta theta and delta velocity (seconds)
+    uint32_t    status;         //!< IMU Status (eImuStatus)
+} is_canfd_pimu;                //!< 32 bytes total
 
-/** FDCID_IMU: IMU angular rate, acceleration, status (28 bytes → 32-byte FD frame) */
+/** FDCID_IMU: IMU angular rate, acceleration, status (28 bytes -> padded to a 32-byte FD frame). */
 typedef struct PACKED
 {
-    float       pqr[3];         // 12
-    float       acc[3];         // 12
-    uint32_t    status;         // 4
-} is_canfd_imu;                 // 28 bytes
+    float       pqr[3];         //!< Angular rate P/Q/R, body/IMU frame (radians/second)
+    float       acc[3];         //!< Acceleration X/Y/Z, body/IMU frame (m/s^2)
+    uint32_t    status;         //!< IMU Status (eImuStatus)
+} is_canfd_imu;                 //!< 28 bytes total
 
-/** FDCID_GNSS1_POS / FDCID_GNSS2_POS: GNSS fix status and mean CNO */
+/** FDCID_GNSS1_POS / FDCID_GNSS2_POS: GNSS fix status and mean CNO. */
 typedef struct PACKED
 {
-    uint32_t    status;         // 4
-    float       cnoMean;        // 4 — native float (gnss_pos_t.cnoMean is float)
-} is_canfd_gnss_pos;            // 8 bytes
+    uint32_t    status;         //!< (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags
+    float       cnoMean;        //!< Average of all non-zero satellite carrier-to-noise ratios (dBHz); native float (gnss_pos_t.cnoMean is float)
+} is_canfd_gnss_pos;            //!< 8 bytes total
 
-/** FDCID_GNSS1_RTK_POS_REL / FDCID_GNSS2_RTK_CMP_REL: RTK data in native float (16 bytes) */
+/** FDCID_GNSS1_RTK_POS_REL / FDCID_GNSS2_RTK_CMP_REL: RTK relative-positioning quality metrics, native float (16 bytes). */
 typedef struct PACKED
 {
-    float       arRatio;            // 4
-    float       differentialAge;    // 4
-    float       distanceToBase;     // 4
-    float       headingToBase;      // 4
-} is_canfd_gnss_rtk_rel;        // 16 bytes
+    float       arRatio;            //!< Ambiguity resolution ratio factor for validation
+    float       differentialAge;    //!< Age of differential correction (seconds)
+    float       distanceToBase;     //!< Distance to base station (meters)
+    float       headingToBase;      //!< Angle from north to vectorToBase in the local tangent plane (radians)
+} is_canfd_gnss_rtk_rel;        //!< 16 bytes total
 
+/** Union of all CAN FD payload types; the active member is selected by the frame's CAN ID. */
 typedef union PACKED
 {
-    is_canfd_ins1           ins1;
-    is_canfd_ins2           ins2;
-    is_canfd_ins3           ins3;
-    is_canfd_ins4           ins4;
-    is_canfd_pimu           pimu;
-    is_canfd_imu            imu;
-    is_canfd_gnss_pos       gnsspos;
-    is_canfd_gnss_rtk_rel   rtkrel;
+    is_canfd_ins1           ins1;       //!< INS-1 fields
+    is_canfd_ins2           ins2;       //!< NED quaternion
+    is_canfd_ins3           ins3;       //!< MSL altitude
+    is_canfd_ins4           ins4;       //!< ECEF quaternion/velocity/position
+    is_canfd_pimu           pimu;       //!< Preintegrated IMU
+    is_canfd_imu            imu;        //!< IMU angular rate/acceleration/status
+    is_canfd_gnss_pos       gnsspos;    //!< GNSS position fix status
+    is_canfd_gnss_rtk_rel   rtkrel;     //!< RTK relative-positioning quality metrics
 } is_canfd_payload;
 
 POP_PACK

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -231,20 +231,20 @@ typedef union PACKED
 {
     is_can_time time;                          //!< GMT week/time-of-week
     is_can_ins_status insstatus;               //!< INS/hardware status flags
-    is_can_ins_euler euler;                    //!< Euler angles (NED)
+    is_can_ins_euler euler;                    //!< Euler angles, radians (NED)
     is_can_ins_quatn2b quatn2b;                //!< Quaternion body rotation (NED)
     is_can_ins_quate2b quate2b;                //!< Quaternion body rotation (ECEF)
-    is_can_uvw uvw;                            //!< Body-frame velocity
-    is_can_ve ve;                              //!< ECEF velocity
-    is_can_ins_lat lat;                        //!< WGS84 latitude
-    is_can_ins_lon lon;                        //!< WGS84 longitude
-    is_can_ins_alt alt;                        //!< WGS84 altitude + GNSS status
-    is_can_north_east ne;                      //!< North/East offset from reference LLA
-    is_can_down down;                          //!< Down offset from reference LLA + INS status
-    is_can_ecef_x ecefx;                       //!< ECEF X position
-    is_can_ecef_y ecefy;                       //!< ECEF Y position
-    is_can_ecef_z ecefz;                       //!< ECEF Z position
-    is_can_msl msl;                            //!< Height above mean sea level
+    is_can_uvw uvw;                            //!< Body-frame velocity, m/s
+    is_can_ve ve;                              //!< ECEF velocity, m/s
+    is_can_ins_lat lat;                        //!< WGS84 latitude, degrees
+    is_can_ins_lon lon;                        //!< WGS84 longitude, degrees
+    is_can_ins_alt alt;                        //!< WGS84 altitude, meters + GNSS status
+    is_can_north_east ne;                      //!< North/East offset from reference LLA, meters
+    is_can_down down;                          //!< Down offset from reference LLA, meters + INS status
+    is_can_ecef_x ecefx;                       //!< ECEF X position, meters
+    is_can_ecef_y ecefy;                       //!< ECEF Y position, meters
+    is_can_ecef_z ecefz;                       //!< ECEF Z position, meters
+    is_can_msl msl;                            //!< Height above mean sea level, meters
     is_can_preint_imu_px pimupx;               //!< Preintegrated IMU, X axis
     is_can_preint_imu_qy pimuqy;                //!< Preintegrated IMU, Y axis
     is_can_preint_imu_rz pimurz;                //!< Preintegrated IMU, Z axis
@@ -253,7 +253,7 @@ typedef union PACKED
     is_can_dual_imu_rz dimurz;                  //!< Dual-rate IMU, Z axis
     is_can_gnss_pos_status gnsspos;             //!< GNSS position fix status
     is_can_gnss_rtk_rel rtkrel;                 //!< RTK relative-positioning quality metrics
-    is_can_roll_rollRate rollrollrate;          //!< INS roll + per-IMU roll rates
+    is_can_roll_rollRate rollrollrate;          //!< INS roll + per-IMU roll rates, radians / radians per second
 } is_can_payload;
 
 
@@ -339,10 +339,10 @@ typedef union PACKED
 {
     is_canfd_ins1           ins1;       //!< INS-1 fields
     is_canfd_ins2           ins2;       //!< NED quaternion
-    is_canfd_ins3           ins3;       //!< MSL altitude
-    is_canfd_ins4           ins4;       //!< ECEF quaternion/velocity/position
-    is_canfd_pimu           pimu;       //!< Preintegrated IMU
-    is_canfd_imu            imu;        //!< IMU angular rate/acceleration/status
+    is_canfd_ins3           ins3;       //!< MSL altitude, meters
+    is_canfd_ins4           ins4;       //!< ECEF quaternion, velocity (m/s), and position (meters)
+    is_canfd_pimu           pimu;       //!< Preintegrated IMU (delta theta radians, delta velocity m/s)
+    is_canfd_imu            imu;        //!< IMU angular rate (radians/second), acceleration (m/s^2), and status
     is_canfd_gnss_pos       gnsspos;    //!< GNSS position fix status
     is_canfd_gnss_rtk_rel   rtkrel;     //!< RTK relative-positioning quality metrics
 } is_canfd_payload;

--- a/src/filters.h
+++ b/src/filters.h
@@ -1,10 +1,20 @@
-/*
- * filters.h
+/**
+ * @file filters.h
+ * @brief IIR/FIR low-pass filtering, running-average/variance filters, and IMU coning-and-sculling
+ * (preintegration) helpers.
  *
- * Created: 3/17/2011 8:27:37 AM
- *  Author: waltj
- */ 
-
+ * Includes precomputed single-pole low-pass filter alpha/beta coefficient tables for common
+ * sample-rate/corner-frequency combinations (see the ALPH_[sampleRate]SR_[cornerFreq]CF /
+ * BETA_[sampleRate]SR_[cornerFreq]CF naming convention below), the O0_LP_FILTER/O1_LP_FILTER family
+ * of filter macros that apply those coefficients, and functions to combine/convert between IMU and
+ * preintegrated-IMU (PIMU) data.
+ *
+ * Unless otherwise noted: angular rates are in radians/second, accelerations are in meters/second^2,
+ * and IMU/PIMU data is in the body/IMU frame.
+ *
+ * @author Walt Johnson
+ * @copyright Copyright (c) 2011-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
 
 #ifndef FILTERS_H_
 #define FILTERS_H_
@@ -16,10 +26,12 @@
 
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   100Hz (10ms) Sample Rate
+/**
+ * Single-pole low-pass filter coefficients, precomputed for a 100Hz (10ms) sample rate:
+ *   Alpha = (Fc/Fs)/(1 + Fc/Fs); Beta = 1.0 - Alpha
+ * Named ALPH_100SR_[Fc]CF / BETA_100SR_[Fc]CF, where [Fc] is the corner frequency in Hz (with 'p'
+ * standing in for a decimal point, e.g. 0p001 = 0.001Hz). Apply via O0_LP_FILTER or O0_LPF_VEC3.
+ */
 #define    ALPH_100SR_0p001CF   (0.0000099999f)        // 0.001Hz corner freq @ 100Hz sample rate
 #define    BETA_100SR_0p001CF   (0.9999900001f)
 #define    ALPH_100SR_0p01CF    (0.0000999900f)        // 0.01Hz corner freq @ 100Hz sample rate
@@ -46,10 +58,7 @@
 #define    BETA_100SR_100CF     (0.5000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   200Hz (5ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 200Hz (5ms) sample rate. */
 #define    ALPH_200SR_0p001CF   (0.0000050000f)        // 0.001Hz corner freq @ 200Hz sample rate
 #define    BETA_200SR_0p001CF   (0.9999950000f)
 #define    ALPH_200SR_0p01CF    (0.0000499975f)        // 0.01Hz corner freq @ 200Hz sample rate
@@ -80,10 +89,7 @@
 #define    BETA_200SR_200CF     (0.5000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   250Hz (4ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 250Hz (4ms) sample rate. */
 #define    ALPH_250SR_0p001CF   (0.0000040000f)        // 0.001Hz corner freq @ 250Hz sample rate
 #define    BETA_250SR_0p001CF   (0.9999960000f)
 #define    ALPH_250SR_0p01CF    (0.0000399984f)        // 0.01Hz corner freq @ 250Hz sample rate
@@ -116,10 +122,7 @@
 #define    BETA_250SR_250CF     (0.5000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   333Hz (3ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 333Hz (3ms) sample rate. */
 #define    ALPH_333SR_0p001CF   (0.0000030000f)        // 0.001Hz corner freq @ 333Hz sample rate
 #define    BETA_333SR_0p001CF   (0.9999970000f)
 #define    ALPH_333SR_0p01CF    (0.0000299991f)        // 0.01Hz corner freq @ 333Hz sample rate
@@ -154,10 +157,7 @@
 #define    BETA_333SR_400CF     (0.4545454545f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   400Hz (2.5ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 400Hz (2.5ms) sample rate. */
 #define    ALPH_400SR_0p001CF   (0.0000025000f)        // 0.001Hz corner freq @ 400Hz sample rate
 #define    BETA_400SR_0p001CF   (0.9999975000f)
 #define    ALPH_400SR_0p01CF    (0.0000249994f)        // 0.01Hz corner freq @ 400Hz sample rate
@@ -192,10 +192,7 @@
 #define    BETA_400SR_400CF     (0.5000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   500Hz (2ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 500Hz (2ms) sample rate. */
 #define    ALPH_500SR_0p001CF   (0.0000020000f)        // 0.001Hz corner freq @ 500Hz sample rate
 #define    BETA_500SR_0p001CF   (0.9999980000f)
 #define    ALPH_500SR_0p01CF    (0.0000199996f)        // 0.01Hz corner freq @ 500Hz sample rate
@@ -234,10 +231,7 @@
 #define    BETA_500SR_500CF     (0.5000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   1000Hz (1ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 1000Hz (1ms) sample rate. */
 #define    ALPH_1000SR_0p001CF  (0.0000010000f)     // 0.001Hz corner freq @ 1000Hz sample rate
 #define    BETA_1000SR_0p001CF  (0.9999990000f)
 #define    ALPH_1000SR_0p01CF   (0.0000099999f)     // 0.01Hz corner freq @ 1000Hz sample rate
@@ -278,10 +272,7 @@
 #define    BETA_1000SR_1000CF   (0.50000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   2000Hz (0.5ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 2000Hz (0.5ms) sample rate. */
 #define    ALPH_2000SR_0p001CF  (0.0000005000f)        // 0.001Hz corner freq @ 2000Hz sample rate
 #define    BETA_2000SR_0p001CF  (0.9999995000f)
 #define    ALPH_2000SR_0p01CF   (0.0000050000f)        // 0.01Hz corner freq @ 2000Hz sample rate
@@ -324,10 +315,7 @@
 #define    BETA_2000SR_2000CF   (0.50000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   4000Hz (0.25ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for a 4000Hz (0.25ms) sample rate. */
 #define    ALPH_4000SR_0p001CF  (0.0000002500f)        // 0.001Hz corner freq @ 4000Hz sample rate
 #define    BETA_4000SR_0p001CF  (0.9999997500f)
 #define    ALPH_4000SR_0p01CF   (0.0000025000f)        // 0.01Hz corner freq @ 4000Hz sample rate
@@ -372,10 +360,7 @@
 #define    BETA_4000SR_4000CF   (0.50000000000f)
 
 
-// Low Pass Filter Coefficients
-//   Alpha = (Fc/Fs)/(1 + Fc/Fs)
-//   Beta = 1.0 - Alpha
-//   8000Hz (0.125ms) Sample Rate
+/** Single-pole low-pass filter coefficients (see the 100Hz table above for the naming convention and formula), precomputed for an 8000Hz (0.125ms) sample rate. */
 #define    ALPH_8000SR_0p001CF  (0.0000001250f)        // 0.001Hz corner freq @ 8000Hz sample rate
 #define    BETA_8000SR_0p001CF  (0.9999998750f)
 #define    ALPH_8000SR_0p01CF   (0.0000012500f)        // 0.01Hz corner freq @ 8000Hz sample rate
@@ -432,135 +417,223 @@
 // #define I_BETA           91          // = ALPHA_PLUS_BETA - I_ALPHA
 // #define ALPHA_PLUS_BETA  100
 
-#define ACCUM_WORD_NBITS            32        // Bit size of IIR accumulator
-#define MAX_NUMBER_IIR_CHANNELS     10
+#define ACCUM_WORD_NBITS            32        //!< Bit size of IIR accumulator
+#define MAX_NUMBER_IIR_CHANNELS     10         //!< Maximum number of channels supported by iif_filter_t
 
+/** Configuration for a fixed-point IIR low-pass filter bank (see iif_filter_t). */
 typedef struct
-{   
-    float Fs;                       // (Hz) sample frequency
-    float Fc;                       // (Hz) corner frequency
-    unsigned int n_channels;        // number of channels in filter (i.e. ADC channels)
-    unsigned int input_size;        // input buffer length (= n_channels * n_input_samples)
-    unsigned int sig_word_nbits;    // (bits) input signal resolution bit size
-    
-     unsigned int bit_shift;        // bits to shift ADC int to IIR fixed point
+{
+    float Fs;                       //!< Sample frequency (Hz)
+    float Fc;                       //!< Corner frequency (Hz)
+    unsigned int n_channels;        //!< Number of channels in filter (i.e. ADC channels)
+    unsigned int input_size;        //!< Input buffer length (= n_channels * n_input_samples)
+    unsigned int sig_word_nbits;    //!< Input signal resolution bit size (bits)
+
+    unsigned int bit_shift;         //!< Bits to shift ADC int to IIR fixed point
 //     int gama_x;                  // = alpha_x + beta_x
 //     unsigned int adc_to_iir;     // = 2^bit_shift
-    float iir_to_adc;               // = 1/adc_to_iir
+    float iir_to_adc;               //!< = 1/adc_to_iir
 //     unsigned int alpha;          // = TsFc/(1 + TsFc)*alpha_plus_beta, sample period (Ts) and corner freq (Fc).  0.001*100/(1 + 0.001*100)*100 = 0.0909
-    int alpha_x;                    // = alpha*adc_to_iir
-    int beta;                       // = alpha_plus_beta - alpha;
+    int alpha_x;                    //!< = alpha*adc_to_iir
+    int beta;                       //!< = alpha_plus_beta - alpha
 } iir_options_t;
 
 
 
+/** Fixed-point IIR low-pass filter bank state: configuration plus one accumulator per channel. */
 typedef struct
-{   
-    iir_options_t opt;
-    int accum[MAX_NUMBER_IIR_CHANNELS];
+{
+    iir_options_t opt;                          //!< Filter configuration
+    int accum[MAX_NUMBER_IIR_CHANNELS];         //!< Per-channel fixed-point accumulator state
 } iif_filter_t;
 
 
-typedef struct  
-{   
-    int         count;              // Sample count
-    double      mean;               // input average
+/** Running-mean filter state: sample count plus the current mean. */
+typedef struct
+{
+    int         count;              //!< Sample count
+    double      mean;               //!< Input average
 } rmean_filter_t;
 
 
 //_____ P R O T O T Y P E S ________________________________________________
 
+/**
+ * @brief Initialize (zero) an IIR filter bank's accumulator state.
+ * @param f Filter bank to initialize; f->opt must already be configured.
+ */
 void init_iir_filter(iif_filter_t *f);
 
+/**
+ * @brief Run one sample through a fixed-point IIR low-pass filter bank, uint16 input.
+ * @param f      Filter bank state (configuration + accumulators).
+ * @param input  Input sample, one value per channel (length f->opt.n_channels).
+ * @param output Output: filtered value per channel (length f->opt.n_channels).
+ */
 void iir_filter_u16(iif_filter_t *f, unsigned short input[], float output[]);
+
+/**
+ * @brief Run one sample through a fixed-point IIR low-pass filter bank, int16 input.
+ * @param f      Filter bank state (configuration + accumulators).
+ * @param input  Input sample, one value per channel (length f->opt.n_channels).
+ * @param output Output: filtered value per channel (length f->opt.n_channels).
+ */
 void iir_filter_s16(iif_filter_t *f, short input[], float output[]);
 
 
-/** 
- * \brief Running Average Filter
- *  A running average of the input array is collected in the mean array.  Filter
- *  is reset when sampleCount equals 0.
+/**
+ * @brief Running Average Filter.
+ * A running average of the input array is collected in the mean array. Filter
+ * is reset when sampleCount equals 0.
  *
- * \param mean          Average of input
- * \param input         Floating point value to be included in the average.
- * \param arraySize     Array length of mean and input arrays.
- * \param sampleCount   Sample number of input.  0 causes filter to be reset.
+ * @param input         Floating point value(s) to be included in the average.
+ * @param mean          Average of input; updated in place.
+ * @param arraySize     Array length of mean and input arrays.
+ * @param sampleCount   Sample number of input. 0 causes filter to be reset.
  */
-void running_mean_filter(float mean[], float input[], int arraySize, int sampleCount);
+void running_mean_filter(float input[], float mean[], int arraySize, int sampleCount);
 
 
-/** 
- * \brief Running Average Filter (double)
- *  A running average of the input array is collected in the mean array.  Filter
- *  is reset when sampleCount equals 0.
+/**
+ * @brief Running Average Filter (double).
+ * A running average of the input array is collected in the mean array. Filter
+ * is reset when sampleCount equals 0.
  *
- * \param mean          Average of input
- * \param input         Double (float 64) value to be included in the average.
- * \param arraySize     Array length of mean and input arrays.
- * \param sampleCount   Sample number of input.  0 causes filter to be reset.
+ * @param mean          Average of input; updated in place.
+ * @param input         Double (float 64) value(s) to be included in the average.
+ * @param arraySize     Array length of mean and input arrays.
+ * @param sampleCount   Sample number of input. 0 causes filter to be reset.
  */
 void running_mean_filter_f64(double mean[], float input[], int arraySize, int sampleCount);
 
 /**
- * \brief Recursive Moving Average and Variance Filter
+ * @brief Recursive Moving Average and Variance Filter.
  * Recursive computation of expected moving average and variance given their previous
  * values, new element in the set, number of elements in the set (window size) and
  * assuming that one of the elements in the set is removed when new one is
  * added (i.e. fixed window size).
  * Reference: http://math.stackexchange.com/questions/1063962/how-can-i-recursively-approximate-a-moving-average-and-standard-deviation
  *
- * \param mean          Moving average of the set
- * \param var           Moving variance of the set
- * \param input         Floating point value added to the set
-  * \param sampleCount   Number of samples in the sliding window
-*/
+ * @param mean          Moving average of the set; updated in place.
+ * @param var           Moving variance of the set; updated in place.
+ * @param input         Floating point value added to the set.
+ * @param sampleCount   Number of samples in the sliding window.
+ */
 void recursive_moving_mean_var_filter(float *mean, float *var, float input, int sampleCount);
 
-// Condense multiple IMUs down to one IMU
+/**
+ * @brief Condense multiple IMUs' samples down to a single averaged IMU sample.
+ * @param result     Output: averaged IMU sample.
+ * @param imus       Input: multiple IMUs' samples (numDevices of them).
+ * @param numDevices Number of IMU devices (and samples) in imus.
+ */
 void multiToSingleImu(imu_t *result, const imus_t *imus, const int numDevices);
-int multiToSingleImuExc(imu_t *result, const imus_t *di, const int numDevices, bool *exclude); // for individual IMU exclusion
-void multiToSingleImuAxis(imu_t* result, const imus_t* di, const int numDevices, bool exclude_gyro[3], bool exclude_acc[3], int iaxis);  // for individual gyro/accelerometer (per axis) exclusion
 
-// Duplicate one IMU to multiple IMUs
+/**
+ * @brief Condense multiple IMUs' samples down to a single averaged IMU sample, excluding individual IMUs.
+ * @param result     Output: averaged IMU sample.
+ * @param di         Input: multiple IMUs' samples (numDevices of them).
+ * @param numDevices Number of IMU devices (and samples) in di.
+ * @param exclude    Per-IMU exclusion flags (length numDevices); true excludes that IMU from the average.
+ * @return 1 on success, 0 on failure (e.g. all IMUs excluded).
+ */
+int multiToSingleImuExc(imu_t *result, const imus_t *di, const int numDevices, bool *exclude);
+
+/**
+ * @brief Condense multiple IMUs' samples down to a single averaged IMU sample, excluding individual gyro/accelerometer axes.
+ * @param result       Output: averaged IMU sample.
+ * @param di           Input: multiple IMUs' samples (numDevices of them).
+ * @param numDevices   Number of IMU devices (and samples) in di.
+ * @param exclude_gyro Per-axis gyro exclusion flags (X/Y/Z); true excludes that axis from the average.
+ * @param exclude_acc  Per-axis accelerometer exclusion flags (X/Y/Z); true excludes that axis from the average.
+ * @param iaxis        Axis index (0=X, 1=Y, 2=Z) being processed by this call.
+ */
+void multiToSingleImuAxis(imu_t* result, const imus_t* di, const int numDevices, bool exclude_gyro[3], bool exclude_acc[3], int iaxis);
+
+/**
+ * @brief Duplicate one IMU sample to fill a multi-IMU (imus_t) sample.
+ * @param result     Output: multi-IMU sample with every device set to imu.
+ * @param imu        Input: single IMU sample to duplicate.
+ * @param numDevices Number of IMU devices to fill in result.
+ */
 void singleToMultiImu(imus_t *result, imu_t *imu, const int numDevices);
 
-// Convert integrated IMU to IMU. Returns 1 on success, 0 on failure (e.g. when dt == 0).
+/**
+ * @brief Convert a preintegrated IMU (PIMU) sample to an integer-count IMU sample (imui_t).
+ * @param imu   Output: IMU sample as integer counts.
+ * @param pImu  Input: preintegrated IMU (delta theta/velocity + integration period).
+ * @param divDt Reciprocal of the integration period (1/dt) used to convert deltas back to rates.
+ * @return 1 on success, 0 on failure (e.g. when dt == 0).
+ */
 int preintegratedImuToImuI(imui_t *imu, const pimu_t *pImu, float divDt);
+
+/**
+ * @brief Convert a preintegrated IMU (PIMU) sample to a rate-based IMU sample.
+ * @param imu    Output: IMU sample as angular rate/acceleration.
+ * @param imuInt Input: preintegrated IMU (delta theta/velocity + integration period).
+ * @return 1 on success, 0 on failure (e.g. when dt == 0).
+ */
 int preintegratedImuToImu(imu_t *imu, const pimu_t *imuInt);
+
+/**
+ * @brief Convert a rate-based IMU sample to a preintegrated IMU (PIMU) sample.
+ * @param pImu Output: preintegrated IMU (delta theta/velocity + integration period).
+ * @param imu  Input: IMU sample as angular rate/acceleration.
+ * @param dt   Integration period (seconds) to scale the rates into deltas.
+ * @return 1 on success, 0 on failure (e.g. when dt == 0).
+ */
 int imuToPreintegratedImu(pimu_t *pImu, const imu_t *imu, float dt);
 
+/**
+ * @brief Compute the coning-and-sculling (preintegration) delta theta/velocity between two IMU samples via Riemann-sum integration.
+ * @param output  Output: coning-and-sculling integral (delta theta/velocity).
+ * @param imu     Current gyro and accelerometer sample.
+ * @param imuLast Previous gyro and accelerometer sample.
+ * @return The integration period (dt, seconds) between imuLast and imu.
+ */
 float deltaThetaDeltaVelRiemannSum( pimu_t *output, imu_t *imu, imu_t *imuLast );
+
+/**
+ * @brief Compute the coning-and-sculling (preintegration) delta theta/velocity between two IMU samples via trapezoidal integration.
+ * @param output  Output: coning-and-sculling integral (delta theta/velocity).
+ * @param imu     Current gyro and accelerometer sample.
+ * @param imuLast Previous gyro and accelerometer sample.
+ * @return The integration period (dt, seconds) between imuLast and imu.
+ */
 float deltaThetaDeltaVelTrapezoidal( pimu_t *output, imu_t *imu, imu_t *imuLast );
 
-/** 
- * \brief Compute coning and sculling integrals from gyro and accelerometer samples
+/**
+ * @brief Compute coning and sculling integrals from gyro and accelerometer samples.
  *
- * \param output        Coning and sculling integral
- * \param imu           Gyro and accelerometer sample.
- * \param imuLast       Previous gyro and accelerometer sample.
+ * @param output        Coning and sculling integral
+ * @param imu           Gyro and accelerometer sample.
+ * @param imuLast       Previous gyro and accelerometer sample.
  */
 void integratePimu(pimu_t *output, imu_t *imu, imu_t *imuLast);
 
-/** 
- * \brief Compute coning and sculling integrals from multiple gyro and accelerometer samples
+/**
+ * @brief Compute coning and sculling integrals from multiple gyro and accelerometer samples.
  *
- * \param pimuOut       Coning and sculling integral output array
- * \param pimuCnt       Number of elements in pimuOut array
- * \param imusIn        Array of gyro and accelerometer samples.
- * \param imuLastArray  Array of previous gyro and accelerometer samples.
+ * @param pimuArray     Coning and sculling integral output array
+ * @param arraySize     Number of elements in pimuArray
+ * @param imusIn        Array of gyro and accelerometer samples.
+ * @param imuLastArray  Array of previous gyro and accelerometer samples.
  */
-void integrateImusIntoPimuArray(pimu_t pimuOut[MAX_IMU_DEVICES], const int pimuCnt, const imus_t *imusIn, imu_t imuLastArray[MAX_IMU_DEVICES]);
+void integrateImusIntoPimuArray(pimu_t pimuArray[MAX_IMU_DEVICES], const int arraySize, const imus_t *imusIn, imu_t imuLastArray[MAX_IMU_DEVICES]);
 
-// Set integral, time, and status to zero
+/**
+ * @brief Zero out a preintegrated IMU sample's integral, time, and status fields.
+ * @param pimu Preintegrated IMU sample to clear.
+ */
 void zeroPimu(pimu_t *pimu);
 
-/** 
- * \brief Find alpha and beta parameters for single pole Low-Pass filter
+/**
+ * @brief Find alpha and beta parameters for a single-pole low-pass filter.
  *
- * \param dt            (sec) Update period
- * \param cornerFreq    (Hz) Low-pass filter corner frequency
- * \param alpha         Filter alpha parameter (input gain)
- * \param beta          Filter beta parameter (memory gain)
+ * @param dt            Update period (seconds)
+ * @param cornerFreqHz  Low-pass filter corner frequency (Hz)
+ * @param alpha         Output: filter alpha parameter (input gain)
+ * @param beta          Output: filter beta parameter (memory gain)
  */
 static __inline void lpf_alpha_beta(float dt, float cornerFreqHz, float *alpha, float *beta)
 {
@@ -570,32 +643,94 @@ static __inline void lpf_alpha_beta(float dt, float cornerFreqHz, float *alpha, 
 }
 
 
-// LPF zero order:                                            val = beta*lastVal + alpha*input
+/**
+ * @brief Zero-order single-pole low-pass filter: val = beta*lastVal + alpha*input.
+ * @param val   Filter output and running state; updated in place.
+ * @param input New input sample.
+ * @param alph  Filter alpha parameter (input gain), from lpf_alpha_beta().
+ * @param beta  Filter beta parameter (memory gain), from lpf_alpha_beta().
+ */
 #define O0_LP_FILTER(val,input,alph,beta)                    (val = (((beta)*(val)) + ((alph)*(input))))
 
-// LPF first order model coefficient:                        c = beta*c + alph*((input - val) / dt)        (dt long)
-// LPF input into state estimate:                            val = beta*((val) + c*dt) + alph*input        (dt short)
+/**
+ * @brief First-order single-pole low-pass filter with an explicit model-coefficient state (for larger dt).
+ * Updates the model coefficient c = beta*c + alph*((input - val) / dt), then the state estimate
+ * val = beta*(val + c*dt) + alph*input.
+ * @param val   Filter output and running state; updated in place.
+ * @param input New input sample.
+ * @param alph  Filter alpha parameter (input gain), from lpf_alpha_beta().
+ * @param beta  Filter beta parameter (memory gain), from lpf_alpha_beta().
+ * @param c     Model-coefficient state; updated in place.
+ * @param dt    Time since the last update (seconds).
+ */
 #define O1_LP_FILTER(val,input,alph,beta,c,dt)                { c = beta*c + alph*((input-val)/dt);   val = beta*(val + c*dt) + alph*input; }
 
 
-// Propagate filter estimate when no input is available
+/**
+ * @brief Propagate a first-order filter's state estimate forward when no new input is available (shorter dt).
+ * @param val   Filter output and running state; updated in place.
+ * @param input Unused (kept for macro-call-site symmetry with @ref O1X_LP_FILTER).
+ * @param c     Model-coefficient state from the most recent @ref O1X_LP_FILTER update.
+ * @param dt    Time since the last update (seconds).
+ */
 #define O1X_LP_FILTER_NO_INPUT(val,input,c,dt)                { val = val + c*dt; }                        // (shorter dt)
-    
-// LPF first order model coefficient:                        c = beta*c + alph*((input - val2) / dt2)
-// LPF input into state estimate:                            val = val2 = beta*((val2) + c*dt2) + alph*input
+
+/**
+ * @brief First-order single-pole low-pass filter maintaining two synchronized state copies (val, val2).
+ * Updates the model coefficient c = beta*c + alph*((input - val2) / dt2), then both state copies:
+ * val = val2 = beta*(val2 + c*dt2) + alph*input.
+ * @param val   Filter output; set equal to val2 after update.
+ * @param val2  Filter running state; updated in place, then copied to val.
+ * @param input New input sample.
+ * @param alph  Filter alpha parameter (input gain), from lpf_alpha_beta().
+ * @param beta  Filter beta parameter (memory gain), from lpf_alpha_beta().
+ * @param c     Model-coefficient state; updated in place.
+ * @param dt2   Time since the last update (seconds).
+ */
 #define O1X_LP_FILTER(val,val2,input,alph,beta,c,dt2)        { c = beta*c + alph*((input-val2)/dt2);   val = val2 = beta*(val2 + c*dt2) + alph*input; }
 
 
+/**
+ * @brief Vector-3 (per-axis) version of @ref O0_LP_FILTER.
+ * @param val   3-element filter output/state array; updated in place.
+ * @param input 3-element new input sample.
+ * @param alph  Filter alpha parameter (input gain).
+ * @param beta  Filter beta parameter (memory gain).
+ */
 #define O0_LPF_VEC3(val,input,alph,beta)                   {O0_LP_FILTER(val[0],input[0],alph,beta); \
                                                             O0_LP_FILTER(val[1],input[1],alph,beta); \
                                                             O0_LP_FILTER(val[2],input[2],alph,beta);}
+/**
+ * @brief Vector-3 (per-axis) version of @ref O1X_LP_FILTER_NO_INPUT.
+ * @param val   3-element filter output/state array; updated in place.
+ * @param input Unused (kept for macro-call-site symmetry with @ref O1X_LPF_VEC3).
+ * @param c     3-element model-coefficient state array from the most recent @ref O1X_LPF_VEC3 update.
+ * @param dt    Time since the last update (seconds).
+ */
 #define O1X_LPF_VEC3_NO_INPUT(val,input,c,dt)               {O1X_LP_FILTER_NO_INPUT(val[0],input[0],c[0],dt); \
                                                             O1X_LP_FILTER_NO_INPUT(val[1],input[1],c[1],dt); \
                                                             O1X_LP_FILTER_NO_INPUT(val[2],input[2],c[2],dt);}
+/**
+ * @brief Vector-3 (per-axis) version of @ref O1X_LP_FILTER.
+ * @param val   3-element filter output array; set equal to val2 after update.
+ * @param val2  3-element filter running state array; updated in place, then copied to val.
+ * @param input 3-element new input sample.
+ * @param alph  Filter alpha parameter (input gain).
+ * @param beta  Filter beta parameter (memory gain).
+ * @param c     3-element model-coefficient state array; updated in place.
+ * @param dt2   Time since the last update (seconds).
+ */
 #define O1X_LPF_VEC3(val,val2,input,alph,beta,c,dt2)       {O1X_LP_FILTER(val[0],val2[0],input[0],alph,beta,c[0],dt2); \
                                                             O1X_LP_FILTER(val[1],val2[1],input[1],alph,beta,c[1],dt2); \
                                                             O1X_LP_FILTER(val[2],val2[2],input[2],alph,beta,c[2],dt2);}
 
+/**
+ * @brief Compute alpha/beta from dt and corner frequency, then apply one zero-order low-pass filter update.
+ * @param val          Filter output and running state; updated in place.
+ * @param input        New input sample.
+ * @param dt           Time since the last update (seconds).
+ * @param cornerFreqHz Low-pass filter corner frequency (Hz).
+ */
 static __inline void lpf_filter(float *val, float input, float dt, float cornerFreqHz)
 {
     float alph, beta;

--- a/src/imx_defaults.h
+++ b/src/imx_defaults.h
@@ -1,3 +1,16 @@
+/**
+ * @file imx_defaults.h
+ * @brief IMX-5/IMX-6 default navigation output periods and platform-config helper functions.
+ *
+ * Defines the minimum (fastest) navigation-output periods for each IMX hardware variant and
+ * operating mode (NAV/AHRS/VRS), selects the active set via the IMX_5 build flag, and declares
+ * the platformConfig <-> nvm_flash_cfg_t IO-config conversion helpers used at startup and when
+ * applying a platform-type preset.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef __IMX_DEFAULTS_H_
 #define __IMX_DEFAULTS_H_
 
@@ -9,36 +22,80 @@ extern "C" {
 
 #include "data_sets.h"
 
-#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE    7       // W/ GPS
-#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE   5       // No GPS
-#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE    4       // No GPS or magnetometer
+/** IMX-5 minimum (fastest) navigation-output periods (ms) per operating mode. */
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE    7       //!< W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE   5       //!< No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE    4       //!< No GPS or magnetometer
 
-#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE    2       // W/ GPS
-#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE   2       // No GPS
-#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE    2       // No GPS or magnetometer
+/** IMX-6 minimum (fastest) navigation-output periods (ms) per operating mode. */
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE    2       //!< W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE   2       //!< No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE    2       //!< No GPS or magnetometer
 
+/** Active navigation-output period set (ms), selected at build time by the IMX_5 flag. */
 #if defined(IMX_5)
-#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE     // W/ GPS
-#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE    // No GPS
-#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE     // No GPS or magnetometer
-#define tNAV_DEFAULT_PERIOD_MS                  tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE          // Reliable / safe period for operation
+#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_NAV_MODE     //!< W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_AHRS_MODE    //!< No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX5_MS_VRS_MODE     //!< No GPS or magnetometer
+#define tNAV_DEFAULT_PERIOD_MS                  tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE          //!< Reliable / safe period for operation
 #else   // IMX_6
-#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE     // W/ GPS
-#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE    // No GPS
-#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE     // No GPS or magnetometer
-#define tNAV_DEFAULT_PERIOD_MS                  5                                           // Reliable / safe period for operation
+#define tNAV_MIN_OUTPUT_PERIOD_MS_NAV_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_NAV_MODE     //!< W/ GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_AHRS_MODE     tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_AHRS_MODE    //!< No GPS
+#define tNAV_MIN_OUTPUT_PERIOD_MS_VRS_MODE      tNAV_MIN_OUTPUT_PERIOD_IMX6_MS_VRS_MODE     //!< No GPS or magnetometer
+#define tNAV_DEFAULT_PERIOD_MS                  5                                           //!< Reliable / safe period for operation
 #endif
 
-#define tMAINT_MAX_RUN_TIME_US                  100000                                      // Used to increment gap count and indicate error
+#define tMAINT_MAX_RUN_TIME_US                  100000                                      //!< Maximum maintenance-task run time (us); used to increment gap count and indicate error
 
 
+/**
+ * @brief Check whether a platformConfig value's platform-type field names a valid, known platform.
+ * @param platformConfig Raw platformConfig value (see @ref ePlatformConfig / PLATFORM_CFG_TYPE_MASK).
+ * @return Non-zero if the platform type is valid, 0 otherwise.
+ */
 int imxPlatformConfigTypeValid(uint32_t platformConfig);
+
+/**
+ * @brief Validate a platformConfig value in place, resetting it to a known-good default if invalid.
+ * @param platformConfig Pointer to the platformConfig value to check and, if necessary, correct.
+ */
 void imxPlatformConfigErrorCheck(uint32_t *platformConfig);
+
+/**
+ * @brief Derive the nvm_flash_cfg_t IO-config fields implied by a full platformConfig value.
+ * @param ioConfig     Output: primary IO configuration bitmask (see nvm_flash_cfg_t::ioConfig).
+ * @param ioConfig2    Output: secondary IO configuration bitmask (see nvm_flash_cfg_t::ioConfig2).
+ * @param platformConfig Input platformConfig value to derive the IO configuration from.
+ */
 void imxPlatformConfigToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t *ioConfig2, uint32_t platformConfig);
+
+/**
+ * @brief Derive the nvm_flash_cfg_t IO-config fields implied by just a platform-type value.
+ * @param ioConfig    Output: primary IO configuration bitmask (see nvm_flash_cfg_t::ioConfig).
+ * @param ioConfig2   Output: secondary IO configuration bitmask (see nvm_flash_cfg_t::ioConfig2).
+ * @param platformType Platform-type value (see ePlatformConfig's PLATFORM_CFG_TYPE_MASK field).
+ */
 void imxPlatformConfigTypeToFlashCfgIoConfig(uint32_t *ioConfig, uint8_t* ioConfig2, uint32_t platformType);
+
+/**
+ * @brief Get the default platformConfig value for a given platform type.
+ * @param platformType Platform-type value (see ePlatformConfig's PLATFORM_CFG_TYPE_MASK field).
+ * @return Default platformConfig value for that platform type.
+ */
 uint32_t imxPlatformConfigTypeToDefaultPlatformConfig(uint32_t platformType);
+
+/**
+ * @brief Get the default platformConfig preset (hardware wiring/pinout variant) for a given platform type.
+ * @param platformType Platform-type value (see ePlatformConfig's PLATFORM_CFG_TYPE_MASK field).
+ * @return Default preset value for that platform type (0 for types without multiple presets, e.g. non-RUG3).
+ */
 uint32_t imxPlatformConfigTypeToDefaultPlatformPreset(uint32_t platformType);
 
+/**
+ * @brief Compute the minimum allowed navigation-output period (ms) for the device's current configuration.
+ * @param cfg Pointer to the device's current flash configuration.
+ * @return Minimum navigation-output period in milliseconds, given cfg's platform type and enabled sensors.
+ */
 uint32_t imxMinNavOutputMs(nvm_flash_cfg_t *cfg);
 
 

--- a/src/luna_data_sets.h
+++ b/src/luna_data_sets.h
@@ -1,6 +1,19 @@
-/*
-Copyright 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-*/
+/**
+ * @file luna_data_sets.h
+ * @brief Data Identification Number (DID) payloads for the EVB-2 "Luna" autonomous-vehicle add-on board.
+ *
+ * Luna is an EVB-2 daughterboard/firmware profile for differential-drive autonomous vehicles (e.g.
+ * robotic mowers): it adds wheel velocity control, remote-kill safety interlocks, bump/proximity
+ * sensing, and geofencing on top of the standard EVB-2 DID set. As with the main data_sets.h, each
+ * DID_EVB_LUNA_* macro's trailing comment names the payload type it carries, and payloads are never
+ * reordered or reused since they are part of the wire protocol.
+ *
+ * Unless otherwise noted: linear velocities are in meters/second, angular velocities are in
+ * radians/second, and positions given as latitude/longitude are in degrees.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
 
 #ifndef LUNA_DATA_SETS_H
 #define LUNA_DATA_SETS_H
@@ -16,484 +29,390 @@ extern "C" {
 #endif
 
 
-#define DID_EVB_LUNA_FLASH_CFG          (eDataIDs)110 /** (evb_luna_flash_cfg_t) EVB Luna configuration. */
-#define DID_EVB_LUNA_STATUS             (eDataIDs)111 /** (evb_luna_status_t) EVB Luna status. */
-#define DID_EVB_LUNA_SENSORS            (eDataIDs)112 /** (evb_luna_sensors_t) EVB Luna sensors (proximity, etc.). */
-#define DID_EVB_LUNA_REMOTE_KILL        (eDataIDs)113 /** (evb_luna_remote_kill_t) EVB remoteKill system */
-#define DID_EVB_LUNA_VELOCITY_CONTROL   (eDataIDs)114 /** (evb_luna_velocity_control_t) EVB wheel control information */
-#define DID_EVB_LUNA_VELOCITY_COMMAND   (eDataIDs)115 /** (evb_luna_velocity_command_t) EVB velocity command */
-#define DID_EVB_LUNA_AUX_COMMAND        (eDataIDs)116 /** (evb_luna_aux_command_t) EVB auxillary commands */
-#define DID_LUNA_COUNT                  (eDataIDs)117                /** Make larger than all Luna DIDs */
+#define DID_EVB_LUNA_FLASH_CFG          (eDataIDs)110 //!< (evb_luna_flash_cfg_t) EVB Luna configuration.
+#define DID_EVB_LUNA_STATUS             (eDataIDs)111 //!< (evb_luna_status_t) EVB Luna status.
+#define DID_EVB_LUNA_SENSORS            (eDataIDs)112 //!< (evb_luna_sensors_t) EVB Luna sensors (proximity, etc.).
+#define DID_EVB_LUNA_REMOTE_KILL        (eDataIDs)113 //!< (evb_luna_remote_kill_t) EVB remoteKill system
+#define DID_EVB_LUNA_VELOCITY_CONTROL   (eDataIDs)114 //!< (evb_luna_velocity_control_t) EVB wheel control information
+#define DID_EVB_LUNA_VELOCITY_COMMAND   (eDataIDs)115 //!< (evb_luna_velocity_command_t) EVB velocity command
+#define DID_EVB_LUNA_AUX_COMMAND        (eDataIDs)116 //!< (evb_luna_aux_command_t) EVB auxillary commands
+#define DID_LUNA_COUNT                  (eDataIDs)117                //!< Sentinel: made larger than all Luna DIDs
 
 
 PUSH_PACK_1
 
 
 
+/** Config bits for evb_luna_flash_cfg_t::bits: enables individual Luna subsystems. */
 typedef enum
 {
-    EVB_LUNA_CFG_BITS_ENABLE_SS_GEOFENCE                = 0x00000001,
-    EVB_LUNA_CFG_BITS_ENABLE_SS_BUMP_ADC                = 0x00000002,
-    EVB_LUNA_CFG_BITS_ENABLE_SS_PROXIMITY               = 0x00000004,
-    EVB_LUNA_CFG_BITS_ENABLE_SS_BUMP_I2C                = 0x00000008,
-    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL              = 0x00000100,    // On vehicle
-    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_1     = 0x00000200,    // External buttons
-    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_2     = 0x00000400,    // No external buttons
-    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_MASK  = 0x00000600,
+    EVB_LUNA_CFG_BITS_ENABLE_SS_GEOFENCE                = 0x00000001,   //!< Enable geofence boundary enforcement
+    EVB_LUNA_CFG_BITS_ENABLE_SS_BUMP_ADC                = 0x00000002,   //!< Enable analog (ADC) bump sensors
+    EVB_LUNA_CFG_BITS_ENABLE_SS_PROXIMITY               = 0x00000004,   //!< Enable proximity (range) sensors
+    EVB_LUNA_CFG_BITS_ENABLE_SS_BUMP_I2C                = 0x00000008,   //!< Enable I2C bump sensors
+    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL              = 0x00000100,   //!< Enable remote-kill subsystem (on vehicle)
+    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_1     = 0x00000200,   //!< Remote-kill client 1: external buttons
+    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_2     = 0x00000400,   //!< Remote-kill client 2: no external buttons
+    EVB_LUNA_CFG_BITS_ENABLE_SS_REMOTEKILL_CLIENT_MASK  = 0x00000600,   //!< Mask of both remote-kill client bits
 } eEvbLunaFlashCfgBits;
 
 
+/** Wheel-motor control scheme, selected by evb_luna_velocity_control_cfg_t::config (masked by TYPE_MASK). */
 typedef enum
 {
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_UNDEFINED             = 0,
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_HOVERBOT              = 1,
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_ZERO_TURN             = 2,
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_PWM                   = 3,
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_Z1R                   = 4,
-    EVB_WHEEL_CONTROL_CONFIG_TYPE_MASK                  = 0x00000007,
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_UNDEFINED             = 0,             //!< Not configured
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_HOVERBOT              = 1,             //!< Hoverboard-motor-derived control
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_ZERO_TURN             = 2,             //!< Zero-turn-radius (skid-steer) control
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_PWM                   = 3,             //!< Direct PWM duty-cycle control
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_Z1R                   = 4,             //!< Z1R actuator control
+    EVB_WHEEL_CONTROL_CONFIG_TYPE_MASK                  = 0x00000007,    //!< Mask isolating the control-type field
 } eEvbLunaWheelControlConfig_t;
 
 
+/** Vehicle-level (as opposed to per-wheel) velocity-control tuning parameters. */
 typedef struct
 {
-    /** Forward velocity (m/s) */
-    float   u_min;
-    float   u_cruise;
-    float   u_max;
-    float   u_slewLimit;
+    float   u_min;              //!< Forward velocity, minimum (m/s)
+    float   u_cruise;           //!< Forward velocity, cruise/nominal (m/s)
+    float   u_max;               //!< Forward velocity, maximum (m/s)
+    float   u_slewLimit;         //!< Forward velocity, commanded slew-rate limit (m/s)
 
-    /** Turn rate velocity (rad/s) */
-    float   w_max_autonomous;
-    float   w_max;
-    float   w_slewLimit;
+    float   w_max_autonomous;    //!< Turn-rate velocity, maximum while under autonomous control (rad/s)
+    float   w_max;               //!< Turn-rate velocity, maximum (rad/s)
+    float   w_slewLimit;         //!< Turn-rate velocity, commanded slew-rate limit (rad/s)
 
-    /** Test sweep rate (m/s/s) */
-    float   testSweepRate;
+    float   testSweepRate;       //!< Test sweep rate (m/s/s)
 
-    /** Forward velocity feedback proportional gain */
-    float   u_FB_Kp;
+    float   u_FB_Kp;             //!< Forward velocity feedback proportional gain
 
-    /** Turn rate feedback proportional gain */
-    float   w_FB_Kp;
+    float   w_FB_Kp;             //!< Turn rate feedback proportional gain
 
-    /** Turn rate feedback integral gain */
-    float   w_FB_Ki;
+    float   w_FB_Ki;             //!< Turn rate feedback integral gain
 
-    /** Turn rate feedforward (rad/s) */
-    float   w_FF_c0;
-    float   w_FF_c1;
+    float   w_FF_c0;             //!< Turn rate feedforward coefficient 0 (rad/s)
+    float   w_FF_c1;             //!< Turn rate feedforward coefficient 1 (rad/s)
 
-    /** Turn rate feedforward deadband (rad/s) */
-    float   w_FF_deadband;
+    float   w_FF_deadband;       //!< Turn rate feedforward deadband (rad/s)
 } evb_luna_velocity_control_vehicle_cfg_t;
 
-#define NUM_FF_COEFS    2
-#define NUM_AL_COEFS    5
+#define NUM_FF_COEFS    2   //!< Number of feedforward coefficients per wheel (see evb_luna_velocity_control_wheel_cfg_t)
+#define NUM_AL_COEFS    5   //!< Number of actuator-linearization coefficients per wheel (see evb_luna_velocity_control_wheel_cfg_t)
 
+/** Per-wheel velocity-control tuning parameters: feedforward/feedback gains, actuator linearization, and trim. */
 typedef struct
 {
-    /** Commanded velocity slew rate (rad/s/s) */
-    float   slewRate;
+    float   slewRate;                    //!< Commanded velocity slew rate (rad/s/s)
 
-    /** Commanded velocity max (rad/s) */
-    float   velMax;
+    float   velMax;                      //!< Commanded velocity max (rad/s)
 
-    /** Feedforward deadband (m/s) */
-    float   FF_vel_deadband;
+    float   FF_vel_deadband;             //!< Feedforward deadband (m/s)
 
-    /** Feedforward coefficient estimation gain.  Zero to disable estimation. */
-    float   FF_c_est_Ki[NUM_FF_COEFS];
+    float   FF_c_est_Ki[NUM_FF_COEFS];   //!< Feedforward coefficient estimation gain. Zero to disable estimation.
 
-    /** Feedforward coefficient estimation maximum value */
-    float   FF_c_est_max[NUM_FF_COEFS];
+    float   FF_c_est_max[NUM_FF_COEFS];  //!< Feedforward coefficient estimation maximum value
 
-    /** Feedforward coefficients */
-    float   FF_c_l[NUM_FF_COEFS];
-    float   FF_c_r[NUM_FF_COEFS];
+    float   FF_c_l[NUM_FF_COEFS];        //!< Feedforward coefficients, left wheel
+    float   FF_c_r[NUM_FF_COEFS];        //!< Feedforward coefficients, right wheel
 
-    /** (rpm) Engine RPM corresponding with control gains. */
-    float   FF_FB_engine_rpm;
+    float   FF_FB_engine_rpm;            //!< Engine RPM corresponding with control gains (rpm)
 
-    /** Feedback proportional gain */
-    float   FB_Kp;
+    float   FB_Kp;                       //!< Feedback proportional gain
 
-    /** Feedback integral gain */
-    float   FB_Ki;
+    float   FB_Ki;                       //!< Feedback integral gain
 
-    /** Feedback derivative gain */
-    float   FB_Kd;
+    float   FB_Kd;                       //!< Feedback derivative gain
 
-    /** Feedback deadband - Feedback gains will be linearly reduced down to FB_gain_deadband_reduction at zero. (rad/s) */
-    float   FB_gain_deadband;
-    /** Feedback deadband - Reduce gains by this amount near zero and transition to full gain at and above deadband. */
-    float   FB_gain_deadband_reduction;
+    float   FB_gain_deadband;             //!< Feedback deadband (rad/s): feedback gains are linearly reduced down to FB_gain_deadband_reduction at zero
+    float   FB_gain_deadband_reduction;   //!< Feedback deadband: reduce gains by this amount near zero, transitioning to full gain at and above the deadband
 
-    /** EVB2 velocity Linearization Coefficients */
-    float   InversePlant_l[NUM_AL_COEFS];
-    float   InversePlant_r[NUM_AL_COEFS];
+    float   InversePlant_l[NUM_AL_COEFS]; //!< EVB2 velocity linearization coefficients, left wheel
+    float   InversePlant_r[NUM_AL_COEFS]; //!< EVB2 velocity linearization coefficients, right wheel
 
-    /** Sets actuator zero velocity (center) position relative to home point. */
-    float   actuatorTrim_l;
-    float   actuatorTrim_r;
+    float   actuatorTrim_l;      //!< Sets actuator zero-velocity (center) position relative to home point, left wheel
+    float   actuatorTrim_r;      //!< Sets actuator zero-velocity (center) position relative to home point, right wheel
 
-    /** Wheel controller effort limits for 1. actuator angle or 2. velocity, based on actuator type. */
-    float   actuatorLimits_l[2];
-    float   actuatorLimits_r[2];
+    float   actuatorLimits_l[2]; //!< Wheel controller effort limits for 1. actuator angle or 2. velocity (based on actuator type), left wheel
+    float   actuatorLimits_r[2]; //!< Wheel controller effort limits for 1. actuator angle or 2. velocity (based on actuator type), right wheel
 
-    /** Control effort from zero (trim) before wheels start spinning. */
-    float   actuatorDeadbandDuty_l;
-    float   actuatorDeadbandDuty_r;
-    float   actuatorDeadbandVel;
+    float   actuatorDeadbandDuty_l; //!< Control effort from zero (trim) before the left wheel starts spinning
+    float   actuatorDeadbandDuty_r; //!< Control effort from zero (trim) before the right wheel starts spinning
+    float   actuatorDeadbandVel;    //!< Wheel velocity below which the actuator deadband duty is applied
 } evb_luna_velocity_control_wheel_cfg_t;
 
+/** Top-level wheel-velocity-controller configuration: motor/actuator type, wheel geometry, and vehicle/wheel tuning. */
 typedef struct
 {
-    /** Various config like motor control types, etc. (eEvbLunaWheelControlConfig_t) */
-    uint32_t                                config;
+    uint32_t                                config;         //!< Various config like motor control types, etc. (eEvbLunaWheelControlConfig_t)
 
-    /** Timeout period before motors disable is triggered.*/
-    uint32_t                                cmdTimeoutMs;
+    uint32_t                                cmdTimeoutMs;   //!< Timeout period before motors disable is triggered
 
-    /** (m) Wheel radius */
-    float                                   wheelRadius;
+    float                                   wheelRadius;    //!< Wheel radius (m)
 
-    /** (m) Wheel baseline, distance between wheels */
-    float                                   wheelBaseline;
+    float                                   wheelBaseline;  //!< Wheel baseline, distance between wheels (m)
 
-    /** (rpm) Current engine RPM.  Used for wheel control gain scheduling. */
-    float                                   engine_rpm;
+    float                                   engine_rpm;     //!< Current engine RPM (rpm). Used for wheel control gain scheduling.
 
-    /** Vehicle control */
-    evb_luna_velocity_control_vehicle_cfg_t vehicle;
+    evb_luna_velocity_control_vehicle_cfg_t vehicle;        //!< Vehicle-level velocity control tuning
 
-    /** Wheel control */
-    evb_luna_velocity_control_wheel_cfg_t   wheel;
+    evb_luna_velocity_control_wheel_cfg_t   wheel;          //!< Per-wheel velocity control tuning (shared by both wheels)
 } evb_luna_velocity_control_cfg_t;
 
 /**
-* (DID_EVB_LUNA_FLASH_CFG) EVB-2 Luna specific flash config.
-* This can be up to 4096 bytes in size.  If more is needed, we can adjust the IS SDK EVB-2 project to allocate more.
-*/
-typedef struct
-{  
-    /** Size of this struct */
-    uint32_t    size;
-
-    /** Checksum, excluding size and checksum */
-    uint32_t                        checksum;
-
-    /** Manufacturer method for restoring flash defaults */
-    uint32_t                        key;
-    
-    /** Config bits (see eEvbLunaFlashCfgBits) */
-    uint32_t                        bits;
-
-    /** Geofence Min Latitude **/
-    double                          minLatGeofence;
-    
-    /** Geofence Max Latitude **/
-    double                          maxLatGeofence;
-
-    /** Geofence Min Latitude **/
-    double                          minLonGeofence;
-
-    /** Geofence Max Longitude **/
-    double                          maxLonGeofence;
-    
-    /** Timeout period before motors disable is triggered.*/
-    uint32_t                        remoteKillTimeoutMs;
-
-    /** Bump detection threshhold */
-    float                           bumpSensitivity;
-
-    /** Proximity threshhold for prox error.*/
-    float                           minProxDistance;
-
-    /** Velocity control */
-    evb_luna_velocity_control_cfg_t velControl;
-} evb_luna_flash_cfg_t;
-
-/**
-* (DID_EVB_LUNA_STATUS) EVB-2 Luna status.
-*/
+ * @brief (DID_EVB_LUNA_FLASH_CFG) EVB-2 Luna specific flash config.
+ * This can be up to 4096 bytes in size. If more is needed, we can adjust the IS SDK EVB-2 project to allocate more.
+ */
 typedef struct
 {
-    /** GPS time of week (since Sunday morning) in milliseconds */
-    uint32_t                   timeOfWeekMs;
-    
-    /** Status (eEvbLunaStatus) Reset faults by setting these to zero */
-    uint32_t                evbLunaStatus;
+    uint32_t    size;                              //!< Size of this struct
 
-    /** Motor state (eLunaMotorState) */
-    uint32_t                motorState;
+    uint32_t                        checksum;       //!< Checksum, excluding size and checksum
 
-    /** Remotekill mode (eLunaRemoteKillMode) */
-    uint32_t                remoteKillMode;
+    uint32_t                        key;            //!< Manufacturer method for restoring flash defaults
 
-    /** Supply voltage (V) */
-    float                   supplyVoltage;
+    uint32_t                        bits;           //!< Config bits (see eEvbLunaFlashCfgBits)
+
+    double                          minLatGeofence;  //!< Geofence minimum latitude (degrees)
+
+    double                          maxLatGeofence;  //!< Geofence maximum latitude (degrees)
+
+    double                          minLonGeofence;  //!< Geofence minimum longitude (degrees)
+
+    double                          maxLonGeofence;  //!< Geofence maximum longitude (degrees)
+
+    uint32_t                        remoteKillTimeoutMs; //!< Timeout period before motors disable is triggered
+
+    float                           bumpSensitivity;  //!< Bump detection threshold
+
+    float                           minProxDistance;  //!< Proximity threshold for prox error
+
+    evb_luna_velocity_control_cfg_t velControl;       //!< Velocity control configuration
+} evb_luna_flash_cfg_t;
+
+/** @brief (DID_EVB_LUNA_STATUS) EVB-2 Luna status. */
+typedef struct
+{
+    uint32_t                   timeOfWeekMs;    //!< GPS time of week (since Sunday morning) in milliseconds
+
+    uint32_t                evbLunaStatus;      //!< Status (eEvbLunaStatus). Reset faults by setting these to zero.
+
+    uint32_t                motorState;         //!< Motor state (eLunaMotorState)
+
+    uint32_t                remoteKillMode;     //!< Remotekill mode (eLunaRemoteKillMode)
+
+    float                   supplyVoltage;      //!< Supply voltage (V)
 
 } evb_luna_status_t;
 
+/** Status/error/fault bits for evb_luna_status_t::evbLunaStatus. */
 typedef enum
 {
-    /** Motor command timeout */
-    EVB_LUNA_STATUS_WHEEL_CMD_TIMEOUT       = 0x00000001,
+    EVB_LUNA_STATUS_WHEEL_CMD_TIMEOUT       = 0x00000001,   //!< Motor command timeout
 
-    /** Geofence boundary exceeded */
-    EVB_LUNA_STATUS_ERR_GEOFENCE_EXCEEDED   = 0x00000002,
-        
-    /** Remote kill - motors disabled by remote kill */
-    EVB_LUNA_STATUS_ERR_REMOTE_KILL         = 0x00000004,
-    
-    /** Emergency stop button */
-    EVB_LUNA_STATUS_ERR_ESTOP               = 0x00000008,
-        
-    /** Bump sensor mask */
-    EVB_LUNA_STATUS_ERR_BUMP_MASK           = 0x000000F0,
+    EVB_LUNA_STATUS_ERR_GEOFENCE_EXCEEDED   = 0x00000002,   //!< Geofence boundary exceeded
 
-    /** Bump sensor front */
-    EVB_LUNA_STATUS_ERR_BUMP_FRONT          = 0x00000010,
-    
-    /** Bump sensor back */
-    EVB_LUNA_STATUS_ERR_BUMP_BACK           = 0x00000020,
-    
-    /** Bump sensor left */
-    EVB_LUNA_STATUS_ERR_BUMP_LEFT           = 0x00000040,
+    EVB_LUNA_STATUS_ERR_REMOTE_KILL         = 0x00000004,   //!< Remote kill: motors disabled by remote kill
 
-    /** Bump sensor right */
-    EVB_LUNA_STATUS_ERR_BUMP_RIGHT          = 0x00000080,
-    
-    /** Range Sensor */
-    EVB_LUNA_STATUS_ERR_PROXIMITY           = 0x00000100,
+    EVB_LUNA_STATUS_ERR_ESTOP               = 0x00000008,   //!< Emergency stop button pressed
 
-    /** EVB Error bit mask.  Errors in this mask will stop control. */
-    EVB_LUNA_STATUS_ERR_MASK                = 0x00000FFF,
+    EVB_LUNA_STATUS_ERR_BUMP_MASK           = 0x000000F0,   //!< Mask of all bump-sensor error bits
 
-    /** Wheel encoder fault */
-    EVB_LUNA_STATUS_FAULT_WHEEL_ENCODER     = 0x00001000,
+    EVB_LUNA_STATUS_ERR_BUMP_FRONT          = 0x00000010,   //!< Bump sensor front triggered
 
-    /** Bump sensor not communicating */
-    EVB_LUNA_STATUS_FAULT_BUMP_SENSOR_COM   = 0x00002000,
+    EVB_LUNA_STATUS_ERR_BUMP_BACK           = 0x00000020,   //!< Bump sensor back triggered
 
-    /** Etop button (or interlock) was pressed in the past 10 seconds */
-    EVB_LUNA_STATUS_FAULT_ESTOP_RECENT      = 0x00004000,
+    EVB_LUNA_STATUS_ERR_BUMP_LEFT           = 0x00000040,   //!< Bump sensor left triggered
 
-    /** Mower blade on */
-    EVB_LUNA_STATUS_MOWER_BLADE_ON          = 0x00010000,
+    EVB_LUNA_STATUS_ERR_BUMP_RIGHT          = 0x00000080,   //!< Bump sensor right triggered
 
-    /** Axis is in an invalid state */
-    EVB_LUNA_STATUS_AXIS_ERR_INVALID_STATE  = 0x01000000,
-    
-    /** Watchdog has expired */
-    EVB_LUNA_STATUS_AXIS_ERR_WATCHDOG       = 0x02000000,
-    
-    /** Motor or driver temperature is above limits */
-    EVB_LUNA_STATUS_AXIS_ERR_TEMP           = 0x04000000,
-    
-    /** Axis error bit mask */ 
-    EVB_LUNA_STATUS_AXIS_ERR_MASK           = 0xFF000000,
+    EVB_LUNA_STATUS_ERR_PROXIMITY           = 0x00000100,   //!< Range/proximity sensor triggered
+
+    EVB_LUNA_STATUS_ERR_MASK                = 0x00000FFF,   //!< EVB error bit mask. Errors in this mask will stop control.
+
+    EVB_LUNA_STATUS_FAULT_WHEEL_ENCODER     = 0x00001000,   //!< Wheel encoder fault
+
+    EVB_LUNA_STATUS_FAULT_BUMP_SENSOR_COM   = 0x00002000,   //!< Bump sensor not communicating
+
+    EVB_LUNA_STATUS_FAULT_ESTOP_RECENT      = 0x00004000,   //!< Estop button (or interlock) was pressed in the past 10 seconds
+
+    EVB_LUNA_STATUS_MOWER_BLADE_ON          = 0x00010000,   //!< Mower blade on
+
+    EVB_LUNA_STATUS_AXIS_ERR_INVALID_STATE  = 0x01000000,   //!< Axis is in an invalid state
+
+    EVB_LUNA_STATUS_AXIS_ERR_WATCHDOG       = 0x02000000,   //!< Watchdog has expired
+
+    EVB_LUNA_STATUS_AXIS_ERR_TEMP           = 0x04000000,   //!< Motor or driver temperature is above limits
+
+    EVB_LUNA_STATUS_AXIS_ERR_MASK           = 0xFF000000,   //!< Mask of all axis-error bits
 
 } eEvbLunaStatus;
 
+/** Motor-control enable state for evb_luna_status_t::motorState. */
 typedef enum
 {
-    LMS_UNSPECIFIED             = 0,
-    LMS_MOTOR_CONTROL_ENABLE    = 1,    // Motor control enabled.
-    LMS_MOTOR_CONTROL_DISABLE   = 2,    // Motor control disabled.  Engine shutoff is controlled only by remote kill.
+    LMS_UNSPECIFIED             = 0,    //!< Not specified
+    LMS_MOTOR_CONTROL_ENABLE    = 1,    //!< Motor control enabled.
+    LMS_MOTOR_CONTROL_DISABLE   = 2,    //!< Motor control disabled. Engine shutoff is controlled only by remote kill.
 } eLunaMotorState;
 
+/** Remote-kill safety-interlock mode for evb_luna_status_t::remoteKillMode and evb_luna_remote_kill_t::mode. */
 typedef enum
 {
-    LRKM_UNSPECIFIED            = 0,
-    LRKM_ENABLE                 = 1,    // Keep alive motors enabled.
-    LRKM_DISABLE                = 2,    // Disable motors.
-    LRKM_PAUSE                  = 3,    // Keep alive motors paused.
-    LRKM_DISARM                 = 4,    // Turn off remote kill and then switch to LMS_MOTOR_CONTROL_ENABLE.
+    LRKM_UNSPECIFIED            = 0,    //!< Not specified
+    LRKM_ENABLE                 = 1,    //!< Keep alive motors enabled.
+    LRKM_DISABLE                = 2,    //!< Disable motors.
+    LRKM_PAUSE                  = 3,    //!< Keep alive motors paused.
+    LRKM_DISARM                 = 4,    //!< Turn off remote kill and then switch to LMS_MOTOR_CONTROL_ENABLE.
 } eLunaRemoteKillMode;
 
-/**
-* (DID_EVB_LUNA_SENSORS) EVB-2 Luna sensors (proximity, etc.).
-*/
+/** @brief (DID_EVB_LUNA_SENSORS) EVB-2 Luna sensors (proximity, etc.). */
 typedef struct
 {
-    /** GPS time of week (since Sunday morning) in milliseconds */
-    uint32_t    timeOfWeekMs;
-    
-    /*Proximity Sensory distance measurement arrays*/
-    float       proxSensorOutput[9];
-    
-    int32_t     bumpEvent;
+    uint32_t    timeOfWeekMs;         //!< GPS time of week (since Sunday morning) in milliseconds
+
+    float       proxSensorOutput[9];  //!< Proximity sensor distance measurement array, one entry per sensor
+
+    int32_t     bumpEvent;            //!< Bump event indicator (see eEvbLunaStatus bump bits); non-zero when a bump was detected
 } evb_luna_sensors_t;
 
 
-/**
-* (DID_EVB_LUNA_REMOTE_KILL) EVB Luna Remote Kill system.
-*/
+/** @brief (DID_EVB_LUNA_REMOTE_KILL) EVB Luna Remote Kill system. */
 typedef struct
 {
-    /** (eLunaRemoteKillMode) */
-    int32_t     mode;
+    int32_t     mode;    //!< Remote-kill mode (eLunaRemoteKillMode)
 } evb_luna_remote_kill_t;
 
-/**
-* (DID_EVB_LUNA_VELOCITY_COMMAND) EVB Luna wheel command.
-*/
+/** @brief (DID_EVB_LUNA_VELOCITY_COMMAND) EVB Luna wheel command. */
 typedef struct
 {
-    /** Local system time in milliseconds */
-    uint32_t    timeMs;
+    uint32_t    timeMs;      //!< Local system time in milliseconds
 
-    /** Control mode (see eLunaVelocityControlMode) */
-    uint32_t    modeCmd;
+    uint32_t    modeCmd;     //!< Control mode (see eLunaVelocityControlMode)
 
-    /** Forward velocity (m/s) */
-    float       fwd_vel;
+    float       fwd_vel;     //!< Forward velocity (m/s)
 
-    /** Turn rate (rad/s) */
-    float       turn_rate;
+    float       turn_rate;   //!< Turn rate (rad/s)
 } evb_luna_velocity_command_t;
 
+/** @brief (DID_EVB_LUNA_AUX_COMMAND) EVB Luna auxiliary command (e.g. blade, e-brake, beep). */
 typedef struct evb_luna_aux_command_t
 {
-    uint32_t    command;    // (see eLunaAuxCommands)
+    uint32_t    command;    //!< Auxiliary command to execute (see eLunaAuxCommands)
 }evb_luna_aux_command_t;
 
+/** Auxiliary commands for evb_luna_aux_command_t::command. */
 typedef enum
 {
-    //Possible Commands
-    AUX_CMD_BLADE_OFF           = 0,
-    AUX_CMD_BLADE_ON            = 1,
-    AUX_CMD_EBRAKE_ENGAGE       = 2,
-    AUX_CMD_EBRAKE_DISENGAGE    = 3,
-    AUX_CMD_BEEP                = 4,
+    AUX_CMD_BLADE_OFF           = 0,    //!< Turn mower blade off
+    AUX_CMD_BLADE_ON            = 1,    //!< Turn mower blade on
+    AUX_CMD_EBRAKE_ENGAGE       = 2,    //!< Engage the electronic brake
+    AUX_CMD_EBRAKE_DISENGAGE    = 3,    //!< Disengage the electronic brake
+    AUX_CMD_BEEP                = 4,    //!< Sound an audible beep
     // AUX_CMD_DIDS_LOG_START      = 5,        // Used in inertial_sense_ros node
     // AUX_CMD_DIDS_LOG_STOP       = 6,
 } eLunaAuxCommands;
 
+/** Operating/test mode for evb_luna_velocity_control_t::current_mode. */
 typedef enum
 {
-    LVC_MODE_DISABLED               = 0,
-    LVC_MODE_STOP                   = 1,
-    LVC_MODE_ENABLE                 = 2,    // With watchdog
-    LVC_MODE_MANUAL                 = 3,    // 
+    LVC_MODE_DISABLED               = 0,     //!< Velocity control disabled
+    LVC_MODE_STOP                   = 1,     //!< Commanded to stop
+    LVC_MODE_ENABLE                 = 2,     //!< Normal operation, with watchdog
+    LVC_MODE_MANUAL                 = 3,     //!< Manual (joystick/pot) control
     // Velocity TESTS
-    LVC_MODE_TEST_VEL_VEHICLE_CMD   = 4,    // Use left vel cmd to drive left and right together
-    LVC_MODE_TEST_VEL_WHEEL_CMD     = 5,
-    LVC_MODE_TEST_VEL_SWEEP         = 6,
+    LVC_MODE_TEST_VEL_VEHICLE_CMD   = 4,     //!< Test: use left vel cmd to drive left and right together
+    LVC_MODE_TEST_VEL_WHEEL_CMD     = 5,     //!< Test: independent per-wheel velocity command
+    LVC_MODE_TEST_VEL_SWEEP         = 6,     //!< Test: velocity sweep
     // Effort TESTS
-    LVC_MODE_TEST_EFFORT            = 7,    // (Keep as first effort test)
-    // Duty TESTS    
-    LVC_MODE_TEST_DUTY              = 8,    // (Keep as first duty cycle test)
-    LVC_MODE_TEST_DUTY_SWEEP        = 9,    // Watchdog disabled in testing
-    LVC_MODE_TEST_WHL_ANG_VEL_SWEEP = 10,
-    // Solve for Feedforward    
-    LVC_MODE_CALIBRATE_FEEDFORWARD  = 11,
+    LVC_MODE_TEST_EFFORT            = 7,     //!< Test: open-loop control effort (keep as first effort test)
+    // Duty TESTS
+    LVC_MODE_TEST_DUTY              = 8,     //!< Test: duty cycle (keep as first duty cycle test)
+    LVC_MODE_TEST_DUTY_SWEEP        = 9,     //!< Test: duty cycle sweep. Watchdog disabled in testing.
+    LVC_MODE_TEST_WHL_ANG_VEL_SWEEP = 10,    //!< Test: wheel angular velocity sweep
+    // Solve for Feedforward
+    LVC_MODE_CALIBRATE_FEEDFORWARD  = 11,    //!< Solve for feedforward coefficients
 } eLunaVelocityControlMode;
 
+/** Status/limiting bits for evb_luna_velocity_control_t::status. */
 typedef enum
 {
-    LVC_STATUS_FAULT_L                  = 0x00000001,
-    LVC_STATUS_FAULT_R                  = 0x00000002,
-    LVC_STATUS_VEL_CMD_LIMITED_L        = 0x00000010,
-    LVC_STATUS_VEL_CMD_LIMITED_R        = 0x00000020,
-    LVC_STATUS_VEL_CMD_LIMITED_MASK     = (LVC_STATUS_VEL_CMD_LIMITED_L | LVC_STATUS_VEL_CMD_LIMITED_R),
-    LVC_STATUS_VEL_CMD_SLEW_LIMITED_L   = 0x00000040,
-    LVC_STATUS_VEL_CMD_SLEW_LIMITED_R   = 0x00000080,
-    LVC_STATUS_VEL_LIMITED_L_MASK       = (LVC_STATUS_VEL_CMD_LIMITED_L | LVC_STATUS_VEL_CMD_SLEW_LIMITED_L),
-    LVC_STATUS_VEL_LIMITED_R_MASK       = (LVC_STATUS_VEL_CMD_LIMITED_R | LVC_STATUS_VEL_CMD_SLEW_LIMITED_R),
-    LVC_STATUS_VEL_CMD_SLEW_LIMITED_F   = 0x00010000,
-    LVC_STATUS_VEL_CMD_SLEW_LIMITED_W   = 0x00020000,
-    LVC_STATUS_VEL_CMD_MANUAL_INPUT     = 0x00040000,
+    LVC_STATUS_FAULT_L                  = 0x00000001,   //!< Left wheel fault
+    LVC_STATUS_FAULT_R                  = 0x00000002,   //!< Right wheel fault
+    LVC_STATUS_VEL_CMD_LIMITED_L        = 0x00000010,   //!< Left wheel velocity command was limited
+    LVC_STATUS_VEL_CMD_LIMITED_R        = 0x00000020,   //!< Right wheel velocity command was limited
+    LVC_STATUS_VEL_CMD_LIMITED_MASK     = (LVC_STATUS_VEL_CMD_LIMITED_L | LVC_STATUS_VEL_CMD_LIMITED_R),   //!< Mask of both wheels' velocity-limited bits
+    LVC_STATUS_VEL_CMD_SLEW_LIMITED_L   = 0x00000040,   //!< Left wheel velocity command was slew-rate limited
+    LVC_STATUS_VEL_CMD_SLEW_LIMITED_R   = 0x00000080,   //!< Right wheel velocity command was slew-rate limited
+    LVC_STATUS_VEL_LIMITED_L_MASK       = (LVC_STATUS_VEL_CMD_LIMITED_L | LVC_STATUS_VEL_CMD_SLEW_LIMITED_L),   //!< Mask of left wheel's velocity- and slew-limited bits
+    LVC_STATUS_VEL_LIMITED_R_MASK       = (LVC_STATUS_VEL_CMD_LIMITED_R | LVC_STATUS_VEL_CMD_SLEW_LIMITED_R),   //!< Mask of right wheel's velocity- and slew-limited bits
+    LVC_STATUS_VEL_CMD_SLEW_LIMITED_F   = 0x00010000,   //!< Vehicle forward velocity command was slew-rate limited
+    LVC_STATUS_VEL_CMD_SLEW_LIMITED_W   = 0x00020000,   //!< Vehicle turn-rate command was slew-rate limited
+    LVC_STATUS_VEL_CMD_MANUAL_INPUT     = 0x00040000,   //!< Velocity command is coming from manual input
 } eLunaVelocityControlStatus;
 
+/** Vehicle-level (forward + turn-rate) velocity control state: command, slew-limited command, actual, error, and effort. */
 typedef struct
 {
-    /** Vehicle forward and angular velocity, Commanded (m/s, rad/s) */
-    float       velCmd_f;
-    float       velCmd_w;
+    float       velCmd_f;        //!< Vehicle forward velocity, commanded (m/s)
+    float       velCmd_w;        //!< Vehicle angular (turn-rate) velocity, commanded (rad/s)
 
-    /** Wheel velocity, Manually Commanded (m/s, rad/s) */
-    float       velCmdMnl_f;
-    float       velCmdMnl_w;
+    float       velCmdMnl_f;     //!< Vehicle forward velocity, manually commanded (m/s)
+    float       velCmdMnl_w;     //!< Vehicle angular (turn-rate) velocity, manually commanded (rad/s)
 
-    /** Vehicle forward and angular velocity, slew rate limited commanded (m/s, rad/s) */
-    float       velCmdSlew_f;
-    float       velCmdSlew_w;
+    float       velCmdSlew_f;    //!< Vehicle forward velocity, slew-rate-limited commanded (m/s)
+    float       velCmdSlew_w;    //!< Vehicle angular (turn-rate) velocity, slew-rate-limited commanded (rad/s)
 
-    /** Vehicle forward and angular velocity (m/s, rad/s) */
-    float       vel_f;
-    float       vel_w;
+    float       vel_f;           //!< Vehicle forward velocity, actual (m/s)
+    float       vel_w;           //!< Vehicle angular (turn-rate) velocity, actual (rad/s)
 
-    /** Vehicle forward and angular velocity, error (m/s, rad/s) */
-    float       err_f;
-    float       err_w;
+    float       err_f;           //!< Vehicle forward velocity, error (m/s)
+    float       err_w;           //!< Vehicle angular (turn-rate) velocity, error (rad/s)
 
-    /** Vehicle forward and angular velocity, effort (m/s, rad/s) */
-    float       eff_f;
-    float       eff_w;
+    float       eff_f;           //!< Vehicle forward velocity, control effort (m/s)
+    float       eff_w;           //!< Vehicle angular (turn-rate) velocity, control effort (rad/s)
 } evb_luna_velocity_control_vehicle_t;
 
+/** Per-wheel velocity control state: command, actual, error, and feedforward/feedback/total control effort. */
 typedef struct
 {
-    /** Wheel velocity, Commanded (rad/s) */
-    float       velCmd;
-    
-    /** Wheel velocity commanded after slew rate (rad/s) */
-    float       velCmdSlew;
+    float       velCmd;          //!< Wheel velocity, commanded (rad/s)
 
-    /** Wheel velocity (rad/s) */
-    float       vel;
+    float       velCmdSlew;      //!< Wheel velocity commanded after slew rate limiting (rad/s)
 
-    /** Wheel velocity error (rad/s) */
-    float       err;
+    float       vel;             //!< Wheel velocity, actual (rad/s)
 
-    /** Feedforward control effort */
-    float       ff_eff;
+    float       err;             //!< Wheel velocity error (rad/s)
 
-    /** Feedback control effort */
-    float       fb_eff;
+    float       ff_eff;          //!< Feedforward control effort
 
-    /** Feedback integral control effort */
-    float       fb_eff_integral;
+    float       fb_eff;          //!< Feedback control effort
 
-    /** Control effort = ff_eff_x + fb_eff_x */
-    float       eff;
+    float       fb_eff_integral; //!< Feedback integral control effort
 
-    /** Control effort intermediate */
-    float       effInt;
+    float       eff;             //!< Total control effort = ff_eff + fb_eff
 
-    /** Duty cycle control effort at actuator (-1.0 to 1.0) */
-    float       effDuty;
+    float       effInt;          //!< Control effort, intermediate (pre-limiting) value
+
+    float       effDuty;         //!< Duty cycle control effort at actuator (-1.0 to 1.0)
 } evb_luna_velocity_control_wheel_t;
 
-/**
-* (DID_EVB_LUNA_VELOCITY_CONTROL) EVB Luna wheel controller info.
-*/
+/** @brief (DID_EVB_LUNA_VELOCITY_CONTROL) EVB Luna wheel controller info. */
 typedef struct
 {
-    /** Local system time in milliseconds */
-    uint32_t                                timeMs;
+    uint32_t                                timeMs;     //!< Local system time in milliseconds
 
-    /** Delta time */
-    float                                   dt;
+    float                                   dt;          //!< Delta time since the previous update (seconds)
 
-    /** Wheel control status (see eLunaVelocityControlStatus) */
-    uint32_t                                status;
+    uint32_t                                status;      //!< Wheel control status (see eLunaVelocityControlStatus)
 
-    /** Wheel control mode: (see eLunaVelocityControlMode) */
-    uint32_t                                current_mode;
+    uint32_t                                current_mode; //!< Wheel control mode (see eLunaVelocityControlMode)
 
-    /** Vehicle velocity control */
-    evb_luna_velocity_control_vehicle_t     vehicle;
+    evb_luna_velocity_control_vehicle_t     vehicle;     //!< Vehicle-level velocity control state
 
-    /** Wheel velocity control */
-    evb_luna_velocity_control_wheel_t       wheel_l;
-    evb_luna_velocity_control_wheel_t       wheel_r;
+    evb_luna_velocity_control_wheel_t       wheel_l;     //!< Left wheel velocity control state
+    evb_luna_velocity_control_wheel_t       wheel_r;     //!< Right wheel velocity control state
 
-    /** Manual control */
-    float                                   potV_l;
-    float                                   potV_r;
+    float                                   potV_l;      //!< Manual control input potentiometer voltage, left wheel (V)
+    float                                   potV_r;      //!< Manual control input potentiometer voltage, right wheel (V)
 } evb_luna_velocity_control_t;
 
 

--- a/src/rtk_defines.h
+++ b/src/rtk_defines.h
@@ -4,8 +4,9 @@
  * limits, and per-constellation satellite numbering ranges used by the embedded RTK positioning engine.
  *
  * Constellation support is selected at compile time via the ENA* macros below; enabling a constellation
- * pulls in its satellite-numbering range (MINPRN*/MAXPRN*/NSAT*) and system count (NSYS*), otherwise
- * those are defined as 0 so downstream array sizing (e.g. GPS_EPHEMERIS_ARRAY_SIZE) stays consistent.
+ * pulls in its satellite-numbering range (the MINPRN, MAXPRN, and NSAT macros for that constellation)
+ * and system count (the NSYS macro for that constellation), otherwise those are defined as 0 so
+ * downstream array sizing (e.g. GPS_EPHEMERIS_ARRAY_SIZE) stays consistent.
  * DO NOT reorder or resize these without checking every consumer -- several are used as fixed array
  * dimensions in wire-format structures.
  *
@@ -16,7 +17,7 @@
 #ifndef __RTK_EMBEDDED_DEFINES_H_
 #define __RTK_EMBEDDED_DEFINES_H_
 
-/** Enabled GNSS constellations (comment out to disable; see the corresponding NSYS*/MINPRN*/MAXPRN* below). */
+/** Enabled GNSS constellations (comment out to disable; see the corresponding NSYS, MINPRN, and MAXPRN macros below). */
 #define ENAGAL      //!< Galileo enabled
 #define ENACMP      //!< BeiDou (Compass) enabled
 // #define ENAGLO   //!< GLONASS -- disabled

--- a/src/rtk_defines.h
+++ b/src/rtk_defines.h
@@ -1,22 +1,40 @@
+/**
+ * @file rtk_defines.h
+ * @brief RTKLIB-derived build-time configuration: enabled GNSS constellations, observation/frequency
+ * limits, and per-constellation satellite numbering ranges used by the embedded RTK positioning engine.
+ *
+ * Constellation support is selected at compile time via the ENA* macros below; enabling a constellation
+ * pulls in its satellite-numbering range (MINPRN*/MAXPRN*/NSAT*) and system count (NSYS*), otherwise
+ * those are defined as 0 so downstream array sizing (e.g. GPS_EPHEMERIS_ARRAY_SIZE) stays consistent.
+ * DO NOT reorder or resize these without checking every consumer -- several are used as fixed array
+ * dimensions in wire-format structures.
+ *
+ * @author Inertial Sense, Inc. (RTKLIB-derived)
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef __RTK_EMBEDDED_DEFINES_H_
 #define __RTK_EMBEDDED_DEFINES_H_
 
-#define ENAGAL
-#define ENACMP
-// #define ENAGLO
-// #define ENAQZS
-// #define ENASBS
+/** Enabled GNSS constellations (comment out to disable; see the corresponding NSYS*/MINPRN*/MAXPRN* below). */
+#define ENAGAL      //!< Galileo enabled
+#define ENACMP      //!< BeiDou (Compass) enabled
+// #define ENAGLO   //!< GLONASS -- disabled
+// #define ENAQZS   //!< QZSS -- disabled
+// #define ENASBS   //!< SBAS -- disabled
 
-#define NUMSATSOL   30      // Max number of observations used in the solution
-#define MAXOBS      55      // Max number of observations used in pre-buffer
-#define NFREQ       2       // Number of carrier frequencies
-#define NEXOBS      0       // Number of extended obs codes
+/** Observation buffer and frequency limits. */
+#define NUMSATSOL   30      //!< Max number of observations used in the solution
+#define MAXOBS      55      //!< Max number of observations used in pre-buffer
+#define NFREQ       2       //!< Number of carrier frequencies
+#define NEXOBS      0       //!< Number of extended obs codes
 
+/** Selects which second-frequency slot RTK uses: L2 for u-blox ZED-F9P (GPX_GNSS_F9P), L5 otherwise. */
 #if defined(GPX_GNSS_F9P)
     #error "F9P defined. Are you sure want to do this?  If so comment this line out in rtk_defines.h"
-    #define L1_L5_RTK   0        // Use second slot for L2 
+    #define L1_L5_RTK   0        //!< Use second slot for L2
 #else
-    #define L1_L5_RTK   1        // Use second slot for L5 
+    #define L1_L5_RTK   1        //!< Use second slot for L5
 #endif
 
 // #if defined(RTK_EMBEDDED)
@@ -29,170 +47,188 @@
 // // #define RTK_CALLOC calloc    // not supported
 // #define RTK_FREE FREE
 
-#define NFREQ2 (NFREQ == 1 ? 2 : NFREQ) // DO NOT CHANGE
-#define RTK_INPUT_COUNT 2 // rover, base station - DO NOT CHANGE
+#define NFREQ2 (NFREQ == 1 ? 2 : NFREQ) //!< Effective frequency count for array sizing -- DO NOT CHANGE
+#define RTK_INPUT_COUNT 2 //!< Number of RTK input streams: rover, base station -- DO NOT CHANGE
 
-#define HALF_MAXOBS (MAXOBS/2)
+#define HALF_MAXOBS (MAXOBS/2) //!< Half of @ref MAXOBS, used for splitting rover/base observation buffers
 
-#define MAXSUBFRMLEN 152
-#define MAXRAWLEN 2048
+#define MAXSUBFRMLEN 152   //!< Max GNSS navigation subframe length (bytes)
+#define MAXRAWLEN 2048     //!< Max raw GNSS receiver message length (bytes)
 
+/** Per-constellation carrier-frequency counts, used for array sizing when the constellation is enabled. */
 #ifdef ENAGLO
-#define NFREQGLO 2
+#define NFREQGLO 2  //!< GLONASS carrier-frequency count
 #else
-#define NFREQGLO 0
+#define NFREQGLO 0  //!< GLONASS disabled
 #endif
 
 #ifdef ENAGAL
-#define NFREQGAL 2
+#define NFREQGAL 2  //!< Galileo carrier-frequency count
 #else
-#define NFREQGAL 0
+#define NFREQGAL 0  //!< Galileo disabled
 #endif
 
-#define MINPRNGPS   1                   /* min satellite PRN number of GPS */
-#define MAXPRNGPS   32                  /* max satellite PRN number of GPS */
-#define NSATGPS     (MAXPRNGPS-MINPRNGPS+1) /* number of GPS satellites */
-#define NSYSGPS     1
+/** GPS satellite PRN numbering range and system count (always enabled). */
+#define MINPRNGPS   1                   //!< min satellite PRN number of GPS
+#define MAXPRNGPS   32                  //!< max satellite PRN number of GPS
+#define NSATGPS     (MAXPRNGPS-MINPRNGPS+1) //!< number of GPS satellites
+#define NSYSGPS     1                   //!< GPS system count (always 1; GPS cannot be disabled)
 
+/** GLONASS satellite slot numbering range and system count; zeroed out when ENAGLO is not defined. */
 #ifdef ENAGLO
-#define MINPRNGLO   1                   /* min satellite slot number of GLONASS */
-#define MAXPRNGLO   27                  /* max satellite slot number of GLONASS */
-#define NSATGLO     (MAXPRNGLO-MINPRNGLO+1) /* number of GLONASS satellites */
-#define NSYSGLO     1
+#define MINPRNGLO   1                   //!< min satellite slot number of GLONASS
+#define MAXPRNGLO   27                  //!< max satellite slot number of GLONASS
+#define NSATGLO     (MAXPRNGLO-MINPRNGLO+1) //!< number of GLONASS satellites
+#define NSYSGLO     1                   //!< GLONASS enabled: system count 1
 #else
-#define MINPRNGLO   0
-#define MAXPRNGLO   0
-#define NSATGLO     0
-#define NSYSGLO     0
+#define MINPRNGLO   0                   //!< GLONASS disabled
+#define MAXPRNGLO   0                   //!< GLONASS disabled
+#define NSATGLO     0                   //!< GLONASS disabled: no satellites
+#define NSYSGLO     0                   //!< GLONASS disabled: system count 0
 #endif
 
+/** Galileo satellite PRN numbering range and system count; zeroed out when ENAGAL is not defined. */
 #ifdef ENAGAL
-#define MINPRNGAL   1                   /* min satellite PRN number of Galileo */
-#define MAXPRNGAL   36                  /* max satellite PRN number of Galileo */
-#define NSATGAL    (MAXPRNGAL-MINPRNGAL+1) /* number of Galileo satellites */
-#define NSYSGAL     1
+#define MINPRNGAL   1                   //!< min satellite PRN number of Galileo
+#define MAXPRNGAL   36                  //!< max satellite PRN number of Galileo
+#define NSATGAL    (MAXPRNGAL-MINPRNGAL+1) //!< number of Galileo satellites
+#define NSYSGAL     1                   //!< Galileo enabled: system count 1
 #else
-#define MINPRNGAL   0
-#define MAXPRNGAL   0
-#define NSATGAL     0
-#define NSYSGAL     0
+#define MINPRNGAL   0                   //!< Galileo disabled
+#define MAXPRNGAL   0                   //!< Galileo disabled
+#define NSATGAL     0                   //!< Galileo disabled: no satellites
+#define NSYSGAL     0                   //!< Galileo disabled: system count 0
 #endif
 
+/** QZSS satellite PRN numbering range (including SAIF sub-range) and system count; zeroed out when ENAQZS is not defined. */
 #ifdef ENAQZS
-#define MINPRNQZS   193                 /* min satellite PRN number of QZSS */
-#define MAXPRNQZS   202                 /* max satellite PRN number of QZSS */
-#define MINPRNQZS_S 183                 /* min satellite PRN number of QZSS SAIF */
-#define MAXPRNQZS_S 191                 /* max satellite PRN number of QZSS SAIF */
-#define NSATQZS     (MAXPRNQZS-MINPRNQZS+1) /* number of QZSS satellites */
-#define NSYSQZS     1
+#define MINPRNQZS   193                 //!< min satellite PRN number of QZSS
+#define MAXPRNQZS   202                 //!< max satellite PRN number of QZSS
+#define MINPRNQZS_S 183                 //!< min satellite PRN number of QZSS SAIF
+#define MAXPRNQZS_S 191                 //!< max satellite PRN number of QZSS SAIF
+#define NSATQZS     (MAXPRNQZS-MINPRNQZS+1) //!< number of QZSS satellites
+#define NSYSQZS     1                   //!< QZSS enabled: system count 1
 #else
-#define MINPRNQZS   0
-#define MAXPRNQZS   0
-#define MINPRNQZS_S 0
-#define MAXPRNQZS_S 0
-#define NSATQZS     0
-#define NSYSQZS     0
+#define MINPRNQZS   0                   //!< QZSS disabled
+#define MAXPRNQZS   0                   //!< QZSS disabled
+#define MINPRNQZS_S 0                   //!< QZSS disabled
+#define MAXPRNQZS_S 0                   //!< QZSS disabled
+#define NSATQZS     0                   //!< QZSS disabled: no satellites
+#define NSYSQZS     0                   //!< QZSS disabled: system count 0
 #endif
 
+/** BeiDou satellite numbering range and system count; zeroed out when ENACMP is not defined. */
 #ifdef ENACMP
-#define MINPRNCMP   1                   /* min satellite sat number of BeiDou */
-#define MAXPRNCMP   63                  /* max satellite sat number of BeiDou */
-#define NSATCMP     (MAXPRNCMP-MINPRNCMP+1) /* number of BeiDou satellites */
-#define NSYSCMP     1
+#define MINPRNCMP   1                   //!< min satellite sat number of BeiDou
+#define MAXPRNCMP   63                  //!< max satellite sat number of BeiDou
+#define NSATCMP     (MAXPRNCMP-MINPRNCMP+1) //!< number of BeiDou satellites
+#define NSYSCMP     1                   //!< BeiDou enabled: system count 1
 #else
-#define MINPRNCMP   0
-#define MAXPRNCMP   0
-#define NSATCMP     0
-#define NSYSCMP     0
+#define MINPRNCMP   0                   //!< BeiDou disabled
+#define MAXPRNCMP   0                   //!< BeiDou disabled
+#define NSATCMP     0                   //!< BeiDou disabled: no satellites
+#define NSYSCMP     0                   //!< BeiDou disabled: system count 0
 #endif
 
+/** IRNSS satellite numbering range and system count; zeroed out when ENAIRN is not defined. */
 #ifdef ENAIRN
-#define MINPRNIRN   1                   /* min satellite sat number of IRNSS */
-#define MAXPRNIRN   14                  /* max satellite sat number of IRNSS */
-#define NSATIRN     (MAXPRNIRN-MINPRNIRN+1) /* number of IRNSS satellites */
-#define NSYSIRN     1
+#define MINPRNIRN   1                   //!< min satellite sat number of IRNSS
+#define MAXPRNIRN   14                  //!< max satellite sat number of IRNSS
+#define NSATIRN     (MAXPRNIRN-MINPRNIRN+1) //!< number of IRNSS satellites
+#define NSYSIRN     1                   //!< IRNSS enabled: system count 1
 #else
-#define MINPRNIRN   0
-#define MAXPRNIRN   0
-#define NSATIRN     0
-#define NSYSIRN     0
+#define MINPRNIRN   0                   //!< IRNSS disabled
+#define MAXPRNIRN   0                   //!< IRNSS disabled
+#define NSATIRN     0                   //!< IRNSS disabled: no satellites
+#define NSYSIRN     0                   //!< IRNSS disabled: system count 0
 #endif
 
+/** LEO (low earth orbit augmentation) satellite numbering range and system count; zeroed out when ENALEO is not defined. */
 #ifdef ENALEO
-#define MINPRNLEO   1                   /* min satellite sat number of LEO */
-#define MAXPRNLEO   10                  /* max satellite sat number of LEO */
-#define NSATLEO     (MAXPRNLEO-MINPRNLEO+1) /* number of LEO satellites */
-#define NSYSLEO     1
+#define MINPRNLEO   1                   //!< min satellite sat number of LEO
+#define MAXPRNLEO   10                  //!< max satellite sat number of LEO
+#define NSATLEO     (MAXPRNLEO-MINPRNLEO+1) //!< number of LEO satellites
+#define NSYSLEO     1                   //!< LEO enabled: system count 1
 #else
-#define MINPRNLEO   0
-#define MAXPRNLEO   0
-#define NSATLEO     0
-#define NSYSLEO     0
+#define MINPRNLEO   0                   //!< LEO disabled
+#define MAXPRNLEO   0                   //!< LEO disabled
+#define NSATLEO     0                   //!< LEO disabled: no satellites
+#define NSYSLEO     0                   //!< LEO disabled: system count 0
 #endif
 
+/** SBAS satellite PRN numbering range, system count, and ephemeris array size; zeroed out when ENASBS is not defined. */
 #ifdef ENASBS
-#define MINPRNSBS   120                 /* min satellite PRN number of SBAS */
-#define MAXPRNSBS   158                 /* max satellite PRN number of SBAS */
-#define NSATSBS     (MAXPRNSBS-MINPRNSBS+1) /* number of SBAS satellites */
-#define SBAS_EPHEMERIS_ARRAY_SIZE NSATSBS
+#define MINPRNSBS   120                 //!< min satellite PRN number of SBAS
+#define MAXPRNSBS   158                 //!< max satellite PRN number of SBAS
+#define NSATSBS     (MAXPRNSBS-MINPRNSBS+1) //!< number of SBAS satellites
+#define SBAS_EPHEMERIS_ARRAY_SIZE NSATSBS //!< SBAS ephemeris array size, equal to @ref NSATSBS
 #else
-#define MINPRNSBS   0
-#define MAXPRNSBS   0
-#define NSATSBS     0
-#define SBAS_EPHEMERIS_ARRAY_SIZE 0
+#define MINPRNSBS   0                   //!< SBAS disabled
+#define MAXPRNSBS   0                   //!< SBAS disabled
+#define NSATSBS     0                   //!< SBAS disabled: no satellites
+#define SBAS_EPHEMERIS_ARRAY_SIZE 0     //!< SBAS disabled: no ephemeris storage needed
 #endif
 
-#define NSYS        (NSYSGPS+NSYSGLO+NSYSGAL+NSYSQZS+NSYSCMP+NSYSIRN+NSYSLEO) /* number of systems */
+#define NSYS        (NSYSGPS+NSYSGLO+NSYSGAL+NSYSQZS+NSYSCMP+NSYSIRN+NSYSLEO) //!< number of enabled navigation systems
 
-#define NX 7       /* Number of estimated parameters for point-positioning: 
-                   (3) ECEF receiver position (m) + 
-                   (1) GPS receiver clock bias (expresed in meters, i.e. multiplied by speed of light) + 
-                   (1) glo-gps time offset (expresed in meters) +
-                   (1) gal-gps time offset (expresed in meters) +
-                   (1) bds-gps time offset (expresed in meters) */
+/**
+ * Number of estimated parameters for point-positioning:
+ *  - (3) ECEF receiver position (m)
+ *  - (1) GPS receiver clock bias (expressed in meters, i.e. multiplied by speed of light)
+ *  - (1) GLONASS-GPS time offset (expressed in meters)
+ *  - (1) Galileo-GPS time offset (expressed in meters)
+ *  - (1) BeiDou-GPS time offset (expressed in meters)
+ */
+#define NX 7
 
-#define MAXERRMSG 0
+#define MAXERRMSG 0     //!< Max error message length (currently unused/reserved)
 
-#define GPS_EPHEMERIS_ARRAY_SIZE (NSATGPS + NSATGAL + NSATQZS + NSATCMP)
-#define GLONASS_EPHEMERIS_ARRAY_SIZE (NSATGLO)
+#define GPS_EPHEMERIS_ARRAY_SIZE (NSATGPS + NSATGAL + NSATQZS + NSATCMP)  //!< Ephemeris storage sized for GPS + the constellations sharing its broadcast ephemeris format (Galileo, QZSS, BeiDou)
+#define GLONASS_EPHEMERIS_ARRAY_SIZE (NSATGLO)  //!< GLONASS ephemeris array size (GLONASS uses a distinct ephemeris format, stored separately)
 
-#define DATA_TYPE_NONE 0
-#define DATA_TYPE_OBSERVATION 1
-#define DATA_TYPE_EPHEMERIS 2
-#define DATA_TYPE_SBS 3
-#define DATA_TYPE_ANTENNA_POSITION 5
-#define DATA_TYPE_DGPS 7
-#define DATA_TYPE_ION_UTC_ALMANAC 9
-#define DATA_TYPE_SSR 10
-#define DATA_TYPE_LEX 31
-#define DATA_TYPE_CONTINUE 999
-#define DATA_TYPE_ERROR -1
+/** Raw-observation data-type discriminator, identifying which member of a raw GNSS message union is populated. */
+#define DATA_TYPE_NONE 0                 //!< No data / uninitialized
+#define DATA_TYPE_OBSERVATION 1          //!< Pseudorange/carrier-phase observation data (obsd_t[])
+#define DATA_TYPE_EPHEMERIS 2            //!< Broadcast ephemeris data
+#define DATA_TYPE_SBS 3                  //!< SBAS message data
+#define DATA_TYPE_ANTENNA_POSITION 5     //!< Base station position / antenna information
+#define DATA_TYPE_DGPS 7                 //!< DGPS correction data
+#define DATA_TYPE_ION_UTC_ALMANAC 9      //!< Ionosphere model, UTC, and almanac data
+#define DATA_TYPE_SSR 10                 //!< State-space representation (SSR) correction data
+#define DATA_TYPE_LEX 31                 //!< QZSS LEX message data
+#define DATA_TYPE_CONTINUE 999           //!< Sentinel: more data of the same type follows (multi-part message)
+#define DATA_TYPE_ERROR -1               //!< Sentinel: data parsing/decoding error
 
-#define SYS_NONE    0x00                /* navigation system: none */
-#define SYS_GPS     0x01                /* navigation system: GPS */
-#define SYS_SBS     0x02                /* navigation system: SBAS */
-#define SYS_GLO     0x04                /* navigation system: GLONASS */
-#define SYS_GAL     0x08                /* navigation system: Galileo */
-#define SYS_QZS     0x10                /* navigation system: QZSS */
-#define SYS_CMP     0x20                /* navigation system: BeiDou */
-#define SYS_IRN     0x40                /* navigation system: IRNS */
-#define SYS_LEO     0x80                /* navigation system: LEO */
-#define SYS_ALL     0xFF                /* navigation system: all */
+/** Navigation-system bitmask values, usable individually or OR'd together to select a set of systems. */
+#define SYS_NONE    0x00                //!< navigation system: none
+#define SYS_GPS     0x01                //!< navigation system: GPS
+#define SYS_SBS     0x02                //!< navigation system: SBAS
+#define SYS_GLO     0x04                //!< navigation system: GLONASS
+#define SYS_GAL     0x08                //!< navigation system: Galileo
+#define SYS_QZS     0x10                //!< navigation system: QZSS
+#define SYS_CMP     0x20                //!< navigation system: BeiDou
+#define SYS_IRN     0x40                //!< navigation system: IRNSS
+#define SYS_LEO     0x80                //!< navigation system: LEO
+#define SYS_ALL     0xFF                //!< navigation system: all
 
 
+/**
+ * On bare-metal ARM targets (non-Zephyr), stub out the Linux pthread/dirent types and macros that
+ * RTKLIB code references, so that code doesn't need to be #if-guarded everywhere it appears. The
+ * mutex macros expand to nothing since there is no threading to guard against on these targets.
+ */
 #if PLATFORM_IS_ARM
 #ifndef __ZEPHYR__
 
-// typedef out linux types not used, this saves having to #if the RTKLib code everywhere
-typedef uint32_t pthread_t;
-typedef uint32_t pthread_mutex_t;
-typedef int lock_t;
-typedef int DIR;
-struct dirent { char* d_name; };
+typedef uint32_t pthread_t;         //!< Stub: unused on bare-metal ARM
+typedef uint32_t pthread_mutex_t;   //!< Stub: unused on bare-metal ARM
+typedef int lock_t;                 //!< Stub: unused on bare-metal ARM
+typedef int DIR;                    //!< Stub: unused on bare-metal ARM
+struct dirent { char* d_name; };    //!< Stub: unused on bare-metal ARM
 
-#define pthread_mutex_init(f, f2)
-#define pthread_mutex_lock(f)
-#define pthread_mutex_unlock(f)
+#define pthread_mutex_init(f, f2)   //!< Stub: no-op, no threading on bare-metal ARM
+#define pthread_mutex_lock(f)       //!< Stub: no-op, no threading on bare-metal ARM
+#define pthread_mutex_unlock(f)     //!< Stub: no-op, no threading on bare-metal ARM
 
 #endif
 #endif // ARM

--- a/src/statistics.h
+++ b/src/statistics.h
@@ -5,6 +5,22 @@
  *      Author: Walt Johnson
  */
 
+/**
+ * @file statistics.h
+ * @brief Mean, variance, and standard-deviation helpers over strided arrays and 3-vectors, plus a
+ * low-cost realtime (LPF-based) standard-deviation estimator.
+ *
+ * The scalar functions (mean/variance/standard_deviation and their _int32/_int64/_d suffixed
+ * variants) walk an array using an explicit byteIncrement rather than assuming a packed C array,
+ * so they can compute statistics over one field of a larger struct array (e.g. every Nth float
+ * inside an array of structs) without copying. The _Vec3 functions apply the same scalar functions
+ * independently to each of a 3-vector's components (units follow whatever the caller's data
+ * represents; these functions are unit-agnostic).
+ *
+ * @author Walt Johnson
+ * @copyright Copyright (c) 2013-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef STATISTICS_H_
 #define STATISTICS_H_
 
@@ -15,15 +31,16 @@
 
 //_____ D E F I N I T I O N S ______________________________________________
 
+/** Realtime (LPF-based) per-axis mean/variance/standard-deviation estimator state (see @ref init_realtime_std_dev_Vec3 / @ref realtime_std_dev_Vec3). */
 typedef struct
 {
-    ixVector3                 ave;      // mean
-    ixVector3                 var;      // variance
-    ixVector3                 std;      // standard deviation
-    float                   aveAlph;    // alpha gain
-    float                   aveBeta;    // beta  gain
-    float                   varAlph;    // alpha gain
-    float                   varBeta;    // beta  gain
+    ixVector3                 ave;      //!< Mean, low-pass filtered
+    ixVector3                 var;      //!< Variance, low-pass filtered
+    ixVector3                 std;      //!< Standard deviation (sqrt of var)
+    float                   aveAlph;    //!< Mean filter alpha gain
+    float                   aveBeta;    //!< Mean filter beta gain
+    float                   varAlph;    //!< Variance filter alpha gain
+    float                   varBeta;    //!< Variance filter beta gain
 } sRTSDVec3;
 
 //_____ G L O B A L S ______________________________________________________
@@ -31,50 +48,201 @@ typedef struct
 //_____ P R O T O T Y P E S ________________________________________________
 
 
-/*
- * Find the average value of the array.
+/**
+ * @brief Find the average value of a strided array of 32-bit floats.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements to average.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @return Average value.
  */
 f_t mean(f_t *input, int size, int byteIncrement);
-f_t mean_int32(int32_t *input, int size, int byteIncrement);
-double mean_int64(int64_t *input, int size, int byteIncrement);
-double mean(double *input, int size, int byteIncrement);
 
-/*
- * Find the variance of the array.
+/**
+ * @brief Find the average value of a strided array of int32_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements to average.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int32_t) for a packed array).
+ * @return Average value.
+ */
+f_t mean_int32(int32_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the average value of a strided array of int64_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements to average.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int64_t) for a packed array).
+ * @return Average value.
+ */
+double mean_int64(int64_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the average value of a strided array of doubles.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements to average.
+ * @param byteIncrement Byte offset between successive elements (sizeof(double) for a packed array).
+ * @return Average value.
+ */
+double mean_d(double *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the variance of a strided array of 32-bit floats.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @return Variance.
  */
 f_t variance(f_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the variance of a strided array of int32_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int32_t) for a packed array).
+ * @return Variance.
+ */
 f_t variance_int32(int32_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the variance of a strided array of int64_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int64_t) for a packed array).
+ * @return Variance.
+ */
 double variance_int64(int64_t *input, int size, int byteIncrement);
-double variance(double *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the variance of a strided array of doubles.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(double) for a packed array).
+ * @return Variance.
+ */
+double variance_d(double *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the variance of a strided array of 32-bit floats, also returning the mean used.
+ * @param input         Pointer to the first element.
+ * @param ave           Output: the mean computed and used to derive the variance.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @return Variance.
+ */
 f_t variance_mean(f_t *input, f_t *ave, int size, int byteIncrement);
 
-/*
-* Sum of the squares of input minus ave.
-*/
+/**
+ * @brief Sum of the squares of (input - ave) over a strided array of 32-bit floats.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @param ave           Reference value to subtract from each element before squaring.
+ * @return Sum of squared deviations from ave.
+ */
 f_t delta_mean(f_t *input, int size, int byteIncrement, float ave);
 
-/*
- * \brief Find the standard deviation of array.
- * 
- * \param input         Float pointer to start of data.
- * \param length        Number of values used in output.
- * \param byteIncrement Number of bytes size of data structure used to increment pointer by (f_t = 4).  Used to iterate across an structure arrays. 
+/**
+ * @brief Find the standard deviation of a strided array of 32-bit floats.
+ *
+ * @param input         Float pointer to start of data.
+ * @param size          Number of values used in output.
+ * @param byteIncrement Number of bytes size of data structure used to increment pointer by (f_t = 4).  Used to iterate across an structure arrays.
+ * @return Standard deviation.
  */
 f_t standard_deviation(f_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of a strided array of doubles.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(double) for a packed array).
+ * @return Standard deviation.
+ */
 double standard_deviation_d(double *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of a strided array of int32_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int32_t) for a packed array).
+ * @return Standard deviation.
+ */
 f_t standard_deviation_int32(int32_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of a strided array of int64_t.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(int64_t) for a packed array).
+ * @return Standard deviation.
+ */
 double standard_deviation_int64(int64_t *input, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of a strided array of 32-bit floats, given a precomputed mean.
+ * @param input         Pointer to the first element.
+ * @param mean          Precomputed mean of the array.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @return Standard deviation.
+ */
 f_t standard_deviation_mean(f_t *input, f_t *mean, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of each component of a strided array of 3-vectors.
+ * @param result        Output: standard deviation per axis (X, Y, Z).
+ * @param input         Pointer to the first 3-vector's X component; Y and Z are input[1]/input[2].
+ * @param size           Number of 3-vectors.
+ * @param byteIncrement Byte offset between successive 3-vectors (sizeof(ixVector3) for a packed array).
+ */
 void standard_deviation_Vec3(ixVector3 result, ixVector3 input, int size, int byteIncrement);
+
+/**
+ * @brief Find the standard deviation of each component of a strided array of 3-vectors, given a precomputed per-axis mean.
+ * @param result        Output: standard deviation per axis (X, Y, Z).
+ * @param input         Pointer to the first 3-vector's X component; Y and Z are input[1]/input[2].
+ * @param mean          Precomputed mean per axis (X, Y, Z).
+ * @param size           Number of 3-vectors.
+ * @param byteIncrement Byte offset between successive 3-vectors (sizeof(ixVector3) for a packed array).
+ */
 void stardard_deviation_mean_Vec3(ixVector3 result, ixVector3 input, ixVector3 mean, int size, int byteIncrement);
+
+/**
+ * @brief Find the average of each component of a strided array of 3-vectors.
+ * @param ave           Output: average per axis (X, Y, Z).
+ * @param input         Pointer to the first 3-vector's X component; Y and Z are input[1]/input[2].
+ * @param size           Number of 3-vectors.
+ * @param byteIncrement Byte offset between successive 3-vectors (sizeof(ixVector3) for a packed array).
+ */
 void mean_Vec3(ixVector3 ave, ixVector3 input, int size, int byteIncrement);
 
-// Set ave to zero to get true RMS
+/**
+ * @brief Root-mean-squared of (input - ave) over a strided array of 32-bit floats. Pass ave = 0 to get true RMS.
+ * @param input         Pointer to the first element.
+ * @param size           Number of elements.
+ * @param byteIncrement Byte offset between successive elements (sizeof(f_t) for a packed array).
+ * @param ave           Reference value to subtract from each element before squaring; 0 for true RMS.
+ * @return Root-mean-squared value.
+ */
 f_t root_mean_squared(f_t *input, int size, int byteIncrement, float ave);
 
 
+/**
+ * @brief Initialize a realtime (LPF-based) per-axis standard-deviation estimator.
+ * @param s               Estimator state to initialize.
+ * @param dt              Expected update period (seconds), used to derive the LPF alpha/beta gains.
+ * @param aveCornerFreqHz Low-pass corner frequency (Hz) for the running mean filter.
+ * @param varCornerFreqHz Low-pass corner frequency (Hz) for the running variance filter.
+ * @param initVal         Initial mean value per axis (X, Y, Z).
+ */
 void init_realtime_std_dev_Vec3(sRTSDVec3 *s, float dt, float aveCornerFreqHz, float varCornerFreqHz, ixVector3 initVal);
 
+/**
+ * @brief Update a realtime (LPF-based) per-axis standard-deviation estimator with a new 3-vector sample.
+ * This is less accurate than @ref standard_deviation_Vec3 and must run every iteration (more processing
+ * expensive overall), but requires far less memory since it doesn't retain a sample history.
+ * @param input Latest 3-vector sample (X, Y, Z).
+ * @param v     Estimator state; updated in place (mean, variance, and standard deviation).
+ */
 void realtime_std_dev_Vec3(f_t *input, sRTSDVec3 *v);
 
 #endif /* STATISTICS_H_ */

--- a/src/time_conversion.h
+++ b/src/time_conversion.h
@@ -1,3 +1,16 @@
+/**
+ * @file time_conversion.h
+ * @brief GPS <-> UTC <-> Julian-date time conversions, and a UTC-timezone-force helper.
+ *
+ * All GPS times are referenced to January 6th, 1980 (the GPS epoch) and expressed as a week number
+ * plus a time-of-week (seconds or milliseconds); a leap-second offset (18s as of December 31, 2016,
+ * passed explicitly to each function) converts to/from UTC. Julian dates are days since noon
+ * Universal Time on January 1, 4713 BCE.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2026 Inertial Sense, Inc. - http://inertialsense.com
+ */
+
 #ifndef _C_TIMECONV_H_
 #define _C_TIMECONV_H_
 
@@ -8,53 +21,85 @@ extern "C" {
 #include <ctime>
 #include "stdint.h"
 
-#define C_SECONDS_PER_WEEK          (604800)        // (60 * 60 * 24 * 7)
-#define C_SECONDS_PER_DAY           (86400)
-#define C_MILLISECONDS_PER_WEEK     (604800000)     // (60 * 60 * 24 * 7 * 1000)
-#define C_MILLISECONDS_PER_DAY      (86400000)
-#define C_MILLISECONDS_PER_HOUR     (3600000)
-#define C_MILLISECONDS_PER_MINUTE   (60000)
-#define C_MILLISECONDS_PER_SECOND   (1000)
-#define C_DAYS_PER_SECOND           (1.1574074074074074074074074074074e-5)
-#define C_GPS_TO_UNIX_OFFSET_S      (315964800)
+#define C_SECONDS_PER_WEEK          (604800)        //!< Seconds per week (60 * 60 * 24 * 7)
+#define C_SECONDS_PER_DAY           (86400)         //!< Seconds per day
+#define C_MILLISECONDS_PER_WEEK     (604800000)     //!< Milliseconds per week (60 * 60 * 24 * 7 * 1000)
+#define C_MILLISECONDS_PER_DAY      (86400000)      //!< Milliseconds per day
+#define C_MILLISECONDS_PER_HOUR     (3600000)       //!< Milliseconds per hour
+#define C_MILLISECONDS_PER_MINUTE   (60000)         //!< Milliseconds per minute
+#define C_MILLISECONDS_PER_SECOND   (1000)          //!< Milliseconds per second
+#define C_DAYS_PER_SECOND           (1.1574074074074074074074074074074e-5)  //!< Days per second (1 / 86400)
+#define C_GPS_TO_UNIX_OFFSET_S      (315964800)     //!< Offset (seconds) from the Unix epoch (1970-01-01) to the GPS epoch (1980-01-06)
 
+/** Calendar date, with day-of-week for convenience. */
 typedef struct
 {
-    int year;
-    int month;
-    int day;        // Day of month
-    int weekday;    // Day of week
+    int year;       //!< Full year (e.g. 2026)
+    int month;      //!< Month (1-12)
+    int day;        //!< Day of month (1-31)
+    int weekday;    //!< Day of week (0-Sunday .. 6-Saturday)
 } utc_date_t;
 
+/** Time of day. */
 typedef struct
 {
-    int hour;
-    int minute;
-    int second;
-    int millisecond;
+    int hour;         //!< Hour (0-23)
+    int minute;       //!< Minute (0-59)
+    int second;       //!< Second (0-59)
+    int millisecond;  //!< Millisecond (0-999)
 } utc_time_t;
 
 /**
- * @brief Set and revert the UTC Time Zone object
+ * @brief Force the process's local timezone to UTC (Linux only; no-op elsewhere), saving the
+ * previous TZ environment variable so it can be restored with @ref RevertUtcTimeZone.
  */
-void SetUtcTimeZone(); 
+void SetUtcTimeZone();
+
+/**
+ * @brief Restore the timezone saved by the most recent @ref SetUtcTimeZone call (Linux only; no-op elsewhere).
+ */
 void RevertUtcTimeZone();
 
-/** Convert GPS time of week in milliseconds to UTC time */
+/**
+ * @brief Convert GPS time of week in milliseconds to UTC time-of-day.
+ * @param gpsTimeOfWeekMs GPS time of week (milliseconds).
+ * @param gpsLeapS        Leap seconds to subtract to convert GPS time to UTC.
+ * @param time            Output: UTC time-of-day.
+ */
 void gpsTowMsToUtcTime(uint32_t gpsTimeOfWeekMs, int gpsLeapS, utc_time_t *time);
 
-/** Convert GPS week and time of week in milliseconds to UTC date and time */
+/**
+ * @brief Convert GPS week and time of week in milliseconds to UTC calendar date and time-of-day.
+ * @param gpsWeek      GPS week number since January 6th, 1980.
+ * @param gpsTowMs     GPS time of week (milliseconds).
+ * @param gpsLeapS     Leap seconds to subtract to convert GPS time to UTC.
+ * @param date         Output: UTC calendar date.
+ * @param time         Output: UTC time-of-day.
+ * @param milliseconds Output: UTC milliseconds within the current second.
+ */
 void gpsWeekTowMsToUtcDateTime(uint32_t gpsWeek, uint32_t gpsTowMs, int gpsLeapS, utc_date_t *date, utc_time_t *time, uint32_t *milliseconds);
 
-/** Convert UTC time to GPS time of week in milliseconds */
+/**
+ * @brief Convert UTC time-of-day to GPS time of week in milliseconds.
+ * @param time             UTC time-of-day.
+ * @param utcWeekday       UTC day of week (0-Sunday .. 6-Saturday), needed since time-of-day alone
+ *                         doesn't determine which day's GPS time-of-week to compute.
+ * @param gpsTimeOfWeekMs  Output: GPS time of week (milliseconds).
+ * @param gpsLeapS         Leap seconds to add to convert UTC time to GPS.
+ */
 void utcTimeToGpsTowMs(utc_time_t *time, int utcWeekday, uint32_t *gpsTimeOfWeekMs, int gpsLeapS);
 
-/** Convert GPS time in milliseconds to UTC weekday */
+/**
+ * @brief Convert GPS time of week in milliseconds to UTC day of week.
+ * @param gpsTowMs GPS time of week (milliseconds).
+ * @param leapS    Leap seconds to subtract to convert GPS time to UTC.
+ * @return UTC day of week (0-Sunday .. 6-Saturday).
+ */
 int gpsTowMsToUtcWeekday(int gpsTowMs, int leapS);
 
 /**
  * @brief Convert GPS time of week in milliseconds to UTC date and time.
- * 
+ *
  * @param gpsSecondsOfWeek Output GPS seconds of week.
  * @param gpsWeek Output GPS week number since January 6th, 1980.
  * @param leapSeconds Leap seconds to account for difference between GPS and UTC time (18s by default).
@@ -63,34 +108,56 @@ int gpsTowMsToUtcWeekday(int gpsTowMs, int leapS);
 std::tm stdGpsTimeToUtcDateTime(uint32_t gpsSecondsOfWeek, uint32_t gpsWeek, int leapSeconds);
 
 /**
- * @brief Convert UTC date and time to GPS seconds in week and week number.  This function is 8x computationally 
- * more intensive than UtcDateTimeToGpsTime(). 
- * 
+ * @brief Convert UTC date and time to GPS seconds in week and week number.  This function is 8x computationally
+ * more intensive than UtcDateTimeToGpsTime().
+ *
  * @param utcTime UTC time as std::tm.
+ * @param leapSeconds Leap seconds to account for difference between GPS and UTC time (18s by default).
  * @param gpsSecondsOfWeek Output GPS seconds of week.
  * @param gpsWeek Output GPS week number since January 6th, 1980.
- * @param leapSeconds Leap seconds to account for difference between GPS and UTC time (18s by default).
  */
 void stdUtcDateTimeToGpsTime(const std::tm &utcTime, int leapSeconds, uint32_t &gpsSecondsOfWeek, uint32_t &gpsWeek);
 
 /**
- * @brief Convert UTC date and time to GPS time in time of week in milliseconds and number of weeks.  
+ * @brief Convert UTC date and time to GPS time in time of week in milliseconds and number of weeks.
  * This function is equivalent to and computationally faster than stdUtcDateTimeToGpsTime().
- * 
- * @param datetime[7] input int array of UTC time at GMT time zone {year,month,day,hour,min,sec,msec}
- * @param gpsLeapSeconds input number GPS leap seconds to convert to UTC time
- * @param gpsTowMs output GPS time of week in milliseconds 
- * @param gpsWeek output GPS week number
+ *
+ * @param datetime Input int array of UTC time at GMT time zone: {year, month, day, hour, min, sec, msec}.
+ * @param leapSeconds Input GPS leap seconds to convert to UTC time.
+ * @param gpsTowMs Output GPS time of week in milliseconds.
+ * @param gpsWeek Output GPS week number.
  */
 void UtcDateTimeToGpsTime(const int datetime[7], int leapSeconds, uint32_t &gpsTowMs, uint32_t &gpsWeek);
 
-/** Convert Julian Date to calendar date. */
+/**
+ * @brief Convert a Julian date to a calendar date and time.
+ * @param julian      Julian date (days since noon Universal Time, January 1, 4713 BCE).
+ * @param year        Output: year.
+ * @param month       Output: month (1-12).
+ * @param day         Output: day of month (1-31).
+ * @param hour        Output: hour (0-23).
+ * @param minute      Output: minute (0-59).
+ * @param second      Output: second (0-59).
+ * @param millisecond Output: millisecond (0-999).
+ */
 void julianToDate(double julian, uint32_t* year, uint32_t* month, uint32_t* day, uint32_t* hour, uint32_t* minute, uint32_t* second, uint32_t* millisecond);
 
-/** Convert GPS Week and Ms and leapSeconds to Unix seconds**/
+/**
+ * @brief Convert GPS week + time of week + leap seconds to Unix time.
+ * @param gpsWeek         GPS week number since January 6th, 1980.
+ * @param gpsTimeofWeekMS GPS time of week (milliseconds).
+ * @param leapSeconds     Leap seconds to account for difference between GPS and UTC time.
+ * @return Unix time (seconds since January 1, 1970 UTC).
+ */
 double gpsToUnix(uint32_t gpsWeek, uint32_t gpsTimeofWeekMS, uint8_t leapSeconds);
 
-/** Convert GPS Week and Seconds to Julian Date.  Leap seconds are the GPS-UTC offset (18 seconds as of December 31, 2016). */
+/**
+ * @brief Convert GPS week and milliseconds to a Julian date.
+ * @param gpsWeek        GPS week number since January 6th, 1980.
+ * @param gpsMilliseconds GPS time of week (milliseconds).
+ * @param leapSeconds    Leap seconds, i.e. the GPS-UTC offset (18 seconds as of December 31, 2016).
+ * @return Julian date (days since noon Universal Time, January 1, 4713 BCE).
+ */
 double gpsToJulian(uint32_t gpsWeek, uint32_t gpsMilliseconds, uint32_t leapSeconds);
 
 

--- a/src/time_conversion.h
+++ b/src/time_conversion.h
@@ -100,8 +100,8 @@ int gpsTowMsToUtcWeekday(int gpsTowMs, int leapS);
 /**
  * @brief Convert GPS time of week in milliseconds to UTC date and time.
  *
- * @param gpsSecondsOfWeek Output GPS seconds of week.
- * @param gpsWeek Output GPS week number since January 6th, 1980.
+ * @param gpsSecondsOfWeek Input GPS seconds of week.
+ * @param gpsWeek Input GPS week number since January 6th, 1980.
  * @param leapSeconds Leap seconds to account for difference between GPS and UTC time (18s by default).
  * @return std::tm UTC time.
  */


### PR DESCRIPTION
## Summary

Part of [SN-8279](https://inertialsense.atlassian.net/browse/SN-8279) ([SDK] Doxygen documentation epic), story [SN-8294](https://inertialsense.atlassian.net/browse/SN-8294). Follows the exact style precedent established in SN-8293 (`data_sets.h`).

Documents all 15 files in the story's scope, in three logical groups:

1. **Data structure headers** — `data_sets_canbus.h`, `luna_data_sets.h`, `imx_defaults.h`, `rtk_defines.h`.
2. **Algorithmic APIs** — `convert_ins.h`, `time_conversion.h`, `filters.h`, `statistics.h`.
3. **GNSS and math** — `ISGnss.h`, `ISEarth.h`, `ISMatrix.h` (923 lines), `ISPose.h`, `ISPolynomial.h`, `IS_calibration.h`, `IS_calibration_convert.h`.

Every file gets an `@file` block with `@brief` + prose; struct/enum members get trailing `//!<` comments; functions get `@param`/`@return` with units and coordinate-frame conventions stated (radians, NED/ECEF/body frame, etc.), verified against each `.cpp`/`.c` implementation rather than guessed. **Exception**: per the epic's own reduced bar for `ISMatrix.h` ("at least a brief description" for its many small vector/matrix operations), that file gets concise one-line `@brief` blocks rather than exhaustive per-argument docs.

## Notable findings (flagging for reviewers)

While verifying docs against implementations, found and fixed two genuine pre-existing header/definition drifts — both zero-risk (confirmed no callers anywhere in the `imx` tree rely on the broken names):

- **`filters.h`**: `running_mean_filter`'s declared parameter order (`mean`, `input`) was backwards relative to its actual implementation (`input`, `mean`) in `filters.cpp` — a landmine for any future caller trusting the header. Reordered to match.
- **`statistics.h`**: the header declared `double mean(double*, ...)` and `double variance(double*, ...)` overloads that don't exist anywhere in the compiled library — only `mean_d`/`variance_d` are actually defined. Renamed the declarations to match the real, linkable symbols.

Also fixed several stale `@param` names that didn't match their signatures (`ISgpst2time`'s `weel` → `week`, `ISutc2gpst`'s `args` → `t`, a combined `t1, t2` `@param` that doesn't parse correctly, `UtcDateTimeToGpsTime`'s `datetime[7]`/`gpsLeapSeconds` mismatches).

Left the disabled `#if 0` blocks in `time_conversion.h` and `filters.h` untouched (dead code, not part of the compiled API).

## Test plan

- [x] Ran a baseline `doxygen` pass (installed locally) against all 15 files before touching anything, then after each of the three phases, diffing warnings to catch regressions immediately (caught and fixed a few — an unsupported `<Fc>`-looking tag, `@ref`s to `static` functions that Doxygen doesn't extract under this `Doxyfile`'s `EXTRACT_STATIC=NO`).
- [x] SDK-wide doxygen warning count: 717 → 703 (net improvement). Remaining 20 warnings in `filters.h`/`ISEarth.h` are pre-existing "multiple @param documentation sections" issues caused by duplicate doc comments in `filters.cpp`/`ISEarth.c`/`ISPose.c` — those files aren't in this story's scope, left untouched.
- [x] Every one of the 15 files confirmed to have an `@file` block (no file left with a plain MIT-only header).

[SN-8279]: https://inertialsense.atlassian.net/browse/SN-8279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SN-8294]: https://inertialsense.atlassian.net/browse/SN-8294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ