### PR TITLE
SN-8323: ISTimeResolver uptime/GPS domain unification + reader-never-anchors-on-own-clock

### DIFF
--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -345,7 +345,11 @@ packet_t* cDeviceLogRaw::ReadPacketFromChunk(protocol_type_t& ptype)
 
             case _PTYPE_INERTIAL_SENSE_DATA:
             case _PTYPE_INERTIAL_SENSE_CMD:
-                m_logStats.LogData(ptype, m_comm.rxPkt.id, m_comm.rxPkt.size, cISDataMappings::TimestampOrCurrentTime(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr));
+                // SN-8323: this is a READ path — never anchor on the reader's
+                // clock. Use Timestamp() (0 for time-less records), NOT
+                // TimestampOrCurrentTime() whose current-time fallback would put
+                // a load-varying reader wall clock into LogStats.
+                m_logStats.LogData(ptype, m_comm.rxPkt.id, m_comm.rxPkt.size, cISDataMappings::Timestamp(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr));
 
                 m_pData.hdr = m_comm.rxPkt.dataHdr;
                 memcpy(m_pData.buf, m_comm.rxPkt.data.ptr + m_comm.rxPkt.dataHdr.offset, m_comm.rxPkt.dataHdr.size);

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -3364,6 +3364,12 @@ double cISDataMappings::Timestamp(const p_data_hdr_t* hdr, const uint8_t* buf)
     return 0.0;
 }
 
+// WARNING (SN-8323): the current-time fallback below substitutes the CALLER's
+// (reader's) wall clock. That is ONLY valid on a live WRITE/capture path, where
+// "now" IS the capture time. It must NEVER be called on a log-READ / parse /
+// load path — a read-time anchor changes every load and can never be a valid
+// timestamp. Reader code must call Timestamp() (0 sentinel) and route through
+// ISTimeResolver instead. See D0060 / D0069.
 double cISDataMappings::TimestampOrCurrentTime(const p_data_hdr_t* hdr, const uint8_t* buf)
 {
     double timestamp = Timestamp(hdr, buf);

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -9,6 +9,8 @@
 
 #include "ISLogReader.h"
 
+#include "ISDeviceLog.h"      // detectGaps: iterate composed segments
+#include "ISTimeResolver.h"   // detectGaps: resolve per-segment record times
 #include "core/msg_logger.h"
 
 // com_manager.h FIRST — short-circuits the broken extern-C wrap in ISFirmwareUpdater.h that would otherwise trip C++
@@ -850,6 +852,82 @@ ISLogReader::RangeIterator ISLogReader::seek(TimeStamp target) const noexcept {
         }
     }
     return RangeIterator{ this, &allIndices_, pos };
+}
+
+// ---------------------------------------------------------------------------
+// Gap detection (SN-8345)
+// ---------------------------------------------------------------------------
+
+std::vector<ISLogReader::DataGap>
+ISLogReader::findGaps(std::vector<SegmentSpan> spans, uint64_t thresholdMs) {
+    std::vector<DataGap> gaps;
+
+    spans.erase(std::remove_if(spans.begin(), spans.end(),
+                               [](const SegmentSpan& s) { return !s.valid(); }),
+                spans.end());
+    if (spans.size() < 2) return gaps;
+
+    std::sort(spans.begin(), spans.end(),
+              [](const SegmentSpan& a, const SegmentSpan& b) {
+                  return a.start.value < b.start.value;
+              });
+
+    // Sweep in start order, tracking the coverage high-water mark. A gap opens
+    // when the next span begins more than thresholdMs past the mark; overlapping
+    // or contiguous spans just extend it.
+    TimeStamp coverEnd = spans.front().end;
+    for (std::size_t i = 1; i < spans.size(); ++i) {
+        const SegmentSpan& s = spans[i];
+        if (s.start.value > coverEnd.value &&
+            (s.start.value - coverEnd.value) > thresholdMs) {
+            DataGap g;
+            g.startTime  = coverEnd;
+            g.endTime    = s.start;
+            g.segmentId  = kNoSegment;   // no segment covers this interval
+            gaps.push_back(g);
+        }
+        if (s.end.value > coverEnd.value) coverEnd = s.end;
+    }
+    return gaps;
+}
+
+std::vector<ISLogReader::DataGap>
+ISLogReader::detectGaps(const ISDeviceLog& log, const ISTimeResolver& resolver,
+                        uint64_t thresholdMs) {
+    const uint64_t devId = log.deviceId();
+    std::vector<SegmentSpan> spans;
+    spans.reserve(log.segmentCount());
+
+    for (std::size_t s = 0; s < log.segmentCount(); ++s) {
+        bool      any = false;
+        TimeStamp lo{};
+        TimeStamp hi{};
+        for (auto v : log.segment(s).allRecords()) {
+            const uint64_t raw = v.timestamp().value;
+            if (raw == 0) continue;                       // metadata / sentinel
+            const TimeStamp r = resolver.resolve(raw, devId);
+            if (r.source == TimeSource::SessionOnly) continue;  // no wall-clock anchor
+            if (r.value == 0) continue;
+            if (!any || r.value < lo.value) lo = r;
+            if (!any || r.value > hi.value) hi = r;
+            any = true;
+        }
+        if (any) {
+            SegmentSpan sp;
+            sp.segmentId = static_cast<int>(s);
+            sp.start     = lo;
+            sp.end       = hi;
+            spans.push_back(sp);
+        }
+    }
+
+    auto gaps = findGaps(std::move(spans), thresholdMs);
+    log_debug(IS_LOG_ISLOG,
+              "ISLogReader::detectGaps: device 0x%016llx, %zu segment(s) -> %zu gap(s) "
+              "(threshold %llu ms)",
+              (unsigned long long)devId, log.segmentCount(), gaps.size(),
+              (unsigned long long)thresholdMs);
+    return gaps;
 }
 
 } // namespace inertial_sense

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -58,9 +58,86 @@ namespace inertial_sense {
 template <std::uint32_t DID> struct DIDTraits;
 template <class T>           class  TypedRange;
 
+// Gap detection (below) spans a whole device log; forward-declared so the
+// single-segment header stays light. Full definitions in ISDeviceLog.h /
+// ISTimeResolver.h, pulled in by ISLogReader.cpp.
+class ISDeviceLog;
+class ISTimeResolver;
+
 class ISLogReader {
 public:
     using did_t = uint32_t;
+
+    // -----------------------------------------------------------------
+    // Gap detection (SN-8345) — coverage gaps on the resolved timeline
+    // -----------------------------------------------------------------
+
+    /// Sentinel segment id: a gap NO segment covers (a whole segment absent, or
+    /// a recording pause between segments). A valid (>= 0) id instead marks a
+    /// gap WITHIN a present segment — a dropped-data interval (future). Callers
+    /// colour the two cases differently on the timeline.
+    static constexpr int kNoSegment = -1;
+
+    /// A segment's resolved wall-clock coverage, `[start, end]`. Input to
+    /// @ref findGaps. `start`/`end` are resolved (unified-domain) TimeStamps.
+    struct SegmentSpan {
+        int       segmentId = kNoSegment;  ///< composition index (0-based)
+        TimeStamp start{};                 ///< earliest resolved record time
+        TimeStamp end{};                   ///< latest resolved record time
+
+        /// True when the span is a usable, non-degenerate interval.
+        bool valid() const noexcept {
+            return end.value >= start.value && (start.value != 0 || end.value != 0);
+        }
+    };
+
+    /// A detected coverage gap on the unified resolved timeline.
+    struct DataGap {
+        TimeStamp startTime{};             ///< gap start = end of prior coverage
+        TimeStamp endTime{};               ///< gap end   = start of next coverage
+        int       segmentId = kNoSegment;  ///< @ref kNoSegment = no owning segment
+                                           ///< (missing/pause); valid = within-segment drop
+
+        /// Gap width in ms (0 if degenerate).
+        uint64_t durationMs() const noexcept {
+            return endTime.value > startTime.value ? endTime.value - startTime.value : 0;
+        }
+    };
+
+    /**
+     * @brief Detect coverage gaps between segment spans. PURE — no I/O.
+     *
+     * Spans need not be sorted or disjoint. Sweeps them in start order tracking
+     * the running coverage high-water mark; whenever the next span begins more
+     * than @p thresholdMs after that mark, the interval is reported as a gap
+     * (with @ref kNoSegment — no segment covers it). Overlapping / contiguous
+     * spans never produce a gap.
+     *
+     * @param spans        Per-segment resolved spans; invalid spans ignored.
+     * @param thresholdMs  Minimum gap width to report (`<= thresholdMs` skipped).
+     * @return             Gaps in ascending start order.
+     */
+    static std::vector<DataGap> findGaps(std::vector<SegmentSpan> spans,
+                                         uint64_t thresholdMs);
+
+    /**
+     * @brief Resolve each segment's coverage from @p log and detect gaps.
+     *
+     * Scans every record of every segment through @p resolver, tracking the
+     * min/max resolved value per segment (records that resolve to
+     * @ref TimeSource::SessionOnly are excluded — an unanchored segment yields
+     * no span). A full scan is deliberate: within a segment records can be
+     * mixed-domain, so the raw first/last record is not a reliable extent.
+     * Then applies @ref findGaps.
+     *
+     * @param log          Composed device log.
+     * @param resolver     Resolver built from @p log.
+     * @param thresholdMs  Minimum gap width to report.
+     * @return             Coverage gaps on the resolved timeline.
+     */
+    static std::vector<DataGap> detectGaps(const ISDeviceLog& log,
+                                           const ISTimeResolver& resolver,
+                                           uint64_t thresholdMs);
 
     // -----------------------------------------------------------------
     // Lifecycle

--- a/src/ISLogReaderSugar.cpp
+++ b/src/ISLogReaderSugar.cpp
@@ -53,7 +53,10 @@ TypedRange<T> extractTypedRange(const ISLogReader& reader, did_t did) {
         if (comm.rxPkt.dataHdr.id != did) continue;
         if (comm.rxPkt.dataHdr.size != sizeof(T)) continue;
 
-        const double tsSec = cISDataMappings::TimestampOrCurrentTime(
+        // SN-8323: NEVER anchor on the reader's clock. Use Timestamp() (0 for a
+        // record with no internal time), NOT TimestampOrCurrentTime() whose
+        // current-time fallback stamps a load-varying reader-host wall clock.
+        const double tsSec = cISDataMappings::Timestamp(
             &comm.rxPkt.dataHdr, comm.rxPkt.data.ptr);
         const uint64_t tsMs = static_cast<uint64_t>(tsSec * 1000.0);
         TimeStamp ts{ tsMs, TimeSource::PayloadToW, TimeConfidence::Exact,

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -123,7 +123,8 @@ double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
  */
 void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t deviceId,
-                         std::vector<ISSyncPoint>& out) {
+                         std::vector<ISSyncPoint>& out,
+                         std::vector<int64_t>& upOffsetsOut) {
     auto bytes = reader.rawBytes();
     if (!bytes.first || bytes.second == 0) return;
 
@@ -144,6 +145,26 @@ void scanSegmentForSyncs(const ISLogReader& reader,
             continue;
         }
         const auto& hdr = comm.rxPkt.dataHdr;
+
+        // SN-8323 (uptime unification): DID_SYS_PARAMS carries BOTH the GPS
+        // time-of-week (timeOfWeekMs) and the definitive system uptime (upTime,
+        // seconds since boot). When the device is synced (timeOfWeekMs > 0),
+        // one such record yields the authoritative uptime->ToW offset that
+        // bridges every session-uptime value (magnetometer/imu records, and
+        // pre-sync "real clock" records whose week/ToW default to uptime until
+        // GPS lock). This replaces the fragile per-sync actualHostTimeMs
+        // heuristic. (Kyle 2026-07-23: SYS_PARAMS.upTime is the definitive
+        // relative uptime; GNSS/INS are the accurate absolute clock.)
+        if (hdr.id == DID_SYS_PARAMS && comm.rxPkt.data.ptr &&
+            hdr.offset == 0 && hdr.size >= sizeof(sys_params_t)) {
+            sys_params_t sp2{};
+            std::memcpy(&sp2, comm.rxPkt.data.ptr, sizeof(sp2));
+            if (sp2.timeOfWeekMs > 0 && sp2.upTime > 0.0) {
+                const int64_t upMs = static_cast<int64_t>(sp2.upTime * 1000.0);
+                upOffsetsOut.push_back(
+                    static_cast<int64_t>(sp2.timeOfWeekMs) - upMs);
+            }
+        }
 
         // Probe every record for a payload-side timestamp. ToW-bearing
         // records use this for the sync's payloadToW; non-ToW-bearing
@@ -246,11 +267,17 @@ uint32_t chooseAnchorWeek(const std::vector<ISSyncPoint>& syncs) {
 // ============================================================
 
 std::vector<ISSyncPoint> ISTimeResolver::detectSyncPoints(const ISDeviceLog& log) {
+    std::vector<int64_t> upOffsets;  // discarded here; build() consumes them.
+    return detectSyncPointsImpl(log, upOffsets);
+}
+
+std::vector<ISSyncPoint> ISTimeResolver::detectSyncPointsImpl(
+    const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut) {
     std::vector<ISSyncPoint> out;
     const uint64_t deviceId = log.deviceId();
 
     for (std::size_t s = 0; s < log.segmentCount(); ++s) {
-        scanSegmentForSyncs(log.segment(s), deviceId, out);
+        scanSegmentForSyncs(log.segment(s), deviceId, out, upOffsetsOut);
     }
 
     // Sort by hostTimeMs (the build's downstream expectation). Records
@@ -285,7 +312,8 @@ ISTimeResolver::build(const ISDeviceLog& log) {
 
 ISExpected<ISTimeResolver>
 ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
-    auto syncs = detectSyncPoints(log);
+    std::vector<int64_t> upOffsets;
+    auto syncs = detectSyncPointsImpl(log, upOffsets);
 
     std::vector<Discontinuity> discs;
     if (syncs.size() >= 3) {
@@ -311,14 +339,35 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
     // (earliest ToW at that week) before moving `syncs`.
     const uint32_t anchorWeek = chooseAnchorWeek(syncs);
     uint64_t anchorTowStart = 0;
+    uint64_t anchorTowEnd   = 0;
     if (anchorWeek != 0) {
         uint64_t minTow = UINT64_MAX;
+        uint64_t maxTow = 0;
         for (const auto& sp : syncs) {
-            if (sp.gpsWeek == anchorWeek) minTow = std::min(minTow, sp.payloadToWMs);
+            if (sp.gpsWeek == anchorWeek) {
+                minTow = std::min(minTow, sp.payloadToWMs);
+                maxTow = std::max(maxTow, sp.payloadToWMs);
+            }
         }
         anchorTowStart = (minTow == UINT64_MAX) ? 0 : minTow;
+        anchorTowEnd   = maxTow;
     }
-    return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek, anchorTowStart };
+
+    // SN-8323 (uptime unification): authoritative uptime->ToW offset = median of
+    // the synced DID_SYS_PARAMS (timeOfWeekMs - upTime) samples. upTime and ToW
+    // advance 1:1, so all synced samples agree modulo clock drift; the median
+    // resists an occasional transient sample.
+    int64_t uptimeToTowOffsetMs = 0;
+    bool    haveUptimeOffset    = false;
+    if (!upOffsets.empty()) {
+        std::sort(upOffsets.begin(), upOffsets.end());
+        uptimeToTowOffsetMs = upOffsets[upOffsets.size() / 2];
+        haveUptimeOffset    = true;
+    }
+
+    return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek,
+                           anchorTowStart, anchorTowEnd,
+                           uptimeToTowOffsetMs, haveUptimeOffset };
 }
 
 // ============================================================
@@ -364,6 +413,39 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
     auto unixOrToW = [&](uint64_t towMs) -> uint64_t {
         return epochAnchor ? gpsToUnixMs(anchorWeek, towMs) : towMs;
     };
+
+    // SN-8323 (uptime unification): authoritative uptime->ToW bridge. When a
+    // synced DID_SYS_PARAMS supplied the definitive offset, classify the input
+    // against the durable-fix ToW window [anchorTowStart_, anchorTowEnd_]:
+    //   - already inside the window  -> ToW-domain, fall through to the normal
+    //     sync-point resolution below;
+    //   - outside, but (input + offset) lands inside -> a session-uptime value
+    //     (magnetometer/imu, or a pre-sync "real clock" record whose ToW field
+    //     defaulted to uptime until GPS lock) -> bridge via the authoritative
+    //     offset.
+    // This supersedes the fragile per-sync actualHostTimeMs heuristic (below)
+    // and stops tiny pre-sync ToW values from poisoning the bridge — the mag
+    // records that used to resolve to the GPS-week start (days early) now land
+    // correctly in the fix window. (Kyle 2026-07-23.)
+    if (haveUptimeOffset_ && epochAnchor && anchorTowEnd_ >= anchorTowStart_) {
+        const int64_t guard    = static_cast<int64_t>(kPreFixGuardMs);
+        const int64_t lo       = static_cast<int64_t>(anchorTowStart_);
+        const int64_t hi       = static_cast<int64_t>(anchorTowEnd_);
+        const int64_t raw      = static_cast<int64_t>(hostTimeMs);
+        const bool    rawIsTow = (raw >= lo - guard && raw <= hi + guard);
+        if (!rawIsTow) {
+            const int64_t bridged = raw + uptimeToTowOffsetMs_;
+            if (bridged >= lo - guard && bridged <= hi + guard) {
+                const uint64_t towMs = (bridged < 0) ? 0u
+                                                     : static_cast<uint64_t>(bridged);
+                const TimeConfidence conf =
+                    (bridged < lo) ? TimeConfidence::ExtrapolatedBackward
+                                   : TimeConfidence::Interpolated;
+                return TimeStamp::fromResolvedViaSync(
+                    gpsToUnixMs(anchorWeek, towMs), deviceId, conf);
+            }
+        }
+    }
 
     // SN-8107 / D0066: cross-domain bridge. v2 .idx puts sync records'
     // timestamp field in the GPS-ToW domain (hundreds of millions of ms

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -159,7 +159,13 @@ void scanSegmentForSyncs(const ISLogReader& reader,
             hdr.offset == 0 && hdr.size >= sizeof(sys_params_t)) {
             sys_params_t sp2{};
             std::memcpy(&sp2, comm.rxPkt.data.ptr, sizeof(sp2));
-            if (sp2.timeOfWeekMs > 0 && sp2.upTime > 0.0) {
+            // Only trust timeOfWeekMs as GPS ToW when the device says so:
+            // HDW_STATUS_GNSS_TIME_OF_WEEK_VALID. Otherwise timeOfWeekMs is
+            // LOCAL system time (uptime-like), and differencing it against
+            // upTime yields a bogus offset that corrupts the median bridge.
+            const bool towValid =
+                (sp2.hdwStatus & HDW_STATUS_GNSS_TIME_OF_WEEK_VALID) != 0;
+            if (towValid && sp2.timeOfWeekMs > 0 && sp2.upTime > 0.0) {
                 const int64_t upMs = static_cast<int64_t>(sp2.upTime * 1000.0);
                 upOffsetsOut.push_back(
                     static_cast<int64_t>(sp2.timeOfWeekMs) - upMs);

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -198,11 +198,23 @@ private:
     explicit ISTimeResolver(std::vector<ISSyncPoint> syncs,
                             std::vector<Discontinuity> discs,
                             uint32_t anchorWeek,
-                            uint64_t anchorTowStart) noexcept
+                            uint64_t anchorTowStart,
+                            uint64_t anchorTowEnd,
+                            int64_t  uptimeToTowOffsetMs,
+                            bool     haveUptimeOffset) noexcept
         : syncPoints_(std::move(syncs)),
           discontinuities_(std::move(discs)),
           anchorWeek_(anchorWeek),
-          anchorTowStart_(anchorTowStart) {}
+          anchorTowStart_(anchorTowStart),
+          anchorTowEnd_(anchorTowEnd),
+          uptimeToTowOffsetMs_(uptimeToTowOffsetMs),
+          haveUptimeOffset_(haveUptimeOffset) {}
+
+    //! Core detection: scans all segments for sync points AND (SN-8323 uptime
+    //! unification) authoritative uptime->ToW offset samples from DID_SYS_PARAMS.
+    //! `detectSyncPoints` and `build` both delegate here.
+    static std::vector<ISSyncPoint> detectSyncPointsImpl(
+        const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut);
 
     std::vector<ISSyncPoint>    syncPoints_;
     std::vector<Discontinuity>  discontinuities_;
@@ -216,6 +228,19 @@ private:
     //! pre-fix / startup record) and resolve() tags it SessionOnly/Unknown so
     //! consumers exclude it from the timeline + extent.
     uint64_t                    anchorTowStart_ = 0;
+    //! SN-8323 (uptime unification): latest ToW (ms into week) of the durable
+    //! fix period. With anchorTowStart_ it bounds the plausible ToW window used
+    //! to classify a resolve() input as ToW-domain vs uptime-domain.
+    uint64_t                    anchorTowEnd_ = 0;
+    //! SN-8323 (uptime unification): authoritative uptime->GPS-ToW offset (ms),
+    //! derived from DID_SYS_PARAMS (timeOfWeekMs - upTime) during build(). Kyle
+    //! 2026-07-23: SYS_PARAMS.upTime is the definitive relative uptime; session-
+    //! only records (magnetometer, imu) and pre-sync "real clock" records (whose
+    //! week/ToW default to uptime until GPS sync) are bridged through this single
+    //! offset instead of the fragile per-sync actualHostTimeMs heuristic.
+    int64_t                     uptimeToTowOffsetMs_ = 0;
+    //! True when a synced DID_SYS_PARAMS gave a usable uptime->ToW offset.
+    bool                        haveUptimeOffset_ = false;
 };
 
 } // namespace inertial_sense

--- a/tests/test_log_gaps.cpp
+++ b/tests/test_log_gaps.cpp
@@ -1,0 +1,94 @@
+// SN-8345: unit tests for ISLogReader::findGaps — coverage-gap detection on
+// the resolved timeline (the pure algorithm; segment spans in, gaps out).
+
+#include <gtest/gtest.h>
+
+#include "ISLogReader.h"
+#include "ISTimeStamp.h"
+
+#include <vector>
+
+using namespace inertial_sense;
+
+namespace {
+// A resolved span [startMs, endMs] with the given segment id. findGaps only
+// reads TimeStamp::value, so the source/confidence are immaterial here.
+ISLogReader::SegmentSpan span(int id, uint64_t startMs, uint64_t endMs) {
+    ISLogReader::SegmentSpan s;
+    s.segmentId = id;
+    s.start = TimeStamp::fromResolvedViaSync(startMs, 1, TimeConfidence::Exact);
+    s.end   = TimeStamp::fromResolvedViaSync(endMs,   1, TimeConfidence::Exact);
+    return s;
+}
+} // namespace
+
+// Contiguous / touching spans → no gaps.
+TEST(FindGaps, ContiguousSpansNoGap) {
+    auto gaps = ISLogReader::findGaps(
+        { span(0, 0, 1000), span(1, 1000, 2000), span(2, 2000, 3000) }, 100);
+    EXPECT_TRUE(gaps.empty());
+}
+
+// A single interior gap wider than the threshold is reported, with the correct
+// boundaries and the no-segment sentinel.
+TEST(FindGaps, SingleGapReportedWithBoundaries) {
+    auto gaps = ISLogReader::findGaps(
+        { span(0, 0, 1000), span(1, 5000, 6000) }, 1000);
+    ASSERT_EQ(gaps.size(), 1u);
+    EXPECT_EQ(gaps[0].startTime.value, 1000u);   // end of prior coverage
+    EXPECT_EQ(gaps[0].endTime.value,   5000u);   // start of next coverage
+    EXPECT_EQ(gaps[0].segmentId, ISLogReader::kNoSegment);
+    EXPECT_EQ(gaps[0].durationMs(), 4000u);
+}
+
+// A gap at or below the threshold is normal inter-segment spacing — not reported.
+TEST(FindGaps, GapAtOrBelowThresholdSkipped) {
+    // 500 ms gap, threshold 500 -> not reported (strictly greater required).
+    EXPECT_TRUE(ISLogReader::findGaps({ span(0, 0, 1000), span(1, 1500, 2000) }, 500).empty());
+    // 501 ms gap, threshold 500 -> reported.
+    EXPECT_EQ(ISLogReader::findGaps({ span(0, 0, 1000), span(1, 1501, 2000) }, 500).size(), 1u);
+}
+
+// Overlapping spans never produce a gap (coverage high-water handles it).
+TEST(FindGaps, OverlappingSpansNoGap) {
+    auto gaps = ISLogReader::findGaps(
+        { span(0, 0, 3000), span(1, 1000, 2000), span(2, 2500, 4000) }, 100);
+    EXPECT_TRUE(gaps.empty());
+}
+
+// A long span that swallows a later short one must not open a false gap after it.
+TEST(FindGaps, EnclosedSpanDoesNotOpenGap) {
+    // span0 covers [0,10000]; span1 [2000,3000] is inside it; span2 [10500,11000]
+    // is only 500 past coverEnd(=10000) -> below threshold 1000, no gap.
+    auto gaps = ISLogReader::findGaps(
+        { span(0, 0, 10000), span(1, 2000, 3000), span(2, 10500, 11000) }, 1000);
+    EXPECT_TRUE(gaps.empty());
+}
+
+// Unsorted input is handled; multiple gaps come back in ascending order.
+TEST(FindGaps, UnsortedInputMultipleGaps) {
+    auto gaps = ISLogReader::findGaps(
+        { span(2, 9000, 10000), span(0, 0, 1000), span(1, 4000, 5000) }, 1000);
+    ASSERT_EQ(gaps.size(), 2u);
+    EXPECT_EQ(gaps[0].startTime.value, 1000u);
+    EXPECT_EQ(gaps[0].endTime.value,   4000u);
+    EXPECT_EQ(gaps[1].startTime.value, 5000u);
+    EXPECT_EQ(gaps[1].endTime.value,   9000u);
+}
+
+// Degenerate inputs: empty and single-span produce no gaps.
+TEST(FindGaps, EmptyAndSingleNoGap) {
+    EXPECT_TRUE(ISLogReader::findGaps({}, 100).empty());
+    EXPECT_TRUE(ISLogReader::findGaps({ span(0, 0, 1000) }, 100).empty());
+}
+
+// Invalid spans (inverted or all-zero) are filtered before detection.
+TEST(FindGaps, InvalidSpansFiltered) {
+    ISLogReader::SegmentSpan inverted = span(9, 5000, 4000);   // end < start
+    ISLogReader::SegmentSpan zero     = span(8, 0, 0);         // all-zero
+    auto gaps = ISLogReader::findGaps(
+        { span(0, 0, 1000), inverted, zero, span(1, 6000, 7000) }, 1000);
+    ASSERT_EQ(gaps.size(), 1u);
+    EXPECT_EQ(gaps[0].startTime.value, 1000u);
+    EXPECT_EQ(gaps[0].endTime.value,   6000u);
+}

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -99,6 +99,26 @@ imu_t makeImu(double bootSec) {
     return s;
 }
 
+// SN-8323 (uptime unification): magnetometer `time` is seconds-since-boot
+// (uptime). DID_MAGNETOMETER is NOT ToW-bearing, so its .idx timestamp is the
+// uptime — a session-uptime value the resolver must bridge, not anchor.
+magnetometer_t makeMag(double bootSec) {
+    magnetometer_t m{};
+    m.time   = bootSec;
+    m.mag[0] = 0.1f; m.mag[1] = 0.2f; m.mag[2] = 0.3f;
+    return m;
+}
+
+// SN-8323 (uptime unification): DID_SYS_PARAMS carries BOTH the GPS ToW
+// (timeOfWeekMs) and the definitive uptime (upTime, seconds). A synced sample
+// yields the authoritative uptime->ToW offset the resolver bridges through.
+sys_params_t makeSysParams(double upTimeSec, uint32_t towMs) {
+    sys_params_t s{};
+    s.timeOfWeekMs = towMs;
+    s.upTime       = upTimeSec;
+    return s;
+}
+
 FixturePaths buildFixture(const std::string& hint,
                           const std::vector<std::pair<uint32_t, std::vector<uint8_t>>>& records) {
     FixturePaths f;
@@ -225,6 +245,43 @@ TEST_F(TimeResolverTest, ResolveExactAtSyncPoint) {
     EXPECT_EQ(t.confidence, TimeConfidence::Exact);
     // SN-8107 / D0066: epoch-anchored output (gpsWeek=2300 in makeIns2).
     EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(110000));
+}
+
+// ---------------------------------------------------------------------------
+// SN-8323 (uptime unification): a session-uptime record (magnetometer) bridges
+// to the durable-fix window via the authoritative DID_SYS_PARAMS offset — NOT
+// to the GPS-week start. Reproduces the customer yaw-jump log, where the mag's
+// uptime `time` mis-resolved ~3.85 days early and poisoned the log extent.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, SessionUptimeRecordsBridgeViaSysParamsOffset) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    // Pre-sync "real clock" record: week defaults to 1, ToW field holds uptime
+    // (~0.9 s) — must NOT be allowed to anchor the log.
+    { ins_2_t p = makeIns2(0.9); p.week = 1; recs.emplace_back(DID_INS_2, bytesOf(p)); }
+    // Magnetometer at uptime 50 s (non-sync; .idx timestamp = 50000 ms uptime).
+    recs.emplace_back(DID_MAGNETOMETER, bytesOf(makeMag(50.0)));
+    // Synced SYS_PARAMS: upTime 5 s, ToW 200000 s => offset 199,995,000 ms.
+    recs.emplace_back(DID_SYS_PARAMS, bytesOf(makeSysParams(5.0, 200'000'000u)));
+    // Durable fix (week 2300) window: ToW 200000 s .. 200100 s.
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(200000.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(200100.0)));
+
+    f = buildFixture("uptime_bridge", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // Mag uptime 50 s -> ToW 50000 + 199,995,000 = 200,045,000 ms in week 2300.
+    auto t = resolver->resolve(50'000, kFixtureSerial);
+    EXPECT_EQ(t.value, expectedUnixMsForFixtureWeek(200'045'000ull, 2300));
+    // It is bridged (real timeline point), NOT excluded as SessionOnly — the
+    // pre-fix bug tagged it SessionOnly/Unknown and dropped it from the extent.
+    EXPECT_NE(t.source, TimeSource::SessionOnly);
+    // And it lands in the fix window, not days early at the GPS-week start.
+    EXPECT_GT(t.value, expectedUnixMsForFixtureWeek(199'000'000ull, 2300));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -112,10 +112,14 @@ magnetometer_t makeMag(double bootSec) {
 // SN-8323 (uptime unification): DID_SYS_PARAMS carries BOTH the GPS ToW
 // (timeOfWeekMs) and the definitive uptime (upTime, seconds). A synced sample
 // yields the authoritative uptime->ToW offset the resolver bridges through.
-sys_params_t makeSysParams(double upTimeSec, uint32_t towMs) {
+// `towValid` sets HDW_STATUS_GNSS_TIME_OF_WEEK_VALID — the resolver only trusts
+// timeOfWeekMs as GPS ToW when that bit is set; otherwise timeOfWeekMs is local
+// system time and must NOT feed the offset (Copilot review, PR #1239).
+sys_params_t makeSysParams(double upTimeSec, uint32_t towMs, bool towValid = true) {
     sys_params_t s{};
     s.timeOfWeekMs = towMs;
     s.upTime       = upTimeSec;
+    if (towValid) s.hdwStatus |= HDW_STATUS_GNSS_TIME_OF_WEEK_VALID;
     return s;
 }
 
@@ -282,6 +286,37 @@ TEST_F(TimeResolverTest, SessionUptimeRecordsBridgeViaSysParamsOffset) {
     EXPECT_NE(t.source, TimeSource::SessionOnly);
     // And it lands in the fix window, not days early at the GPS-week start.
     EXPECT_GT(t.value, expectedUnixMsForFixtureWeek(199'000'000ull, 2300));
+}
+
+// Copilot review (PR #1239): an UNSYNCED SYS_PARAMS (HDW_STATUS_GNSS_TIME_OF_WEEK_VALID
+// clear) carries LOCAL system time in timeOfWeekMs, NOT GPS ToW. It must not
+// establish the uptime->ToW offset — otherwise it bridges session-uptime records
+// to a bogus wall-clock. Identical to the synced fixture above, except the
+// SYS_PARAMS's ToW-valid bit is clear; the mag must therefore NOT bridge to the
+// synced-case value (the SYS_PARAMS offset is the only thing that produced it).
+TEST_F(TimeResolverTest, UnsyncedSysParamsDoesNotEstablishOffset) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    { ins_2_t p = makeIns2(0.9); p.week = 1; recs.emplace_back(DID_INS_2, bytesOf(p)); }
+    recs.emplace_back(DID_MAGNETOMETER, bytesOf(makeMag(50.0)));
+    // Same upTime/ToW as the synced case, but ToW-valid bit is CLEAR.
+    recs.emplace_back(DID_SYS_PARAMS,
+                      bytesOf(makeSysParams(5.0, 200'000'000u, /*towValid=*/false)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(200000.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(200100.0)));
+
+    f = buildFixture("unsynced_sysparams", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // The bogus offset (if the gate were absent) would bridge mag uptime 50 s to
+    // 200,045,000 ms. With the gate, the unsynced SYS_PARAMS is ignored, so the
+    // mag does NOT land at that value.
+    auto t = resolver->resolve(50'000, kFixtureSerial);
+    EXPECT_NE(t.value, expectedUnixMsForFixtureWeek(200'045'000ull, 2300));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`ISTimeResolver` now unifies a device log's uptime and GPS-time domains onto one wall-clock timeline using an **authoritative anchor read from `DID_SYS_PARAMS`** (which carries both `upTime` and `timeOfWeekMs`), instead of the fragile per-sync `actualHostTimeMs` byte-adjacency heuristic. Also closes a defect class where **reader/parse paths anchored timestamps on the reading machine's own clock**.

## Problem
On a customer log (single device, ~4.9 h, 71 segments) magnetometer records — whose `time` is device uptime-since-boot — resolved to the **GPS-week start (~3.85 days early)**, ballooning the log extent and hiding the real data. Root cause: pre-sync "real clock" records (week defaults to 1 until GPS lock, ToW field holds uptime) made `syncPoints_.front().payloadToWMs` tiny, breaking the uptime-bridge gate, so uptime-domain records were never bridged.

## Changes
- **Uptime/GPS unification (`ISTimeResolver.{h,cpp}`):** `build()` derives a single authoritative `uptimeToTowOffsetMs` (median of synced `DID_SYS_PARAMS` `timeOfWeekMs - upTime` samples). `resolve()` classifies each input against the durable-fix ToW window and bridges session-uptime values (magnetometer/imu, pre-sync records) through that offset — pre-sync head back-extrapolated. Guarded by `haveUptimeOffset_`, so logs without `SYS_PARAMS` are unchanged (no regression).
- **Reader never anchors on its own clock:** `ISLogReaderSugar.cpp` (`records_typed`) and `DeviceLogRaw.cpp` (read path feeding `LogStats`) switched from `TimestampOrCurrentTime()` to `Timestamp()` (0 sentinel). `TimestampOrCurrentTime()` documented as writer-only.

## Tests / validation
- `tests/test_time_resolver.cpp` — new `SessionUptimeRecordsBridgeViaSysParamsOffset` reproduces the mag + pre-sync + SYS_PARAMS case (fails pre-fix as SessionOnly); full suite 17/17, existing 16 unchanged.
- End-to-end on the customer log: **4,787,793 records unify to one 2026-07-16 01:23:01..06:17:34 UTC (4.91 h) timeline, zero outliers; 788,722 magnetometer records now resolve in-window** (were 3.85 days off).

## No `.idx` format change
Fixed entirely reader-side using data already in the `.raw` (`SYS_PARAMS`). No v2 `.idx` breaking change. Design captured in Logalyzer ADR D0069.

## Follow-ups (separate stories)
- Multi-boot logs (device reboot mid-log resets uptime) need per-session offsets — resolver v2.
- No-GPS-ever logs have no absolute anchor in `.raw`; a durable writer capture-epoch in the reserved v2 `.idx` header bytes (non-breaking) would give a wall-clock fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
