### PR TITLE
SN-8336 updated InertialSense_log_reader Example Project callback to match new wrapper in InertialSense.h

### DIFF
--- a/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp
+++ b/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp
@@ -16,11 +16,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Change these include paths to the correct paths for your project
 #include "../../src/InertialSense.h"
 
-static int msgHandlerIsb(InertialSense* i, p_data_t* data, port_handle_t port)
+static void msgHandlerIsb(void* i, p_data_t* data, port_handle_t port)
 {
     static uint64_t dataCount;
     printf("Data count: %" PRIu64 "          \r", ++dataCount);
-    return 0;
 }
 
 int main(int argc, char* argv[])

--- a/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp
+++ b/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp
@@ -16,7 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Change these include paths to the correct paths for your project
 #include "../../src/InertialSense.h"
 
-static void msgHandlerIsb(void* i, p_data_t* data, port_handle_t port)
+static void msgHandlerIsb(void* ctx, p_data_t* data, port_handle_t port)
 {
     static uint64_t dataCount;
     printf("Data count: %" PRIu64 "          \r", ++dataCount);


### PR DESCRIPTION
The InertialSense_log_reader Example Project does not build, apparently due to a change to a function wrapper signature in InertialSense.h:
```
/home/tylersheffield/inertial_sense/git_repos/inertial-sense-sdk/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp: In function ‘int main(int, char**)’:
/home/tylersheffield/inertial_sense/git_repos/inertial-sense-sdk/ExampleProjects/InertialSense_log_reader/ISLogReaderExample.cpp:36:46: error: no matching function for call to ‘InertialSense::InertialSense(int (&)(InertialSense*, p_data_t*, port_handle_t))’
   36 |     InertialSense inertialSense(msgHandlerIsb);

```

Claude says:
> The InertialSense constructor now expects a pfnHandleBinaryData callback, which is std::function<void(void* ctx, p_data_t* data, port_handle_t port)> (see  InertialSense.h:69). Your callback in ISLogReaderExample.cpp:19 has the old signature — it returns int and takes InertialSense* as the first parameter instead of  void*. That mismatch is why no conversion is found.
> 
>   Fix: change the signature to match, and cast the void* back to InertialSense* inside if you still need the pointer.
>   The call site InertialSense inertialSense(msgHandlerIsb); stays the same.

This is apparently the location of the change in the header:
```
/** Callback signature for per-DID or global binary-data received callbacks. */
typedef std::function<void(void* ctx, p_data_t* data, port_handle_t port)> pfnHandleBinaryData;

```
  
Made the change to the exproj code to match the new signature.

Fixes the reported compile error and later naming suggestion only, CI coverage intentionally and meta-build inclusion not restored yet.

To be SQUASH-MERGED.
