### PR TITLE
SN-8163 IMX-5 mag gauss uT fix

### DIFF
--- a/src/ISConstants.h
+++ b/src/ISConstants.h
@@ -793,8 +793,9 @@ static inline int is_finite(double v)
 #define C_WIE               7.2321151467e-05   // WGS-84 earth rotation rate (rad/s)
 #define C_WIE_F             7.2321151467e-05f
 
-#define C_TESLA2GAUSS_F     10000.0
-#define C_UTESLA2GAUSS_F    0.01
+#define C_TESLA2GAUSS_F     10000.0f
+#define C_UTESLA2GAUSS_F    0.01f
+#define C_GAUSS2UTESLA_F    100.0f
 
 #define C_0p1_DEG2RAD_F     0.00174532925199433f        // = 0.1f * C_0pDEG2RAD_F
 #define C_0p11_DEG2RAD_F    0.00191986217719376f


### PR DESCRIPTION
This pull request makes minor improvements to the constants defined for unit conversions in `src/ISConstants.h`. The changes ensure floating-point suffix consistency and introduce a new conversion constant.

* Constants for Tesla-to-Gauss and microTesla-to-Gauss conversions now explicitly use the `f` suffix for floating-point precision.
* Added a new constant `C_GAUSS2UTESLA_F` for Gauss-to-microTesla conversion.