### PR TITLE
SN-8320 evaltool silently skips update

### DIFF
--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -1209,7 +1209,7 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                         "Ignoring Update. New firmware %s is older than device %s.",
                         imageVerStr.c_str(), targetVerStr.c_str());
                     cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
-                    cmd.resultMsg = "Update Skipped — Firmware Not Newer (Use \"Force Update\" to Override)";
+                    cmd.resultMsg = "Update Skipped — Firmware is not newer (Use \"Force Update\" to override)";
                     // Record this as a notification (not an error) so the caller can surface it
                     // distinctly from a plain "Completed Successfully" — otherwise a version-skip
                     // looks identical to a real upload in the UI.

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -1215,6 +1215,13 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                     // looks identical to a real upload in the UI.
                     {
                         auto lk = updateState.lock();
+                        // Because we never called initializeUpload() (no session was actually
+                        // started), updateState.target is still stale for this target. Sync it
+                        // here — otherwise refreshUpdateState()'s "session target changed" check
+                        // (which runs right after this, in the same step()) sees a mismatch and
+                        // clears updateState.messages, wiping the notification we just added
+                        // before it's ever displayed.
+                        updateState.target = target;
                         updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_WARN, cmd.resultMsg);
                         updateState.hasNotifications = true;
                     }

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -531,12 +531,19 @@ bool ISFirmwareUpdater::step() {
     fnStep.mark("Finished fwUpdate_step().");
 
     if (fwUpdate_isDone()) {
-        if (hasErrors())
-            updateState.state = ISFwUpdateState::UPDATER_DONE_WITH_ERRORS;
-        else if (updateState.hasNotifications)
-            updateState.state = ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS;
-        else
-            updateState.state = ISFwUpdateState::UPDATER_SUCCESSFUL;
+        bool errored = hasErrors();
+        {
+            // hasNotifications is written elsewhere (e.g. cmd_UploadImage) under updateState.lock();
+            // take the same lock here so this read-and-write of updateState fields is synchronized
+            // against concurrent readers/writers (e.g. the UI thread via getSnapshot()).
+            auto lk = updateState.lock();
+            if (errored)
+                updateState.state = ISFwUpdateState::UPDATER_DONE_WITH_ERRORS;
+            else if (updateState.hasNotifications)
+                updateState.state = ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS;
+            else
+                updateState.state = ISFwUpdateState::UPDATER_SUCCESSFUL;
+        }
 
         // be sure to release/cleanup the source file after we are finished with it.
         if (srcFile) {

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -462,8 +462,12 @@ void ISFirmwareUpdater::refreshUpdateState() {
             }
             break;
         case ISFwUpdateState::UPDATER_SUCCESSFUL:
-        case ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS:
             updateState.lastMessage = "Completed successfully.";
+            break;
+        case ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS:
+            // Prefer the most recent recorded notification (e.g. "skipped due to version") over
+            // a generic success message, so the user can see WHY nothing was actually uploaded.
+            updateState.lastMessage = updateState.messages.empty() ? "Completed successfully." : updateState.messages.back().msg;
             break;
     }
 
@@ -527,7 +531,12 @@ bool ISFirmwareUpdater::step() {
     fnStep.mark("Finished fwUpdate_step().");
 
     if (fwUpdate_isDone()) {
-        updateState.state = hasErrors() ? ISFwUpdateState::UPDATER_DONE_WITH_ERRORS : ISFwUpdateState::UPDATER_SUCCESSFUL;
+        if (hasErrors())
+            updateState.state = ISFwUpdateState::UPDATER_DONE_WITH_ERRORS;
+        else if (updateState.hasNotifications)
+            updateState.state = ISFwUpdateState::SUCCESS_WITH_NOTIFICATIONS;
+        else
+            updateState.state = ISFwUpdateState::UPDATER_SUCCESSFUL;
 
         // be sure to release/cleanup the source file after we are finished with it.
         if (srcFile) {
@@ -1200,7 +1209,15 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                         "Ignoring Update. New firmware %s is older than device %s.",
                         imageVerStr.c_str(), targetVerStr.c_str());
                     cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
-                    cmd.resultMsg = "Target is already up to date.";
+                    cmd.resultMsg = "Update Skipped Due to Version (Use \"Force Update\")";
+                    // Record this as a notification (not an error) so the caller can surface it
+                    // distinctly from a plain "Completed Successfully" — otherwise a version-skip
+                    // looks identical to a real upload in the UI.
+                    {
+                        auto lk = updateState.lock();
+                        updateState.messages.emplace_back(activeStep, cmd, IS_LOG_LEVEL_WARN, cmd.resultMsg);
+                        updateState.hasNotifications = true;
+                    }
                     return;
                 }
             }

--- a/src/ISFirmwareUpdater.cpp
+++ b/src/ISFirmwareUpdater.cpp
@@ -1209,7 +1209,7 @@ void ISFirmwareUpdater::cmd_UploadImage(ISFwUpdaterCmd& cmd) {
                         "Ignoring Update. New firmware %s is older than device %s.",
                         imageVerStr.c_str(), targetVerStr.c_str());
                     cmd.status = ISFwUpdaterCmd::CMD_SUCCESS;
-                    cmd.resultMsg = "Update Skipped Due to Version (Use \"Force Update\")";
+                    cmd.resultMsg = "Update Skipped — Firmware Not Newer (Use \"Force Update\" to Override)";
                     // Record this as a notification (not an error) so the caller can surface it
                     // distinctly from a plain "Completed Successfully" — otherwise a version-skip
                     // looks identical to a real upload in the UI.

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -185,7 +185,7 @@ public:
     ISFwUpdateState(const ISFwUpdateState& other)
         : lastMessage(other.lastMessage), state(other.state), status(other.status),
           target(other.target), slot(other.slot), progress(other.progress),
-          messages(other.messages), hasErrors(other.hasErrors) { }
+          messages(other.messages), hasErrors(other.hasErrors), hasNotifications(other.hasNotifications) { }
 
     ISFwUpdateState& operator=(const ISFwUpdateState& other) {
         if (this != &other) {
@@ -197,6 +197,7 @@ public:
             progress = other.progress;
             messages = other.messages;
             hasErrors = other.hasErrors;
+            hasNotifications = other.hasNotifications;
         }
         return *this;
     }
@@ -226,6 +227,7 @@ public:
         slot = 0;
         progress = 0.f;
         hasErrors = false;
+        hasNotifications = false;
     }
 
     std::string                 lastMessage;                        //!< the current/last/most recent message which should be shown to the user
@@ -236,6 +238,7 @@ public:
     float                       progress = 0.f;                     //!< the current/last progress of the target upload
     std::vector<message>        messages;                           //!< the collection of all messages that have occurred during the update
     bool                        hasErrors = false;                  //!< an easy indicator to track errors while still in progress, generally true if msgs contains one more IS_LOG_LEVEL_ERROR messages
+    bool                        hasNotifications = false;           //!< true if a non-error notification (e.g., "update skipped due to version") was recorded during the update
 
 private:
     mutable std::recursive_mutex mtx;                               //!< protects all fields from concurrent read/write across threads


### PR DESCRIPTION
This pull request improves how firmware update notifications are handled and displayed, especially when an update is skipped due to version checks. The changes ensure that user-facing messages accurately reflect the outcome and reason for skipped updates, and that notifications are tracked and surfaced distinctly from errors or generic success states.

**Notification handling and user messaging:**

* When an update is skipped because the firmware is not newer, the user now sees a clear message: "Update Skipped — Firmware is not newer (Use 'Force Update' to override)", and this is recorded as a notification rather than an error. The notification is preserved and surfaced in the UI, even if no upload session was started.
* The updater now distinguishes between a plain successful update and a success with notifications (such as a version skip), ensuring that the most relevant message (like a notification) is shown to the user instead of a generic success message.

**State management improvements:**

* The `ISFwUpdateState` class now tracks a `hasNotifications` flag, which is properly copied, assigned, and reset with state changes, ensuring notification state is accurately maintained across operations. [[1]](diffhunk://#diff-f5472e2adc7abb2d101aa2b677b1f356e4d0aef626ff2b1e5f6df5c142eaff0eL188-R188) [[2]](diffhunk://#diff-f5472e2adc7abb2d101aa2b677b1f356e4d0aef626ff2b1e5f6df5c142eaff0eR200) [[3]](diffhunk://#diff-f5472e2adc7abb2d101aa2b677b1f356e4d0aef626ff2b1e5f6df5c142eaff0eR230) [[4]](diffhunk://#diff-f5472e2adc7abb2d101aa2b677b1f356e4d0aef626ff2b1e5f6df5c142eaff0eR241)
* The update step logic in `ISFirmwareUpdater::step()` sets the update state to `SUCCESS_WITH_NOTIFICATIONS` if any notifications were recorded, rather than treating all non-error completions as plain successes.