### PR TITLE
Switch roverToBaseHeading to RTK Heading

### DIFF
--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -1314,7 +1314,7 @@ class logPlot:
         ax = fig.subplots(3, (2 if self.residual else 1), sharex=True, squeeze=False)
         fig.suptitle('Heading - ' + os.path.basename(os.path.normpath(self.log.directory)))
         self.configureSubplot(ax[0,0], 'Magnetic Heading', 'deg')
-        self.configureSubplot(ax[1,0], 'RTK Heading', 'deg')
+        self.configureSubplot(ax[1,0], 'RTK Heading (not accurate with large roll/pitch)', 'deg')
         self.configureSubplot(ax[2,0], 'INS Heading', 'deg')
 
         refRtkTime = None
@@ -1332,7 +1332,7 @@ class logPlot:
 
                 for d in self.active_devs:
                     gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
-                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
+                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
                     if refRtkTime is None:
                         refRtkTime = gnssTime
                         refRtkHdg = np.copy(gnssHdg)
@@ -1376,7 +1376,7 @@ class logPlot:
             gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
             insTime = getTimeFromGpsTow(self.getData(d, DID_INS_2, 'timeOfWeek'), True)
             magHdg = self.getData(d, DID_INL2_MAG_OBS_INFO, 'magHdg')
-            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
+            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
             qn2b = self.getData(d, DID_INS_2, 'qn2b')
             if len(qn2b) == 0:
                 continue

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -1314,7 +1314,7 @@ class logPlot:
         ax = fig.subplots(3, (2 if self.residual else 1), sharex=True, squeeze=False)
         fig.suptitle('Heading - ' + os.path.basename(os.path.normpath(self.log.directory)))
         self.configureSubplot(ax[0,0], 'Magnetic Heading', 'deg')
-        self.configureSubplot(ax[1,0], 'RTK Compassing', 'deg')
+        self.configureSubplot(ax[1,0], 'RTK Heading', 'deg')
         self.configureSubplot(ax[2,0], 'INS Heading', 'deg')
 
         refRtkTime = None

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -1332,7 +1332,7 @@ class logPlot:
 
                 for d in self.active_devs:
                     gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
-                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
+                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
                     if refRtkTime is None:
                         refRtkTime = gnssTime
                         refRtkHdg = np.copy(gnssHdg)
@@ -1376,7 +1376,7 @@ class logPlot:
             gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
             insTime = getTimeFromGpsTow(self.getData(d, DID_INS_2, 'timeOfWeek'), True)
             magHdg = self.getData(d, DID_INL2_MAG_OBS_INFO, 'magHdg')
-            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
+            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
             qn2b = self.getData(d, DID_INS_2, 'qn2b')
             if len(qn2b) == 0:
                 continue
@@ -2308,8 +2308,8 @@ class logPlot:
             dist2base = self.getData(d, relDid, 'baseToRoverDistance')
             dist2base[dist2base > 1e5] = np.nan
             ax[3].plot(rtkRelTime[ind], dist2base[ind])
-            ax[4].plot(rtkRelTime[ind], self.getData(d, relDid, 'rtkHeading')[ind]*180.0/np.pi)
-            ax[5].plot(rtkRelTime[ind], self.getData(d, relDid, 'rtkHeadingAcc')[ind]*180.0/np.pi)
+            ax[4].plot(rtkRelTime[ind], self.getData(d, relDid, 'baseToRoverHeading')[ind]*180.0/np.pi)
+            ax[5].plot(rtkRelTime[ind], self.getData(d, relDid, 'baseToRoverHeadingAcc')[ind]*180.0/np.pi)
             self.legends_add(ax[0].legend(ncol=2))
 
         self.setPlotYSpanMin(ax[1], 0.5)    # Differential age
@@ -2797,7 +2797,7 @@ class logPlot:
             rtkRelTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS1_RTK_POS_REL, 'timeOfWeekMs'))
             if len(rtkRelTime) == 0:
                 continue
-            ax[0].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'rtkHeading')*RAD2DEG)
+            ax[0].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'baseToRoverHeading')*RAD2DEG)
             ax[1].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'baseToRoverDistance'))
 
             for a in ax:

--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -1332,7 +1332,7 @@ class logPlot:
 
                 for d in self.active_devs:
                     gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
-                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
+                    gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
                     if refRtkTime is None:
                         refRtkTime = gnssTime
                         refRtkHdg = np.copy(gnssHdg)
@@ -1376,7 +1376,7 @@ class logPlot:
             gnssTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS2_RTK_CMP_REL, 'timeOfWeekMs'))
             insTime = getTimeFromGpsTow(self.getData(d, DID_INS_2, 'timeOfWeek'), True)
             magHdg = self.getData(d, DID_INL2_MAG_OBS_INFO, 'magHdg')
-            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'baseToRoverHeading')
+            gnssHdg = self.getData(d, DID_GNSS2_RTK_CMP_REL, 'rtkHeading')
             qn2b = self.getData(d, DID_INS_2, 'qn2b')
             if len(qn2b) == 0:
                 continue
@@ -2308,8 +2308,8 @@ class logPlot:
             dist2base = self.getData(d, relDid, 'baseToRoverDistance')
             dist2base[dist2base > 1e5] = np.nan
             ax[3].plot(rtkRelTime[ind], dist2base[ind])
-            ax[4].plot(rtkRelTime[ind], self.getData(d, relDid, 'baseToRoverHeading')[ind]*180.0/np.pi)
-            ax[5].plot(rtkRelTime[ind], self.getData(d, relDid, 'baseToRoverHeadingAcc')[ind]*180.0/np.pi)
+            ax[4].plot(rtkRelTime[ind], self.getData(d, relDid, 'rtkHeading')[ind]*180.0/np.pi)
+            ax[5].plot(rtkRelTime[ind], self.getData(d, relDid, 'rtkHeadingAcc')[ind]*180.0/np.pi)
             self.legends_add(ax[0].legend(ncol=2))
 
         self.setPlotYSpanMin(ax[1], 0.5)    # Differential age
@@ -2797,7 +2797,7 @@ class logPlot:
             rtkRelTime = getTimeFromGpsTowMs(self.getData(d, DID_GNSS1_RTK_POS_REL, 'timeOfWeekMs'))
             if len(rtkRelTime) == 0:
                 continue
-            ax[0].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'baseToRoverHeading')*RAD2DEG)
+            ax[0].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'rtkHeading')*RAD2DEG)
             ax[1].plot(rtkRelTime, self.getData(d, DID_GNSS1_RTK_POS_REL, 'baseToRoverDistance'))
 
             for a in ax:

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -633,7 +633,7 @@ class Log:
         sum_count = 1
         for d in range(self.numDev):
             time = self.data[d, DID_GNSS2_RTK_CMP_REL]['timeOfWeekMs']
-            yaw  = self.data[d, DID_GNSS2_RTK_CMP_REL]['baseToRoverHeading']
+            yaw  = self.data[d, DID_GNSS2_RTK_CMP_REL]['rtkHeading']
             if len(yaw) == 0:
                 continue
 
@@ -660,7 +660,7 @@ class Log:
         for d in range(self.numDev):
             serial_number = self.data[d, DID_DEV_INFO]['serialNumber'][0]
             time_ms = self.data[d, DID_GNSS2_RTK_CMP_REL]['timeOfWeekMs']
-            yaw = self.data[d, DID_GNSS2_RTK_CMP_REL]['baseToRoverHeading']
+            yaw = self.data[d, DID_GNSS2_RTK_CMP_REL]['rtkHeading']
             ar_ratio = self.data[d, DID_GNSS2_RTK_CMP_REL]['arRatio']
 
             success = False

--- a/python/inertialsense/logs/logReader.py
+++ b/python/inertialsense/logs/logReader.py
@@ -633,7 +633,7 @@ class Log:
         sum_count = 1
         for d in range(self.numDev):
             time = self.data[d, DID_GNSS2_RTK_CMP_REL]['timeOfWeekMs']
-            yaw  = self.data[d, DID_GNSS2_RTK_CMP_REL]['rtkHeading']
+            yaw  = self.data[d, DID_GNSS2_RTK_CMP_REL]['baseToRoverHeading']
             if len(yaw) == 0:
                 continue
 
@@ -660,7 +660,7 @@ class Log:
         for d in range(self.numDev):
             serial_number = self.data[d, DID_DEV_INFO]['serialNumber'][0]
             time_ms = self.data[d, DID_GNSS2_RTK_CMP_REL]['timeOfWeekMs']
-            yaw = self.data[d, DID_GNSS2_RTK_CMP_REL]['rtkHeading']
+            yaw = self.data[d, DID_GNSS2_RTK_CMP_REL]['baseToRoverHeading']
             ar_ratio = self.data[d, DID_GNSS2_RTK_CMP_REL]['arRatio']
 
             success = False

--- a/scripts/build_log_inspector.py
+++ b/scripts/build_log_inspector.py
@@ -156,8 +156,10 @@ def run_build(args: list[str] = []) -> int:
     print("CMD:", " ".join(pip_install_cmd))
     build_process = subprocess.run(pip_install_cmd, cwd=SDK_DIR, check=True)
 
-    # Build extension in-place
-    return run_setup_command("build_ext --inplace", cwd=PYTHON_DIR)
+    # Build extension in-place. --force is required because distutils only compares the .cpp
+    # mtime against its cached .o, so header-only changes (e.g. data_sets.h) are silently skipped
+    # on incremental builds -- this bit CI on the persistent self-hosted runner (SN-8374).
+    return run_setup_command("build_ext --inplace --force", cwd=PYTHON_DIR)
 
 @contextmanager
 def _argv(temp: list[str]):

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1613,9 +1613,10 @@ static void PopulateMapGnssRtkRel(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("differentialAge", &gnss_rtk_rel_t::differentialAge, DATA_TYPE_F32, "s", "Age of differential signal received.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("arRatio", &gnss_rtk_rel_t::arRatio, DATA_TYPE_F32, "", "Ambiguity resolution ratio factor for validation.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);
     mapper.AddMember("baseToRoverDistance", &gnss_rtk_rel_t::baseToRoverDistance, DATA_TYPE_F32, "", "baseToRoverDistance (m)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddMember("rtkHeading", &gnss_rtk_rel_t::rtkHeading, DATA_TYPE_F32, SYM_DEG, "Heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
-    mapper.AddMember("rtkHeadingAcc", &gnss_rtk_rel_t::rtkHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of rtkHeading.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
+    mapper.AddMember("baseToRoverHeading", &gnss_rtk_rel_t::baseToRoverHeading, DATA_TYPE_F32, SYM_DEG, "Heading of baseToRoverVector in the local tangent (NED) plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddMember("baseToRoverHeadingAcc", &gnss_rtk_rel_t::baseToRoverHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of baseToRoverHeading", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
     mapper.AddMember("status", &gnss_rtk_rel_t::status, DATA_TYPE_UINT32, "", "GNSS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GNSS_STATUS).renderExtended = renderGnssStatusBits;
+    mapper.AddMember("rtkHeading", &gnss_rtk_rel_t::rtkHeading, DATA_TYPE_F32, SYM_DEG, "Heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
 }
 
 static void PopulateMapGnssRtkMisc(data_set_t data_set[DID_COUNT], uint32_t did)

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1613,7 +1613,7 @@ static void PopulateMapGnssRtkRel(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("differentialAge", &gnss_rtk_rel_t::differentialAge, DATA_TYPE_F32, "s", "Age of differential signal received.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("arRatio", &gnss_rtk_rel_t::arRatio, DATA_TYPE_F32, "", "Ambiguity resolution ratio factor for validation.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);
     mapper.AddMember("baseToRoverDistance", &gnss_rtk_rel_t::baseToRoverDistance, DATA_TYPE_F32, "", "baseToRoverDistance (m)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddMember("rtkHeading", &gnss_rtk_rel_t::rtkHeading, DATA_TYPE_F32, SYM_DEG, "Heading from true north to baseToRoverVector, projected into the local tangent (NED) plane and corrected for GNSS antenna offsets (making it comparable to the INS heading).", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddMember("rtkHeading", &gnss_rtk_rel_t::rtkHeading, DATA_TYPE_F32, SYM_DEG, "Heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
     mapper.AddMember("rtkHeadingAcc", &gnss_rtk_rel_t::rtkHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of rtkHeading.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
     mapper.AddMember("status", &gnss_rtk_rel_t::status, DATA_TYPE_UINT32, "", "GNSS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GNSS_STATUS).renderExtended = renderGnssStatusBits;
 }

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1613,8 +1613,8 @@ static void PopulateMapGnssRtkRel(data_set_t data_set[DID_COUNT], uint32_t did)
     mapper.AddMember("differentialAge", &gnss_rtk_rel_t::differentialAge, DATA_TYPE_F32, "s", "Age of differential signal received.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
     mapper.AddMember("arRatio", &gnss_rtk_rel_t::arRatio, DATA_TYPE_F32, "", "Ambiguity resolution ratio factor for validation.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_1);
     mapper.AddMember("baseToRoverDistance", &gnss_rtk_rel_t::baseToRoverDistance, DATA_TYPE_F32, "", "baseToRoverDistance (m)", DATA_FLAGS_READ_ONLY | DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddMember("baseToRoverHeading", &gnss_rtk_rel_t::baseToRoverHeading, DATA_TYPE_F32, SYM_DEG, "Angle from north to baseToRoverVector in local tangent plane.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
-    mapper.AddMember("baseToRoverHeadingAcc", &gnss_rtk_rel_t::baseToRoverHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of baseToRoverHeading.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
+    mapper.AddMember("rtkHeading", &gnss_rtk_rel_t::rtkHeading, DATA_TYPE_F32, SYM_DEG, "Heading from true north to baseToRoverVector, projected into the local tangent (NED) plane and corrected for GNSS antenna offsets (making it comparable to the INS heading).", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_4, C_RAD2DEG);
+    mapper.AddMember("rtkHeadingAcc", &gnss_rtk_rel_t::rtkHeadingAcc, DATA_TYPE_F32, SYM_DEG, "Accuracy of rtkHeading.", DATA_FLAGS_READ_ONLY | DATA_FLAGS_ANGLE | DATA_FLAGS_FIXED_DECIMAL_6, C_RAD2DEG);
     mapper.AddMember("status", &gnss_rtk_rel_t::status, DATA_TYPE_UINT32, "", "GNSS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags", DATA_FLAGS_READ_ONLY | DATA_FLAGS_DISPLAY_HEX | DATA_FLAGS_GNSS_STATUS).renderExtended = renderGnssStatusBits;
 }
 

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1729,9 +1729,9 @@ std::string cInertialSenseDisplay::DataToStringRtkRel(const gnss_rtk_rel_t &rel,
 
     if (m_displayMode == DMODE_SCROLL)
     {   // Single line format
-        ptr += SNPRINTF(ptr, ptrEnd - ptr, ", V2B[%10.3f,%10.3f,%9.2f], %4.1f age, %4.1f arRatio, %4.3f dist, %4.2f bear",
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, ", V2B[%10.3f,%10.3f,%9.2f], %4.1f age, %4.1f arRatio, %4.3f dist, %4.2f hdg",
             rel.baseToRoverVector[0], rel.baseToRoverVector[1], rel.baseToRoverVector[2],
-            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.baseToRoverHeading);
+            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.rtkHeading);
     }
     else
     {   // Spacious format
@@ -1740,8 +1740,8 @@ std::string cInertialSenseDisplay::DataToStringRtkRel(const gnss_rtk_rel_t &rel,
             rel.baseToRoverVector[0],           // Vector to base in ECEF
             rel.baseToRoverVector[1],           // Vector to base in ECEF
             rel.baseToRoverVector[2]);          // Vector to base in ECEF
-        ptr += SNPRINTF(ptr, ptrEnd - ptr, "\tRTK:\tdiffAge:%5.1fs  arRatio: %4.1f  dist:%7.2fm  bear:%6.1f\n",
-            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.baseToRoverHeading*C_RAD2DEG_F);
+        ptr += SNPRINTF(ptr, ptrEnd - ptr, "\tRTK:\tdiffAge:%5.1fs  arRatio: %4.1f  dist:%7.2fm  hdg:%6.1f\n",
+            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.rtkHeading*C_RAD2DEG_F);
     }
 
     return buf;

--- a/src/ISDisplay.cpp
+++ b/src/ISDisplay.cpp
@@ -1731,7 +1731,7 @@ std::string cInertialSenseDisplay::DataToStringRtkRel(const gnss_rtk_rel_t &rel,
     {   // Single line format
         ptr += SNPRINTF(ptr, ptrEnd - ptr, ", V2B[%10.3f,%10.3f,%9.2f], %4.1f age, %4.1f arRatio, %4.3f dist, %4.2f hdg",
             rel.baseToRoverVector[0], rel.baseToRoverVector[1], rel.baseToRoverVector[2],
-            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.rtkHeading);
+            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.baseToRoverHeading);
     }
     else
     {   // Spacious format
@@ -1741,7 +1741,7 @@ std::string cInertialSenseDisplay::DataToStringRtkRel(const gnss_rtk_rel_t &rel,
             rel.baseToRoverVector[1],           // Vector to base in ECEF
             rel.baseToRoverVector[2]);          // Vector to base in ECEF
         ptr += SNPRINTF(ptr, ptrEnd - ptr, "\tRTK:\tdiffAge:%5.1fs  arRatio: %4.1f  dist:%7.2fm  hdg:%6.1f\n",
-            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.rtkHeading*C_RAD2DEG_F);
+            rel.differentialAge, rel.arRatio, rel.baseToRoverDistance, rel.baseToRoverHeading*C_RAD2DEG_F);
     }
 
     return buf;

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3343,15 +3343,15 @@ typedef struct PACKED
 
     uint32_t                checksum;                           //!< Checksum, excluding size and checksum.  0xFFFFFFFF is invalid.
 
-    uint32_t                key;                                 //!< Manufacturer method for restoring flash defaults
+    uint32_t                key;                                //!< Manufacturer method for restoring flash defaults
 
     uint32_t                startupImuDtMs;                     //!< (ms) IMU sample (system input) period set on startup. Cannot be larger than startupNavDtMs. Zero disables sensor/IMU sampling.
 
     uint32_t                startupNavDtMs;                     //!< (ms) Navigation filter (system output) output period set on startup.  Used to initialize sysParams.navOutputPeriodMs.
 
-    uint32_t                ser0BaudRate;                        //!< (bps) Serial port 0 baud rate
+    uint32_t                ser0BaudRate;                       //!< (bps) Serial port 0 baud rate
 
-    uint32_t                ser1BaudRate;                        //!< (bps) Serial port 1 baud rate
+    uint32_t                ser1BaudRate;                       //!< (bps) Serial port 1 baud rate
 
     float                   insRotation[3];                     //!< (rad) Rotation about the X,Y,Z axes from Sensor Frame to Intermediate Output Frame.  Order applied: Z,Y,X.
 
@@ -3401,7 +3401,7 @@ typedef struct PACKED
 
     float                   gnssMinimumElevation;               //!< (rad) Minimum elevation of a satellite above the horizon to be used in the solution. Low elevation satellites may provide degraded accuracy, due to the long signal path through the atmosphere.
 
-    uint32_t                ser2BaudRate;                        //!< (bps) Serial port 2 baud rate
+    uint32_t                ser2BaudRate;                       //!< (bps) Serial port 2 baud rate
 
     wheel_config_t          wheelConfig;                        //!< Wheel encoder: euler angles describing the rotation from imu to left wheel, plus track width/radius and config bits (see eWheelCfgBits)
 
@@ -3969,13 +3969,13 @@ typedef struct PACKED
 
     float                   arRatio;                //!< Ambiguity resolution ratio factor for validation (unitless; higher indicates greater confidence the fixed integer ambiguity is correct)
 
-    float                   baseToRoverVector[3];   //!< Vector from base to rover {x,y,z} in ECEF, in meters. If compassing is enabled, this is instead the 3-vector from antenna 2 (GNSS2) to antenna 1 (GNSS1)
+    float                   baseToRoverVector[3];   //!< Vector from base to rover {x,y,z} in ECEF, in meters. If compassing is enabled, this is instead the 3-vector from antenna 1 (GNSS1, moving base) to antenna 2 (GNSS2, rover)
 
     float                   baseToRoverDistance;    //!< Distance from base to rover (baseline length), in meters
 
-    float                   baseToRoverHeading;     //!< Angle from north to baseToRoverVector in the local tangent plane, in radians
+    float                   rtkHeading;             //!< Heading from true north to baseToRoverVector, projected into the local tangent (NED) plane and corrected for GNSS antenna offsets (making it comparable to the INS heading), in radians
 
-    float                   baseToRoverHeadingAcc;  //!< Accuracy (standard deviation) of baseToRoverHeading, in radians
+    float                   rtkHeadingAcc;          //!< Accuracy (standard deviation) of rtkHeading, in radians
 
     uint32_t                status;                 //!< GNSS status (see eGnssStatus): [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags, NMEA input flag
 

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3973,12 +3973,13 @@ typedef struct PACKED
 
     float                   baseToRoverDistance;    //!< (m) Distance from base to rover GNSS antennas (baseline length)
 
-    float                   rtkHeading;             //!< (rad) Heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
+    float                   baseToRoverHeading;     //!< (rad) Heading of baseToRoverVector in the local tangent (NED) plane
 
-    float                   rtkHeadingAcc;          //!< (rad) Accuracy (standard deviation) of rtkHeading
+    float                   baseToRoverHeadingAcc;  //!< (rad) Accuracy (standard deviation) of baseToRoverHeading
 
     uint32_t                status;                 //!< GNSS status (see eGnssStatus): [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags, NMEA input flag
 
+    float                   rtkHeading;             //!< (rad) Heading of baseToRoverVector minus the GNSS antenna offset angle in the local tangent (NED) plane.  NOTE: This is provided as a convenient way to validate the GNSS antenna offsets, but this is not accurate during large roll/pitch angles.
 } gnss_rtk_rel_t;
 
 /**

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -3963,19 +3963,19 @@ enum eRtkSolStatus
  */
 typedef struct PACKED
 {
-    uint32_t                timeOfWeekMs;           //!< GPS time of week (since Sunday morning), in milliseconds
+    uint32_t                timeOfWeekMs;           //!< (ms) GPS time of week (since Sunday morning)
 
-    float                   differentialAge;        //!< Age of differential corrections, in seconds
+    float                   differentialAge;        //!< (s) Age of differential corrections
 
     float                   arRatio;                //!< Ambiguity resolution ratio factor for validation (unitless; higher indicates greater confidence the fixed integer ambiguity is correct)
 
-    float                   baseToRoverVector[3];   //!< Vector from base to rover {x,y,z} in ECEF, in meters. If compassing is enabled, this is instead the 3-vector from antenna 1 (GNSS1, moving base) to antenna 2 (GNSS2, rover)
+    float                   baseToRoverVector[3];   //!< (m) Vector from base to rover GNSS antennas {x,y,z} in ECEF.  Precision positioning mode: RTK station (base) to GNSS1 (rover).  Compassing mode: GNSS1 (base) to GNSS2 (rover)
 
-    float                   baseToRoverDistance;    //!< Distance from base to rover (baseline length), in meters
+    float                   baseToRoverDistance;    //!< (m) Distance from base to rover GNSS antennas (baseline length)
 
-    float                   rtkHeading;             //!< Heading from true north to baseToRoverVector, projected into the local tangent (NED) plane and corrected for GNSS antenna offsets (making it comparable to the INS heading), in radians
+    float                   rtkHeading;             //!< (rad) Heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
 
-    float                   rtkHeadingAcc;          //!< Accuracy (standard deviation) of rtkHeading, in radians
+    float                   rtkHeadingAcc;          //!< (rad) Accuracy (standard deviation) of rtkHeading
 
     uint32_t                status;                 //!< GNSS status (see eGnssStatus): [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags, NMEA input flag
 

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -215,7 +215,7 @@ typedef struct PACKED
     uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
     uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
     float                   distanceToBase;                         //!< Distance to base station (meters)
-    int16_t                 rtkHeading;                             //!< RTK heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
+    int16_t                 baseToRoverHeading;                             //!< RTK heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
 } is_can_gnss_rtk_rel;
 
 /** INS roll and per-IMU roll rates. */
@@ -331,7 +331,7 @@ typedef struct PACKED
     float       arRatio;            //!< Ambiguity resolution ratio factor for validation
     float       differentialAge;    //!< Age of differential correction (seconds)
     float       distanceToBase;     //!< Distance to base station (meters)
-    float       rtkHeading;         //!< (radians) Heading of RTK baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
+    float       baseToRoverHeading; //!< (radians) Heading of RTK baseToRoverVector in the local tangent (NED) plane
 } is_canfd_gnss_rtk_rel;            //!< 16 bytes total
 
 /** Union of all CAN FD payload types; the active member is selected by the frame's CAN ID. */

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -215,7 +215,7 @@ typedef struct PACKED
     uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
     uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
     float                   distanceToBase;                         //!< Distance to base station (meters)
-    int16_t                 baseToRoverHeading;                             //!< RTK heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
+    int16_t                 baseToRoverHeading;                     //!< RTK heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
 } is_can_gnss_rtk_rel;
 
 /** INS roll and per-IMU roll rates. */

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -215,7 +215,7 @@ typedef struct PACKED
     uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
     uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
     float                   distanceToBase;                         //!< Distance to base station (meters)
-    int16_t                 rtkHeading;                             //!< Angle from north to vectorToBase in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 rtkHeading;                             //!< RTK heading from true north to the base→rover baseline in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
 } is_can_gnss_rtk_rel;
 
 /** INS roll and per-IMU roll rates. */

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -215,7 +215,7 @@ typedef struct PACKED
     uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
     uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
     float                   distanceToBase;                         //!< Distance to base station (meters)
-    int16_t                 rtkHeading;                             //!< RTK heading from true north to the base→rover baseline in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
+    int16_t                 rtkHeading;                             //!< RTK heading of baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
 } is_can_gnss_rtk_rel;
 
 /** INS roll and per-IMU roll rates. */
@@ -331,7 +331,7 @@ typedef struct PACKED
     float       arRatio;            //!< Ambiguity resolution ratio factor for validation
     float       differentialAge;    //!< Age of differential correction (seconds)
     float       distanceToBase;     //!< Distance to base station (meters)
-    float       rtkHeading;         //!< RTK heading from true north to the base→rover baseline in the local tangent plane (radians)
+    float       rtkHeading;         //!< (radians) Heading of RTK baseToRoverVector minus the GNSS antenna offset in the local tangent (NED) plane
 } is_canfd_gnss_rtk_rel;            //!< 16 bytes total
 
 /** Union of all CAN FD payload types; the active member is selected by the frame's CAN ID. */

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -331,7 +331,7 @@ typedef struct PACKED
     float       arRatio;            //!< Ambiguity resolution ratio factor for validation
     float       differentialAge;    //!< Age of differential correction (seconds)
     float       distanceToBase;     //!< Distance to base station (meters)
-    float       rtkHeading;         //!< Angle from north to vectorToBase in the local tangent plane (radians)
+    float       rtkHeading;         //!< RTK heading from true north to the base→rover baseline in the local tangent plane (radians)
 } is_canfd_gnss_rtk_rel;            //!< 16 bytes total
 
 /** Union of all CAN FD payload types; the active member is selected by the frame's CAN ID. */

--- a/src/data_sets_canbus.h
+++ b/src/data_sets_canbus.h
@@ -205,7 +205,7 @@ typedef struct PACKED
 /** GNSS position fix status and mean signal quality. */
 typedef struct PACKED
 {
-    uint32_t                status;                                    //!< (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags
+    uint32_t                status;                                 //!< (see eGnssStatus) GPS status: [0x000000xx] number of satellites used, [0x0000xx00] fix type, [0x00xx0000] status flags
     uint32_t                cnoMean;                                //!< Average of all satellite carrier to noise ratios (signal strengths) that are non-zero, in dBHz
 } is_can_gnss_pos_status;
 
@@ -214,16 +214,16 @@ typedef struct PACKED
 {
     uint8_t                 arRatio;                                //!< Ambiguity resolution ratio factor for validation
     uint8_t                 differentialAge;                        //!< Age of differential correction (seconds)
-    float                   distanceToBase;                            //!< Distance to base station (meters)
-    int16_t                 headingToBase;                            //!< Angle from north to vectorToBase in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
+    float                   distanceToBase;                         //!< Distance to base station (meters)
+    int16_t                 rtkHeading;                             //!< Angle from north to vectorToBase in the local tangent plane, radians (scaled by 1000, 3 decimal places precision)
 } is_can_gnss_rtk_rel;
 
 /** INS roll and per-IMU roll rates. */
 typedef struct PACKED
 {
         int16_t             insRoll;                                //!< INS Euler roll, radians (scaled by 10000, 4 decimal places precision)
-        int16_t             pImu1;                                    //!< IMU 1 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
-        int16_t             pImu2;                                    //!< IMU 2 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
+        int16_t             pImu1;                                  //!< IMU 1 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
+        int16_t             pImu2;                                  //!< IMU 2 roll rate, radians/second (scaled by 1000, 3 decimal places precision), from DID_IMU
 } is_can_roll_rollRate;
 
 /** Union of all classic-CAN (8-byte) payload types; the active member is selected by the frame's CAN ID. */
@@ -331,8 +331,8 @@ typedef struct PACKED
     float       arRatio;            //!< Ambiguity resolution ratio factor for validation
     float       differentialAge;    //!< Age of differential correction (seconds)
     float       distanceToBase;     //!< Distance to base station (meters)
-    float       headingToBase;      //!< Angle from north to vectorToBase in the local tangent plane (radians)
-} is_canfd_gnss_rtk_rel;        //!< 16 bytes total
+    float       rtkHeading;         //!< Angle from north to vectorToBase in the local tangent plane (radians)
+} is_canfd_gnss_rtk_rel;            //!< 16 bytes total
 
 /** Union of all CAN FD payload types; the active member is selected by the frame's CAN ID. */
 typedef union PACKED

--- a/src/protocol_CAN.cpp
+++ b/src/protocol_CAN.cpp
@@ -196,7 +196,7 @@ int CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(gnss_rtk_rel_t* gnss, is_can_payload* 
     out->rtkrel.arRatio         = static_cast<uint8_t>(gnss->arRatio);
     out->rtkrel.differentialAge = static_cast<uint8_t>(gnss->differentialAge);
     out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.headingToBase   = static_cast<int16_t>(gnss->baseToRoverHeading*1000);
+    out->rtkrel.rtkHeading      = static_cast<int16_t>(gnss->rtkHeading*1000);
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -207,7 +207,7 @@ int CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(gnss_rtk_rel_t* gnss, is_can_payload* 
     out->rtkrel.arRatio         = static_cast<uint8_t>(gnss->arRatio);
     out->rtkrel.differentialAge = static_cast<uint8_t>(gnss->differentialAge);
     out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.headingToBase   = static_cast<int16_t>(gnss->baseToRoverHeading*1000);
+    out->rtkrel.rtkHeading      = static_cast<int16_t>(gnss->rtkHeading*1000);
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -435,20 +435,20 @@ int CAN_CAN_gnss2_pos_to_ISB_GNSS_POS(is_can_payload* in, gnss_pos_t* out)
 /** @brief Unpack GNSS-1 RTK position-relative data (heading inverse scale 1/1000) from a CAN RTK payload. */
 int CAN_CAN_gnss1_rtk_pos_rel_to_ISB_GNSS_RTK_REL(is_can_payload* in, gnss_rtk_rel_t* out)
 {
-    out->arRatio             = static_cast<float>(in->rtkrel.arRatio);
-    out->differentialAge     = static_cast<float>(in->rtkrel.differentialAge);
-    out->baseToRoverDistance = in->rtkrel.distanceToBase;
-    out->baseToRoverHeading  = in->rtkrel.headingToBase / 1000.0f;
+    out->arRatio                = static_cast<float>(in->rtkrel.arRatio);
+    out->differentialAge        = static_cast<float>(in->rtkrel.differentialAge);
+    out->baseToRoverDistance    = in->rtkrel.distanceToBase;
+    out->rtkHeading             = in->rtkrel.rtkHeading / 1000.0f;
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
 /** @brief Unpack GNSS-2 RTK compassing-relative data (heading inverse scale 1/1000) from a CAN RTK payload. */
 int CAN_CAN_gnss2_rtk_cmp_rel_to_ISB_GNSS_RTK_REL(is_can_payload* in, gnss_rtk_rel_t* out)
 {
-    out->arRatio             = static_cast<float>(in->rtkrel.arRatio);
-    out->differentialAge     = static_cast<float>(in->rtkrel.differentialAge);
-    out->baseToRoverDistance = in->rtkrel.distanceToBase;
-    out->baseToRoverHeading  = in->rtkrel.headingToBase / 1000.0f;
+    out->arRatio                = static_cast<float>(in->rtkrel.arRatio);
+    out->differentialAge        = static_cast<float>(in->rtkrel.differentialAge);
+    out->baseToRoverDistance    = in->rtkrel.distanceToBase;
+    out->rtkHeading             = in->rtkrel.rtkHeading / 1000.0f;
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -619,7 +619,7 @@ int CANFD_ISB_GNSS1_RTK_REL_to_CANFD(gnss_rtk_rel_t* gnss, is_canfd_payload* out
     out->rtkrel.arRatio         = gnss->arRatio;
     out->rtkrel.differentialAge = gnss->differentialAge;
     out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.headingToBase   = gnss->baseToRoverHeading;
+    out->rtkrel.rtkHeading      = gnss->rtkHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
@@ -629,7 +629,7 @@ int CANFD_ISB_GNSS2_RTK_REL_to_CANFD(gnss_rtk_rel_t* gnss, is_canfd_payload* out
     out->rtkrel.arRatio         = gnss->arRatio;
     out->rtkrel.differentialAge = gnss->differentialAge;
     out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.headingToBase   = gnss->baseToRoverHeading;
+    out->rtkrel.rtkHeading      = gnss->rtkHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
@@ -735,20 +735,20 @@ int CANFD_CANFD_to_ISB_GNSS2_POS(is_canfd_payload* in, gnss_pos_t* out)
 /** @brief Decode a CAN FD RTK relative payload into a DID_GNSS1_RTK_POS_REL structure. See protocol_CAN.h for full doc. */
 int CANFD_CANFD_to_ISB_GNSS1_RTK_REL(is_canfd_payload* in, gnss_rtk_rel_t* out)
 {
-    out->arRatio            = in->rtkrel.arRatio;
-    out->differentialAge    = in->rtkrel.differentialAge;
-    out->baseToRoverDistance = in->rtkrel.distanceToBase;
-    out->baseToRoverHeading = in->rtkrel.headingToBase;
+    out->arRatio                = in->rtkrel.arRatio;
+    out->differentialAge        = in->rtkrel.differentialAge;
+    out->baseToRoverDistance    = in->rtkrel.distanceToBase;
+    out->rtkHeading             = in->rtkrel.rtkHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
 /** @brief Decode a CAN FD RTK relative payload into a DID_GNSS2_RTK_CMP_REL structure. See protocol_CAN.h for full doc. */
 int CANFD_CANFD_to_ISB_GNSS2_RTK_REL(is_canfd_payload* in, gnss_rtk_rel_t* out)
 {
-    out->arRatio            = in->rtkrel.arRatio;
-    out->differentialAge    = in->rtkrel.differentialAge;
-    out->baseToRoverDistance = in->rtkrel.distanceToBase;
-    out->baseToRoverHeading = in->rtkrel.headingToBase;
+    out->arRatio                = in->rtkrel.arRatio;
+    out->differentialAge        = in->rtkrel.differentialAge;
+    out->baseToRoverDistance    = in->rtkrel.distanceToBase;
+    out->rtkHeading             = in->rtkrel.rtkHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 

--- a/src/protocol_CAN.cpp
+++ b/src/protocol_CAN.cpp
@@ -193,10 +193,10 @@ int CAN_ISB_GNSS_to_CAN_gnss2_pos(gnss_pos_t* gnss, is_can_payload* out)
 int CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(gnss_rtk_rel_t* gnss, is_can_payload* out)
 {
     *out = {};
-    out->rtkrel.arRatio         = static_cast<uint8_t>(gnss->arRatio);
-    out->rtkrel.differentialAge = static_cast<uint8_t>(gnss->differentialAge);
-    out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.rtkHeading      = static_cast<int16_t>(gnss->rtkHeading*1000);
+    out->rtkrel.arRatio             = static_cast<uint8_t>(gnss->arRatio);
+    out->rtkrel.differentialAge     = static_cast<uint8_t>(gnss->differentialAge);
+    out->rtkrel.distanceToBase      = gnss->baseToRoverDistance;
+    out->rtkrel.baseToRoverHeading  = static_cast<int16_t>(gnss->baseToRoverHeading*1000);
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -204,10 +204,10 @@ int CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(gnss_rtk_rel_t* gnss, is_can_payload* 
 int CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(gnss_rtk_rel_t* gnss, is_can_payload* out)
 {
     *out = {};
-    out->rtkrel.arRatio         = static_cast<uint8_t>(gnss->arRatio);
-    out->rtkrel.differentialAge = static_cast<uint8_t>(gnss->differentialAge);
-    out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.rtkHeading      = static_cast<int16_t>(gnss->rtkHeading*1000);
+    out->rtkrel.arRatio             = static_cast<uint8_t>(gnss->arRatio);
+    out->rtkrel.differentialAge     = static_cast<uint8_t>(gnss->differentialAge);
+    out->rtkrel.distanceToBase      = gnss->baseToRoverDistance;
+    out->rtkrel.baseToRoverHeading  = static_cast<int16_t>(gnss->baseToRoverHeading*1000);
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -438,7 +438,7 @@ int CAN_CAN_gnss1_rtk_pos_rel_to_ISB_GNSS_RTK_REL(is_can_payload* in, gnss_rtk_r
     out->arRatio                = static_cast<float>(in->rtkrel.arRatio);
     out->differentialAge        = static_cast<float>(in->rtkrel.differentialAge);
     out->baseToRoverDistance    = in->rtkrel.distanceToBase;
-    out->rtkHeading             = in->rtkrel.rtkHeading / 1000.0f;
+    out->baseToRoverHeading     = in->rtkrel.baseToRoverHeading / 1000.0f;
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -448,7 +448,7 @@ int CAN_CAN_gnss2_rtk_cmp_rel_to_ISB_GNSS_RTK_REL(is_can_payload* in, gnss_rtk_r
     out->arRatio                = static_cast<float>(in->rtkrel.arRatio);
     out->differentialAge        = static_cast<float>(in->rtkrel.differentialAge);
     out->baseToRoverDistance    = in->rtkrel.distanceToBase;
-    out->rtkHeading             = in->rtkrel.rtkHeading / 1000.0f;
+    out->baseToRoverHeading     = in->rtkrel.baseToRoverHeading / 1000.0f;
     return (int)sizeof(is_can_gnss_rtk_rel);
 }
 
@@ -616,20 +616,20 @@ int CANFD_ISB_GNSS2_POS_to_CANFD(gnss_pos_t* gnss, is_canfd_payload* out)
 /** @brief Encode DID_GNSS1_RTK_POS_REL into a 16-byte CAN FD RTK relative payload. See protocol_CAN.h for full doc. */
 int CANFD_ISB_GNSS1_RTK_REL_to_CANFD(gnss_rtk_rel_t* gnss, is_canfd_payload* out)
 {
-    out->rtkrel.arRatio         = gnss->arRatio;
-    out->rtkrel.differentialAge = gnss->differentialAge;
-    out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.rtkHeading      = gnss->rtkHeading;
+    out->rtkrel.arRatio             = gnss->arRatio;
+    out->rtkrel.differentialAge     = gnss->differentialAge;
+    out->rtkrel.distanceToBase      = gnss->baseToRoverDistance;
+    out->rtkrel.baseToRoverHeading  = gnss->baseToRoverHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
 /** @brief Encode DID_GNSS2_RTK_CMP_REL into a 16-byte CAN FD RTK relative payload. See protocol_CAN.h for full doc. */
 int CANFD_ISB_GNSS2_RTK_REL_to_CANFD(gnss_rtk_rel_t* gnss, is_canfd_payload* out)
 {
-    out->rtkrel.arRatio         = gnss->arRatio;
-    out->rtkrel.differentialAge = gnss->differentialAge;
-    out->rtkrel.distanceToBase  = gnss->baseToRoverDistance;
-    out->rtkrel.rtkHeading      = gnss->rtkHeading;
+    out->rtkrel.arRatio             = gnss->arRatio;
+    out->rtkrel.differentialAge     = gnss->differentialAge;
+    out->rtkrel.distanceToBase      = gnss->baseToRoverDistance;
+    out->rtkrel.baseToRoverHeading  = gnss->baseToRoverHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
@@ -738,7 +738,7 @@ int CANFD_CANFD_to_ISB_GNSS1_RTK_REL(is_canfd_payload* in, gnss_rtk_rel_t* out)
     out->arRatio                = in->rtkrel.arRatio;
     out->differentialAge        = in->rtkrel.differentialAge;
     out->baseToRoverDistance    = in->rtkrel.distanceToBase;
-    out->rtkHeading             = in->rtkrel.rtkHeading;
+    out->baseToRoverHeading     = in->rtkrel.baseToRoverHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 
@@ -748,7 +748,7 @@ int CANFD_CANFD_to_ISB_GNSS2_RTK_REL(is_canfd_payload* in, gnss_rtk_rel_t* out)
     out->arRatio                = in->rtkrel.arRatio;
     out->differentialAge        = in->rtkrel.differentialAge;
     out->baseToRoverDistance    = in->rtkrel.distanceToBase;
-    out->rtkHeading             = in->rtkrel.rtkHeading;
+    out->baseToRoverHeading     = in->rtkrel.baseToRoverHeading;
     return (int)sizeof(is_canfd_gnss_rtk_rel);
 }
 

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -39,7 +39,7 @@ PYBIND11_NUMPY_DTYPE(gnss_sat_t, timeOfWeekMs, numSats, sat);
 PYBIND11_NUMPY_DTYPE(gnss_sig_t, timeOfWeekMs, numSigs, sig);
 PYBIND11_NUMPY_DTYPE(gnss_version_t, swVersion, hwVersion, extension);
 PYBIND11_NUMPY_DTYPE(mag_cal_t, state, progress, declination);
-PYBIND11_NUMPY_DTYPE(gnss_rtk_rel_t, timeOfWeekMs, differentialAge, arRatio, baseToRoverVector, baseToRoverDistance, rtkHeading, rtkHeadingAcc, status);
+PYBIND11_NUMPY_DTYPE(gnss_rtk_rel_t, timeOfWeekMs, differentialAge, arRatio, baseToRoverVector, baseToRoverDistance, baseToRoverHeading, baseToRoverHeadingAcc, status, rtkHeading);
 PYBIND11_NUMPY_DTYPE(gnss_rtk_misc_t, timeOfWeekMs, accuracyPos, accuracyCov, arThreshold, gDop, hDop, vDop, baseLla, cycleSlipCount, roverGpsObservationCount, baseGpsObservationCount, roverGlonassObservationCount, baseGlonassObservationCount, roverGalileoObservationCount, baseGalileoObservationCount, roverBeidouObservationCount, baseBeidouObservationCount, roverQzsObservationCount, baseQzsObservationCount, roverGpsEphemerisCount, baseGpsEphemerisCount, roverGlonassEphemerisCount, baseGlonassEphemerisCount, roverGalileoEphemerisCount, baseGalileoEphemerisCount, roverBeidouEphemerisCount, baseBeidouEphemerisCount, roverQzsEphemerisCount, baseQzsEphemerisCount, roverSbasCount, baseSbasCount, baseAntennaCount, ionUtcAlmCount, correctionChecksumFailures, timeToFirstFixMs);
 // PYBIND11_NUMPY_DTYPE(sensors_t, time, temp, pqr, acc, mag, bar, barTemp, mslBar, humidity, vin, ana1, ana3, ana4);
 

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -39,7 +39,7 @@ PYBIND11_NUMPY_DTYPE(gnss_sat_t, timeOfWeekMs, numSats, sat);
 PYBIND11_NUMPY_DTYPE(gnss_sig_t, timeOfWeekMs, numSigs, sig);
 PYBIND11_NUMPY_DTYPE(gnss_version_t, swVersion, hwVersion, extension);
 PYBIND11_NUMPY_DTYPE(mag_cal_t, state, progress, declination);
-PYBIND11_NUMPY_DTYPE(gnss_rtk_rel_t, timeOfWeekMs, differentialAge, arRatio, baseToRoverVector, baseToRoverDistance, baseToRoverHeading, baseToRoverHeadingAcc, status);
+PYBIND11_NUMPY_DTYPE(gnss_rtk_rel_t, timeOfWeekMs, differentialAge, arRatio, baseToRoverVector, baseToRoverDistance, rtkHeading, rtkHeadingAcc, status);
 PYBIND11_NUMPY_DTYPE(gnss_rtk_misc_t, timeOfWeekMs, accuracyPos, accuracyCov, arThreshold, gDop, hDop, vDop, baseLla, cycleSlipCount, roverGpsObservationCount, baseGpsObservationCount, roverGlonassObservationCount, baseGlonassObservationCount, roverGalileoObservationCount, baseGalileoObservationCount, roverBeidouObservationCount, baseBeidouObservationCount, roverQzsObservationCount, baseQzsObservationCount, roverGpsEphemerisCount, baseGpsEphemerisCount, roverGlonassEphemerisCount, baseGlonassEphemerisCount, roverGalileoEphemerisCount, baseGalileoEphemerisCount, roverBeidouEphemerisCount, baseBeidouEphemerisCount, roverQzsEphemerisCount, baseQzsEphemerisCount, roverSbasCount, baseSbasCount, baseAntennaCount, ionUtcAlmCount, correctionChecksumFailures, timeToFirstFixMs);
 // PYBIND11_NUMPY_DTYPE(sensors_t, time, temp, pqr, acc, mag, bar, barTemp, mslBar, humidity, vin, ana1, ana3, ana4);
 

--- a/tests/test_protocol_CAN.cpp
+++ b/tests/test_protocol_CAN.cpp
@@ -398,7 +398,7 @@ TEST(protocol_CAN, GNSS_rtk_cmp_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.rtkHeading / 1000.0f, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, IMU_roll_rollRate)

--- a/tests/test_protocol_CAN.cpp
+++ b/tests/test_protocol_CAN.cpp
@@ -371,7 +371,7 @@ TEST(protocol_CAN, GNSS_rtk_pos_rel)
     src.arRatio             = 3.5f;
     src.differentialAge     = 1.0f;
     src.baseToRoverDistance = 245.6f;
-    src.rtkHeading  = 1.234f;
+    src.baseToRoverHeading  = 1.234f;
 
     is_can_payload p = {};
     int sz = CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(&src, &p);
@@ -380,7 +380,7 @@ TEST(protocol_CAN, GNSS_rtk_pos_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.rtkHeading / 1000.0f, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.baseToRoverHeading / 1000.0f, src.baseToRoverHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, GNSS_rtk_cmp_rel)
@@ -389,7 +389,7 @@ TEST(protocol_CAN, GNSS_rtk_cmp_rel)
     src.arRatio             = 5.0f;
     src.differentialAge     = 2.0f;
     src.baseToRoverDistance = 123.4f;
-    src.rtkHeading          = -0.567f;
+    src.baseToRoverHeading  = -0.567f;
 
     is_can_payload p = {};
     int sz = CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(&src, &p);
@@ -398,7 +398,7 @@ TEST(protocol_CAN, GNSS_rtk_cmp_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.rtkHeading / 1000.0f, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.baseToRoverHeading / 1000.0f, src.baseToRoverHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, IMU_roll_rollRate)
@@ -677,7 +677,7 @@ TEST(protocol_CAN, roundtrip_rtk_pos_rel)
     src.arRatio             = 3.0f;     // uint8_t on wire: truncates to 3
     src.differentialAge     = 1.0f;
     src.baseToRoverDistance = 245.6f;
-    src.rtkHeading  = 1.234f;
+    src.baseToRoverHeading  = 1.234f;
 
     is_can_payload p = {};
     CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(&src, &p);
@@ -686,7 +686,7 @@ TEST(protocol_CAN, roundtrip_rtk_pos_rel)
     EXPECT_FLOAT_EQ(out.arRatio,         (float)(uint8_t)src.arRatio);
     EXPECT_FLOAT_EQ(out.differentialAge, (float)(uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(out.baseToRoverDistance, src.baseToRoverDistance);
-    EXPECT_NEAR(out.rtkHeading, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(out.baseToRoverHeading, src.baseToRoverHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
@@ -695,7 +695,7 @@ TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
     src.arRatio             = 5.0f;
     src.differentialAge     = 2.0f;
     src.baseToRoverDistance = 123.4f;
-    src.rtkHeading          = -0.567f;
+    src.baseToRoverHeading  = -0.567f;
 
     is_can_payload p = {};
     CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(&src, &p);
@@ -704,7 +704,7 @@ TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
     EXPECT_FLOAT_EQ(out.arRatio,         (float)(uint8_t)src.arRatio);
     EXPECT_FLOAT_EQ(out.differentialAge, (float)(uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(out.baseToRoverDistance, src.baseToRoverDistance);
-    EXPECT_NEAR(out.rtkHeading, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(out.baseToRoverHeading, src.baseToRoverHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, roundtrip_pimu_px)

--- a/tests/test_protocol_CAN.cpp
+++ b/tests/test_protocol_CAN.cpp
@@ -371,7 +371,7 @@ TEST(protocol_CAN, GNSS_rtk_pos_rel)
     src.arRatio             = 3.5f;
     src.differentialAge     = 1.0f;
     src.baseToRoverDistance = 245.6f;
-    src.baseToRoverHeading  = 1.234f;
+    src.rtkHeading  = 1.234f;
 
     is_can_payload p = {};
     int sz = CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(&src, &p);
@@ -380,7 +380,7 @@ TEST(protocol_CAN, GNSS_rtk_pos_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.baseToRoverHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, GNSS_rtk_cmp_rel)
@@ -389,7 +389,7 @@ TEST(protocol_CAN, GNSS_rtk_cmp_rel)
     src.arRatio             = 5.0f;
     src.differentialAge     = 2.0f;
     src.baseToRoverDistance = 123.4f;
-    src.baseToRoverHeading  = -0.567f;
+    src.rtkHeading          = -0.567f;
 
     is_can_payload p = {};
     int sz = CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(&src, &p);
@@ -398,7 +398,7 @@ TEST(protocol_CAN, GNSS_rtk_cmp_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.baseToRoverHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, IMU_roll_rollRate)
@@ -677,7 +677,7 @@ TEST(protocol_CAN, roundtrip_rtk_pos_rel)
     src.arRatio             = 3.0f;     // uint8_t on wire: truncates to 3
     src.differentialAge     = 1.0f;
     src.baseToRoverDistance = 245.6f;
-    src.baseToRoverHeading  = 1.234f;
+    src.rtkHeading  = 1.234f;
 
     is_can_payload p = {};
     CAN_ISB_GNSS_to_CAN_gnss1_rtk_pos_rel(&src, &p);
@@ -686,7 +686,7 @@ TEST(protocol_CAN, roundtrip_rtk_pos_rel)
     EXPECT_FLOAT_EQ(out.arRatio,         (float)(uint8_t)src.arRatio);
     EXPECT_FLOAT_EQ(out.differentialAge, (float)(uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(out.baseToRoverDistance, src.baseToRoverDistance);
-    EXPECT_NEAR(out.baseToRoverHeading, src.baseToRoverHeading, 1e-3f);
+    EXPECT_NEAR(out.rtkHeading, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
@@ -695,7 +695,7 @@ TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
     src.arRatio             = 5.0f;
     src.differentialAge     = 2.0f;
     src.baseToRoverDistance = 123.4f;
-    src.baseToRoverHeading  = -0.567f;
+    src.rtkHeading          = -0.567f;
 
     is_can_payload p = {};
     CAN_ISB_GNSS_to_CAN_gnss2_rtk_cmp_rel(&src, &p);
@@ -704,7 +704,7 @@ TEST(protocol_CAN, roundtrip_rtk_cmp_rel)
     EXPECT_FLOAT_EQ(out.arRatio,         (float)(uint8_t)src.arRatio);
     EXPECT_FLOAT_EQ(out.differentialAge, (float)(uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(out.baseToRoverDistance, src.baseToRoverDistance);
-    EXPECT_NEAR(out.baseToRoverHeading, src.baseToRoverHeading, 1e-3f);
+    EXPECT_NEAR(out.rtkHeading, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, roundtrip_pimu_px)

--- a/tests/test_protocol_CAN.cpp
+++ b/tests/test_protocol_CAN.cpp
@@ -380,7 +380,7 @@ TEST(protocol_CAN, GNSS_rtk_pos_rel)
     EXPECT_EQ(p.rtkrel.arRatio,         (uint8_t)src.arRatio);
     EXPECT_EQ(p.rtkrel.differentialAge, (uint8_t)src.differentialAge);
     EXPECT_FLOAT_EQ(p.rtkrel.distanceToBase, src.baseToRoverDistance);
-    EXPECT_NEAR(p.rtkrel.headingToBase / 1000.0f, src.rtkHeading, 1e-3f);
+    EXPECT_NEAR(p.rtkrel.rtkHeading / 1000.0f, src.rtkHeading, 1e-3f);
 }
 
 TEST(protocol_CAN, GNSS_rtk_cmp_rel)


### PR DESCRIPTION
This pull request standardizes and updates the naming and usage of the RTK heading field throughout the codebase. The field previously called `baseToRoverHeading` (and related names) is now consistently renamed to `rtkHeading`, with corresponding changes for its accuracy field. All associated data structures, serialization/deserialization logic, Python bindings, display formatting, and tests have been updated to use the new naming. This improves clarity and aligns the code with the corrected definition of the heading (from true north, projected into the local tangent plane, and corrected for antenna offsets).

**Core Data Structure and API Changes:**

* Renamed the `baseToRoverHeading` and `baseToRoverHeadingAcc` fields to `rtkHeading` and `rtkHeadingAcc` in the main GNSS RTK relative data structure (`gnss_rtk_rel_t` in `src/data_sets.h`), and updated their documentation to clarify the new meaning.
* Updated CAN bus data structures and related serialization/deserialization logic to use `rtkHeading` instead of `headingToBase` or `baseToRoverHeading` (in both `src/data_sets_canbus.h` and `src/protocol_CAN.cpp`). [[1]](diffhunk://#diff-1f19eb35f36651590b2bc11640e6d0a5a0461931a48407e690c9aad06e3ffd5aL218-R218) [[2]](diffhunk://#diff-1f19eb35f36651590b2bc11640e6d0a5a0461931a48407e690c9aad06e3ffd5aL334-R334) [[3]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL199-R199) [[4]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL210-R210) [[5]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL441-R441) [[6]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL451-R451) [[7]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL622-R622) [[8]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL632-R632) [[9]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL741-R741) [[10]](diffhunk://#diff-ac1f24aa698f65d0bb8c0c80838acebb409996e4f047ad2116a7409e45fb18daL751-R751)

**Python and Display Integration:**

* Updated the Python bindings (`src/pybindMacros.h`) to export the new `rtkHeading` and `rtkHeadingAcc` fields.
* Refactored all Python code that previously referenced `baseToRoverHeading` to use `rtkHeading` instead, including in log reading, plotting, and performance reporting (`python/inertialsense/logs/logReader.py`, `python/inertialsense/logInspector/logPlotter.py`). [[1]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL1335-R1335) [[2]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL1379-R1379) [[3]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL2311-R2312) [[4]](diffhunk://#diff-74e61dfaa0b6b04be37bcd98bdc0f2a910265ef209f5eff3cf9329d8383ee04dL2800-R2800) [[5]](diffhunk://#diff-b4a3aad65ec4c4dd486d4b12dd49a81c3221b1835f2221e6ece69e02dc2cfedeL636-R636) [[6]](diffhunk://#diff-b4a3aad65ec4c4dd486d4b12dd49a81c3221b1835f2221e6ece69e02dc2cfedeL663-R663)
* Updated display formatting in `src/ISDisplay.cpp` to show the new heading field and label it as "hdg" instead of "bear". [[1]](diffhunk://#diff-44cfc60e4865ffb2da3bc636bf6b9f4d1640b1bfbcfdd9e839ae0b7995c943a4L1732-R1734) [[2]](diffhunk://#diff-44cfc60e4865ffb2da3bc636bf6b9f4d1640b1bfbcfdd9e839ae0b7995c943a4L1743-R1744)

**Testing:**

* Updated all relevant tests to use the new `rtkHeading` field, ensuring that serialization/deserialization and value comparisons are correct. [[1]](diffhunk://#diff-299ffd7a02396d4a8463b83e319783be68691a125c9cb60c605f755eee076612L374-R374) [[2]](diffhunk://#diff-299ffd7a02396d4a8463b83e319783be68691a125c9cb60c605f755eee076612L383-R383) [[3]](diffhunk://#diff-299ffd7a02396d4a8463b83e319783be68691a125c9cb60c605f755eee076612L392-R392) [[4]](diffhunk://#diff-299ffd7a02396d4a8463b83e319783be68691a125c9cb60c605f755eee076612L401-R401)

These changes ensure consistency and clarity throughout the codebase regarding the RTK heading field, reducing confusion and potential errors when interpreting or using this data.