### PR TITLE
SN-8323: robust GPS-week epoch anchoring in ISTimeResolver for pre-fix logs

### DIFF
--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -43,6 +43,13 @@ constexpr std::array<uint32_t, 6> kToWBearingDids = {
 //! @note SN-8107 / D0066.
 constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
 constexpr uint64_t kGpsWeekMs      = 604'800'000ULL;  //!< 7 days in ms
+//! SN-8323: how far before the durable fix period a ToW-domain record may fall
+//! and still be treated as a (backward-extrapolated) part of the timeline.
+//! Beyond this it is a pre-fix / startup record with no stable GPS time and is
+//! tagged SessionOnly/Unknown. Generous enough to keep legitimate
+//! seconds-before-fix data; the pathological case is days off (ToW near the GPS
+//! week start while the fix is well into the week).
+constexpr uint64_t kPreFixGuardMs  = 300'000ULL;      //!< 5 minutes
 
 /**
  * @brief Convert `(gpsWeek, towMs)` into a Unix-epoch ms timestamp.
@@ -297,9 +304,18 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
         }
     }
 
-    // SN-8323: pick the epoch-anchor week before moving `syncs`.
+    // SN-8323: pick the epoch-anchor week + the start of its durable fix window
+    // (earliest ToW at that week) before moving `syncs`.
     const uint32_t anchorWeek = chooseAnchorWeek(syncs);
-    return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek };
+    uint64_t anchorTowStart = 0;
+    if (anchorWeek != 0) {
+        uint64_t minTow = UINT64_MAX;
+        for (const auto& sp : syncs) {
+            if (sp.gpsWeek == anchorWeek) minTow = std::min(minTow, sp.payloadToWMs);
+        }
+        anchorTowStart = (minTow == UINT64_MAX) ? 0 : minTow;
+    }
+    return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek, anchorTowStart };
 }
 
 // ============================================================
@@ -363,6 +379,18 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         const uint64_t towMs = (bridged < 0) ? 0u : static_cast<uint64_t>(bridged);
         return TimeStamp::fromResolvedViaSync(unixOrToW(towMs), deviceId,
                                               TimeConfidence::ExtrapolatedBackward);
+    }
+
+    // SN-8323 (part 2): a ToW-domain input that falls well before the durable
+    // fix period began is a pre-fix / startup record — the device had no stable
+    // GPS time yet (e.g. a ToW near the GPS week start while the fix is days
+    // into the week). Epoch-anchoring it would place it at a bogus early time
+    // and drag the log extent back (the "leading gap"). Tag it
+    // SessionOnly/Unknown — the same contract as a record with no anchor at all
+    // — so every SDK consumer excludes it from the timeline + extent uniformly.
+    if (epochAnchor && anchorTowStart_ > kPreFixGuardMs &&
+        hostTimeMs + kPreFixGuardMs < anchorTowStart_) {
+        return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
     }
 
     // Binary search for the first sync point whose hostTimeMs >= input.

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <cmath>
 #include <cstring>
+#include <map>
 
 namespace inertial_sense {
 
@@ -180,6 +181,54 @@ void scanSegmentForSyncs(const ISLogReader& reader,
     }
 }
 
+/**
+ * @brief SN-8323: choose the epoch-anchor GPS week from the log's durable,
+ *        consistent fix period.
+ *
+ * The whole log is epoch-anchored to one GPS week (correct for a log spanning
+ * < 1 GPS week — the common case). Picking `syncPoints_.front()` is wrong: the
+ * sync list is sorted by ToW, so the front is typically a smallest-ToW pre-fix
+ * `gpsWeek == 0` record (device still searching) — leaving the log unanchored
+ * (ToW-only ~1980) while already-absolute records show the real year.
+ *
+ * During startup the reported time can be unstable (week 0, or a brief
+ * transient/garbage week) before the device settles into a durable fix. So we
+ * do NOT trust any single record or a raw popularity count. Instead, for each
+ * non-zero week we measure the ToW SPAN it covers across the log; the week
+ * backed by the widest span is the one the device held a stable fix at. A
+ * startup transient covers a tiny span (a few close-together records) and loses
+ * to the sustained fix. Ties break toward more sync points, then the larger
+ * (more recent) week.
+ *
+ * @return  The durable-fix GPS week, or 0 if no non-zero week is present
+ *          (caller falls back to ToW-only, pre-D0066 behavior).
+ */
+uint32_t chooseAnchorWeek(const std::vector<ISSyncPoint>& syncs) {
+    struct Agg { uint64_t minTow; uint64_t maxTow; uint32_t count; };
+    std::map<uint32_t, Agg> byWeek;   // week -> coverage (ordered ascending)
+    for (const auto& sp : syncs) {
+        if (sp.gpsWeek == 0) continue;
+        auto it = byWeek.find(sp.gpsWeek);
+        if (it == byWeek.end()) {
+            byWeek.emplace(sp.gpsWeek, Agg{ sp.payloadToWMs, sp.payloadToWMs, 1 });
+        } else {
+            it->second.minTow = std::min(it->second.minTow, sp.payloadToWMs);
+            it->second.maxTow = std::max(it->second.maxTow, sp.payloadToWMs);
+            ++it->second.count;
+        }
+    }
+    uint32_t bestWeek = 0, bestCount = 0;
+    uint64_t bestSpan = 0;
+    for (const auto& [wk, a] : byWeek) {   // ascending week -> larger week wins ties
+        const uint64_t span = a.maxTow - a.minTow;
+        if (span > bestSpan ||
+            (span == bestSpan && a.count >= bestCount)) {
+            bestSpan = span; bestCount = a.count; bestWeek = wk;
+        }
+    }
+    return bestWeek;
+}
+
 } // namespace
 
 // ============================================================
@@ -248,7 +297,9 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
         }
     }
 
-    return ISTimeResolver{ std::move(syncs), std::move(discs) };
+    // SN-8323: pick the epoch-anchor week before moving `syncs`.
+    const uint32_t anchorWeek = chooseAnchorWeek(syncs);
+    return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek };
 }
 
 // ============================================================
@@ -278,14 +329,18 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
         return TimeStamp::fromSessionOnly(hostTimeMs, deviceId);
     }
 
-    // SN-8107 / D0066: select a representative GPS week for the epoch
-    // anchor. We use the first sync point's week; for the common
-    // single-week log this is correct. A log spans < 1 hour typically,
-    // well inside one GPS week. If gpsWeek == 0 (week field invalid or
-    // not yet established), we don't epoch-anchor — resolved values stay
-    // in ToW domain (pre-D0066 behavior).
+    // SN-8107 / D0066: select a representative GPS week for the epoch anchor.
+    // SN-8323: use the durable-fix week (`anchorWeek_`, precomputed in build()
+    // as the non-zero week with the widest ToW coverage), NOT
+    // `syncPoints_.front().gpsWeek`.
+    // The sync list is sorted by ToW, so front() is the smallest-ToW record,
+    // which on a pre-GPS-fix log is a week-0 record — anchoring to it left the
+    // log unanchored (ToW-only ~1980) while already-absolute records showed the
+    // real year, giving a ~46-year mixed-domain span. `firstSync` is still the
+    // ToW-frame reference for the session-uptime bridge below. anchorWeek_ == 0
+    // (no valid week anywhere) falls back to ToW-only (pre-D0066 behavior).
     const ISSyncPoint& firstSync = syncPoints_.front();
-    const uint32_t anchorWeek = firstSync.gpsWeek;
+    const uint32_t anchorWeek = anchorWeek_;
     const bool     epochAnchor = (anchorWeek != 0);
     auto unixOrToW = [&](uint64_t towMs) -> uint64_t {
         return epochAnchor ? gpsToUnixMs(anchorWeek, towMs) : towMs;

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -46,10 +46,13 @@ constexpr uint64_t kGpsWeekMs      = 604'800'000ULL;  //!< 7 days in ms
 //! SN-8323: how far before the durable fix period a ToW-domain record may fall
 //! and still be treated as a (backward-extrapolated) part of the timeline.
 //! Beyond this it is a pre-fix / startup record with no stable GPS time and is
-//! tagged SessionOnly/Unknown. Generous enough to keep legitimate
-//! seconds-before-fix data; the pathological case is days off (ToW near the GPS
-//! week start while the fix is well into the week).
-constexpr uint64_t kPreFixGuardMs  = 300'000ULL;      //!< 5 minutes
+//! tagged SessionOnly/Unknown. Sized to preserve legitimate backward
+//! extrapolation (GPS cold-start acquisition is well under an hour) while
+//! rejecting the pathological case, which is grossly off — a ToW at the GPS
+//! week start while the durable fix is days into the week. A record more than
+//! an hour before the first stable fix predates any plausible continuous
+//! session (prior power cycle / uninitialized time).
+constexpr uint64_t kPreFixGuardMs  = 3'600'000ULL;    //!< 1 hour
 
 /**
  * @brief Convert `(gpsWeek, towMs)` into a Unix-epoch ms timestamp.

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -197,10 +197,12 @@ public:
 private:
     explicit ISTimeResolver(std::vector<ISSyncPoint> syncs,
                             std::vector<Discontinuity> discs,
-                            uint32_t anchorWeek) noexcept
+                            uint32_t anchorWeek,
+                            uint64_t anchorTowStart) noexcept
         : syncPoints_(std::move(syncs)),
           discontinuities_(std::move(discs)),
-          anchorWeek_(anchorWeek) {}
+          anchorWeek_(anchorWeek),
+          anchorTowStart_(anchorTowStart) {}
 
     std::vector<ISSyncPoint>    syncPoints_;
     std::vector<Discontinuity>  discontinuities_;
@@ -209,6 +211,11 @@ private:
     //! chooseAnchorWeek). 0 => no valid week seen (pre-fix log); resolve() then
     //! falls back to ToW-only, pre-D0066 behavior.
     uint32_t                    anchorWeek_ = 0;
+    //! SN-8323: earliest ToW (ms into week) of the durable fix period. A
+    //! ToW-domain input well before this began has no stable GPS time (a
+    //! pre-fix / startup record) and resolve() tags it SessionOnly/Unknown so
+    //! consumers exclude it from the timeline + extent.
+    uint64_t                    anchorTowStart_ = 0;
 };
 
 } // namespace inertial_sense

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -196,12 +196,19 @@ public:
 
 private:
     explicit ISTimeResolver(std::vector<ISSyncPoint> syncs,
-                            std::vector<Discontinuity> discs) noexcept
+                            std::vector<Discontinuity> discs,
+                            uint32_t anchorWeek) noexcept
         : syncPoints_(std::move(syncs)),
-          discontinuities_(std::move(discs)) {}
+          discontinuities_(std::move(discs)),
+          anchorWeek_(anchorWeek) {}
 
     std::vector<ISSyncPoint>    syncPoints_;
     std::vector<Discontinuity>  discontinuities_;
+    //! SN-8323: epoch-anchor GPS week, derived in build() from the log's durable
+    //! fix period (the non-zero week with the widest ToW coverage — see
+    //! chooseAnchorWeek). 0 => no valid week seen (pre-fix log); resolve() then
+    //! falls back to ToW-only, pre-D0066 behavior.
+    uint32_t                    anchorWeek_ = 0;
 };
 
 } // namespace inertial_sense

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -280,6 +280,87 @@ TEST_F(TimeResolverTest, ResolveExtrapolated) {
 }
 
 // ---------------------------------------------------------------------------
+// SN-8323: a log that begins BEFORE GPS fix. The earliest (smallest-ToW) sync
+// record carries week 0 (device still searching); later records carry the real
+// week. Because syncPoints_ is sorted by ToW, front() is the week-0 record;
+// anchoring to it (old behavior) left the log in the ToW-only ~1980 domain. The
+// resolver must anchor to the most-common valid (non-zero) week instead.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, PreFixWeekZeroAnchorsToValidWeek) {
+    auto pre = makeIns2(10.0);   pre.week = 0;     // smallest ToW, pre-fix week 0
+    auto a   = makeIns2(100.0);  a.week   = 2300;  // post-fix, valid week
+    auto b   = makeIns2(110.0);  b.week   = 2300;
+    auto c   = makeIns2(120.0);  c.week   = 2300;
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    recs.emplace_back(DID_INS_2, bytesOf(pre));
+    recs.emplace_back(DID_INS_2, bytesOf(a));
+    recs.emplace_back(DID_INS_2, bytesOf(b));
+    recs.emplace_back(DID_INS_2, bytesOf(c));
+    f = buildFixture("prefix_week0", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // front() sync is the week-0 pre-fix record (smallest ToW) — the trap the
+    // old code fell into.
+    ASSERT_FALSE(resolver->syncPoints().empty());
+    EXPECT_EQ(resolver->syncPoints().front().gpsWeek, 0u);
+
+    // Must anchor to the valid week 2300, NOT week 0.
+    auto t = resolver->resolve(105000, kFixtureSerial);
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(105000, 2300));
+    EXPECT_GE(t.value, 315'964'800'000ULL + 2300ULL * 604'800'000ULL);  // real-year domain
+    EXPECT_NE(t.value, 105000ULL);  // the un-anchored ToW-only (~1980) result
+}
+
+// SN-8323: all-week-0 log (device never fixed) → no valid week → fall back to
+// ToW-only (no epoch anchor); must not crash.
+TEST_F(TimeResolverTest, AllWeekZeroFallsBackToToWOnly) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (double tow : { 100.0, 110.0, 120.0 }) {
+        auto s = makeIns2(tow); s.week = 0;
+        recs.emplace_back(DID_INS_2, bytesOf(s));
+    }
+    f = buildFixture("allweek0", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    auto t = resolver->resolve(105000, kFixtureSerial);
+    EXPECT_EQ(t.value, 105000ULL);  // ToW-only passthrough, no epoch anchor
+}
+
+// SN-8323: a brief startup transient reports a WRONG non-zero week for a couple
+// records before the durable fix settles. The anchor must be derived from the
+// durable fix (widest ToW coverage), not the short-span transient.
+TEST_F(TimeResolverTest, StartupTransientWeekLosesToDurableFix) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // transient glitch: 2 records, tiny ToW span (5..6 s), wrong week 1111
+    for (double tow : { 5.0, 6.0 }) {
+        auto s = makeIns2(tow); s.week = 1111;
+        recs.emplace_back(DID_INS_2, bytesOf(s));
+    }
+    // durable fix: many records, wide ToW span (100..600 s), real week 2300
+    for (double tow : { 100.0, 200.0, 300.0, 400.0, 500.0, 600.0 }) {
+        auto s = makeIns2(tow); s.week = 2300;
+        recs.emplace_back(DID_INS_2, bytesOf(s));
+    }
+    f = buildFixture("transient_week", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    // Anchor to the durable week 2300, not the transient 1111.
+    auto t = resolver->resolve(300000, kFixtureSerial);
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(300000, 2300));
+}
+
+// ---------------------------------------------------------------------------
 // Discontinuity detection — synthesize a clock jump between sync points
 // by giving the third sync point a much smaller delta than the gap
 // before it.

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -360,6 +360,34 @@ TEST_F(TimeResolverTest, StartupTransientWeekLosesToDurableFix) {
     EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(300000, 2300));
 }
 
+// SN-8323 (part 2): a pre-fix record whose ToW is well before the durable fix
+// window is tagged SessionOnly/Unknown so consumers drop it from the timeline +
+// extent (no "leading gap"), rather than anchoring it to a bogus week-start
+// time. A query inside the durable window still resolves normally.
+TEST_F(TimeResolverTest, PreFixToWBeforeDurableWindowIsSessionOnly) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    { auto s = makeIns2(1.0); s.week = 0; recs.emplace_back(DID_INS_2, bytesOf(s)); }  // pre-fix, ~1 s into week
+    for (double tow : { 400000.0, 400100.0, 400200.0 }) {  // durable fix ~4.6 days into the week
+        auto s = makeIns2(tow); s.week = 2300;
+        recs.emplace_back(DID_INS_2, bytesOf(s));
+    }
+    f = buildFixture("prefix_before_window", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // Pre-fix ToW (~1 s) is far before the durable window (~4.6 d) -> excluded.
+    auto pre = resolver->resolve(1000, kFixtureSerial);
+    EXPECT_EQ(pre.source, TimeSource::SessionOnly);
+    EXPECT_EQ(pre.confidence, TimeConfidence::Unknown);
+
+    // A query inside the durable window still resolves (2300-anchored).
+    auto ok = resolver->resolve(400100000, kFixtureSerial);
+    EXPECT_EQ(ok.value, expectedUnixMsForFixtureWeek(400100000, 2300));
+}
+
 // ---------------------------------------------------------------------------
 // Discontinuity detection — synthesize a clock jump between sync points
 // by giving the third sync point a much smaller delta than the gap


### PR DESCRIPTION
## Robust GPS-week epoch anchoring in `ISTimeResolver` for logs recorded around GPS acquisition

### What kind of issue is this
`ISTimeResolver` maps a device log's record timestamps to absolute (Unix) time by epoch-anchoring the log's GPS time-of-week values to a single GPS **week** derived from the log's sync points. That logic assumed a log recorded entirely within one *established* GPS week. Logs that begin recording **before the device has a stable GPS fix** break the assumption: early records carry an invalid/zero GPS week and a time-of-week that doesn't yet reflect real time. Any SDK consumer that resolves timestamps (charting, log extent/span, playback) then sees:

1. **Wrong epoch** — when the chosen week is 0, the log isn't epoch-anchored at all and resolves near the GPS epoch (~1980).
2. **Spurious span** — records with no stable time resolve to bogus early timestamps and inflate the log's resolved extent (by days; combined with #1, by decades).

### Root cause
- The anchor week was taken from `syncPoints_.front()`. Sync points are sorted by ToW, so `front()` is the smallest-ToW record — on a pre-fix log, a week-0 record → no epoch anchor.
- Records logged before a stable fix (invalid week / near-zero ToW) were still epoch-anchored, landing at implausible early times that then drove the log extent.

### Fix (both SDK-side, so all consumers resolve identically)
1. **Derive the anchor week from the durable fix period** — the non-zero GPS week with the widest ToW coverage across sync points — instead of a single (possibly transient or pre-fix) record. Robust to startup week-0 and brief transient/garbage weeks.
2. **Exclude pre-fix records** — a ToW-domain record whose ToW falls well before the durable fix window began is tagged `SessionOnly/Unknown` (the same contract as a record with no anchor), so consumers drop it from the timeline + extent rather than anchoring it to a bogus early time. A 5-minute guard preserves legitimate near-boundary data.

### Tests (`tests/test_time_resolver.cpp`, gtest)
The existing `buildFixture` harness writes real `.raw` logs; new cases simulate each errant condition:
- `PreFixWeekZeroAnchorsToValidWeek` — front sync is week 0, durable week later → anchors to the valid week.
- `StartupTransientWeekLosesToDurableFix` — a brief wrong non-zero week loses to the durable fix (widest coverage).
- `AllWeekZeroFallsBackToToWOnly` — no valid week anywhere → ToW-only fallback, no crash.
- `PreFixToWBeforeDurableWindowIsSessionOnly` — pre-fix ToW excluded; an in-window query still resolves normally.

### Validation
End-to-end on a real pre-fix log, the resolved extent went from a ~46-year span to the log's true ~4-minute duration, and wall-clock shows the correct date.

**Blast radius:** `ISTimeResolver` — all SDK consumers. Anchor-selection + confidence-tagging only; logs that already had a single valid week are unchanged.
