### PR TITLE
SN-8296: SDK Docs — Logger, I/O, and data serialization

### DIFF
--- a/src/DataCSV.h
+++ b/src/DataCSV.h
@@ -1,14 +1,15 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DataCSV.h
+ * @brief CSV (de)serialization for a single data set (DID), used by DeviceLogCSV.
+ *
+ * Each row is `<orderId>,<field1>,<field2>,...` where the order id (see cCsvLog::orderId) lets
+ * DeviceLogCSV::ReadData() merge multiple per-DID files back into their original write order. The
+ * header row is `_ID_,<name1>,<name2>,...`, with array fields expanded into `<name>[<i>]` columns.
+ * Field names and layout come from `cISDataMappings`, keyed by DID.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DATA_CVS_H
 #define DATA_CVS_H
@@ -20,29 +21,55 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "com_manager.h"
 #include "ISDataMappings.h"
 
+/** @brief Stateless CSV (de)serialization helpers for one data set (DID) at a time. */
 class cDataCSV
 {
 public:
+    /**
+     * @brief Write the CSV header row (`_ID_,<field names>`) for @p id's data set.
+     * @param pFile file to write to.
+     * @param id data ID whose field layout (from `cISDataMappings`) to write column names for.
+     * @return the number of bytes written, or 0 if @p pFile is null, @p id is out of range, or @p id has no known field mapping.
+     */
     int WriteHeaderToFile(FILE* pFile, uint32_t id);
+
+    /**
+     * @brief Read and parse a CSV header row into column descriptors.
+     * @param pFile file to read the header row from.
+     * @param id data ID whose field mapping (from `cISDataMappings`) resolves each column name; unresolved columns are recorded as `DATA_TYPE_BINARY` ("UNKNOWN" if the column name itself was empty).
+     * @param[out] columnHeaders per-column field descriptors, in file order; cleared and repopulated by this call.
+     * @return the number of bytes read, or 0 on a read error or end of file (always 0 on embedded platforms, which don't support header parsing).
+     */
     int ReadHeaderFromFile(FILE* pFile, uint32_t id, std::vector<data_info_t>& columnHeaders);
+
+    /**
+     * @brief Write one data set as a new CSV row (`<orderId>,<fields>`).
+     * @param orderId value to write into column 0, used later to restore write order across data sets; see cCsvLog::orderId.
+     * @param pFile file to write to.
+     * @param dataHdr header describing @p dataBuf's data ID, size, and offset.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @return the number of bytes written, or 0 if @p pFile is null, @p dataHdr.id has no known field mapping, or the data set has zero size.
+     */
     int WriteDataToFile(uint64_t orderId, FILE* pFile, const p_data_hdr_t& dataHdr, const uint8_t* dataBuf);
 
     /**
-    * Parse a csv string into a data packet
-    * data needs the id set to the proper data id
-    * buf memory to fill with data
-    * bufSize size of available memory in buf
-    * order id contains the value for ordering data
-    * returns true if success, false if no map found
-    */
+     * @brief Parse one CSV row (with no leading order id) into a data set, using a previously-parsed header's column layout.
+     * @param s the CSV row to parse (mutated: trailing line terminators are stripped and a trailing comma is appended internally).
+     * @param hdr on input, `id` must already be set to the target data ID; on success, `offset` is set to 0 and `size` to the DID's full struct size.
+     * @param buf destination buffer to fill; zeroed before parsing, and must be at least @p hdr.size (the DID's full struct size) bytes.
+     * @param bufSize size of @p buf, in bytes.
+     * @param columnHeaders column layout from ReadHeaderFromFile(), matching @p s's columns positionally.
+     * @return true if every field parsed successfully; false if @p hdr.id has no known field mapping, @p hdr.offset/size/bufSize are inconsistent, or any field failed to parse.
+     */
     bool StringCSVToData(std::string& s, p_data_hdr_t& hdr, uint8_t* buf, uint32_t bufSize, const std::vector<data_info_t>& columnHeaders);
 
     /**
-    * Convert data to a csv string
-    * buf is assumed to be large enough to hold the data structure
-    * csv filled with csv data
-    * return true if success, false if no map found
-    */
+     * @brief Convert one data set to a CSV row string (comma-prefixed fields, no order id, no trailing newline stripped).
+     * @param hdr header describing @p buf's data ID, size, and offset; a partial buffer (offset/size narrower than the DID's full struct) is zero-padded around its actual bytes before conversion.
+     * @param buf the data payload described by @p hdr.
+     * @param[out] csv the resulting CSV row, including a trailing newline; cleared and repopulated by this call.
+     * @return true on success; false if @p hdr.id has no known field mapping.
+     */
     bool DataToStringCSV(const p_data_hdr_t& hdr, const uint8_t* buf, std::string& csv);
 };
 

--- a/src/DataChunk.h
+++ b/src/DataChunk.h
@@ -1,14 +1,18 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DataChunk.h
+ * @brief Chunk framing layer: `sChunkHeader` on-disk header and `cDataChunk` in-memory staging
+ *        buffer used by the raw/serial device log formats (DeviceLogRaw, DeviceLogSerial).
+ *
+ * A "chunk" is a marker-delimited, header-prefixed block of data written as a unit to a
+ * `.raw`/`.dat` log file. `cDataChunk` owns a single fixed-size, non-wrapping buffer: bytes are
+ * appended at the tail (PushBack()) and consumed from the head (PopFront()/WriteToFile()); it does
+ * not recycle space until explicitly Clear()'d, so a chunk is filled once, flushed, and reset.
+ * `sChunkHeader` mirrors the current on-disk layout (`version` 2) alongside the legacy v1 layout
+ * (`sChunkHeader::v1`) kept only so old `.dat` files remain readable.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DATA_CHUNK_H
 #define DATA_CHUNK_H
@@ -28,45 +32,62 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "com_manager.h"
 #include "ISLogFileBase.h"
 
+/**
+ * @brief Debug-only sink for chunk read/write statistics (see LOG_CHUNK_STATS above).
+ *
+ * Writes formatted text either to the terminal (EVB-2, via `vprintf`) or to a lazily-created
+ * `STATS_.txt` log file (host platforms, via a static `cISLogFileBase` opened on first call).
+ * @param format printf-style format string, followed by its matching arguments.
+ */
 void logStats(const char *format, ...);
 
 // #define CHUNK_VER_1
 
-//!< Chunk Header
 PUSH_PACK_1
 
+/**
+ * @brief On-disk chunk header written immediately before a chunk's data payload.
+ *
+ * The anonymous struct is the current (v2, `version == 2`) layout; `v1` is the legacy layout kept
+ * only so `.dat` files written by older SDKs can still be parsed by ReadFromFile(). Both layouts
+ * share the same leading `marker` field so a reader can identify which layout follows by first
+ * inspecting `marker`/`version` before committing to one struct or the other.
+ */
 struct sChunkHeader
 {
     union {
         struct {
-            uint32_t marker;                             //!< Chunk marker (0xFC05EA32)
-            uint8_t version;                             //!< Chunk Version
-            uint8_t dataOffset;                          //!< offset from this position until the start of the chunk data (34 = sum of all hdr bytes following this byte, upto the chnk data, or sizeof(sChunkHeader) - 6).
-            char protocolVersion[2];                     //!< major/minor version of the underlying line/protocol
-            char name[4];                                //!< Chunk name
-            char invName[4];                             //!< Bitwise inverse of chunk name
-            uint32_t dataSize;                           //!< Chunk data length in bytes
-            uint32_t invDataSize;                        //!< Bitwise inverse of chunk data length
-            uint32_t grpNum;                             //!< Chunk Group Number: 0 = serial data, 1 = sorted data...
-            uint32_t devSerialNum;                       //!< Device serial number
-            uint16_t portId;                             //!< Device port id
-            uint16_t portType;                           //!< Device port type
-            char fwVersion[4];                           //!< Device firmware version
+            uint32_t marker;                             //!< chunk marker, always DATA_CHUNK_MARKER (0xFC05EA32)
+            uint8_t version;                             //!< chunk header version; 2 for this layout
+            uint8_t dataOffset;                          //!< byte offset from this field to the start of chunk data (34 = sizeof(sChunkHeader) - 6)
+            char protocolVersion[2];                      //!< major/minor version of the underlying comm protocol
+            char name[4];                                //!< 4-character chunk type name (e.g. "PDAT")
+            char invName[4];                              //!< bitwise inverse of name, for framing validation on read
+            uint32_t dataSize;                           //!< chunk data length in bytes, following this header
+            uint32_t invDataSize;                        //!< bitwise inverse of dataSize, for framing validation on read
+            uint32_t grpNum;                             //!< chunk group number: 0 = serial data, 1 = sorted data, ...
+            uint32_t devSerialNum;                       //!< serial number of the device that produced this chunk
+            uint16_t portId;                              //!< port id the data was received on
+            uint16_t portType;                            //!< port type (see PORT_TYPE__* constants) the data was received on
+            char fwVersion[4];                            //!< firmware version of the source device (defaults to the SDK version until overwritten by devInfo)
         };
+        /** @brief Legacy v1 chunk header layout, kept for reading old `.dat` files. */
         struct {
-            uint32_t marker;                             //!< Chunk marker (0xFC05EA32)
-            uint16_t version;                            //!< Chunk Version
-            uint16_t classification;                     //!< Chunk classification
-            char name[4];                                //!< Chunk name
-            char invName[4];                             //!< Bitwise inverse of chunk name
-            uint32_t dataSize;                           //!< Chunk data length in bytes
-            uint32_t invDataSize;                        //!< Bitwise inverse of chunk data length
-            uint32_t grpNum;                             //!< Chunk Group Number: 0 = serial data, 1 = sorted data...
-            uint32_t devSerialNum;                       //!< Device serial number
-            uint32_t pHandle;                            //!< Device port handle
-            uint32_t reserved;                           //!< Unused
+            uint32_t marker;                             //!< chunk marker, always DATA_CHUNK_MARKER (0xFC05EA32)
+            uint16_t version;                            //!< chunk header version; 1 for this layout
+            uint16_t classification;                     //!< chunk classification
+            char name[4];                                //!< 4-character chunk type name
+            char invName[4];                              //!< bitwise inverse of name, for framing validation on read
+            uint32_t dataSize;                           //!< chunk data length in bytes, following this header
+            uint32_t invDataSize;                        //!< bitwise inverse of dataSize, for framing validation on read
+            uint32_t grpNum;                             //!< chunk group number: 0 = serial data, 1 = sorted data, ...
+            uint32_t devSerialNum;                       //!< serial number of the device that produced this chunk
+            uint32_t pHandle;                             //!< legacy device port handle
+            uint32_t reserved;                            //!< unused
         } v1;
     };
+
+    /** @brief Initialize a v2 header with the marker, version, and current SDK firmware version. */
     sChunkHeader() {
         marker = DATA_CHUNK_MARKER;
         version = 2;
@@ -85,6 +106,7 @@ struct sChunkHeader
         fwVersion[3] = 0;
     }
 #if LOG_CHUNK_STATS
+    /** @brief Debug-only: dump this header's fields via logStats(). Compiled in only when LOG_CHUNK_STATS is non-zero. */
     void print()
     {
     #ifdef CHUNK_VER_1
@@ -126,57 +148,132 @@ struct sChunkHeader
 
 POP_PACK
 
+/**
+ * @brief Fixed-size, non-wrapping staging buffer for one chunk's worth of raw/serial log data.
+ *
+ * Data is appended at the tail via PushBack() and consumed from the head via PopFront() or
+ * WriteToFile(); the buffer does not recycle freed head space until Clear() rewinds both pointers
+ * back to the start, so callers must drain (or discard) a chunk before it fills. The backing
+ * storage is a fixed `DEFAULT_CHUNK_DATA_SIZE`-byte array owned by this instance, not the heap.
+ */
 class cDataChunk {
 public:
     cDataChunk();
 
     virtual ~cDataChunk();
 
+    /** @brief Total capacity of the backing buffer in bytes (constant for the lifetime of the instance). */
     int32_t GetBuffSize() { return (int32_t) (m_buffTail - m_buffHead); }
 
+    /** @brief Unused capacity remaining at the tail of the buffer, available to PushBack(). */
     int32_t GetBuffFree() { return (int32_t) (m_buffTail - m_dataTail); }
 
+    /** @brief Number of bytes of unconsumed data currently buffered (tail minus head). */
     int32_t GetDataSize() { return (int32_t) (m_dataTail - m_dataHead); }
 
+    /**
+     * @brief Set the chunk's 4-character type name and its bitwise-inverse validation field.
+     * @param name 4-character chunk type name (e.g. "PDAT"); ignored (no-op) if null.
+     */
     void SetName(const char name[4]);
 
+    /** @brief Copy the source device's serial number and firmware version into the chunk header. */
     void SetDevInfo(const dev_info_t& devInfo);
 
+    /**
+     * @brief Get a pointer to the start of the currently buffered, unconsumed data.
+     * @return pointer to the data, or null if GetDataSize() is 0.
+     */
     uint8_t *GetDataPtr();
 
+    /**
+     * @brief Discard @p size bytes from the front of the buffered data.
+     *
+     * If @p size exceeds GetDataSize(), the entire chunk is Clear()'d (not just partially
+     * consumed) and false is returned — callers can't rely on partial consumption on failure.
+     *
+     * @param size number of bytes to discard from the front of the buffer.
+     * @return true if exactly @p size bytes were discarded; false if @p size exceeded the
+     *         buffered data size, in which case the chunk was cleared entirely instead.
+     */
     bool PopFront(int32_t size);
 
-    int32_t WriteToFile(cISLogFileBase *pFile, int groupNumber = 0, bool writeHeader = true); // Returns number of bytes written to file and clears the chunk
+    /**
+     * @brief Write this chunk's header (optional) and buffered data to @p pFile, then Clear() it.
+     * @param pFile destination file; must not be null.
+     * @param groupNumber value written into the header's `grpNum` field before writing.
+     * @param writeHeader if true, write the chunk header (and any subclass-provided additional
+     *        header via WriteAdditionalChunkHeader()) before the data.
+     * @return the number of bytes written, or -1 if @p pFile is null or the byte count written
+     *         didn't match the expected header + data size.
+     */
+    int32_t WriteToFile(cISLogFileBase *pFile, int groupNumber = 0, bool writeHeader = true);
 
+    /**
+     * @brief Clear() this chunk, then read a header (optional) and its data from @p pFile.
+     * @param pFile source file; must not be null.
+     * @param readHeader if true, read and validate a chunk header (and any subclass-provided
+     *        additional header via ReadAdditionalChunkHeader()) before reading data; if false,
+     *        treat all bytes read as raw, unframed data with no header validation.
+     * @return the number of bytes read (header + data) on success; -1 if @p pFile is null, the
+     *         header's `dataSize`/`invDataSize` checksum didn't match, the marker didn't match
+     *         DATA_CHUNK_MARKER, or fewer bytes were read than the header promised.
+     */
     int32_t ReadFromFile(cISLogFileBase *pFile, bool readHeader = true);
 
+    /**
+     * @brief Append up to two buffers to the tail of the chunk's data.
+     * @param d1 first buffer to append; must not be null.
+     * @param d1Size number of bytes to append from @p d1.
+     * @param d2 optional second buffer to append immediately after @p d1; may be null.
+     * @param d2Size number of bytes to append from @p d2 (ignored if @p d2 is null).
+     * @return the total number of bytes appended (`d1Size + d2Size`), or 0 if the combined size
+     *         exceeds GetBuffFree() and nothing was appended.
+     */
     int32_t PushBack(uint8_t *d1, int32_t d1Size, uint8_t *d2 = NULL, int32_t d2Size = 0);
 
+    /** @brief Reset the chunk to empty: zeroes the header's data-size fields and rewinds the head/tail pointers to the start of the buffer. Does not clear the buffer's contents, only its bookkeeping. */
     virtual void Clear();
 
-    sChunkHeader m_hdr = { };
+    sChunkHeader m_hdr = { };   //!< current chunk header; rewritten by SetName()/SetDevInfo() and on every WriteToFile()/ReadFromFile()
 
 #if LOG_CHUNK_STATS
+    /** @brief Debug-only per-DID read counters, indexed by data ID. Compiled in only when LOG_CHUNK_STATS is non-zero. */
     struct
     {
-        uint32_t count;     // Number of occurrences
-        uint32_t size;      // Size of each data structure
-        uint32_t total;     // Total bytes read
+        uint32_t count;     //!< number of occurrences read for this DID
+        uint32_t size;      //!< size in bytes of each occurrence's data structure
+        uint32_t total;     //!< total bytes read across all occurrences of this DID
     } m_stats[DID_COUNT];
 #endif
 
 protected:
+    /**
+     * @brief Extension point for subclasses to write additional header data after the base chunk header.
+     * @param pFile destination file, already positioned after the base sChunkHeader.
+     * @return number of additional bytes written. Base implementation writes nothing and returns 0.
+     */
     virtual int32_t WriteAdditionalChunkHeader(cISLogFileBase *pFile);
 
+    /**
+     * @brief Extension point for subclasses to read additional header data after the base chunk header.
+     * @param pFile source file, already positioned after the base sChunkHeader.
+     * @return number of additional bytes read. Base implementation reads nothing and returns 0.
+     */
     virtual int32_t ReadAdditionalChunkHeader(cISLogFileBase *pFile);
 
+    /**
+     * @brief Total on-disk header size, including any subclass additional header.
+     * @return `sizeof(sChunkHeader)` in the base implementation; subclasses that override
+     *         WriteAdditionalChunkHeader()/ReadAdditionalChunkHeader() should override this too.
+     */
     virtual int32_t GetHeaderSize();
 
 private:
-    uint8_t m_buffHead[DEFAULT_CHUNK_DATA_SIZE];    // Start of buffer
-    uint8_t *m_buffTail;    // End of buffer
-    uint8_t *m_dataHead;    // Front of data in buffer.  This moves as data is read.
-    uint8_t *m_dataTail;    // End of data in buffer.  This moves as data is written.
+    uint8_t m_buffHead[DEFAULT_CHUNK_DATA_SIZE];    //!< start of the fixed backing buffer
+    uint8_t *m_buffTail;    //!< end of the backing buffer (m_buffHead + DEFAULT_CHUNK_DATA_SIZE)
+    uint8_t *m_dataHead;    //!< front of unconsumed data in the buffer; advances as data is popped
+    uint8_t *m_dataTail;    //!< end of buffered data; advances as data is pushed
 };
 
 

--- a/src/DataJSON.h
+++ b/src/DataJSON.h
@@ -1,14 +1,16 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DataJSON.h
+ * @brief JSON (de)serialization for a single data set (DID), used by DeviceLogJSON.
+ *
+ * Each data set is one JSON object: `{"id":<did>,"<field1>":<value1>,...}`. Field names and
+ * layout come from `cISDataMappings`, keyed by DID. Parsing (StringJSONToData()) uses a simple
+ * bracket/quote scanner rather than a general JSON parser — it expects an already-isolated,
+ * single top-level object (as produced by DeviceLogJSON's balanced-brace file scanner), not
+ * arbitrary JSON.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DATA_JSON_H
 #define DATA_JSON_H
@@ -20,6 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "com_manager.h"
 #include "ISLogFileBase.h"
 
+/** @brief Check whether @p c is a character that must be escaped inside a JSON string value. */
 static inline bool IS_JSON_ESCAPE_CHAR(char c)
 {
     switch (c)
@@ -37,34 +40,42 @@ static inline bool IS_JSON_ESCAPE_CHAR(char c)
     return false;
 }
 
+/** @brief Stateless JSON (de)serialization helpers for one data set (DID) at a time. */
 class cDataJSON
 {
 public:
-    /*
-    * Write data to json file
-    * pFile the file to write to
-    * dataHdr data header
-    * dataBuf data buffer
-    * prefix prefix if data is written
-    */
+    /**
+     * @brief Write one data set as a JSON object (`{"id":...,"field":value,...}`) to @p pFile.
+     * @param pFile file to write to.
+     * @param dataHdr header describing @p dataBuf's data ID, size, and offset.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @param prefix if non-null, written immediately before the JSON object (e.g. `",\n"` to separate array elements); not included in the returned byte count.
+     * @return the number of bytes of the JSON object written (excluding @p prefix), or 0 if @p pFile is null or @p dataHdr.id has no known field mapping.
+     */
     int WriteDataToFile(cISLogFileBase* pFile, const p_data_hdr_t& dataHdr, const uint8_t* dataBuf, const char* prefix);
 
     /**
-    * Parse a json string into a data packet
-    * data needs the id set to the proper data id
-    * buf memory to fill with data
-    * bufSize size of available memory in buf
-    * order id contains the value for ordering data
-    * returns true if success, false if no map found
-    */
+     * @brief Parse a single JSON object string into a data set.
+     *
+     * Expects @p s to be exactly one top-level `{...}` object with an `"id"` field appearing
+     * first; fields that don't map to a known field for that DID are silently skipped rather than
+     * treated as an error.
+     *
+     * @param s the JSON object to parse.
+     * @param[out] hdr `id` is set from the object's `"id"` field; on success, `size` is set to the DID's full struct size.
+     * @param buf destination buffer to fill; must be at least the DID's full struct size.
+     * @param bufSize size of @p buf, in bytes (currently unused — the caller is responsible for @p buf being large enough).
+     * @return true if an `"id"` field was found, it mapped to a known DID, and every recognized field parsed successfully; false otherwise.
+     */
     bool StringJSONToData(std::string& s, p_data_hdr_t& hdr, uint8_t* buf, uint32_t bufSize);
 
     /**
-    * Convert data to a json string
-    * buf is assumed to be large enough to hold the data structure
-    * json filled with json data
-    * return true if success, false if no map found
-    */
+     * @brief Convert one data set to a JSON object string (`{"id":...,"field":value,...}`, no trailing newline).
+     * @param hdr header describing @p buf's data ID, size, and offset; a partial buffer (offset/size narrower than the DID's full struct) is zero-padded around its actual bytes before conversion.
+     * @param buf the data payload described by @p hdr.
+     * @param[out] json the resulting JSON object string; cleared and repopulated by this call.
+     * @return true on success; false if @p hdr.id has no known field mapping.
+     */
     bool DataToStringJSON(const p_data_hdr_t& hdr, const uint8_t* buf, std::string& json);
 };
 

--- a/src/DataKML.h
+++ b/src/DataKML.h
@@ -1,14 +1,17 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DataKML.h
+ * @brief Extracts KML-relevant samples (position/attitude) from recognized navigation/GNSS data
+ *        sets, bucketed into logical channels (`cDataKML::MyEnum`) for DeviceLogKML.
+ *
+ * Unlike DataCSV/DataJSON (which serialize an arbitrary DID generically via `cISDataMappings`),
+ * this is a narrow, hand-coded allow-list: only the specific DIDs listed in DID_TO_KID() are
+ * recognized, and WriteDataToFile() only ever extracts time/position/attitude (plus a
+ * dead-reckoning flag) — never the full struct. Actual KML/XML rendering happens in
+ * DeviceLogKML::CloseWriteFile(), not here; this class only buffers `sKmlLogData` samples.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DATA_KML_H
 #define DATA_KML_H
@@ -24,13 +27,24 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #    include "../../cpp/libs/families/imx/IS_internal.h"
 #endif
 
+/** @brief One extracted position/attitude sample, buffered per-channel until DeviceLogKML::CloseWriteFile() renders it to XML. */
 struct sKmlLogData
 {
-    double                  time;
-    double                  lla[3];
-    float                   theta[3];
-    bool                    deadReckoning;
+    double                  time;               //!< sample time in seconds (GPS time-of-week, or derived from a millisecond timestamp)
+    double                  lla[3];              //!< latitude (deg), longitude (deg), altitude (m)
+    float                   theta[3];            //!< Euler attitude (roll, pitch, yaw), radians; zero for position-only (GNSS) samples
+    bool                    deadReckoning;       //!< true if this sample was not aided by GNSS position (see `INS_STATUS_GNSS_AIDING_POS`); unused/false for GNSS-only samples
+
+    /** @brief Construct a zero-initialized (all-default) sample. */
     sKmlLogData() {}
+
+    /**
+     * @brief Construct a full INS-style sample (position + attitude).
+     * @param _time sample time in seconds.
+     * @param _lla latitude (deg), longitude (deg), altitude (m).
+     * @param _theta Euler attitude (roll, pitch, yaw), radians.
+     * @param _deadReckoning true if this sample was not aided by GNSS position.
+     */
     sKmlLogData(double _time, double _lla[3], float _theta[3], bool _deadReckoning=false)
     {
         time = _time;
@@ -43,6 +57,11 @@ struct sKmlLogData
         deadReckoning = _deadReckoning;
     }
 
+    /**
+     * @brief Construct a GNSS-style, position-only sample (no attitude, never dead-reckoned).
+     * @param _timeMs sample time in milliseconds; converted to seconds for @ref time.
+     * @param _lla latitude (deg), longitude (deg), altitude (m).
+     */
     sKmlLogData(unsigned int _timeMs, double _lla[3])
     {
         time = _timeMs*0.001;
@@ -55,26 +74,33 @@ struct sKmlLogData
 };
 
 
+/** @brief Extracts KML-relevant samples from a narrow allow-list of navigation/GNSS DIDs; see the file-level documentation above. */
 class cDataKML
 {
 public:
+    /** @brief Logical KML output channels; each maps to its own file in DeviceLogKML. */
     enum MyEnum
     {
-        KID_INS = 0,
-        KID_REF,
-        KID_GNSS,
-        KID_GNSS1,
-        KID_GNSS2,
-        KID_RTK,
-        MAX_NUM_KID,
+        KID_INS = 0,    //!< primary INS solution (position + attitude)
+        KID_REF,        //!< reference/truth INS solution, when a reference device (serial 99999 or 10101) is present
+        KID_GNSS,       //!< primary GNSS position (`DID_GNSS1_POS`)
+        KID_GNSS1,      //!< receiver-reported GNSS1 position (`DID_GNSS1_RCVR_POS`)
+        KID_GNSS2,      //!< GNSS2 position (`DID_GNSS2_POS`)
+        KID_RTK,        //!< RTK-corrected GNSS position (`DID_GNSS1_RTK_POS`)
+        MAX_NUM_KID,    //!< number of channels; not a valid channel itself
     };
 
+    /**
+     * @brief Map a recognized DID to its output channel.
+     * @param did data ID to map.
+     * @return the matching `MyEnum` channel, or -1 if @p did is not one of the specific DIDs this class recognizes (`DID_INS_1`, `DID_INS_2`, `DID_GNSS1_POS`, `DID_GNSS1_RCVR_POS`, `DID_GNSS2_POS`, `DID_GNSS1_RTK_POS`) — this is a narrow allow-list, not a general DID→channel mapping.
+     */
     static inline int DID_TO_KID(int did)
     {
         switch (did)
         {
             default:                return -1; // Unused
-            case DID_INS_1:         // FALL THROUGH       
+            case DID_INS_1:         // FALL THROUGH
             case DID_INS_2:         return KID_INS;
             case DID_GNSS1_POS:      return KID_GNSS;
             case DID_GNSS1_RCVR_POS: return KID_GNSS1;
@@ -83,6 +109,11 @@ public:
         }
     }
 
+    /**
+     * @brief Estimated bytes per buffered sample for a channel, used only to size-limit the in-memory buffer before a flush (see DeviceLogKML::WriteDateToFile()) — not a measured or exact size.
+     * @param kid channel to estimate; one of `MyEnum`'s `KID_*` values.
+     * @return 130 for `KID_INS`/`KID_REF` (position + attitude), 65 for the GNSS-family channels (position only), or -1 for any other value.
+     */
     static inline int BYTES_PER_KID(int kid)
     {
         switch (kid)
@@ -99,9 +130,31 @@ public:
                 return 65;
         }
     }
-    
+
     cDataKML();
+
+    /**
+     * @brief Get the short name used to build a channel's KML filename (e.g. "ins", "gnss1").
+     * @param kid channel to name; one of `MyEnum`'s `KID_*` values.
+     * @return the channel's short name, or an empty string for any other value.
+     */
     std::string GetDatasetName(int kid);
+
+    /**
+     * @brief Extract a KML sample from one recognized data set and append it to @p list.
+     *
+     * Recognizes `DID_INS_1`/`DID_INS_2`/`DID_INS_3` (full position + attitude, with the
+     * dead-reckoning flag derived from `INS_STATUS_GNSS_AIDING_POS`) and `DID_GNSS1_POS`/
+     * `DID_GNSS1_RCVR_POS`/`DID_GNSS2_POS`/`DID_GNSS1_RTK_POS` (position only). Any other data
+     * set is ignored.
+     *
+     * @param list the calling channel's sample buffer (typically `sKmlLog::data`); a recognized
+     *        sample is appended to it, otherwise it is left unchanged.
+     * @param dataHdr header identifying the data set's DID; determines whether/how it's extracted.
+     * @param dataBuf the data payload described by @p dataHdr, reinterpreted per-DID.
+     * @return always 0. @note the return value does not indicate whether a sample was actually
+     *         appended — check @p list's size before/after if that matters to the caller.
+     */
     int WriteDataToFile(std::vector<sKmlLogData>& list, const p_data_hdr_t* dataHdr, const uint8_t* dataBuf);
 };
 

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -1,14 +1,18 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLog.h
+ * @brief Per-device log base class: file rotation, `.idx` sidecar indexing, and the abstract
+ *        SaveData()/ReadData() contract each on-disk format implements.
+ *
+ * `cDeviceLog` owns exactly one device's log: it decides when to roll over to a new file
+ * (OpenNewSaveFile()/OpenNextReadFile()), names files consistently (GetNewFileName()), and
+ * maintains the per-segment `.idx` sidecar (addIndexRecord()/writeIndexChunk()/finalizeIndex(),
+ * see ISLogIndex.h for the sidecar format itself). It does not know how to serialize a data set to
+ * bytes — SaveData()/ReadData() are format-specific and implemented by the DeviceLog{CSV,JSON,KML,
+ * Raw,Serial} subclasses.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DEVICE_LOG_H
 #define DEVICE_LOG_H
@@ -35,81 +39,198 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 
+/**
+ * @brief Abstract per-device log; see the file-level documentation above for the overview.
+ *
+ * Subclasses (DeviceLog{CSV,JSON,KML,Raw,Serial}) implement ReadData(), SetSerialNumber(), and
+ * LogFileExtention() at minimum, and typically override InitDeviceForWriting()/CloseAllFiles() to
+ * layer their own per-format file state on top of this class's rotation/indexing bookkeeping.
+ */
 class cDeviceLog {
 public:
-    // Legacy v1 .idx record (host-uptime ms + record counter, 16 bytes).
-    // Kept for back-compat readers per D-01 (SN-7879). Writers emit v2
-    // exclusively; the v1 layout is here only so legacy-aware reader
-    // code can deserialize old `.idx` files produced by SDK <= 2.x.
+    /**
+     * @brief Legacy v1 `.idx` record layout (host-uptime ms + record counter, 16 bytes).
+     *
+     * Kept for back-compat readers per D-01 (SN-7879). Writers emit v2 exclusively (see
+     * `index_record_t`); this layout exists only so legacy-aware reader code can deserialize old
+     * `.idx` files produced by SDK <= 2.x.
+     */
     typedef struct index_record_v1_s {
-        uint32_t time;
-        uint32_t offset;
-        uint32_t msg_id;
-        uint32_t reserved;
+        uint32_t time;      //!< host-uptime milliseconds at the time this record was written
+        uint32_t offset;    //!< byte offset into the corresponding `.raw`/`.dat` segment
+        uint32_t msg_id;    //!< data ID of the record
+        uint32_t reserved;  //!< unused
     } index_record_v1_t;
 
-    // Public spelling now aliases the v2 record. New code uses the v2
-    // fields (timestamp = payload-derived ms, did = data ID, flags
-    // bit 0 = ToW signal, 64-bit offset).
+    /**
+     * @brief Current (v2) `.idx` record type. Both spellings alias `is_log_idx_record_v2_t`.
+     *
+     * New code uses the v2 fields: `timestamp` is payload-derived milliseconds (falling back to
+     * host-uptime delta when the payload carries none), `did` is the data ID (0 for the
+     * streaming-only path), `flags` bit 0 signals a real ToW, and `offset` is a 64-bit byte offset.
+     */
     using index_record_s = inertial_sense::idx::is_log_idx_record_v2_t;
-    using index_record_t = inertial_sense::idx::is_log_idx_record_v2_t;
+    using index_record_t = inertial_sense::idx::is_log_idx_record_v2_t;    //!< preferred spelling for new code
 
+    /** @brief Construct with no bound device; HardwareId()/SerialNumber() read as unset until SetSerialNumber() or SetupReadInfo() is called. */
     cDeviceLog();
 
+    /**
+     * @brief Construct bound to a live device, deriving hardware ID/serial number/device ID from it.
+     * @param dev device to bind to; must not be null.
+     * @throws std::invalid_argument if @p dev is null.
+     */
     cDeviceLog(device_handle_t dev);
 
+    /** @brief Construct for a device identified only by hardware ID + serial number, with no live `ISDevice` (e.g. reading a log from disk). */
     cDeviceLog(uint16_t hdwId, uint32_t serial);
 
+    /** @brief Closes any open file (see OpenNewSaveFile()/OpenNextReadFile()) and calls CloseAllFiles(). */
     virtual ~cDeviceLog();
 
+    /**
+     * @brief Prepare this log for writing: reset rotation/index state and record where/how to write files.
+     * @param timestamp timestamp string used to name new log files (see GetNewFileName()).
+     * @param directory directory new log files are created in.
+     * @param maxDiskSpace drive-usage limit forwarded from the owning `cISLogger`; not enforced by this class directly.
+     * @param maxFileSize largest size, in bytes, a single log file should reach before rolling over.
+     */
     virtual void InitDeviceForWriting(const std::string& timestamp, const std::string& directory, uint64_t maxDiskSpace, uint32_t maxFileSize);
 
+    /** @brief Prepare this log for reading: resets size/count bookkeeping and log statistics. Call SetupReadInfo() first to discover the files to read. */
     virtual void InitDeviceForReading();
 
+    /** @brief Close all files, then re-initialize for writing or reading (whichever mode was last active), effectively restarting the log from scratch. */
     virtual void ResetToStart();
 
+    /**
+     * @brief Close the current file. In write mode, flushes any buffered `.idx` records and
+     *        finalizes the `.idx` header (see writeIndexChunk()/finalizeIndex()), then writes a
+     *        per-device `summary_SN<serial>.txt` statistics file.
+     * @return true (base implementation always succeeds).
+     */
     virtual bool CloseAllFiles();
 
+    /** @brief Flush buffered writes to disk without closing the file. Base implementation is a no-op that always returns true; formats with buffered I/O should override. */
     virtual bool FlushToFile() { return true; };
 
+    /** @brief Open the current log file with the OS's default associated application (Windows only; a no-op elsewhere). @return true (base implementation always succeeds). */
     virtual bool OpenWithSystemApp();
 
+    /**
+     * @brief Record one already-parsed data set into this device's log statistics and `.idx` index.
+     *
+     * The base implementation only updates statistics and calls addIndexRecord() — it does not
+     * write the data set's bytes anywhere; format subclasses that store parsed data (CSV/JSON/KML)
+     * override this to actually serialize @p dataBuf.
+     *
+     * @param dataHdr header describing @p dataBuf's data ID, size, and offset; if null, statistics/indexing are skipped.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @param ptype protocol type the data arrived as; affects how its timestamp is derived.
+     * @return true (base implementation always succeeds).
+     */
     virtual bool SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, protocol_type_t ptype = _PTYPE_INERTIAL_SENSE_DATA);
 
+    /**
+     * @brief Streaming raw-bytes save path (`LOGTYPE_RAW`/`LOGTYPE_DAT` only).
+     *
+     * The base implementation is a no-op: it has no parsed header to index or account for.
+     * cDeviceLogRaw overrides this to parse individual packets out of the byte stream and emit its
+     * own per-packet `.idx` records as it goes, since a coarse chunk-level record here (with no
+     * DID) would be strictly less useful.
+     *
+     * @param dataSize number of bytes in @p dataBuf.
+     * @param dataBuf the raw bytes to save.
+     * @param globalLogStats the owning `cISLogger`'s aggregate statistics, for overrides that update it directly.
+     * @return true (base implementation always succeeds).
+     */
     virtual bool SaveData(int dataSize, const uint8_t *dataBuf, cLogStats &globalLogStats);
 
+    /**
+     * @brief Read the next data set from the log.
+     * @return the next data set, or null if no more data is available. Pure virtual; every format subclass must implement this.
+     */
     virtual p_data_buf_t *ReadData() = 0;
 
+    /**
+     * @brief Read the next raw packet from the log (raw/serial formats only).
+     * @param[out] ptype protocol type of the returned packet.
+     * @return the next packet. Base implementation always returns null; only cDeviceLogRaw overrides this.
+     */
     virtual packet_t* ReadPacket(protocol_type_t& ptype) { (void)ptype; return NULL; };
 
+    /**
+     * @brief Set the device's serial number when there is no live `ISDevice` to derive it from (e.g. reading a log from disk).
+     * @param serialNumber serial number to record. Pure virtual; every format subclass must implement this.
+     */
     virtual void SetSerialNumber(uint32_t serialNumber) = 0;
 
+    /** @brief Get the bound `ISDevice`, if any. @return the device, or null if this log was constructed without one. */
     device_handle_t getDevice() { return device; }
 
+    /**
+     * @brief Get this format's log file extension, including the leading dot (e.g. ".csv").
+     * @return the file extension. Pure virtual; every format subclass must implement this.
+     */
     virtual std::string LogFileExtention() = 0;
 
+    /** @brief Force any pending buffered data out (distinct from FlushToFile(), which targets the OS file buffer). Base implementation is a no-op. */
     virtual void Flush() {}
 
+    /**
+     * @brief Discover the log file(s) for a device, for later reading via OpenNextReadFile().
+     * @param directory directory to search.
+     * @param deviceName serial number as a string; pass "0" together with an empty @p timeStamp to match any serial number's file by index only.
+     * @param timeStamp timestamp string identifying the log instance directory/filename set to search for.
+     * @return true (base implementation always succeeds, even if no matching files were found — check FileCount() after calling).
+     */
     bool SetupReadInfo(const std::string &directory, const std::string &deviceName, const std::string &timeStamp);
 
+    /** @brief Get the bound `ISDevice`. @return the device; behavior is undefined if this log was constructed without one (see getDevice() for a null-safe accessor). */
     device_handle_t Device();
 
+    /** @brief Get the bound `ISDevice`'s device info. @return the device info; behavior is undefined if this log was constructed without a device. */
     dev_info_t DeviceInfo();
 
+    /** @brief Get the device's encoded hardware ID. */
     uint16_t HardwareId() { return m_devHdwId; }
+
+    /** @brief Get the device's serial number. */
     uint32_t SerialNumber() { return m_devSerialNo; }
+
+    /** @brief Get the device's string identifier (hardware ID + serial number). */
     std::string& getDeviceId() { return m_deviceId; }
 
-    // void SetDeviceInfo(const dev_info_t *info);
+    /** @brief Total size, in bytes, of the currently open log file. */
     uint64_t FileSize() { return m_fileSize; }
 
+    /** @brief Total size, in bytes, of this device's entire log (all files). */
     uint64_t LogSize() { return m_logSize; }
 
+    /** @brief Number of log files written or discovered so far for this device. */
     uint32_t FileCount() { return m_fileCount; }
 
+    /**
+     * @brief Build a new log file's base name (directory + prefix + serial + timestamp + index), without the format's file extension.
+     * @param serialNumber device serial number to embed in the filename.
+     * @param fileCount file index to embed in the filename (wrapped to 4 digits, modulo 10000).
+     * @param suffix optional suffix appended after the index (e.g. for a companion file); ignored if null or empty.
+     * @return the base file name/path, with no extension.
+     */
     std::string GetNewBaseFileName(uint32_t serialNumber, uint32_t fileCount, const char* suffix);
+
+    /** @brief GetNewBaseFileName() with this format's LogFileExtention() appended. @return the full file name/path. */
     std::string GetNewFileName(uint32_t serialNumber, uint32_t fileCount, const char *suffix);
 
+    /**
+     * @brief Configure KML output options.
+     * @param gnssData include GNSS position data in the KML output.
+     * @param showTracks draw the flight/travel path as a line.
+     * @param showPoints draw individual sample points along the path.
+     * @param showPointTimestamps label sample points with their timestamp.
+     * @param pointUpdatePeriodSec minimum time between consecutive drawn sample points, in seconds.
+     * @param altClampToGround clamp altitude to ground level in the KML viewer instead of using the logged altitude.
+     */
     void SetKmlConfig(bool gnssData = true, bool showTracks = true, bool showPoints = true, bool showPointTimestamps = true, double pointUpdatePeriodSec = 1.0, bool altClampToGround = true) {
         m_enableGnssLogging = gnssData;
         m_showTracks = showTracks;
@@ -119,33 +240,81 @@ public:
         m_altClampToGround = altClampToGround;
     }
 
+    /** @brief Enable or disable printing of parse errors encountered while reading this log. */
     void ShowParseErrors(bool show) { m_showParseErrors = show; }
 
+    /** @brief Record one already-read data set into this device's log statistics, using its payload-derived timestamp. */
     void UpdateStatsFromFile(p_data_buf_t *data);
+
+    /** @brief Record one already-read item into this device's log statistics using an explicit timestamp, when no full data set/header is available. */
     void UpdateStatsFromFile(protocol_type_t ptype, int id, double timestamp);
+
+    /** @brief Get this device's log statistics, formatted as a human-readable string. */
     std::string LogStatsString() { return m_logStats.Stats(); }
 
+    /** @brief Get the IS-comm parser instance backing this log, if any. @return the parser instance, or null. Only cDeviceLogRaw overrides this to return a real instance. */
     virtual is_comm_instance_t* IsCommInstance() { return NULL; }
 
-    // D-01 / SN-7879: addIndexRecord populates a v2 record from the
-    // packet header / buffer when available, else falls back to a
-    // streaming-path entry with did=0 and timestamp=host-uptime-delta.
-    // The default-args overload preserves the existing void signature
-    // for the streaming-only callers (cDeviceLogRaw) that have no
-    // parsed header.
+    /**
+     * @brief Buffer one `.idx` v2 record for the current segment, to be flushed by writeIndexChunk().
+     *
+     * When @p dataHdr is provided, the record's `did`/`timestamp`/ToW flag are derived from the
+     * parsed header and payload (falling back to a host-uptime-delta timestamp with no ToW flag if
+     * the payload carries no timestamp of its own). When called with no arguments — the streaming
+     * path used by cDeviceLogRaw for callers with no parsed header — the record gets `did = 0` and
+     * a host-uptime-delta timestamp.
+     *
+     * @param dataHdr header describing the data set this record indexes, or null for the streaming path.
+     * @param dataBuf the data payload described by @p dataHdr; ignored if @p dataHdr is null.
+     */
     void addIndexRecord(const p_data_hdr_t* dataHdr = nullptr,
                         const uint8_t* dataBuf = nullptr);
+
+    /**
+     * @brief Flush buffered `.idx` records (from addIndexRecord()) to the current segment's `.idx` sidecar file.
+     *
+     * Writes the `.idx` header on the first call for a segment (see OpenNewSaveFile(), which
+     * resets the per-segment header/counter state). No-ops successfully if there's nothing
+     * buffered and the header was already written. Fails without writing anything if no segment
+     * file name has been set yet (avoids creating an orphan `.idx` with no corresponding data file).
+     *
+     * @return true on success (including the no-op case); false if no file name is set yet, the
+     *         `.idx` file couldn't be opened, or a record/header write failed partway through.
+     */
     bool writeIndexChunk();
-    // Rewrites the header at offset 0 with final totals + sets the
-    // FINALIZED flag. Idempotent. Called by CloseAllFiles().
+
+    /**
+     * @brief Rewrite the `.idx` header at offset 0 with final record totals/timestamps and set the FINALIZED flag.
+     *
+     * Idempotent: a no-op success if no header was ever written for this segment (i.e. no records
+     * were ever indexed). Called by CloseAllFiles().
+     *
+     * @return true on success (including the no-op case); false if the `.idx` file couldn't be reopened, seeked to offset 0, or rewritten.
+     */
     bool finalizeIndex();
 
 protected:
+    /**
+     * @brief Close any currently open save file and open a new one, rolling the file index forward.
+     *
+     * Also resets the per-segment `.idx` bookkeeping (offset, header-written flag, record totals)
+     * so the new segment gets its own `.idx` header rather than inheriting the prior segment's.
+     *
+     * @return true if the new file was created and opened successfully; false if `m_directory` is
+     *         empty, the device has no resolvable serial number, or the file failed to open.
+     */
     bool OpenNewSaveFile();
 
+    /**
+     * @brief Close any currently open read file and open the next one discovered by SetupReadInfo().
+     * @return true if a next file was opened; false if every discovered file has already been consumed, or the open failed.
+     */
     bool OpenNextReadFile();
 
+    /** @brief Hook called after ReadPacket() successfully reads a packet, to record it in log statistics. */
     void OnReadPacket(packet_t* pkt, protocol_type_t ptype);
+
+    /** @brief Hook called after ReadData() successfully reads a data set, to record it in log statistics. */
     void OnReadData(p_data_buf_t *data);
 
     device_handle_t device;                                     //!< ISDevice reference to source of data
@@ -154,26 +323,26 @@ protected:
     uint32_t m_devSerialNo = static_cast<uint32_t>(-1);        //!< used when reading a file, and no ISDevice is available
     std::string m_deviceId;                                     //!< a string representation of a unique device id (hdwid+sn)
 
-    std::vector<std::string> m_fileNames;
-    cISLogFileBase *m_pFile = NULL;
-    cISLogFileBase *m_indexFile = NULL;
-    std::string m_directory;
-    std::string m_timeStamp;
-    std::string m_fileName;
+    std::vector<std::string> m_fileNames;      //!< files discovered by SetupReadInfo(), consumed in order by OpenNextReadFile()
+    cISLogFileBase *m_pFile = NULL;             //!< currently open data file (write or read mode); owned by this instance
+    cISLogFileBase *m_indexFile = NULL;         //!< currently unused: writeIndexChunk()/finalizeIndex() open their own local `.idx` file handles instead of this member
+    std::string m_directory;                    //!< directory new files are created in (write mode) or were discovered in (read mode)
+    std::string m_timeStamp;                    //!< timestamp string used to name new log files; see GetNewFileName()
+    std::string m_fileName;                     //!< name of the currently open file, without its format extension
     bool m_writeMode = false;                                   //!< Logger initialized for writing
-    bool m_showParseErrors = false;
-    uint64_t m_fileSize = 0;
-    uint64_t m_logSize = 0;
-    uint32_t m_fileCount = 0;
-    uint64_t m_maxDiskSpace;
-    uint32_t m_maxFileSize;
-    bool m_altClampToGround = true;
-    bool m_enableGnssLogging = true;
-    bool m_showTracks = true;
-    bool m_showPoints;
-    bool m_showPointTimestamps = true;
-    double m_pointUpdatePeriodSec = 1.0f;
-    cLogStats m_logStats;
+    bool m_showParseErrors = false;             //!< whether parse errors are printed while reading; see ShowParseErrors()
+    uint64_t m_fileSize = 0;                    //!< size, in bytes, of the currently open file
+    uint64_t m_logSize = 0;                     //!< total size, in bytes, of this device's entire log (all files)
+    uint32_t m_fileCount = 0;                   //!< number of files written (write mode) or consumed so far (read mode)
+    uint64_t m_maxDiskSpace;                    //!< drive-usage limit forwarded from the owning cISLogger; not enforced directly by this class
+    uint32_t m_maxFileSize;                     //!< largest size, in bytes, a single log file should reach before rolling over
+    bool m_altClampToGround = true;             //!< KML config: clamp altitude to ground level; see SetKmlConfig()
+    bool m_enableGnssLogging = true;            //!< KML config: include GNSS position data; see SetKmlConfig()
+    bool m_showTracks = true;                   //!< KML config: draw the path as a line; see SetKmlConfig()
+    bool m_showPoints;                          //!< KML config: draw individual sample points; see SetKmlConfig()
+    bool m_showPointTimestamps = true;          //!< KML config: label sample points with their timestamp; see SetKmlConfig()
+    double m_pointUpdatePeriodSec = 1.0f;       //!< KML config: minimum time between drawn sample points, in seconds; see SetKmlConfig()
+    cLogStats m_logStats;                       //!< this device's aggregate data/error counters
     std::vector<index_record_t> m_indexChunks;      //!< v2 records buffered in memory, waiting to be flushed via writeIndexChunk()
     uint64_t m_lastIndexOffset = 0;                 //!< running byte offset into the .raw segment; v2 widened from u32 to u64 since segments can exceed 4GB
     uint32_t m_logStartUpTime = 0;                  //!< the system uptime (in millis) at the moment this index was created

--- a/src/DeviceLogCSV.h
+++ b/src/DeviceLogCSV.h
@@ -1,14 +1,16 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLogCSV.h
+ * @brief CSV log format: one CSV file per data set (DID), reassembled into a single time-ordered
+ *        stream on read via an incrementing per-row order id.
+ *
+ * Unlike the raw/serial formats, a CSV log has no single file to read sequentially — each data set
+ * gets its own file (see cCsvLog), so ReadData() does a k-way merge across every currently-open
+ * per-DID file, picking the row with the lowest cCsvLog::orderId (the value written into column 0
+ * at write time) to reconstruct the original write order across data sets.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DEVICE_LOG_CSV_H
 #define DEVICE_LOG_CSV_H
@@ -22,22 +24,24 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "DeviceLog.h"
 #include "com_manager.h"
 
+/** @brief Per-data-set (per-DID) CSV file state, both for writing and for reading. */
 class cCsvLog
 {
 public:
     cCsvLog() : pFile(NULL), fileCount(0), fileSize(0), dataId(0), orderId(0) { }
 
-    FILE* pFile;
-    uint32_t fileCount;
-    uint64_t fileSize;
-    uint32_t dataId;
-    uint32_t dataSize;
-    uint64_t orderId;
-    std::string nextLine;
-    std::vector<data_info_t> columnHeaders;
+    FILE* pFile;                                //!< currently open file for this data set; null if not yet opened
+    uint32_t fileCount;                         //!< number of files written/opened so far for this data set
+    uint64_t fileSize;                           //!< size, in bytes, of the currently open file
+    uint32_t dataId;                             //!< data ID (DID) this log holds rows for
+    uint32_t dataSize;                           //!< size, in bytes, of the @ref dataId struct (read mode only)
+    uint64_t orderId;                            //!< order id parsed from column 0 of @ref nextLine; used to merge multiple data sets' files back into write order
+    std::string nextLine;                        //!< next unconsumed CSV row read from @ref pFile (read mode only)
+    std::vector<data_info_t> columnHeaders;      //!< column layout parsed from the file's header row (read mode only)
 };
 
 
+/** @brief `cDeviceLog` implementation that writes/reads one CSV file per data set. */
 class cDeviceLogCSV : public cDeviceLog
 {
 public:
@@ -46,24 +50,53 @@ public:
     cDeviceLogCSV(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
 
     void InitDeviceForWriting(const std::string& timestamp, const std::string& directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
+
+    /** @brief Discover every existing per-DID CSV file for this device and open the first file (with data) for each. */
     void InitDeviceForReading() OVERRIDE;
+
     bool CloseAllFiles() OVERRIDE;
+
+    /** @brief Write one data set as a new row to its data set's CSV file, opening/rotating files as needed (see OpenNewFile()). */
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
+
+    /** @brief Read the next data set in original write order, merged across every open per-data-set file by cCsvLog::orderId. @return the next data set, or null if every data set's files are exhausted. */
     p_data_buf_t* ReadData() OVERRIDE;
+
     void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
     std::string LogFileExtention() OVERRIDE { return std::string(".csv"); }
 
 private:
+    /**
+     * @brief Open the next file for @p log, either for writing (a new file) or reading (the next discovered file).
+     * @param log data set to open a file for.
+     * @param readOnly if true, advance to and open the next file in `m_currentFiles[log.dataId]`
+     *        (skipping files whose header fails to parse); if false, create and open a new write file.
+     * @return true if a file was opened successfully; false if the data set is unknown, `m_directory`
+     *         is empty, no serial number is resolvable, no files remain to read, or the open failed
+     *         (in the failure/exhausted case, @p log's entry is removed from `m_logs`).
+     */
     bool OpenNewFile(cCsvLog& log, bool readOnly);
+
+    /**
+     * @brief Read the next row from @p log's open file into `log.nextLine`/`log.orderId` (read mode only).
+     * @param log data set to read the next line for.
+     * @return true if a row was read and its order id (column 0) parsed; false on EOF, no open file, or a row with no comma-separated order id.
+     */
     bool GetNextLineForFile(cCsvLog& log);
 
+    /**
+     * @brief Parse @p log's currently buffered row (from GetNextLineForFile()) into a data set, then advance to the next row.
+     * @param log data set to read from.
+     * @return the parsed data set, or null if the row failed to parse as @p log's data ID.
+     */
     p_data_buf_t* ReadDataFromFile(cCsvLog& log);
-    std::map<uint32_t, cCsvLog> m_logs;
-    cDataCSV m_csv;
-    std::map<uint32_t, std::vector<std::string> > m_currentFiles; // all files for each data set
-    std::map<uint32_t, uint32_t> m_currentFileIndex; // contains the current csv file index for each data set
-    p_data_buf_t m_data;
-    uint64_t m_nextId; // for writing the log, column 0 of csv is an incrementing id. This lets us read the log back in order.
+
+    std::map<uint32_t, cCsvLog> m_logs;                                   //!< open per-data-set state, keyed by data ID
+    cDataCSV m_csv;                                                        //!< CSV (de)serialization helper shared across all data sets
+    std::map<uint32_t, std::vector<std::string> > m_currentFiles;         //!< all discovered files for each data set (read mode)
+    std::map<uint32_t, uint32_t> m_currentFileIndex;                      //!< current index into `m_currentFiles[id]` for each data set (read mode)
+    p_data_buf_t m_data;                                                   //!< scratch buffer for the most recently read data set
+    uint64_t m_nextId;                                                     //!< next order id to write into column 0; lets ReadData() reconstruct write order across data sets
 };
 
 #endif // DEVICE_LOG_CSV_H

--- a/src/DeviceLogJSON.h
+++ b/src/DeviceLogJSON.h
@@ -1,14 +1,15 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLogJSON.h
+ * @brief JSON log format: every data set for a device is written as one JSON object into a single
+ *        top-level JSON array per log file (unlike DeviceLogCSV, which splits by data set).
+ *
+ * A file is a `[` ... comma-separated `{...}` objects ... `]` JSON array. Reading scans for
+ * balanced-brace top-level objects (GetNextItemForFile()) rather than parsing the whole file as
+ * JSON, so a file can be read incrementally without holding it entirely in memory.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef DEVICE_LOG_JSON_H
 #define DEVICE_LOG_JSON_H
@@ -22,6 +23,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "DeviceLog.h"
 #include "com_manager.h"
 
+/** @brief `cDeviceLog` implementation that writes/reads a single JSON-array log file. */
 class cDeviceLogJSON : public cDeviceLog
 {
 public:
@@ -29,19 +31,34 @@ public:
     cDeviceLogJSON(const device_handle_t dev) : cDeviceLog(dev) {};
     cDeviceLogJSON(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
 
+    /** @brief Close the current file, writing the closing `]` first if one is open. */
     bool CloseAllFiles() OVERRIDE;
+
+    /** @brief Write one data set as a new JSON object to the current file, opening (with a leading `[`) or rotating (closing with `]`) files as needed. */
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
+
+    /** @brief Read the next JSON object from the current (or next) file. @return the parsed data set, or null if no more objects/files are available or the current object failed to parse. */
     p_data_buf_t* ReadData() OVERRIDE;
+
     void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
     std::string LogFileExtention() OVERRIDE { return std::string(".json"); }
 
 private:
+    /**
+     * @brief Scan the current file for the next balanced-brace top-level `{...}` JSON object into `m_jsonString`.
+     * @return true if a complete object was found; false on EOF or if no file is open.
+     */
     bool GetNextItemForFile();
 
+    /**
+     * @brief Parse the object most recently scanned by GetNextItemForFile() (advancing to the next file/object first) into a data set.
+     * @return the parsed data set, or null if no object could be scanned or it failed to parse.
+     */
     p_data_buf_t* ReadDataFromFile();
-    std::string m_jsonString;
-    cDataJSON m_json;
-    p_data_buf_t m_data;
+
+    std::string m_jsonString;      //!< most recently scanned top-level JSON object, from GetNextItemForFile()
+    cDataJSON m_json;              //!< JSON (de)serialization helper
+    p_data_buf_t m_data;           //!< scratch buffer for the most recently read data set
 };
 
 #endif // DEVICE_LOG_CSV_H

--- a/src/DeviceLogKML.h
+++ b/src/DeviceLogKML.h
@@ -1,14 +1,16 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLogKML.h
+ * @brief KML log format: write-only flight-path visualization, one KML file per logical channel
+ *        (INS, reference INS, GNSS variants, RTK — see `cDataKML::MyEnum`) rather than per-DID.
+ *
+ * Unlike the other formats, KML reading is not implemented — ReadData() and its helpers are stubs
+ * (`cISLogger::LoadFromDirectory()` already refuses `LOGTYPE_KML` for exactly this reason). Data
+ * sets are buffered in memory per channel (`sKmlLog::data`) and only rendered to XML and written
+ * out when a channel's buffer crosses `m_maxFileSize` (CloseWriteFile()) or the log is closed.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_SDK__DEVICE_LOG_KML_H
 #define IS_SDK__DEVICE_LOG_KML_H
@@ -26,18 +28,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 
+/** @brief In-memory buffer of not-yet-written points/track for one KML channel (see `cDataKML::MyEnum`). */
 struct sKmlLog
 {
-    std::vector<sKmlLogData> data;
+    std::vector<sKmlLogData> data;   //!< buffered points for this channel, cleared once written out by CloseWriteFile()
 
-    std::string     fileName;
-    uint32_t        fileCount;
-    uint32_t        fileDataSize;   // Byte size of chunk data.  Excludes chunk header.
-    uint32_t        fileSize;
+    std::string     fileName;        //!< name of the file this channel was (or will be) written to
+    uint32_t        fileCount;       //!< number of files written so far for this channel
+    uint32_t        fileDataSize;    //!< unused
+    uint32_t        fileSize;        //!< estimated buffered size in bytes (`data.size() * cDataKML::BYTES_PER_KID()`); compared against `m_maxFileSize` to trigger a flush
 };
 
 
-
+/** @brief `cDeviceLog` implementation that renders buffered points to write-only KML files, one per logical channel. */
 class cDeviceLogKML : public cDeviceLog
 {
 public:
@@ -45,24 +48,68 @@ public:
     cDeviceLogKML(device_handle_t dev) : cDeviceLog(dev) {};
     cDeviceLogKML(uint16_t hdwId, uint32_t serialNo) : cDeviceLog(hdwId, serialNo) {};
 
+    /** @brief Clear every channel's buffered points/counters and reset the reference-INS detection flag. */
     void InitDeviceForWriting(const std::string& timestamp, const std::string& directory, uint64_t maxDiskSpace, uint32_t maxFileSize) OVERRIDE;
+
+    /** @brief Flush and write out every channel's buffered points via CloseWriteFile(). */
     bool CloseAllFiles() OVERRIDE;
+
+    /**
+     * @brief Render @p log's buffered points to a KML document and write it to a new file, then clear the buffer.
+     *
+     * @p kid is remapped from `KID_INS` to `KID_REF` if this device was detected as a reference INS
+     * (serial number 99999 or 10101; see SaveData()). GNSS-family channels are skipped entirely if
+     * GNSS logging is disabled (SetKmlConfig()).
+     *
+     * @param kid logical channel to write; see `cDataKML::MyEnum`.
+     * @param log the channel's buffered data.
+     * @return true on success; false if @p log has no buffered data, `m_directory` is empty, the
+     *         channel is a disabled GNSS variant, no serial number is resolvable, or the XML write failed.
+     */
     bool CloseWriteFile(int kid, sKmlLog& log);
+
+    /** @brief Open every channel's current KML file with the OS's default associated application (Windows only; a no-op elsewhere). */
     bool OpenWithSystemApp(void) OVERRIDE;
+
+    /**
+     * @brief Buffer one data set into its channel via WriteDateToFile(), and detect reference-INS devices.
+     *
+     * If @p dataHdr is `DID_DEV_INFO` and the reported serial number is 99999 or 10101, this
+     * device's `KID_INS` channel is treated as the reference INS (`KID_REF`) for the remainder of
+     * the log.
+     */
     bool SaveData(p_data_hdr_t* dataHdr, const uint8_t* dataBuf, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
+
+    /**
+     * @brief Not implemented for KML — always fails.
+     * @return null; see the file-level documentation for why KML reading isn't supported.
+     */
     p_data_buf_t* ReadData() OVERRIDE;
+
     void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
     std::string LogFileExtention() OVERRIDE { return std::string(".kml"); }
 
 private:
+    /** @brief Unused stub kept for interface symmetry with the other formats; always succeeds without doing anything. */
     bool OpenNewSaveFile(int kid, sKmlLog &log) { (void)kid; (void)log; return true; }
+
+    /** @brief Not implemented — always returns null. See ReadData(). */
     p_data_buf_t* ReadDataFromChunk();
+
+    /** @brief Not implemented — always returns true without reading anything. @note Because this never returns false, ReadData()'s retry loop around it would spin forever if ever called; KML reading is not a supported path (see ReadData()). */
     bool ReadChunkFromFile();
+
+    /**
+     * @brief Route one data set to its channel's buffer (via `cDataKML::DID_TO_KID()`), and flush if the channel's estimated size crosses `m_maxFileSize`.
+     * @param dataHdr header identifying the data set; data sets that don't map to a known channel, or map to a disabled GNSS channel, are silently ignored.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @return true if the data was buffered (or ignored) successfully; false if a size-triggered flush via CloseWriteFile() failed.
+     */
     bool WriteDateToFile(const p_data_hdr_t *dataHdr, const uint8_t *dataBuf);
 
-    cDataKML                m_kml;
-    sKmlLog                 m_Log[cDataKML::MAX_NUM_KID];
-    bool                    m_isRefIns;
+    cDataKML                m_kml;                            //!< KML point-buffering helper shared across all channels
+    sKmlLog                 m_Log[cDataKML::MAX_NUM_KID];      //!< per-channel buffered state, indexed by `cDataKML::MyEnum`
+    bool                    m_isRefIns;                        //!< true once a companion device with a reference-INS serial number (99999 or 10101) has been detected; remaps this device's KID_INS output to KID_REF
 };
 
 #endif // IS_SDK__DEVICE_LOG_KML_H

--- a/src/DeviceLogRaw.h
+++ b/src/DeviceLogRaw.h
@@ -1,14 +1,19 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLogRaw.h
+ * @brief `LOGTYPE_RAW` log format (`.raw`): the undecoded, multi-protocol byte stream from the
+ *        device, framed through a `cDataChunk` staging buffer with no per-chunk header.
+ *
+ * Unlike DeviceLogSerial (which stores already-parsed `p_data_hdr_t`/payload pairs), this format's
+ * SaveData() takes raw bytes straight off the wire and feeds them byte-by-byte through an
+ * `is_comm_instance_t` parser (`m_comm`) that recognizes multiple protocols (IS binary, NMEA,
+ * RTCM3, u-blox) — so a `.raw` log can capture correction streams and third-party protocols
+ * alongside IS data, not just `p_data_hdr_t`-shaped records. Its `cDataChunk` writes/reads with
+ * `writeHeader = false` (see WriteChunkToFile()/ReadChunkFromFile()), so the on-disk file is a
+ * flat, unframed byte stream rather than a sequence of `sChunkHeader`-prefixed chunks.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_SDK__DEVICE_LOG_RAW_H
 #define IS_SDK__DEVICE_LOG_RAW_H
@@ -24,6 +29,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISLogStats.h"
 
 
+/** @brief `cDeviceLog` implementation for the raw, multi-protocol byte-stream format; see the file-level documentation above. */
 class cDeviceLogRaw : public cDeviceLog
 {
 public:
@@ -31,31 +37,64 @@ public:
     cDeviceLogRaw(device_handle_t dev);
     cDeviceLogRaw(uint16_t hdwId, uint32_t serialNo);
 
+    /** @brief Clear the staging chunk and record the device's serial number/port info in its header. */
     void InitDeviceForWriting(const std::string& timestamp, const std::string& directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
+
+    /** @brief Clear the staging chunk. */
     void InitDeviceForReading() OVERRIDE;
+
     bool CloseAllFiles() OVERRIDE;
     bool FlushToFile() OVERRIDE;
+
+    /**
+     * @brief Parse @p dataBuf byte-by-byte for statistics/DID_DEV_INFO capture, then buffer it (unparsed) into the current chunk.
+     *
+     * Every recognized packet is indexed via `addIndexRecord()` as it's parsed. When the chunk
+     * fills, it's flushed to disk via WriteChunkToFile() first.
+     *
+     * @param dataSize number of bytes in @p dataBuf.
+     * @param dataBuf raw bytes as received from the device; may span partial or multiple packets/protocols.
+     * @param globalLogStats the owning `cISLogger`'s aggregate statistics, updated alongside this device's own.
+     * @return true if the bytes were buffered (and any triggered flush succeeded); false if a flush failed or the chunk couldn't hold the data.
+     */
     bool SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &globalLogStats) OVERRIDE;
+
+    /** @brief Read the next `_PTYPE_INERTIAL_SENSE_DATA`/`_PTYPE_INERTIAL_SENSE_CMD` packet, skipping over packets of other recognized protocols. @return the parsed data set, or null if the log is exhausted. */
     p_data_buf_t* ReadData() OVERRIDE;
+
+    /** @brief Read the next packet of any recognized protocol. @param[out] ptype protocol type of the returned packet. @return the next packet, or null if the log is exhausted. */
     packet_t* ReadPacket(protocol_type_t& ptype) OVERRIDE;
 
     void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
     std::string LogFileExtention() OVERRIDE { return std::string(".raw"); }
     void Flush() OVERRIDE;
+
+    /** @brief Get the IS-comm parser instance used to recognize packets in this log's byte stream. */
     is_comm_instance_t* IsCommInstance() OVERRIDE { return &m_comm; }
 
-    cDataChunk m_chunk;
+    cDataChunk m_chunk;     //!< staging buffer for not-yet-flushed raw bytes; written/read with no chunk header (see the file-level documentation)
 
 private:
+    /** @brief Initialize `m_comm` and enable the recognized protocols (IS binary data, NMEA, RTCM3, u-blox). */
     void initCommInstance();
+
+    /**
+     * @brief Parse and consume the next recognized packet from `m_chunk`, one byte at a time.
+     * @param[out] ptype protocol type of the returned packet; `_PTYPE_NONE` if the chunk was exhausted with no complete packet found.
+     * @return the parsed packet, or null if no complete packet was found in the currently buffered data.
+     */
     packet_t* ReadPacketFromChunk(protocol_type_t& ptype);
+
+    /** @brief Read the next unframed chunk of raw bytes from the file into `m_chunk`, opening the next file if the current one is exhausted. @return true if a chunk was read; false if no more data/files are available. */
     bool ReadChunkFromFile();
+
+    /** @brief Write `m_chunk`'s buffered bytes to the current file with no chunk header (opening a new file first if needed), then clear the chunk. @return true on success; false if there's nothing to write or the file couldn't be opened/written. */
     bool WriteChunkToFile();
 
-    uint8_t m_commBuf[PKT_BUF_SIZE];
-    p_data_buf_t m_pData;
-    is_comm_instance_t m_comm;
-    protocol_type_t m_protocolType;
+    uint8_t m_commBuf[PKT_BUF_SIZE];       //!< working buffer owned by `m_comm` for in-progress packet assembly
+    p_data_buf_t m_pData;                   //!< scratch buffer for the most recently read data set
+    is_comm_instance_t m_comm;              //!< multi-protocol packet parser (IS binary, NMEA, RTCM3, u-blox)
+    protocol_type_t m_protocolType;         //!< unused
 };
 
 #endif // IS_SDK__DEVICE_LOG_RAW_H

--- a/src/DeviceLogSerial.h
+++ b/src/DeviceLogSerial.h
@@ -1,14 +1,18 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file DeviceLogSerial.h
+ * @brief `LOGTYPE_DAT` log format (`.dat`): already-parsed data sets (`p_data_hdr_t` + payload
+ *        pairs), framed through a `cDataChunk` staging buffer with a full chunk header.
+ *
+ * Unlike DeviceLogRaw (which stores the undecoded, multi-protocol byte stream), this format's
+ * SaveData() takes an already-parsed data set — it pushes the `p_data_hdr_t` header and payload
+ * as-is into the staging chunk, with no IS-comm protocol parsing. Its `cDataChunk` writes/reads
+ * with the default `writeHeader = true` (see WriteChunkToFile()/ReadChunkFromFile()), so the
+ * on-disk file is a sequence of `sChunkHeader`-prefixed chunks, each containing a run of
+ * `p_data_hdr_t`/payload pairs.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_SDK__DEVICE_LOG_SERIAL_H
 #define IS_SDK__DEVICE_LOG_SERIAL_H
@@ -22,30 +26,55 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "com_manager.h"
 
 
-class cDeviceLogSerial : public cDeviceLog 
+/** @brief `cDeviceLog` implementation for the already-parsed, chunk-header-framed `.dat` format; see the file-level documentation above. */
+class cDeviceLogSerial : public cDeviceLog
 {
 public:
     cDeviceLogSerial();
     cDeviceLogSerial(device_handle_t dev);
     cDeviceLogSerial(uint16_t hdwId, uint32_t serialNo);
+
+    /** @note Declared but not defined anywhere in the SDK; calling it will fail to link. */
     cDeviceLogSerial(port_handle_t port);
 
+    /** @brief Clear the staging chunk and record the device's serial number/port info in its header. */
     void InitDeviceForWriting(const std::string& timestamp, const std::string& directory, uint64_t maxDiskSpace, uint32_t maxFilesize) OVERRIDE;
+
+    /** @brief Clear the staging chunk. */
     void InitDeviceForReading() OVERRIDE;
+
     bool CloseAllFiles() OVERRIDE;
     bool FlushToFile() OVERRIDE;
+
+    /**
+     * @brief Buffer one already-parsed data set (header + payload) into the current chunk, rotating files/chunks as needed.
+     * @param dataHdr header describing @p dataBuf's data ID, size, and offset.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @param ptype protocol type the data arrived as; forwarded to the base class for statistics.
+     * @return true if the data set was buffered (and any triggered chunk flush succeeded); false if a flush failed or the chunk couldn't hold the data.
+     */
     bool SaveData(p_data_hdr_t *dataHdr, const uint8_t *dataBuf, protocol_type_t ptype = _PTYPE_INERTIAL_SENSE_DATA) OVERRIDE;
+
+    /** @brief Read the next data set, reading the next chunk/file as needed. @return the next data set, or null if the log is exhausted. */
     p_data_buf_t *ReadData() OVERRIDE;
 
     void SetSerialNumber(uint32_t serialNumber) OVERRIDE;
     std::string LogFileExtention() OVERRIDE { return std::string(".dat"); }
     void Flush() OVERRIDE;
 
-    cDataChunk m_chunk;
+    cDataChunk m_chunk;     //!< staging buffer for not-yet-flushed header/payload pairs; written/read with a full chunk header (see the file-level documentation)
 
 private:
+    /**
+     * @brief Pop the next header/payload pair off the front of `m_chunk`.
+     * @return a pointer into the chunk's buffer, valid until the next chunk mutation; null if the chunk is empty.
+     */
     p_data_buf_t *ReadDataFromChunk();
+
+    /** @brief Read the next chunk-header-framed chunk from the file into `m_chunk`, opening the next file if the current one is exhausted. @return true if a chunk was read; false if no more data/files are available. */
     bool ReadChunkFromFile();
+
+    /** @brief Write `m_chunk`'s buffered data to the current file with a full chunk header (opening a new file first if needed), then clear the chunk. @return true on success; false if there's nothing to write or the file couldn't be opened/written. */
     bool WriteChunkToFile();
 };
 

--- a/src/ISFileManager.h
+++ b/src/ISFileManager.h
@@ -1,14 +1,15 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file ISFileManager.h
+ * @brief Cross-platform (Windows/Linux/macOS/EVB-2 FatFs) directory and file utilities used by
+ *        the logger for drive-usage accounting and file culling.
+ *
+ * Every function here has a platform-specific implementation behind `#if PLATFORM_IS_*`
+ * branches in ISFileManager.cpp — this header documents the common contract, not any one
+ * platform's implementation detail, unless a behavior genuinely differs by platform.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_SDK_IS_FILE_MANAGER_H_
 #define IS_SDK_IS_FILE_MANAGER_H_
@@ -20,100 +21,193 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace ISFileManager
 {
+    /** @brief Name, size, and last-modification time of one file, as returned by GetAllFilesInDirectory()/GetDirectorySpaceUsed(). */
     typedef struct
     {
-        std::string name;
-        uint64_t size;
-        time_t lastModificationDate;
+        std::string name;                  //!< full path to the file
+        uint64_t size;                     //!< file size in bytes
+        time_t lastModificationDate;        //!< last-modification time
     } file_info_t;
 
     /**
-     * Is this path directory?
-     * @param path the path to check
-     * @return true if the path is a directory, false otherwise
+     * @brief Check whether a path is a directory.
+     * @param path the path to check.
+     * @return true if the path is a directory, false otherwise (including if it doesn't exist).
      */
     bool PathIsDir(const std::string& path);
 
-    // get all files in a folder - files parameter is not cleared in this function
-    // files contains the full path to the file
-    // return false if no files found, true otherwise
+    /**
+     * @brief Get every file in a directory, as full paths.
+     * @param directory directory to search.
+     * @param recursive if true, also search subdirectories.
+     * @param[out] files matching file paths are appended; NOT cleared before appending.
+     * @return true if any file was appended, false if none were found (or the directory couldn't be opened).
+     */
     bool GetAllFilesInDirectory(const std::string& directory, bool recursive, std::vector<std::string>& files);
+
+    /**
+     * @brief Get every file in a directory, with size/modification-time info.
+     * @param directory directory to search.
+     * @param recursive if true, also search subdirectories.
+     * @param[out] files matching files are appended; NOT cleared before appending.
+     * @return true if any file was appended, false if none were found (or the directory couldn't be opened).
+     */
     bool GetAllFilesInDirectory(const std::string& directory, bool recursive, std::vector<file_info_t>& files);
+
+    /**
+     * @brief Get every file in a directory whose full path matches a regular expression, as full paths.
+     *
+     * @note On Linux, when @p regexPattern is empty, this overload matches nothing (returns no
+     *       files) rather than matching everything — unlike the `file_info_t` overload below,
+     *       which treats an empty pattern as "match all" on every platform. Pass a `file_info_t`
+     *       vector instead (and extract names from it) if you need an unfiltered listing on Linux.
+     *
+     * @param directory directory to search.
+     * @param recursive if true, also search subdirectories.
+     * @param regexPattern case-insensitive regular expression matched against each file's full path.
+     * @param[out] files matching file paths are appended; NOT cleared before appending.
+     * @return true if any file was appended, false if none matched (or the directory couldn't be opened).
+     */
     bool GetAllFilesInDirectory(const std::string& directory, bool recursive, const std::string& regexPattern, std::vector<std::string>& files);
+
+    /**
+     * @brief Get every file in a directory whose full path matches a regular expression, with size/modification-time info.
+     * @param directory directory to search.
+     * @param recursive if true, also search subdirectories.
+     * @param regexPattern case-insensitive regular expression matched against each file's full path; an empty pattern matches every file.
+     * @param[out] files matching files are appended; NOT cleared before appending.
+     * @return true if any file was appended, false if none matched (or the directory couldn't be opened).
+     */
     bool GetAllFilesInDirectory(const std::string& directory, bool recursive, const std::string& regexPattern, std::vector<file_info_t>& files);
 
+    /** @brief Delete a single file. @param fullFilePath path to the file to delete. @return true on success, false otherwise. */
     bool DeleteFile(const std::string& fullFilePath);
+
+    /**
+     * @brief Delete a directory and its contents.
+     * @param directory directory to delete.
+     * @param recursive if true, delete subdirectories and their contents too. @note ignored on EVB-2/FatFs, which always deletes recursively.
+     */
     void DeleteDirectory(const std::string& directory, bool recursive = true);
 
-    // get space used in a directory recursively - files is filled with all files in the directory, sorted by modification date, files is NOT cleared beforehand. sortByDate of false sorts by file name
+    /**
+     * @brief Get the total size of every file in a directory.
+     * @param directory directory to scan.
+     * @param recursive if true, also scan subdirectories.
+     * @return total size in bytes of every file found.
+     */
     uint64_t GetDirectorySpaceUsed(const std::string& directory, bool recursive = true);
+
+    /**
+     * @brief Get the total size of every file in a directory, and the files themselves, sorted.
+     * @param directory directory to scan.
+     * @param[out] files every file found, sorted by @p sortByDate (ascending modification time) or by name; NOT cleared before appending.
+     * @param sortByDate if true, sort @p files by modification date (oldest first); if false, sort by name.
+     * @param recursive if true, also scan subdirectories.
+     * @return total size in bytes of every file found.
+     */
     uint64_t GetDirectorySpaceUsed(const std::string& directory, std::vector<file_info_t>& files, bool sortByDate = true, bool recursive = true);
+
+    /**
+     * @brief Get the total size of every file in a directory matching a pattern, and the files themselves, sorted.
+     * @param directory directory to scan.
+     * @param regexPattern case-insensitive regular expression matched against each file's full path; an empty pattern matches every file.
+     * @param[out] files every matching file, sorted by @p sortByDate (ascending modification time) or by name; NOT cleared before appending.
+     * @param sortByDate if true, sort @p files by modification date (oldest first); if false, sort by name.
+     * @param recursive if true, also scan subdirectories.
+     * @return total size in bytes of every matching file found.
+     */
     uint64_t GetDirectorySpaceUsed(const std::string& directory, std::string regexPattern, std::vector<file_info_t>& files, bool sortByDate = true, bool recursive = true);
 
-    // get free space for the disk that the specified directory exists on
+    /**
+     * @brief Get the free space available on the disk/volume containing a directory.
+     * @param directory directory identifying the disk/volume to query; created temporarily (and removed afterward) if it doesn't already exist.
+     * @return free space in bytes, or 0 on error.
+     */
     uint64_t GetDirectorySpaceAvailable(const std::string& directory);
 
-    // get drive total size that the specified directory exists on
+    /**
+     * @brief Get the total size of the disk/volume containing a directory.
+     * @param directory directory identifying the disk/volume to query; created temporarily (and removed afterward) if it doesn't already exist.
+     * @return total size in bytes, or 0 on error.
+     */
     uint64_t GetDirectoryDriveTotalSize(const std::string& directory);
 
-    // get just the file name from a path
+    /** @brief Get just the file name (with extension) from a path, stripping any directory components. @return the file name, or the whole input if it contains no path separator. */
     std::string GetFileName(const std::string& path);
 
-    // get just the parent/base path from a path
+    /**
+     * @brief Get the parent directory from a path.
+     * @note Despite the name, this returns the same thing as GetFileName() — the component
+     *       *after* the last path separator, not before it. It does NOT return the parent
+     *       directory. Use the lowercase-`g` getParentDirectory() below for the actual parent path.
+     * @return the file name (with extension), or the whole input if it contains no path separator.
+     */
     std::string GetParentDirectory(const std::string& path);
 
-    // get the current working directory
+    /** @brief Get the current working directory. @return the current working directory, or an empty string on error. */
     std::string CurrentWorkingDirectory();
 
     /**
-     * Returns true if the specified path is consider an absolute path
-     * @param path
-     * @return true if absolute, false if relative
+     * @brief Check whether a path is absolute.
+     * @note Relies on `path_seperator` (`/` on Linux, `\` on Windows), which is null on other
+     *       platforms (e.g. EVB-2) — calling this there is undefined behavior.
+     * @param path the path to check.
+     * @return true if absolute, false if relative.
      */
     bool isPathAbsolute(const std::string& path);
 
     /**
-     * returns an absolute path to the parent directory of the specified path
-     * If 'path' is a relative path, it is applied to the current working directory
-     * @param path a complete path
-     * @param parent a string representing the path to the parent directory
-     * @return true on success, otherwise false
+     * @brief Get an absolute path to the parent directory of a path.
+     *
+     * If @p path is relative, it is first resolved against the current working directory.
+     * @note Relies on `path_seperator`, which is null on platforms other than Linux/Windows
+     *       (e.g. EVB-2) — calling this there is undefined behavior.
+     *
+     * @param path a complete path.
+     * @param[out] parent the path to the parent directory.
+     * @return true on success, false if no path separator could be found (even after resolving against the current working directory).
      */
     bool getParentDirectory(const std::string& path, std::string& parent);
 
     /**
-     * Extracts and stores the base, filename, and ext(ension) components from the specified path
-     * @param path the path to parse
-     * @param parent the base or parent directory which contains the file. This is always an absolute path.
-     * @param file the filename which the path references. This is just the filename with the extension, and does not include any directory/path information
-     * @param ext the filename extension of the filename. This is the same as the last matching characters of the filename, and is included for convenience.
-     * @return true if there was sufficient path information to extract the parent of the path, otherwise false.  This is NOT an error condition,
-     * but instead indicates (if true) that parent contains meaningful data.
+     * @brief Extract the parent directory, file name, and extension components from a path.
+     *
+     * @note Relies on getParentDirectory() and `path_seperator` internally — see its note on
+     *       undefined behavior on platforms other than Linux/Windows.
+     *
+     * @param path the path to parse.
+     * @param[out] parent the parent directory containing the file; always an absolute path (see getParentDirectory()).
+     * @param[out] file the filename the path references, including its extension, with no directory/path information.
+     * @param[out] ext the filename's extension, including the leading dot.
+     * @return true if there was sufficient path information to extract the parent of the path, otherwise false. This is NOT an error condition — it indicates (if true) that @p parent contains meaningful data.
      */
     bool getPathComponents(const std::string& path, std::string& parent, std::string& file, std::string& ext);
 
+    /** @brief Update an existing file's last-access/modification time to now; does not create the file if it doesn't already exist. @return true on success. */
     bool TouchFile(const std::string& path);
 
     /**
-     * @brief Create directory specified if it does not exist.
-     * 
-     * @param path relative or absolute path for directory to be created.
-     * @return true on success 
+     * @brief Create a directory if it does not already exist, creating any missing parent directories along the way.
+     *
+     * @param path relative or absolute path for the directory to be created.
+     * @return true on success, including if @p path already existed as a directory; false if
+     *         @p path exists but isn't a directory, or the directory couldn't be created.
      */
     bool CreateDirectory(const std::string& path);
 
     /**
-     * @brief Remove oldest files in the specified directory including all subdirectories until the target size in bytes is met.
-     * 
-     * @param directory path to search to file oldest files to be removed.
-     * @param target_size in bytes that the specified directory must achieve by removing oldest files.
+     * @brief Delete the oldest files (by modification time) in a directory and its subdirectories until the total size is at or under a target.
+     *
+     * @param directory directory to search, recursively, for files to remove.
+     * @param target_size total size, in bytes, the directory should be reduced to (or below) by removing its oldest files. No-op if the directory is already at or under this size.
      */
     void RemoveOldestFiles(const std::string& directory, std::uintmax_t target_size);
 
     /**
-     * @brief Function to recursively remove empty directories.
-     * 
-     * @param directory path to search where files should be removed.
+     * @brief Recursively remove a directory and any of its subdirectories that contain no files (only recursively-empty subdirectories).
+     * @param directory directory to check and, if empty, remove.
+     * @return true if @p directory (after recursively removing empty subdirectories) itself ended up empty and was removed; false if it contains any file, or couldn't be opened.
      */
     bool RemoveEmptyDirectories(const std::string& directory);
 

--- a/src/ISLogFile.h
+++ b/src/ISLogFile.h
@@ -1,6 +1,14 @@
-//
-// Created by robb on 11/5/18.
-//
+/**
+ * @file ISLogFile.h
+ * @brief `cISLogFileBase` implementation backed by standard C stdio (`FILE*`).
+ *
+ * The default `cISLogFileBase` implementation on every host platform (see ISLogFileFactory.h,
+ * which selects this over the FatFs-backed implementation on EVB-2). Every method is a thin,
+ * null-checked pass-through to the corresponding stdio function (`fopen`, `fread`, `fseek`, etc.).
+ *
+ * @author robb on 11/5/18.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef _IS_SDK_IS_LOG_FILE_H_
 #define _IS_SDK_IS_LOG_FILE_H_
@@ -9,12 +17,20 @@
 
 
 
+/** @brief `cISLogFileBase` implementation over a standard C stdio `FILE*`. */
 class cISLogFile : public cISLogFileBase
 {
 public:
+    /** Construct without opening a file; call open() before using any I/O method. */
     cISLogFile();
+
+    /** Construct and immediately open() @p filePath in the given @p mode. Check isOpened() to confirm success. */
     cISLogFile(const std::string& filePath, const char* mode);
+
+    /** Construct and immediately open() @p filePath in the given @p mode. Check isOpened() to confirm success. */
     cISLogFile(const char* filePath, const char* mode);
+
+    /** Closes the underlying file if still open. */
     ~cISLogFile();
 
     bool open(const char* filePath, const char* mode) OVERRIDE;
@@ -28,19 +44,34 @@ public:
     std::size_t write(const void* bytes, std::size_t len) OVERRIDE;
     int lprintf(const char* format, ...) OVERRIDE;
     int vprintf(const char* format, va_list args) OVERRIDE;
-    
-    // Static utility function for formatted printing to stdout
+
+    /**
+     * @brief Formatted print directly to `stdout`, bypassing any `cISLogFile` instance.
+     * @param format printf-style format string, followed by its matching arguments.
+     * @return the number of characters written, as returned by the underlying `vprintf()`.
+     */
     static int lprintfStdout(const char* format, ...);
+
+    /**
+     * @brief Format a `printf()`-style string into a `std::string`.
+     * @param format printf-style format string, followed by its matching arguments.
+     * @return the formatted string, truncated to 255 characters if the formatted output would exceed that length.
+     */
     static std::string formatString(const char* format, ...);
 
     int getch() OVERRIDE;
     std::size_t read(void* bytes, std::size_t len) OVERRIDE;
+
+    /**
+     * @note Defaults to `SEEK_CUR` here, unlike `cISLogFileBase::seek()`'s `SEEK_SET` default —
+     *       see the note on the base declaration. Pass @p origin explicitly when it matters.
+     */
     int seek(long int offset, int origin = SEEK_CUR) OVERRIDE;
     long int tell() OVERRIDE;
     int eof() OVERRIDE;
 
 private:
-    FILE *m_file;
+    FILE *m_file;   //!< underlying stdio file handle; null when no file is open
 };
 
 

--- a/src/ISLogFileBase.h
+++ b/src/ISLogFileBase.h
@@ -1,14 +1,15 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file ISLogFileBase.h
+ * @brief Abstract file I/O interface used by the logger and its file-backed helpers.
+ *
+ * Defines the contract a "log file" must satisfy regardless of the underlying storage: a
+ * standard stdio-backed file (cISLogFile) on host platforms, or a FatFs-backed implementation
+ * on embedded targets (cISLogFileFatFs, EVB-2). Callers program against this interface so the
+ * concrete implementation is chosen once, at construction (see ISLogFileFactory.h).
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef _IS_SDK_IS_LOG_FILE_BASE_H_
 #define _IS_SDK_IS_LOG_FILE_BASE_H_
@@ -19,34 +20,135 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <string>
 
 #define LOG_DEBUG_FILE_WRITE    0   // Enable file debug printout
-#define LOG_DEBUG_FILE_READ     0   // 
+#define LOG_DEBUG_FILE_READ     0   //
 #define LOG_DEBUG_CHUNK_WRITE   0   // Enable chunk debug printout
 #define LOG_DEBUG_CHUNK_READ    0
 #define LOG_CHUNK_STATS         0   // 0 = disabled, 1 = summary, 2 = detailed
 
 
+/**
+ * @brief Abstract interface for a single open file used by the logger and the `.idx`/chunk readers and writers.
+ *
+ * Implementors wrap one underlying file handle and expose byte-oriented, C-stdio-style
+ * read/write/seek primitives. Every method here MUST fail soft when no file is open (or the
+ * operation fails) rather than throw: writes/reads are no-ops that report zero bytes moved,
+ * and character/formatted output returns `EOF`/a negative value, matching stdio conventions.
+ */
 class cISLogFileBase
 {
 public:
     virtual ~cISLogFileBase() {}
 
+    /**
+     * @brief Open the file at @p filePath.
+     * @param filePath path to the file to open.
+     * @param mode stdio-style `fopen()` mode string (e.g. "rb", "wb").
+     * @return true if the file was opened successfully, false otherwise.
+     */
     virtual bool open(const char* filePath, const char* mode)       = 0;
+
+    /**
+     * @brief Close the underlying file, if one is open.
+     * @return true on success, false if no file was open or the close failed.
+     */
     virtual bool close()                                            = 0;
+
+    /**
+     * @brief Flush any buffered writes to the underlying storage.
+     * @return true on success, false if no file is open or the flush failed.
+     */
     virtual bool flush()                                            = 0;
+
+    /**
+     * @brief Check whether the underlying file is free of a recorded error.
+     * @return true if no error has been recorded on the file, false otherwise (including when no file is open).
+     */
     virtual bool good()                                             = 0;
+
+    /**
+     * @brief Check whether a file is currently open on this instance.
+     * @return true if a file handle is open, false otherwise.
+     */
     virtual bool isOpened()                                         = 0;
 
+    /**
+     * @brief Write a single character to the file.
+     * @param ch the character to write.
+     * @return the character written, or EOF if no file is open or the write failed.
+     */
     virtual int putch(char ch)                                      = 0;
+
+    /**
+     * @brief Write a null-terminated string to the file.
+     * @param str the string to write.
+     * @return a non-negative value on success, or EOF if no file is open or the write failed.
+     */
     virtual int puts(const char* str)                               = 0;
+
+    /**
+     * @brief Write raw bytes to the file.
+     * @param bytes pointer to the data to write.
+     * @param len number of bytes to write.
+     * @return the number of bytes actually written; 0 if no file is open.
+     */
     virtual std::size_t write(const void* bytes, std::size_t len)   = 0;
+
+    /**
+     * @brief Write a `printf()`-style formatted string to the file.
+     * @param format printf-style format string, followed by its matching arguments.
+     * @return the number of characters written, or a negative value if no file is open or the write failed.
+     */
     virtual int lprintf(const char* format, ...)                    = 0;
+
+    /**
+     * @brief Write a `printf()`-style formatted string to the file using an already-initialized argument list.
+     * @param format printf-style format string.
+     * @param args argument list initialized with `va_start()`, matching @p format.
+     * @return the number of characters written, or a negative value if no file is open or the write failed.
+     */
     virtual int vprintf(const char* format, va_list args)           = 0;
 
+    /**
+     * @brief Read a single character from the file.
+     * @return the character read, or EOF if no file is open or the end of the file has been reached.
+     */
     virtual int getch()                                             = 0;
+
+    /**
+     * @brief Read raw bytes from the file.
+     * @param bytes destination buffer to fill.
+     * @param len maximum number of bytes to read.
+     * @return the number of bytes actually read; 0 if no file is open or the end of the file has been reached.
+     */
     virtual std::size_t read(void* bytes, std::size_t len)          = 0;
-    virtual int seek(long int offset, int origin = SEEK_SET)        = 0;   // origin = SEEK_SET means offset is from start of file
+
+    /**
+     * @brief Reposition the file's read/write position indicator.
+     *
+     * @note This default argument is evaluated statically per call site, not virtually — code
+     *       calling `seek(offset)` through a `cISLogFileBase*`/`&` gets *this* class's default
+     *       (`SEEK_SET`), even if the concrete implementation declares a different default for
+     *       direct calls on its own type. Pass @p origin explicitly when the call site's static
+     *       type might not be `cISLogFileBase`.
+     *
+     * @param offset offset in bytes, interpreted relative to @p origin.
+     * @param origin one of `SEEK_SET` (from the start of the file), `SEEK_CUR` (from the current
+     *        position), or `SEEK_END` (from the end of the file).
+     * @return 0 on success, non-zero on failure.
+     */
+    virtual int seek(long int offset, int origin = SEEK_SET)        = 0;
+
+    /**
+     * @brief Get the read/write position indicator's current byte offset from the start of the file.
+     * @return the current offset in bytes.
+     */
     virtual long int tell()                                         = 0;
-    virtual int eof()                                               = 0; // returns non-zero at end of file
+
+    /**
+     * @brief Check whether the end of the file has been reached.
+     * @return non-zero if at the end of the file, 0 otherwise.
+     */
+    virtual int eof()                                               = 0;
 
 };
 

--- a/src/ISLogFileFactory.h
+++ b/src/ISLogFileFactory.h
@@ -1,14 +1,14 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file ISLogFileFactory.h
+ * @brief Platform-selecting factory for `cISLogFileBase` instances.
+ *
+ * Callers that need a log file should go through `CreateISLogFile()` / `CloseISLogFile()` rather
+ * than constructing a concrete `cISLogFileBase` implementation directly, so the platform choice
+ * (stdio-backed `cISLogFile` vs. FatFs-backed `cISLogFileFatFs` on EVB-2) stays centralized here.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_SDK_CREATE_IS_LOG_FILE_H_
 #define IS_SDK_CREATE_IS_LOG_FILE_H_
@@ -22,6 +22,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 
+/**
+ * @brief Allocate a new, unopened log file for the current platform.
+ * @return a heap-allocated `cISLogFileBase*` (concrete type depends on platform); never null.
+ *         Caller owns the returned pointer and must release it via CloseISLogFile().
+ */
 inline cISLogFileBase* CreateISLogFile()
 {
 #if PLATFORM_IS_EVB_2
@@ -31,6 +36,14 @@ inline cISLogFileBase* CreateISLogFile()
 #endif
 }
 
+/**
+ * @brief Allocate and open a log file for the current platform.
+ * @param filePath path to the file to open.
+ * @param mode stdio-style `fopen()` mode string (e.g. "rb", "wb").
+ * @return a heap-allocated `cISLogFileBase*` (concrete type depends on platform); never null.
+ *         Caller owns the returned pointer and must release it via CloseISLogFile(). Check
+ *         `isOpened()` on the result to confirm the open succeeded.
+ */
 inline cISLogFileBase* CreateISLogFile(const char* filePath, const char* mode)
 {
 #if PLATFORM_IS_EVB_2
@@ -40,6 +53,14 @@ inline cISLogFileBase* CreateISLogFile(const char* filePath, const char* mode)
 #endif
 }
 
+/**
+ * @brief Allocate and open a log file for the current platform.
+ * @param filePath path to the file to open.
+ * @param mode stdio-style `fopen()` mode string (e.g. "rb", "wb").
+ * @return a heap-allocated `cISLogFileBase*` (concrete type depends on platform); never null.
+ *         Caller owns the returned pointer and must release it via CloseISLogFile(). Check
+ *         `isOpened()` on the result to confirm the open succeeded.
+ */
 inline cISLogFileBase* CreateISLogFile(const std::string& filePath, const char* mode)
 {
 #if PLATFORM_IS_EVB_2
@@ -49,6 +70,10 @@ inline cISLogFileBase* CreateISLogFile(const std::string& filePath, const char* 
 #endif
 }
 
+/**
+ * @brief Close and free a log file allocated by `CreateISLogFile()`.
+ * @param logFile reference to the pointer to close and delete; set to null on return. No-op if already null.
+ */
 inline void CloseISLogFile(cISLogFileBase*& logFile)
 {
     if (logFile != NULLPTR)

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -1,14 +1,18 @@
-/*
-MIT LICENSE
-
-Copyright (c) 2014-2025 Inertial Sense, Inc. - http://inertialsense.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+/**
+ * @file ISLogger.h
+ * @brief Top-level logging orchestrator: fans out data/packets to one `cDeviceLog` per device,
+ *        and owns the on-disk log directory (drive-usage limiting, file culling, statistics).
+ *
+ * `cISLogger` is the entry point applications use to write or read device logs; it does not
+ * serialize any data itself — each registered device gets a format-specific `cDeviceLog`
+ * (cDeviceLogSerial/Raw/CSV/JSON/KML, chosen by `eLogType`) that owns the actual file I/O. The
+ * logger's job is device bookkeeping (registerDevice()/DeviceLogs()), routing LogData()/ReadData()
+ * calls to the right device's log, and directory-level housekeeping in Update() (idle-timeout
+ * flushing and drive-space-limited file culling via ISFileManager).
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_LOGGER_H
 #define IS_LOGGER_H
@@ -45,39 +49,53 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define DEFAULT_LOGS_DIRECTORY          "IS_logs"
 #define DEFAULT_LOGS_MAX_FILE_SIZE      (1024 * 1024 * 5)    // 5 MB
 
+/**
+ * @brief Top-level device-log orchestrator; see the file-level documentation above for the overview.
+ */
 class cISLogger
 {
 public:
+    /** @brief Selects which `cDeviceLog` subclass (and on-disk format) new devices are logged with. */
     enum eLogType
     {
-        LOGTYPE_DAT = 0,    // serial
-        LOGTYPE_RAW,        // packetized serial.  Supports multiple packet types
-        LOGTYPE_CSV,
-        LOGTYPE_KML,
-        LOGTYPE_JSON,
-        LOGTYPE_COUNT
+        LOGTYPE_DAT = 0,    //!< raw serial byte stream, unparsed (cDeviceLogSerial, `.dat`)
+        LOGTYPE_RAW,        //!< packetized serial stream; supports multiple packet types (cDeviceLogRaw, `.raw`)
+        LOGTYPE_CSV,        //!< one CSV file per data set (cDeviceLogCSV, `.csv`)
+        LOGTYPE_KML,        //!< KML flight-path visualization, write-only (cDeviceLogKML, `.kml`)
+        LOGTYPE_JSON,       //!< one JSON-lines file per data set (cDeviceLogJSON, `.json`)
+        LOGTYPE_COUNT       //!< number of log types; not a valid log type itself
     };
 
-    // Static array of strings for log type names
+    /** @brief Display/file-extension name for each `eLogType`, indexed by the enum value. */
     static const char* logTypeStrings[LOGTYPE_COUNT];
 
+    /** @brief Options controlling how InitSave() lays out and limits a new log directory. */
     struct sSaveOptions
     {
-        eLogType logType;                           // File format to use for logger
-        float driveUsageLimitPercent;               // Limit of drive usage in percent of total drive size.
-        float driveUsageLimitMb;                    // Limit of drive usage in megabytes.
-        uint32_t maxFileSize;                       // Largest size of each individual log file.
-        bool useSubFolderTimestamp;                 // Cause each log instance to be written to separate timestamped folder.
-        std::string timeStamp;                      // Used to name each log instance directory.  System date and time used if left empty.
-        std::string subDirectory;                   // Write logs into sub-directory of this name inside log instance directory.
+        eLogType logType;                           //!< file format to use for the logger
+        float driveUsageLimitPercent;               //!< limit of drive usage, as a fraction (0.0-1.0) of the total drive size; 0 disables this limit
+        float driveUsageLimitMb;                    //!< limit of drive usage in megabytes; 0 disables this limit
+        uint32_t maxFileSize;                       //!< largest size of each individual log file, in bytes
+        bool useSubFolderTimestamp;                 //!< write each log instance to its own timestamped subfolder of `directory`
+        std::string timeStamp;                      //!< name used for the log instance directory; current system date/time is used if left empty
+        std::string subDirectory;                   //!< write logs into a subdirectory of this name inside the log instance directory, if non-empty
 
-        sSaveOptions(// Default Options:
-            eLogType type = LOGTYPE_RAW,            // Raw packetized serial.
-            float limitPercent = 0.5,               // 50% of total drive
-            float limitMb = 0,                      // Drive usage limit in MB.  0 disables this limit
-            uint32_t fileSize = 5 * 1024 * 1024,    // 5 MB size of each individual file in log
-            bool useTimestamp = true,               // A timestamped subdirectory is created for new log
-            std::string subDir = ""                 // Logs will be written into a subdirector of this string name within the timestamped subdirectory this string is not empty
+        /**
+         * @brief Construct with default options: raw packetized logging, 50% drive-usage limit, 5 MB files, timestamped subfolder.
+         * @param type file format to use for the logger.
+         * @param limitPercent drive-usage limit as a fraction (0.0-1.0) of total drive size; 0 disables this limit.
+         * @param limitMb drive-usage limit in megabytes; 0 disables this limit.
+         * @param fileSize size, in bytes, of each individual file in the log.
+         * @param useTimestamp if true, a timestamped subdirectory is created for the new log.
+         * @param subDir if non-empty, logs are written into a subdirectory of this name within the log instance directory.
+         */
+        sSaveOptions(
+            eLogType type = LOGTYPE_RAW,
+            float limitPercent = 0.5,
+            float limitMb = 0,
+            uint32_t fileSize = 5 * 1024 * 1024,
+            bool useTimestamp = true,
+            std::string subDir = ""
       ) : logType(type),
             driveUsageLimitPercent(limitPercent),
             driveUsageLimitMb(limitMb),
@@ -87,62 +105,221 @@ public:
         {}
     };
 
-    static const std::string g_emptyString;
+    static const std::string g_emptyString;    //!< shared empty-string default for optional `const std::string&` parameters
 
     cISLogger();
     virtual ~cISLogger();
 
-    // Setup logger to read from file
+    /**
+     * @brief Set up the logger to read an existing log from disk.
+     *
+     * Scans @p directory for files matching @p logType's extension, groups them by the serial
+     * number embedded in their filename (see ParseFilename()), and creates one reading-mode
+     * `cDeviceLog` per unique serial number found (filtered to @p serials, if non-empty).
+     * `LOGTYPE_KML` is not supported for reading and always fails.
+     *
+     * @param directory directory to scan for log files.
+     * @param logType log format to look for; determines the file extension matched.
+     * @param serials if non-empty, only devices whose serial number (as a string) appears in this
+     *        list are loaded; the literal value "ALL" also matches every serial number found.
+     * @return true if at least one device log was found and set up for reading, false otherwise.
+     */
     bool LoadFromDirectory(const std::string& directory, eLogType logType = LOGTYPE_RAW, std::vector<std::string> serials = {});
 
-    // Setup logger for writing to file
+    /**
+     * @brief Set up the logger to write a new log to disk.
+     *
+     * Closes any currently-open files, then creates the log directory tree under @p directory
+     * (optionally a timestamped subfolder and/or `options.subDirectory`), and computes the
+     * effective drive-usage limit from `options.driveUsageLimitPercent`/`driveUsageLimitMb`
+     * clamped to actually-available disk space. Devices registered afterward via registerDevice()
+     * use this directory and limit.
+     *
+     * @param directory root directory to write logs into; DEFAULT_LOGS_DIRECTORY ("IS_logs") is used if empty.
+     * @param options save options; see sSaveOptions.
+     * @return true if the log directory was created successfully, false otherwise.
+     */
     bool InitSave(const std::string& directory = g_emptyString, const sSaveOptions& options = cISLogger::sSaveOptions());
+
+    /** @deprecated Use InitSave(const std::string&, const sSaveOptions&) instead. */
     [[deprecated("Not recommended for future development.  Use InitSave() with sSaveOptions instead.")]]
     bool InitSave(eLogType logType = LOGTYPE_RAW, const std::string& directory = g_emptyString, float driveUsageLimitPercent = 0.5f, uint32_t maxFileSize = 5 * 1024 * 1024, bool useSubFolderTimestamp = true);
+
+    /** @deprecated Use InitSave(const std::string&, const sSaveOptions&) instead. */
     [[deprecated("Not recommended for future development.  Use InitSave() with sSaveOptions instead.")]]
     bool InitSaveTimestamp(const std::string& timeStamp, const std::string& directory = g_emptyString, const std::string& subDirectory = g_emptyString, eLogType logType = LOGTYPE_DAT, float driveUsageLimitPercent = 0.5f, uint32_t maxFileSize = 1024 * 1024 * 5, bool useSubFolderTimestamp = true);
 
-    // Establish link between devices and this logger
+    /**
+     * @brief Establish a link between @p device and this logger, creating its `cDeviceLog` if needed.
+     *
+     * The concrete `cDeviceLog` subclass created is determined by `m_logType` (set by InitSave()).
+     * If @p device already has a `devLogger`, it is reused. Also wires the port so incoming data on
+     * @p device is automatically routed here via logPortData().
+     *
+     * @param device device to register; a no-op returning null if null.
+     * @return the device's `cDeviceLog`, or null if @p device was null.
+     */
     std::shared_ptr<cDeviceLog> registerDevice(device_handle_t device);
+
+    /**
+     * @brief Establish a link between a device identified only by hardware ID + serial number and this logger.
+     *
+     * Use this overload when there is no live `ISDevice` (e.g. setting up devices ahead of connection).
+     * The concrete `cDeviceLog` subclass created is determined by `m_logType` (set by InitSave()).
+     *
+     * @param hdwId encoded hardware ID of the device.
+     * @param serialNo serial number of the device.
+     * @return the newly created `cDeviceLog`.
+     */
     std::shared_ptr<cDeviceLog> registerDevice(uint16_t hdwId, uint32_t serialNo);
+
+    /** @brief Convenience overload of registerDevice() that derives the hardware ID from a `dev_info_t`. */
     std::shared_ptr<cDeviceLog> registerDevice(dev_info_t& devInfo) { return registerDevice(ENCODE_DEV_INFO_TO_HDW_ID(devInfo), devInfo.serialNumber); }
 
-    // Update internal state, handle timeouts, remove old files for file culling, etc.
+    /**
+     * @brief Periodic housekeeping: idle-timeout flushing and drive-space-limited file culling.
+     *
+     * Call regularly (e.g. once per main loop iteration). If no data has been logged for
+     * `TimeoutFlushSeconds()` seconds, flushes every registered device's log. Independently, at
+     * most once every 10 seconds, if logging is enabled and a disk-space limit is set, checks
+     * actual disk usage and — if over the limit — removes the oldest log files/directories via
+     * ISFileManager until back under the limit.
+     */
     void Update();
+
+    /**
+     * @brief Log one already-parsed data set to @p devLogger. Not valid when the logger's type is `LOGTYPE_RAW`.
+     * @param devLogger destination device log; logging is skipped (returns false) if null.
+     * @param dataHdr header describing @p dataBuf's data ID, size, and offset.
+     * @param dataBuf the data payload described by @p dataHdr.
+     * @return true if the call was handled (including recorded failures such as a corrupt header
+     *         or a save failure, which are logged to the error file and counted in the log
+     *         statistics); false if logging is disabled, @p devLogger is null, or the logger's
+     *         type is `LOGTYPE_RAW`.
+     */
     bool LogData(std::shared_ptr<cDeviceLog> devLogger, p_data_hdr_t* dataHdr, const uint8_t* dataBuf);
+
+    /**
+     * @brief Log one raw byte buffer to @p devLogger. Only valid when the logger's type is `LOGTYPE_RAW`.
+     * @param devLogger destination device log; if null and exactly one device is registered, that
+     *        device is used instead.
+     * @param dataSize number of bytes in @p dataBuf.
+     * @param dataBuf the raw bytes to log.
+     * @return true if the call was handled (including a recorded save failure); false if logging
+     *         is disabled, the logger's type isn't `LOGTYPE_RAW`, no device could be resolved, or
+     *         @p dataSize/@p dataBuf are invalid.
+     */
     bool LogData(std::shared_ptr<cDeviceLog> devLogger, int dataSize, const uint8_t* dataBuf);
+
+    /** @brief LogData() overload that looks up the destination device by serial number via DeviceLogBySerialNumber(). */
     bool LogDataBySN(uint32_t serialNo, p_data_hdr_t* dataHdr, const uint8_t* dataBuf) { return LogData(DeviceLogBySerialNumber(serialNo), dataHdr, dataBuf); }
+
+    /** @brief LogData() overload that looks up the destination device by serial number via DeviceLogBySerialNumber(). */
     bool LogDataBySN(uint32_t serialNo, int dataSize, const uint8_t* dataBuf) {  return LogData(DeviceLogBySerialNumber(serialNo), dataSize, dataBuf); }
+
+    /**
+     * @brief Read the next data set from @p devLogger, skipping over (and logging as errors) any corrupt records.
+     * @param devLogger device log to read from; defaults to null, which returns null.
+     * @return the next data set, or null if @p devLogger is null or no more data is available.
+     */
     p_data_buf_t* ReadData(std::shared_ptr<cDeviceLog> devLogger = nullptr);
+
+    /** @brief ReadData() overload that looks up the device by its index in DeviceLogs(). @return the next data set, or null if @p devIndex is out of range or no more data is available. */
     p_data_buf_t* ReadData(size_t devIndex);
+
+    /**
+     * @brief Read the next data set across all registered devices, round-robin starting at @p devIndex.
+     * @param[in,out] devIndex index of the device to try first; advanced to the next device on a
+     *        miss, and reset to 0 once every device has been tried with no data available.
+     * @return the next available data set from some device, or null if no device had data available.
+     */
     p_data_buf_t* ReadNextData(size_t& devIndex);
+
+    /**
+     * @brief Read the next packet from @p devLogger (raw/serial log formats only).
+     * @param[out] ptype protocol type of the returned packet; set to `_PTYPE_PARSE_ERROR` if a corrupt packet was encountered (and logged as an error).
+     * @param devLogger device log to read from; defaults to null, which returns null.
+     * @return the next packet, or null if @p devLogger is null or no more packets are available.
+     */
     packet_t* ReadPacket(protocol_type_t& ptype, std::shared_ptr<cDeviceLog> devLogger = nullptr);
+
+    /** @brief ReadPacket() overload that looks up the device by its index in DeviceLogs(). @return the next packet, or null if @p devIndex is out of range or no more packets are available. */
     packet_t* ReadPacket(protocol_type_t& ptype, size_t devIndex);
+
+    /**
+     * @brief Read the next packet across all registered devices, round-robin starting at @p devIndex.
+     * @param[out] ptype protocol type of the returned packet.
+     * @param[in,out] devIndex index of the device to try first; advanced to the next device on a miss.
+     * @return the next available packet from some device, or null if no device had one available.
+     */
     packet_t* ReadNextPacket(protocol_type_t& ptype, size_t& devIndex);
+
+    /** @brief Enable or disable logging. When disabled, LogData() is a no-op. */
     void EnableLogging(bool enabled) { m_enabled = enabled; }
+
+    /** @brief Check whether logging is currently enabled. */
     bool Enabled() { return m_enabled; }
+
+    /** @brief Close every registered device's open log files and write final statistics to `stats_all.txt`. */
     void CloseAllFiles();
+
+    /** @brief Flush every registered device's log to disk without closing it. */
     void FlushToFile();
+
+    /** @brief Open every registered device's current log file with the OS's default associated application. */
     void OpenWithSystemApp();
+
+    /** @brief Enable or disable printing of parse errors, for this logger and every currently-registered device. */
     void ShowParseErrors(bool show);
+
+    /** @brief Get the timestamp string used to name the current log instance directory. */
     std::string TimeStamp() { return m_timeStamp; }
+
+    /** @brief Get the directory logs are currently being written to (includes any timestamp/sub-directory components). */
     std::string LogDirectory() { return m_directory; }
+
+    /** @brief Get the root log directory passed to InitSave() (excludes any timestamp/sub-directory components). */
     std::string RootDirectory() { return m_rootDirectory; }
+
+    /** @brief Total size, in bytes, of all registered devices' logs. */
     uint64_t LogSizeAll();
+
+    /** @brief Size, in bytes, of the log for the device with the given serial number. @return 0 if no such device is registered. */
     uint64_t LogSize(uint32_t devSerialNo);
+
+    /** @brief LogSizeAll(), in megabytes. */
     float LogSizeAllMB();
+
+    /** @brief LogSize(), in megabytes. @return 0 if no such device is registered. */
     float LogSizeMB(uint32_t devSerialNo);
+
+    /** @brief Size, in megabytes, of the current log file (not the whole log) for the device with the given serial number. @return 0 if no such device is registered. */
     float FileSizeMB(uint32_t devSerialNo);
+
+    /** @brief Number of log files written so far for the device with the given serial number. @return 0 if no such device is registered. */
     uint32_t FileCount(uint32_t devSerialNo);
+
+    /** @brief Configured drive-usage limit, in megabytes; 0 if file culling is disabled. */
     float MaxDiskSpaceMB() { return ((float)m_maxDiskSpace) / (1024*1024); }
+
+    /** @brief Drive usage of the root log directory, in megabytes, as of the last Update() culling check. */
     float UsedDiskSpaceMB() { return ((float)m_usedDiskSpace) / (1024*1024); }
+
+    /** @brief Get the next log file name for the device with the given serial number. @return the file name, or an empty string if no such device is registered. */
     std::string GetNewFileName(uint32_t devSerialNo, uint32_t fileCount, const char* suffix);
+
+    /** @brief Get every currently-registered device's `cDeviceLog`. */
     std::vector<std::shared_ptr<cDeviceLog>> DeviceLogs();
+
+    /** @brief Number of currently-registered devices. */
     uint32_t DeviceCount() { return (uint32_t)m_devices.size(); }
+
+    /** @brief Look up a registered device's `cDeviceLog` by serial number. @return the device's log, or null if no device with that serial number is registered. */
     std::shared_ptr<cDeviceLog> DeviceLogBySerialNumber(uint32_t serialNo) {
         return (m_devices.count(serialNo) ? m_devices[serialNo] : nullptr);
     }
 
+    /** @brief Unregister and release every device, detaching each from its port and clearing log statistics. */
     void Cleanup();
 
     // bool SetDeviceInfo(const dev_info_t *info, unsigned int device = 0);
@@ -150,17 +327,15 @@ public:
 
     /**
      * @brief Copy (convert) one log to another log type.
-     *
-     * @param log Input log
-     * @param timestamp Time to use on the output log
-     * @param outputDir Directory to write output log
-     * @param logType Type of the output log
-     * @param maxFileSize Max size of the individual output files
-     * @param driveUsageLimitPercent Drive usage limit in percent of total drive space
-     * @param driveUsageLimitMb Drive usage limit in MB
-     * @param useSubFolderTimestamp Output logs should be written into a timestamped subdirectory
-     * @param enableCsvIns2ToIns1Conversion  Convert Ins2 to Ins1 within the log
-     * @return true if log copy (conversion) output was successful, false if not.
+     * @param log input log to read and convert.
+     * @param timestamp timestamp to use for the output log's instance directory; current date/time if empty.
+     * @param outputDir directory to write the output log to.
+     * @param logType format of the output log.
+     * @param maxFileSize max size, in bytes, of each individual output file.
+     * @param driveUsageLimitPercent drive usage limit, as a fraction (0.0-1.0) of total drive space.
+     * @param useSubFolderTimestamp output logs should be written into a timestamped subdirectory.
+     * @param enableCsvIns2ToIns1Conversion when @p logType is `LOGTYPE_CSV`, convert `DID_INS_2` records to `DID_INS_1` in the output (skipped if the source log already contains `DID_INS_1`).
+     * @return true if the log copy (conversion) completed successfully, false if the output log's InitSave() failed.
      */
     bool CopyLog(
         cISLogger& log,
@@ -171,35 +346,61 @@ public:
         float driveUsageLimitPercent = 0.5f,
         bool useSubFolderTimestamp = true,
         bool enableCsvIns2ToIns1Conversion = true);
+
+    /** @brief Total number of data sets successfully logged across all registered devices. */
     unsigned int Count() { return m_logStats.Count(); }
+
+    /** @brief Total number of logging errors (corrupt headers, failed saves) across all registered devices. */
     unsigned int Errors() { return m_logStats.Errors(); }
+
+    /** @brief The log format this logger was configured with, via InitSave() or LoadFromDirectory(). */
     eLogType Type() { return m_logType; }
 
     /**
-    * Get the timeout flush parameter in seconds
-    * @return the timeout flush parameter in seconds
-    */
+     * @brief Get the timeout flush parameter in seconds.
+     * @return the timeout flush parameter in seconds.
+     */
     time_t TimeoutFlushSeconds() { return m_timeoutFlushSeconds; }
 
     /**
-    * Set the timeout flush logger parameter in seconds
-    * @param timeoutFlushSeconds the timeout flush logger parameter in seconds
-    */
+     * @brief Set the idle-timeout flush parameter used by Update().
+     * @param timeoutFlushSeconds seconds of inactivity after which Update() flushes every device's
+     *        log; 0 disables idle-timeout flushing.
+     */
     void SetTimeoutFlushSeconds(time_t timeoutFlushSeconds) { m_timeoutFlushSeconds = timeoutFlushSeconds; }
 
-    // check if a data header is corrupt
+    /**
+     * @brief Check whether a data header's fields are self-consistent.
+     * @param hdr header to validate; a null header is always considered corrupt.
+     * @return true if @p hdr is null, has a zero size, a zero id, an offset that isn't a multiple
+     *         of 4, or an offset+size that exceeds MAX_DATASET_SIZE; false otherwise.
+     */
     static bool isHeaderCorrupt(const p_data_hdr_t* hdr);
 
-    // create a timestamp
+    /** @brief Build a timestamp string (`YYYYMMDD_HHMMSS`) from the current date/time, used to name new log instance directories. */
     static std::string CreateCurrentTimestamp();
 
-    // check if a data packet is corrupt, NULL data is OK
+    /**
+     * @brief Check whether a data packet's header is corrupt, per isHeaderCorrupt().
+     * @param data packet to check; null is never considered corrupt (returns false).
+     * @return false if chunk-header validation is disabled (`LOGTYPE_RAW`, which has no chunk
+     *         header) or @p data is null; otherwise the result of isHeaderCorrupt() on its header.
+     */
     bool isDataCorrupt(const p_data_buf_t* data);
 
     // read all log data into memory - if the log is over 1.5 GB this will fail on 32 bit processes
     // the map contains device id (serial number) key and a vector containing log data for each data id, which will be an empty vector if no log data for that id
     // static bool ReadAllLogDataIntoMemory(const std::string& directory, std::map<uint32_t, std::vector<std::vector<uint8_t>>>& data);
 
+    /**
+     * @brief Configure KML output options and apply them to every currently-registered device.
+     * @param gpsData include GNSS position data in the KML output.
+     * @param showPath draw the flight/travel path as a line.
+     * @param showSample draw individual sample points along the path.
+     * @param showTimeStamp label sample points with their timestamp.
+     * @param updatePeriodSec minimum time between consecutive drawn sample points, in seconds.
+     * @param altClampToGround clamp altitude to ground level in the KML viewer instead of using the logged altitude.
+     */
     void SetKmlConfig(bool gpsData = true, bool showPath = true, bool showSample = false, bool showTimeStamp = true, double updatePeriodSec = 1.0, bool altClampToGround = true)
     {
         m_gpsData = gpsData;
@@ -215,6 +416,7 @@ public:
         }
     }
 
+    /** @brief Map a log-type name ("csv", "kml", "json", "raw") to its `eLogType`. @return the matching `eLogType`, or `LOGTYPE_DAT` if @p logTypeString matches none of the recognized names. */
     static eLogType ParseLogType(const std::string& logTypeString)
     {
         if (logTypeString == "csv")
@@ -236,17 +438,57 @@ public:
         return cISLogger::eLogType::LOGTYPE_DAT;
     }
 
+    /**
+     * @brief Parse a log filename into its serial number, date, time, and file-index components.
+     *
+     * Recognizes two forms: `IS_LOG_FILE_PREFIX` followed by `<serial>_<date>_<time>_<index>`
+     * (e.g. "LOG_SN30013_20170103_151023_001.raw"), or a bare `<index>` with no prefix. Any other
+     * form fails to parse.
+     *
+     * @param filename filename to parse (extension is stripped internally; path should already be removed).
+     * @param[out] serialNum parsed serial number; 0 if the bare-index form was used.
+     * @param[out] date parsed date string; empty if the bare-index form was used.
+     * @param[out] time parsed time string; empty if the bare-index form was used.
+     * @param[out] index parsed file index; -1 if parsing failed before reaching it.
+     * @return true if @p filename matched one of the two recognized forms, false otherwise.
+     */
     static bool ParseFilename(std::string filename, int &serialNum, std::string &date, std::string &time, int &index);
+
+    /** @brief Print per-device message statistics. @note currently a no-op; retained as a hook for future diagnostics. */
     void PrintStatistics();
+
+    /** @brief Print IS-comm parser status for every registered device. @note currently a no-op; retained as a hook for future diagnostics. */
     void PrintIsCommStatus();
+
+    /** @brief Print elapsed logging time, current log size, and disk usage/limit to stdout. */
     void PrintLogDiskUsage();
 
     /**
-     * These are static functions which need to use the port_handle_t to identify which cDeviceLog instance they belong to
-     * and then call into that logger as needed...
+     * @brief Look up the registered device (if any) whose `ISDevice` is bound to @p port.
+     *
+     * Used by logPortData() to route port callbacks to the correct `cDeviceLog`, since the
+     * callback only receives the low-level `port_handle_t`, not a device or log reference.
+     *
+     * @param port port handle to search for.
+     * @return the matching device's `cDeviceLog`, or null if no registered device uses @p port.
      */
     std::shared_ptr<cDeviceLog> getDeviceLogByPort(port_handle_t port);
 
+    /**
+     * @brief Port data callback wired up by registerDevice() via `portSetLogger()`.
+     *
+     * Resolves @p port to a registered device via getDeviceLogByPort() and logs @p buf to it as
+     * raw data. As a logger, only outbound/inbound byte data is of interest here regardless of
+     * @p op's direction, so @p op is intentionally ignored.
+     *
+     * @param port port the data was sent/received on.
+     * @param op unused; direction of the data (send vs. receive) doesn't change how it's logged.
+     * @param buf the data bytes to log.
+     * @param len number of bytes in @p buf.
+     * @param userData the `cISLogger*` this callback was registered with.
+     * @return 1 if the data was logged successfully, -1 if @p userData is null, no device matches
+     *         @p port, or the underlying LogData() call failed.
+     */
     static inline int logPortData(port_handle_t port, uint8_t op, const uint8_t* buf, unsigned int len, void* userData) {
         (void)op; // Suppress unused parameter warning
         // remember, that as a logger, we GENERALLY are only interested in WRITING data, regardless of whether that data is sent or received.
@@ -265,9 +507,13 @@ private:
     cISLogger(const cISLogger& copy); // Disable copy constructors
 #endif
 
+    /** @brief Re-register every device in @p devices from scratch (Cleanup() first, then registerDevice() each). @return true if the resulting log directory exists. */
     bool InitDevicesForWriting(std::vector<device_handle_t>& devices);
+
+    /** @brief Debug progress-dot printer; currently disabled (body compiled out). */
     void PrintProgress();
 
+    /** @brief Current time in seconds: device RTC/system uptime on EVB-2, wall-clock `time()` elsewhere. */
     static time_t GetTime()
     {
 #if PLATFORM_IS_EVB_2
@@ -277,37 +523,37 @@ private:
 #endif
     }
 
-    eLogType        m_logType = LOGTYPE_DAT;
-    bool            m_useChunkHeader = true;
-    bool            m_enabled = false;
-    std::string     m_rootDirectory;
-    std::string     m_directory;
-    std::string     m_timeStamp;
-    std::map<uint32_t, std::shared_ptr<cDeviceLog>> m_devices = { };
+    eLogType        m_logType = LOGTYPE_DAT;                              //!< log format devices are registered with; set by InitSave()/LoadFromDirectory()
+    bool            m_useChunkHeader = true;                              //!< true unless reading a `LOGTYPE_RAW` log, which has no per-record chunk header to validate
+    bool            m_enabled = false;                                    //!< logging on/off switch; see EnableLogging()
+    std::string     m_rootDirectory;                                      //!< root log directory passed to InitSave(), before any timestamp/sub-directory is appended
+    std::string     m_directory;                                          //!< directory actually being written to (root + timestamp + sub-directory)
+    std::string     m_timeStamp;                                          //!< timestamp string naming the current log instance directory
+    std::map<uint32_t, std::shared_ptr<cDeviceLog>> m_devices = { };      //!< registered devices, keyed by serial number
 
-    uint64_t        m_maxDiskSpace = 0;        // Limit for logging.  Zero to disable file culling drive management.
-    uint64_t        m_usedDiskSpace = 0;    // Size of all logs
-    uint32_t        m_maxFileSize = 0;
-    cLogStats       m_logStats;
+    uint64_t        m_maxDiskSpace = 0;        //!< drive-usage limit for file culling, in bytes; 0 disables file culling
+    uint64_t        m_usedDiskSpace = 0;       //!< drive space used by m_rootDirectory, as of the last Update() culling check
+    uint32_t        m_maxFileSize = 0;         //!< largest size, in bytes, of each individual log file
+    cLogStats       m_logStats;                //!< aggregate data/error counters across all registered devices
 #if PLATFORM_IS_EVB_2
-    cISLogFileFatFs m_errorFile;
+    cISLogFileFatFs m_errorFile;   //!< sink for LogData()/ReadData() error messages
 #else
-    cISLogFile      m_errorFile;
+    cISLogFile      m_errorFile;   //!< sink for LogData()/ReadData() error messages
 #endif
 
-    bool            m_altClampToGround = false;
-    bool            m_gpsData = false;
-    bool            m_showSample = false;
-    bool            m_showPath = false;
-    bool            m_showTimeStamp = false;
-    double          m_iconUpdatePeriodSec = false;
-    time_t          m_logStartTime = 0;
-    time_t          m_lastCommTime = 0;
-    time_t          m_timeoutFlushSeconds = 0;
-    time_t          m_timeoutFileCullingSeconds = 10;
-    time_t          m_lastFileCullingTime = 0;
-    int             m_progress = 0;
-    bool            m_showParseErrors = true;
+    bool            m_altClampToGround = false;    //!< KML config: clamp altitude to ground level; see SetKmlConfig()
+    bool            m_gpsData = false;              //!< KML config: include GNSS position data; see SetKmlConfig()
+    bool            m_showSample = false;            //!< KML config: draw individual sample points; see SetKmlConfig()
+    bool            m_showPath = false;              //!< KML config: draw the path as a line; see SetKmlConfig()
+    bool            m_showTimeStamp = false;         //!< KML config: label sample points with their timestamp; see SetKmlConfig()
+    double          m_iconUpdatePeriodSec = false;   //!< KML config: minimum time between drawn sample points, in seconds; see SetKmlConfig()
+    time_t          m_logStartTime = 0;              //!< time InitSave() was called; used by PrintLogDiskUsage() to compute elapsed time
+    time_t          m_lastCommTime = 0;              //!< time of the last successful LogData() call; used by Update() for idle-timeout flushing
+    time_t          m_timeoutFlushSeconds = 0;       //!< idle-timeout flush parameter; see SetTimeoutFlushSeconds()
+    time_t          m_timeoutFileCullingSeconds = 10; //!< minimum seconds between Update()'s disk-usage/file-culling checks
+    time_t          m_lastFileCullingTime = 0;       //!< time of the last file-culling check performed by Update()
+    int             m_progress = 0;                  //!< progress counter for PrintProgress(), currently unused (PrintProgress() body is compiled out)
+    bool            m_showParseErrors = true;        //!< whether parse errors are printed; see ShowParseErrors()
 };
 
 #endif // IS_LOGGER_H


### PR DESCRIPTION
## Summary

Doxygen documentation pass over the logging subsystem: the `cISLogger` orchestrator, `cDeviceLog` and its five per-format subclasses, the file-I/O primitives (`cISLogFileBase`/`cISLogFile`/`ISLogFileFactory`), the `DataChunk` framing layer, the per-format data serializers (CSV/JSON/KML), and `ISFileManager`'s cross-platform file utilities.

- Every header in scope gets a `/** @file @brief @author @copyright */` block (replacing the plain MIT-only header block where present), and full coverage — every function documented, every struct member with a trailing `//!<` — following `code-style-guide.md` (preceding `/** */` blocks, trailing `//!<` member docs; no `///`/`///<`), the Doxygen manual it references, and the Google C++ style guide `.clang-format` is based on.
- `ISLogIndex.h` was reviewed and left untouched — it already has full coverage, but its `///`/`///<` syntax predates and conflicts with `code-style-guide.md`'s `/** */` + `//!<` rule, so it was not used as a model for the other 15 files in any respect (density, phrasing, or otherwise). Those 15 follow `code-style-guide.md` directly.
- Flags several real, non-obvious behaviors discovered while reading the implementation to write accurate docs (not fixed — out of scope for a docs-only change):
  - `cISLogFileBase::seek()`'s default `origin` argument (`SEEK_SET`) differs from `cISLogFile::seek()`'s override default (`SEEK_CUR`) — since C++ default args aren't virtual, calling through a base pointer silently uses a different default than a direct call.
  - `ISFileManager::GetParentDirectory()` has the same bug as `GetFileName()` — it returns the filename, not the parent path. Use the lowercase `getParentDirectory()` for the real parent path.
  - `ISFileManager::GetAllFilesInDirectory(..., vector<string>&)`'s Linux branch matches nothing when `regexPattern` is empty (unlike the `file_info_t` overload).
  - `cDeviceLogSerial(port_handle_t)` is declared but never defined — a link-time landmine.
  - `cDeviceLogKML::ReadChunkFromFile()` always returns `true`, so `ReadData()`'s retry loop around it would spin forever if KML reading were ever exercised (it isn't — `cISLogger::LoadFromDirectory()` already refuses `LOGTYPE_KML`).
  - `cDataKML::WriteDataToFile()`'s return value is always `0` regardless of success/failure.
  - Fixed one pre-existing stray `@param` in `ISLogger.h::CopyLog()` that doxygen was warning on (documented a parameter that doesn't exist in the signature).

Docs-only change — no logic was modified.

## Test plan

- [x] Full CMake build of the `InertialSenseSDK` static library succeeds (`cmake` + `make`), clean from scratch.
- [x] Full `tests/` GTest suite builds and runs: 449 passed, 3 skipped (live-fixture-dependent, expected in this environment), 0 failed.
- [x] `doxygen` run against `resources/DoxyfileSDK` (`WARN_IF_UNDOCUMENTED = YES`) shows **zero** "Member ... is not documented" (or any other) warnings for all 16 headers in scope.
- [x] `ISLogIndex.h` diff-verified unchanged (`git diff develop..HEAD -- src/ISLogIndex.h` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)