### PR TITLE
SN-8335 SDK log reader example project exception if missing CL arg

### DIFF
--- a/ExampleProjects/InertialSense_log_reader_RegCmp/LogReader_RegCmp.cpp
+++ b/ExampleProjects/InertialSense_log_reader_RegCmp/LogReader_RegCmp.cpp
@@ -666,7 +666,7 @@ int main(int argc, char* argv[])
     std::time_t logTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     std::string outDir = "out/";// + logTime;
 
-    if (argc < 1)
+    if (argc <= 1)
     {
         printf("Please pass the data log directory path (i.e. \"C:\\Users\\[username]\\Documents\\Inertial Sense\\Logs\\20180716_172323)\"\r\n");
         // In Visual Studio IDE, this can be done through "Project Properties -> Debugging -> Command Arguments: COM3 kml" 


### PR DESCRIPTION
[SDK] Example Project InertialSense_log_reader_RegCmp does not gracefully handle lack of CL arg

If the file path argument is bogus, the program exits gracefully and prints an error message.

```
./ISLogReaderExample filename
Failed to load log files: ./ISLogReaderExample
```
There is an app usage line in the code, but if the argument is empty it does not reach that and appears to throw an uncaught exception instead.  This case should also be handled gracefully and provide instruction to the user.

```
./ISLogReaderExample
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
Aborted (core dumped)
```

Found and fixed argc condition check problem, AI reports the fix should work across all platforms consistently.

To be SQUASH-MERGED upon approval.