### PR TITLE
SN-8297: SDK Docs — Firmware update and bootloader stack

### DIFF
--- a/src/ISBFirmwareUpdater.h
+++ b/src/ISBFirmwareUpdater.h
@@ -22,14 +22,19 @@
 
 //#define BOOTLOADER_RETRIES                  12
 //#define BOOTLOADER_RESPONSE_DELAY           10
-#define BOOTLOADER_REFRESH_DELAY            500
-#define MAX_VERIFY_CHUNK_SIZE               1024
-#define BOOTLOADER_TIMEOUT_DEFAULT          1000
-#define MAX_SEND_COUNT                      510
+#define BOOTLOADER_REFRESH_DELAY            500    //!< minimum interval (ms) between successive ISB step refreshes
+#define MAX_VERIFY_CHUNK_SIZE               1024    //!< maximum number of bytes read back per verify-chunk request
+#define BOOTLOADER_TIMEOUT_DEFAULT          1000    //!< default timeout (ms) for an ISB command/ack exchange
+#define MAX_SEND_COUNT                      510     //!< maximum number of bytes sent per ISB write command
 
 // logical page size, offsets for pages are 0x0000 to 0xFFFF - flash page size on devices will vary and is not relevant to the bootloader client
-#define FLASH_PAGE_SIZE                     65536
+#define FLASH_PAGE_SIZE                     65536   //!< logical page size used for ISB page offsets (0x0000-0xFFFF); independent of the device's actual physical flash page size
 
+/**
+ * Device-side fwUpdate::FirmwareUpdateDevice implementation for the ISB (Inertial Sense
+ * Bootloader) legacy update protocol: erases, writes, and verifies an Intel-HEX image page by
+ * page over the ISB's ASCII command/ack wire protocol.
+ */
 class ISBFirmwareUpdater : public fwUpdate::FirmwareUpdateDevice {
 
 public:

--- a/src/ISBFirmwareUpdater.h
+++ b/src/ISBFirmwareUpdater.h
@@ -1,6 +1,8 @@
 /**
- * @file ISBFirmwareUpdater.h 
- * @brief ${BRIEF_DESC}
+ * @file ISBFirmwareUpdater.h
+ * @brief Device-side fwUpdate::FirmwareUpdateDevice implementation for the ISB (Inertial Sense
+ *        Bootloader) legacy update protocol -- page-oriented erase/write/verify of an Intel-HEX
+ *        image over the ISB's ASCII command/ack wire protocol.
  *
  * @author Kyle Mallory on 5/29/24.
  * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
@@ -32,10 +34,10 @@ class ISBFirmwareUpdater : public fwUpdate::FirmwareUpdateDevice {
 
 public:
     /**
-     * Constructor to establish a connected to the specified device, and optionally validating against hdwId and serialNo
-     * @param device the libusb device which identifies the connected device to update. This is NOT a libusb_device_handle! If null, this function will use to first detected DFU device which matches the hdwId and/or serialNo
-     * @param hdwId the hardware id (from manufacturing info) used to identify which specific hdwType + hdwVer we should be targeting (used in validation)
-     * @param serialNo the device-specific unique Id (or serial number) that is used to uniquely identify a particular device (used in validation)
+     * Constructor to manage an ISB-protocol firmware update of the specified target on the given device.
+     * @param target the fwUpdate target device this updater instance is responsible for
+     * @param device the connected device the target resides on
+     * @param toHost a shared byte-stream queue that outgoing responses/acks are written to, to be sent back to the host
      */
     ISBFirmwareUpdater(fwUpdate::target_t target, const device_handle_t& device, std::deque<uint8_t>& toHost) : FirmwareUpdateDevice(target), device(device), target_devInfo(), toHost(toHost) { }
 
@@ -46,38 +48,60 @@ public:
     };
 
     /**
-     * We override this in this class, because we have to do some better handling for erase/write, rather than chunks.
-     * @param level
-     * @param message
-     * @param ...
-     * @return
+     * Formats and reports a progress/status message. Overridden here because ISB reports progress
+     * per erase/write/verify page step rather than per fixed-size chunk, so the base class's
+     * chunk-count formatting doesn't apply.
+     * @param level the severity of the message (one of IS_LOG_LEVEL_*)
+     * @param message a printf-style format string
+     * @param ... format arguments for message
+     * @return true if the message was successfully formatted and reported, otherwise false
      */
     bool fwUpdate_sendProgressFormatted(int level, const char* message, ...) override;
 
+    /**
+     * Formats and reports a progress/status message that additionally carries an explicit
+     * chunk-count pair, for steps (e.g. page verify) that report progress against a page/chunk
+     * count that differs from the base class's own bookkeeping.
+     * @param level the severity of the message (one of IS_LOG_LEVEL_*)
+     * @param total_chunks the total number of chunks/pages for the current step
+     * @param num_chunks the number of chunks/pages completed so far
+     * @param message a printf-style format string
+     * @param ... format arguments for message
+     * @return true if the message was successfully formatted and reported, otherwise false
+     */
     bool fwUpdate_sendProgressFormatted(int level, int total_chunks, int num_chunks, const char* message, ...);
 
-    // this is called internally by processMessage() to do the things; it should also be called periodically to send status updated, etc.
+    /**
+     * Drives the ISB update state machine forward by one step; called internally by
+     * processMessage() when a message is received, and should also be called periodically
+     * (independent of message reception) so timeouts and page erase/write/verify progress
+     * continue to advance.
+     * @param msg_type the type of message that was last processed, or MSG_UNKNOWN
+     * @param processed true if msg_type was already handled by the caller (additional/optional
+     *        processing may still occur here), false if it was not yet handled
+     * @return true if some action was taken as a result of this step, otherwise false
+     */
     bool fwUpdate_step(fwUpdate::msg_types_e msg_type, bool processed) override;
 
-    // called internally to perform a system reset of various severity per reset_flags (HARD, SOFT, etc)
     /**
      * Performs a system reset of various severity per reset_flags, (ie, RESET_SOFT by informing the OS/MCU to restart the system,
      * vs RESET_HARD, usually by pulling interfacing pins into the MCU either HIGH or LOW to force a reset state on the hardware).
      * Note that some systems may not always be able to respond with a success before the system is reset.
      * If a system is NOT able to perform a reset (ie UNSUPPORTED, etc), this MUST return false.
      * @param target_id the device to reset
+     * @param reset_flags the severity/style of reset to perform (e.g. RESET_SOFT, RESET_HARD)
      * @return true if successful, otherwise false
      */
     bool fwUpdate_performReset(fwUpdate::target_t target_id, fwUpdate::reset_flags_e reset_flags) override;
 
-    // called internally (by the receiving device) to populate the dev_info_t struct for the requested device
     /**
      * Internally called by fwUpdate_processMessage() when a REQ_VERSION_INFO message is received, to request version info for the target device.
      * This is to be implemented by the concrete class.  If the target/requested device can not provide version info, this should return false.
      * If this call returns false, the API will respond with a MSG_VERSION_INFO_RESP, with the message filled with 0xFF, indicating not-supported.
      * NOTE that this call is passed a reference to a const dev_info_t; the base-class provides the instance which is referenced. As the implementer
      * of this class, it is your responsibility to fill it with the appropriate data.
-     * @param a reference to a dev_info_t struct that contains the necessary version information to be returned back to the querying host.
+     * @param target_id the device whose version info is being requested
+     * @param dev_info reference to a dev_info_t struct to fill with the version information to be returned back to the querying host
      * @return true if the message was received and parsed without error, false otherwise.
      */
     bool fwUpdate_queryVersionInfo(fwUpdate::target_t target_id, dev_info_t& dev_info) override;
@@ -88,7 +112,6 @@ public:
      * @return an update_status_e indicating the continued state of the update process, or an error. For fwUpdate_startUpdate
      * this should return "GOOD_TO_GO" on success.
      */
-    // this initializes the system to begin receiving firmware image chunks for the target device, image slot and image size
     fwUpdate::update_status_e fwUpdate_startUpdate(const fwUpdate::payload_t& msg) override;
 
     /**
@@ -101,26 +124,25 @@ public:
      * @return an update_status_e indicating the continued state of the update process, or an error. For fwUpdate_writeImageChunk
      * this should return "WAITING_FOR_DATA" if more chunks are expected, or an error.
      */
-    // writes the indicated block of data (of len bytes) to the target and device-specific image slot, and with the specified offset
     fwUpdate::update_status_e fwUpdate_writeImageChunk(fwUpdate::target_t target_id, int slot_id, int offset, int len, uint8_t *data) override;
 
     /**
-     * Validated and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
+     * Validates and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
      * @param target_id the target_id
      * @param slot_id the image slot, if applicable (otherwise 0)
-     * @return
+     * @param flags additional flags controlling finalization behavior
+     * @return an update_status_e indicating the continued state of the update process, or an error
      */
-    // this marks the finish of the upgrade, that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization
     fwUpdate::update_status_e fwUpdate_finishUpdate(fwUpdate::target_t target_id, int slot_id, int flags) override;
 
     /**
-     * Writes the requested data (usually a packed payload_t) out to the specified device
+     * Writes the requested data (usually a packed payload_t) out to the specified device.
      * Note that the implementation between a target and an actual interface is device-specific. In most cases,
      * for a Device-implementation, this will typically specify TARGET_HOST, which will direct back to the
      * controlling host.
-     * @param target
-     * @param buffer
-     * @param buff_len
+     * @param target the target this message is directed to
+     * @param buffer the encoded buffer to send
+     * @param buff_len the number of bytes in the encoded buffer to send
      * @return true if the data was successfully sent to the underlying communication system, otherwise false
      */
     bool fwUpdate_writeToWire(fwUpdate::target_t target, uint8_t* buffer, int buff_len) override;

--- a/src/ISBootloaderAPP.h
+++ b/src/ISBootloaderAPP.h
@@ -1,3 +1,16 @@
+/**
+ * @file ISBootloaderAPP.h
+ * @brief Bootloader-protocol implementation for a device currently running its normal
+ *        application firmware. Used to detect an application-mode device and command it to
+ *        reboot down into IS-bootloader (ISB) mode so a real bootloader update can proceed;
+ *        download/upload/verify are no-ops since an application image can't be flashed
+ *        through this transport.
+ *
+ * @author Dave Cutting
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
+ */
+
 /*
 MIT LICENSE
 
@@ -17,15 +30,27 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <mutex>
 
+/**
+ * cISBootloaderBase implementation for a device running its normal application firmware
+ * (not an actual bootloader). Used to detect an application-mode device on a serial port,
+ * query its device info, and command it to reboot down into IS-bootloader (ISB) mode;
+ * download/upload/verify are no-ops for this transport.
+ */
 class cISBootloaderAPP : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param port the serial port the application-mode device is connected on
+     */
     cISBootloaderAPP(
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb,
         port_handle_t port
-  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb } 
+  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb }
     {
         m_port = port;
         m_bootloader_type = IS_BL_TYPE_APP;
@@ -33,25 +58,46 @@ public:
         m_port_name = std::string(portName(port));
     }
 
-    ~cISBootloaderAPP() 
+    /** Destructor; the serial port is owned by the caller, not closed here. */
+    ~cISBootloaderAPP()
     {
-        
+
     }
 
+    /** @return the eImageSignature bitmask of images this application-mode device will accept, queried over its normal comm protocol, or IS_IMAGE_SIGN_NONE if it could not be determined */
     ISBootloader::eImageSignature check_is_compatible();
 
+    /**
+     * @param param a null-terminated serial port name to compare against this device's port
+     * @return IS_OP_OK if param matches this device's serial port name, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
 
+    /** @return IS_OP_OK always (application-level reboot is not yet implemented) */
     is_operation_result reboot();
+    /** @return IS_OP_OK always; there is no level above the running application */
     is_operation_result reboot_up() { return IS_OP_OK; }
+    /**
+     * Sends the app-specific bootloader-enable command sequence (m_app.enable_command) over the
+     * serial port to reboot the device down into IS-bootloader (ISB) mode.
+     * @param major unused for this transport
+     * @param minor unused for this transport
+     * @param force unused for this transport
+     * @return IS_OP_OK always
+     */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false);
 
+    /** @return the device's Inertial Sense serial number, queried over its normal comm protocol, or 0 if it could not be read */
     uint32_t get_device_info();
 
+    /** @return IS_OP_OK always (no-op; an application-mode device can't be flashed through this transport) */
     is_operation_result download_image(std::string image) { return IS_OP_OK; }
+    /** @return IS_OP_OK always (no-op; an application-mode device can't be read back through this transport) */
     is_operation_result upload_image(std::string image) { return IS_OP_OK; }
+    /** @return IS_OP_OK always (no-op; an application-mode device can't be verified through this transport) */
     is_operation_result verify_image(std::string image) { return IS_OP_OK; }
 
+    /** Clears the process-wide list of serial numbers already seen in application mode. */
     static void reset_serial_list() { serial_list_mutex.lock(); serial_list.clear(); serial_list_mutex.unlock(); }
 
 private:

--- a/src/ISBootloaderAPP.h
+++ b/src/ISBootloaderAPP.h
@@ -90,11 +90,11 @@ public:
     /** @return the device's Inertial Sense serial number, queried over its normal comm protocol, or 0 if it could not be read */
     uint32_t get_device_info();
 
-    /** @return IS_OP_OK always (no-op; an application-mode device can't be flashed through this transport) */
+    /** @param image unused @return IS_OP_OK always (no-op; an application-mode device can't be flashed through this transport) */
     is_operation_result download_image(std::string image) { return IS_OP_OK; }
-    /** @return IS_OP_OK always (no-op; an application-mode device can't be read back through this transport) */
+    /** @param image unused @return IS_OP_OK always (no-op; an application-mode device can't be read back through this transport) */
     is_operation_result upload_image(std::string image) { return IS_OP_OK; }
-    /** @return IS_OP_OK always (no-op; an application-mode device can't be verified through this transport) */
+    /** @param image unused @return IS_OP_OK always (no-op; an application-mode device can't be verified through this transport) */
     is_operation_result verify_image(std::string image) { return IS_OP_OK; }
 
     /** Clears the process-wide list of serial numbers already seen in application mode. */

--- a/src/ISBootloaderBase.h
+++ b/src/ISBootloaderBase.h
@@ -1,3 +1,15 @@
+/**
+ * @file ISBootloaderBase.h
+ * @brief Common contract for the per-target bootloader protocol implementations
+ *        (cISBootloaderBase and its ISBootloaderAPP/DFU/ISB/SAMBA/STM32/Sony derivatives):
+ *        image-signature detection, reboot-chain navigation between bootloader levels, and the
+ *        download/upload/verify operations each concrete transport must implement.
+ *
+ * @author Dave Cutting
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
+ */
+
 /*
 MIT LICENSE
 
@@ -35,61 +47,95 @@ static constexpr int IS_FIRMWARE_PATH_LENGTH = 256;
 
 static constexpr int IS_REBOOT_DELAY_MS = 3000;
 
+/** Processor family of the connected device, detected from its bootloader/image signature. */
 typedef enum {
-    IS_PROCESSOR_UNKNOWN = -1,
-    IS_PROCESSOR_SAMx70 = 0,        // uINS-3/4, EVB-2
-    IS_PROCESSOR_STM32L4,           // IMX-5
-    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-6
+    IS_PROCESSOR_UNKNOWN = -1,      //!< not yet identified
+    IS_PROCESSOR_SAMx70 = 0,        //!< uINS-3/4, EVB-2
+    IS_PROCESSOR_STM32L4,           //!< IMX-5
+    IS_PROCESSOR_STM32U5,           //!< GPX-1, IMX-6
 
-    IS_PROCESSOR_NUM,               // Must be last
+    IS_PROCESSOR_NUM,               //!< number of known processor types; must be last
 } eProcessorType;
 
+/**
+ * Bitmask identifying which target(s) a firmware/bootloader image is valid for, detected from the
+ * image file itself (see cISBootloaderBase::get_image_signature()). Bootloader signature bits are
+ * assigned first because a bootloader image may also satisfy an application image's signature check.
+ */
 typedef enum {
-    // Bootloaders must be first because bootloaders may contain app signatures
-    IS_IMAGE_SIGN_ISB_STM32L4 = 0x00000001,
-    IS_IMAGE_SIGN_ISB_SAMx70_16K = 0x00000002,
-    IS_IMAGE_SIGN_ISB_SAMx70_24K = 0x00000004,
+    IS_IMAGE_SIGN_ISB_STM32L4 = 0x00000001,     //!< ISB bootloader image, STM32L4 (IMX-5)
+    IS_IMAGE_SIGN_ISB_SAMx70_16K = 0x00000002,  //!< ISB bootloader image, SAMx70 16K (uINS-3/4, EVB-2)
+    IS_IMAGE_SIGN_ISB_SAMx70_24K = 0x00000004,  //!< ISB bootloader image, SAMx70 24K (uINS-3/4, EVB-2)
 
-    IS_IMAGE_SIGN_UINS_3_16K = 0x00000008,
-    IS_IMAGE_SIGN_UINS_3_24K = 0x00000010,
-    IS_IMAGE_SIGN_EVB_2_16K = 0x00000020,
-    IS_IMAGE_SIGN_EVB_2_24K = 0x00000040,
-    IS_IMAGE_SIGN_IMX_5p0 = 0x00000080,
-    
-    IS_IMAGE_SIGN_NUM_BITS_USED = 8,
+    IS_IMAGE_SIGN_UINS_3_16K = 0x00000008,      //!< application image, uINS-3, 16K bootloader
+    IS_IMAGE_SIGN_UINS_3_24K = 0x00000010,       //!< application image, uINS-3, 24K bootloader
+    IS_IMAGE_SIGN_EVB_2_16K = 0x00000020,        //!< application image, EVB-2, 16K bootloader
+    IS_IMAGE_SIGN_EVB_2_24K = 0x00000040,        //!< application image, EVB-2, 24K bootloader
+    IS_IMAGE_SIGN_IMX_5p0 = 0x00000080,          //!< application image, IMX-5.0
 
-    IS_IMAGE_SIGN_APP = IS_IMAGE_SIGN_UINS_3_16K | IS_IMAGE_SIGN_UINS_3_24K | IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K | IS_IMAGE_SIGN_IMX_5p0 | IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K | IS_IMAGE_SIGN_ISB_STM32L4,
-    IS_IMAGE_SIGN_ISB = IS_IMAGE_SIGN_UINS_3_16K | IS_IMAGE_SIGN_UINS_3_24K | IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K | IS_IMAGE_SIGN_IMX_5p0 | IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K | IS_IMAGE_SIGN_ISB_STM32L4,
-    
-    IS_IMAGE_SIGN_SAMBA = IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K,
-    IS_IMAGE_SIGN_DFU = IS_IMAGE_SIGN_ISB_STM32L4,
+    IS_IMAGE_SIGN_NUM_BITS_USED = 8,             //!< number of signature bits actually assigned above
 
-    IS_IMAGE_SIGN_EVB = IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K,
+    IS_IMAGE_SIGN_APP = IS_IMAGE_SIGN_UINS_3_16K | IS_IMAGE_SIGN_UINS_3_24K | IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K | IS_IMAGE_SIGN_IMX_5p0 | IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K | IS_IMAGE_SIGN_ISB_STM32L4,  //!< union of all application-image signature bits
+    IS_IMAGE_SIGN_ISB = IS_IMAGE_SIGN_UINS_3_16K | IS_IMAGE_SIGN_UINS_3_24K | IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K | IS_IMAGE_SIGN_IMX_5p0 | IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K | IS_IMAGE_SIGN_ISB_STM32L4,  //!< union of signature bits valid for an ISB-protocol update
 
-    IS_IMAGE_SIGN_NONE = 0,
-    IS_IMAGE_SIGN_ERROR = 0x80000000,
+    IS_IMAGE_SIGN_SAMBA = IS_IMAGE_SIGN_ISB_SAMx70_16K | IS_IMAGE_SIGN_ISB_SAMx70_24K,  //!< union of signature bits valid for a SAM-BA update
+    IS_IMAGE_SIGN_DFU = IS_IMAGE_SIGN_ISB_STM32L4,                                       //!< union of signature bits valid for a USB DFU update
+
+    IS_IMAGE_SIGN_EVB = IS_IMAGE_SIGN_EVB_2_16K | IS_IMAGE_SIGN_EVB_2_24K,  //!< union of signature bits identifying an EVB-2 image
+
+    IS_IMAGE_SIGN_NONE = 0,             //!< no recognized signature
+    IS_IMAGE_SIGN_ERROR = 0x80000000,   //!< the image could not be read/parsed to determine a signature
 } eImageSignature;
 
-typedef struct 
+/** A single firmware or bootloader image's file path, used by the legacy multi-target update entry points. */
+typedef struct
 {
-    std::string path;
+    std::string path;   //!< path to the image file (empty if not provided/applicable)
 } firmware_t;
 
-typedef struct 
+/** The set of firmware/bootloader image paths for every legacy-supported target, used by mode_device_app()/update_device(). */
+typedef struct
 {
-    firmware_t fw_IMX_5;
-    firmware_t bl_IMX_5;
-    firmware_t fw_uINS_3;
-    firmware_t bl_uINS_3;
-    firmware_t fw_EVB_2;
-    firmware_t bl_EVB_2;
+    firmware_t fw_IMX_5;    //!< IMX-5 application image
+    firmware_t bl_IMX_5;    //!< IMX-5 bootloader image
+    firmware_t fw_uINS_3;   //!< uINS-3 application image
+    firmware_t bl_uINS_3;   //!< uINS-3 bootloader image
+    firmware_t fw_EVB_2;    //!< EVB-2 application image
+    firmware_t bl_EVB_2;    //!< EVB-2 bootloader image
 } firmwares_t;
 
 // typedef is_operation_result (*fwUpdate::pfnProgressCb)(void* obj, float percent);
 // typedef void (*fwUpdate::pfnStatusCb)(void* obj, int level, const char* infoString, ...);
 
+/**
+ * Default upload-progress callback used when the caller does not supply one; discards the report.
+ * @param obj the calling cISBootloaderBase instance (as std::any)
+ * @param percent upload completion percentage (0-100)
+ * @param stepName human-readable name of the current step
+ * @param stepNo the index of the current step
+ * @param totalSteps the total number of steps
+ * @return IS_OP_OK always
+ */
 is_operation_result dummy_update_callback(const std::any& obj, float percent, const std::string& stepName, int stepNo, int totalSteps);
+
+/**
+ * Default verify-progress callback used when the caller does not supply one; discards the report.
+ * @param obj the calling cISBootloaderBase instance (as std::any)
+ * @param percent verify completion percentage (0-100)
+ * @param stepName human-readable name of the current step
+ * @param stepNo the index of the current step
+ * @param totalSteps the total number of steps
+ * @return IS_OP_OK always
+ */
 is_operation_result dummy_verify_callback(const std::any& obj, float percent, const std::string& stepName, int stepNo, int totalSteps);
+
+/**
+ * Default status/info callback used when the caller does not supply one; discards the message.
+ * @param obj the calling cISBootloaderBase instance (as std::any)
+ * @param level the severity of the message (one of eLogLevel)
+ * @param infoString a printf-style format string
+ * @param ... format arguments for infoString
+ */
 static inline void dummy_info_callback(const std::any& obj, eLogLevel level, const char* infoString, ...)
 {
     (void)obj;
@@ -97,16 +143,28 @@ static inline void dummy_info_callback(const std::any& obj, eLogLevel level, con
     (void)level;
 }
 
+/**
+ * Abstract base for a single bootloader-protocol session with one connected device. A concrete
+ * subclass implements the wire transport for one bootloader level (application/ISB/DFU/SAM-BA/
+ * STM32-ROM/Sony) -- image compatibility checking, download/upload/verify, and navigating the
+ * reboot chain to the adjacent bootloader level above or below the one this instance represents.
+ * Progress and status are reported via the upload/verify/info callbacks passed to the constructor.
+ */
 class cISBootloaderBase
 {
 public:
+    /**
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     */
     cISBootloaderBase(
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb
   ) :
-        m_update_callback{upload_cb}, 
-        m_verify_callback{verify_cb}, 
+        m_update_callback{upload_cb},
+        m_verify_callback{verify_cb},
         m_info_callback{info_cb}
     {
         m_success = false;
@@ -125,24 +183,46 @@ public:
 
     virtual ~cISBootloaderBase() {};
 
+    /**
+     * Determines which target(s) the given image file is valid for, by inspecting its contents
+     * (not just its extension/filename).
+     * @param filename path to the firmware/bootloader image file
+     * @param major if non-null, receives the image's major version, when encoded in the image
+     * @param minor if non-null, receives the image's minor version, when encoded in the image
+     * @return an eImageSignature bitmask of the target(s) the image is valid for, or IS_IMAGE_SIGN_ERROR/IS_IMAGE_SIGN_NONE
+     */
     static eImageSignature get_image_signature(std::string filename, uint8_t* major = NULL, char* minor = NULL);
 
+    /**
+     * Tests whether param identifies a device this bootloader-protocol implementation can drive
+     * (e.g. a matching port or libusb device, depending on the concrete subclass).
+     * @param param an implementation-specific device/port identifier to test
+     * @return IS_OP_OK if param matches this implementation's transport, otherwise an error
+     */
     virtual is_operation_result match_test(void* param) = 0;
 
+    /**
+     * Queries the connected device to determine which image signature(s) it can currently accept.
+     * @return the eImageSignature bitmask of images this device's bootloader will accept, or IS_IMAGE_SIGN_ERROR
+     */
     virtual eImageSignature check_is_compatible() = 0;
 
     /**
      * @brief Reboots into the same mode, giving the bootloader a fresh start
+     * @return IS_OP_OK on success, otherwise an error
      */
     virtual is_operation_result reboot() = 0;
+
+    /** @return IS_OP_OK always (default no-op; subclasses may override to force a reboot even from an unresponsive state) */
     virtual is_operation_result reboot_force() { return IS_OP_OK; }
-    
+
     /**
      * @brief Reboots into the level above, if available:
      *  - ISB to App
      *  - SAM-BA to ISB
      *  - DFU to ISB
      *  Make sure to tall the destructor after a successful call to this function
+     * @return IS_OP_OK on success, otherwise an error
      */
     virtual is_operation_result reboot_up() = 0;
 
@@ -152,70 +232,98 @@ public:
      *  - ISB to DFU
      *  - ISB to SAM-BA
      *  Make sure to call the destructor after a successful call to this function
+     * @param major if the target level requires a compatible image, its major version (0 = don't care)
+     * @param minor if the target level requires a compatible image, its minor version (0 = don't care)
+     * @param force if true, reboot even if the target level's compatibility can't be confirmed
+     * @return IS_OP_OK on success, otherwise an error
      */
     virtual is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false) = 0;
 
     /**
      * @brief Get the serial number from the device, and fill out m_ctx with other info
+     * @return the device's Inertial Sense serial number, or 0 if it could not be read
      */
     virtual uint32_t get_device_info() = 0;
 
     /**
      * @brief Write an image to the device
-     * 
+     *
      * @param image path to the image
+     * @return IS_OP_OK on success, otherwise an error
      */
     virtual is_operation_result download_image(std::string image) = 0;
 
     /**
      * @brief Read an image from the device
-     * 
-     * @param image path to the image
+     *
+     * @param image path to write the read-back image to
+     * @return IS_OP_OK on success, otherwise an error
      */
     virtual is_operation_result upload_image(std::string image) = 0;
-    
+
     /**
      * @brief Verify an image against the device
-     * 
-     * @param image path to the image
+     *
+     * @param image path to the image to verify against the device's current contents
+     * @return IS_OP_OK if the device's contents match image, otherwise an error
      */
     virtual is_operation_result verify_image(std::string image) = 0;
 
+    /** @return true if this bootloader-protocol implementation communicates over a serial port, false for USB/other transports */
     virtual bool is_serial_device() { return true; }
 
+    /**
+     * Formats and forwards a status/log message to the info callback supplied at construction.
+     * @param level the severity of the message (one of eLogLevel)
+     * @param infoString a printf-style format string
+     * @param args format arguments for infoString
+     */
     template<typename... Args> void logStatus(eLogLevel level, const char* infoString, Args... args) {
         if (m_info_callback)
             m_info_callback(this, level, infoString, args...);
     }
 
 
-    int m_retries_left = 3;
-    float m_update_progress = 0;
-    float m_verify_progress = 0;
-    bool m_verify = false;
-    bool m_success = false;
+    int m_retries_left = 3;                 //!< number of remaining retry attempts for the current operation
+    float m_update_progress = 0;            //!< current download (upload-to-device) progress, 0-100
+    float m_verify_progress = 0;            //!< current verify progress, 0-100
+    bool m_verify = false;                  //!< true if a verify pass should be performed after download
+    bool m_success = false;                 //!< true if the most recent operation completed successfully
 
     // Callbacks
-    fwUpdate::pfnProgressCb m_update_callback = nullptr;
-    fwUpdate::pfnProgressCb m_verify_callback = nullptr;
-    fwUpdate::pfnStatusCb m_info_callback = nullptr;
+    fwUpdate::pfnProgressCb m_update_callback = nullptr;  //!< invoked to report download progress (never null after construction)
+    fwUpdate::pfnProgressCb m_verify_callback = nullptr;  //!< invoked to report verify progress (never null after construction)
+    fwUpdate::pfnStatusCb m_info_callback = nullptr;      //!< invoked to report status/log messages (never null after construction)
 
-    void* m_thread = nullptr;
-    bool m_finished_flash = false;
-    int m_bootloader_type = false;
-    bool m_use_progress = false;
-    int m_start_time_ms = 0;
+    void* m_thread = nullptr;               //!< opaque handle to a worker thread driving this session, if any (owned/typed by the concrete subclass)
+    bool m_finished_flash = false;          //!< true once the download/verify sequence has completed (success or failure)
+    int m_bootloader_type = false;          //!< implementation-specific bootloader type/variant identifier
+    bool m_use_progress = false;            //!< true if this session should report progress via the callbacks
+    int m_start_time_ms = 0;                //!< timestamp (ms) when the current operation started, for timeout/duration tracking
 
-    port_handle_t m_port = nullptr;
-    std::string m_port_name;
-    int m_baud = 0;
+    port_handle_t m_port = nullptr;         //!< the serial port this session communicates over, if is_serial_device()
+    std::string m_port_name;                //!< the name of m_port (e.g. "/dev/ttyACM0"), for diagnostics
+    int m_baud = 0;                         //!< serial baud rate in use, if is_serial_device()
 
-    uint32_t m_sn = 0;                      // Inertial Sense serial number, i.e. SN60000
-    uint16_t m_hdw = 0;                     // Inertial Sense Hardware Type (IMX, GPX, etc)
-    uint8_t m_isb_major = 0;                // ISB Major revision on device
-    char m_isb_minor = 0;                   // ISB Minor revision on device
-    bool isb_mightUpdate = 0;               // true if device will be updated if bootloader continues
+    uint32_t m_sn = 0;                      //!< Inertial Sense serial number, i.e. SN60000
+    uint16_t m_hdw = 0;                     //!< Inertial Sense Hardware Type (IMX, GPX, etc)
+    uint8_t m_isb_major = 0;                //!< ISB Major revision on device
+    char m_isb_minor = 0;                   //!< ISB Minor revision on device
+    bool isb_mightUpdate = 0;               //!< true if device will be updated if bootloader continues
 
+    /**
+     * Legacy multi-target entry point: given a device already running its application, determine
+     * its bootloader mode/version and add a matching cISBootloaderBase context for it.
+     * @param filenames candidate firmware/bootloader image paths for every supported target
+     * @param port the serial port the device is connected on
+     * @param statusfn callback invoked to report status/log messages
+     * @param updateProgress callback invoked to report download progress
+     * @param verifyProgress callback invoked to report verify progress
+     * @param contexts the shared list of active bootloader contexts to append the new context to
+     * @param addMutex mutex guarding concurrent access to contexts
+     * @param new_context if non-null, receives the newly-created context
+     * @return IS_OP_OK on success, otherwise an error
+     */
     static is_operation_result mode_device_app(
         firmwares_t filenames,
         port_handle_t port,
@@ -227,6 +335,19 @@ public:
         cISBootloaderBase** new_context
 );
 
+    /**
+     * Legacy multi-target entry point: queries a device already in ISB mode for its bootloader
+     * version and adds a matching cISBootloaderBase context for it.
+     * @param filenames candidate firmware/bootloader image paths for every supported target
+     * @param port the serial port the device is connected on
+     * @param statusfn callback invoked to report status/log messages
+     * @param updateProgress callback invoked to report download progress
+     * @param verifyProgress callback invoked to report verify progress
+     * @param contexts the shared list of active bootloader contexts to append the new context to
+     * @param addMutex mutex guarding concurrent access to contexts
+     * @param new_context if non-null, receives the newly-created context
+     * @return IS_OP_OK on success, otherwise an error
+     */
     static is_operation_result get_device_isb_version(
         firmwares_t filenames,
         port_handle_t port,
@@ -239,6 +360,21 @@ public:
         cISBootloaderBase** new_context
 );
 
+    /**
+     * Legacy multi-target entry point: given a device already in ISB mode, add a matching
+     * cISBootloaderBase context for it and (if force or a version mismatch requires it) drive an
+     * ISB bootloader update using filenames.
+     * @param filenames candidate firmware/bootloader image paths for every supported target
+     * @param force if true, update the bootloader even if its version already appears compatible
+     * @param port the serial port the device is connected on
+     * @param statusfn callback invoked to report status/log messages
+     * @param updateProgress callback invoked to report download progress
+     * @param verifyProgress callback invoked to report verify progress
+     * @param contexts the shared list of active bootloader contexts to append the new context to
+     * @param addMutex mutex guarding concurrent access to contexts
+     * @param new_context if non-null, receives the newly-created context
+     * @return IS_OP_OK on success, otherwise an error
+     */
     static is_operation_result mode_device_isb(
         firmwares_t filenames,
         bool force,
@@ -251,6 +387,21 @@ public:
         cISBootloaderBase** new_context
 );
 
+    /**
+     * Legacy multi-target entry point: identifies a serial-connected device's current mode and
+     * drives it through however many reboot/update steps are needed to reach an up-to-date
+     * application image, per filenames.
+     * @param filenames candidate firmware/bootloader image paths for every supported target
+     * @param port the serial port the device is connected on
+     * @param statusfn callback invoked to report status/log messages
+     * @param updateprogress callback invoked to report download progress
+     * @param verifyProgress callback invoked to report verify progress
+     * @param contexts the shared list of active bootloader contexts to append the new context to
+     * @param addMutex mutex guarding concurrent access to contexts
+     * @param new_context if non-null, receives the newly-created context
+     * @param baud the serial baud rate to use
+     * @return IS_OP_OK on success, otherwise an error
+     */
     static is_operation_result update_device(
         firmwares_t filenames,
         port_handle_t port,
@@ -262,6 +413,20 @@ public:
         cISBootloaderBase** new_context,
         uint32_t baud = BAUDRATE_921600
 );
+
+    /**
+     * Legacy multi-target entry point: identifies a USB-connected (DFU-mode) device and drives it
+     * through however many reboot/update steps are needed to reach an up-to-date application image.
+     * @param filenames candidate firmware/bootloader image paths for every supported target
+     * @param handle an open libusb device handle for the connected device
+     * @param statusfn callback invoked to report status/log messages
+     * @param updateprogress callback invoked to report download progress
+     * @param verifyProgress callback invoked to report verify progress
+     * @param contexts the shared list of active bootloader contexts to append the new context to
+     * @param addMutex mutex guarding concurrent access to contexts
+     * @param new_context if non-null, receives the newly-created context
+     * @return IS_OP_OK on success, otherwise an error
+     */
     static is_operation_result update_device(
         firmwares_t filenames,
         libusb_device_handle* handle,
@@ -273,29 +438,52 @@ public:
         cISBootloaderBase** new_context
 );
 
-    std::string m_filename;
-    bool m_isISB = false;
+    std::string m_filename;                 //!< path to the image most recently downloaded/uploaded/verified
+    bool m_isISB = false;                   //!< true if this context represents an ISB-protocol session
 
 protected:
+    /**
+     * Convenience wrapper to forward a single already-formatted message to the info callback.
+     * @param info the message text (no printf-style formatting is applied)
+     * @param level the severity of the message (one of eLogLevel)
+     */
     void status_update(const char* info, eLogLevel level)
-    { 
+    {
         if (m_info_callback) m_info_callback(std::any_cast<cISBootloaderBase*>(this), level, info);
     }
 
+    /** Legacy application-mode version info and the app-specific bootloader-enable command string. */
     struct
     {
-        uint8_t uins_version[4];
-        uint8_t evb_version[4];
+        uint8_t uins_version[4];        //!< uINS-3 application version, as reported by the device
+        uint8_t evb_version[4];         //!< EVB-2 application version, as reported by the device
 
-        char enable_command[5];         // "EBLE" (EVB) or "BLEN" (uINS) 
+        char enable_command[5];         //!< the ASCII command that switches this app into bootloader mode: "EBLE" (EVB) or "BLEN" (uINS)
     } m_app;
 
     /**
      * @brief Get the file extension from a file name
+     * @param filename the file name/path to extract an extension from
+     * @return pointer to the extension within filename (including the leading '.'), or "" if none
      */
     static const char* get_file_ext(const char* filename);
     
+    /**
+     * Determines the image signature of an Intel-HEX (.hex) image by inspecting its records.
+     * @param image path to the .hex image file
+     * @param major if non-null, receives the image's major version, when encoded in the image
+     * @param minor if non-null, receives the image's minor version, when encoded in the image
+     * @return an eImageSignature bitmask of the target(s) the image is valid for, or IS_IMAGE_SIGN_ERROR/IS_IMAGE_SIGN_NONE
+     */
     static eImageSignature get_hex_image_signature(std::string image, uint8_t* major = NULL, char* minor = NULL);
+
+    /**
+     * Determines the image signature of a raw binary (.bin) image by inspecting its contents.
+     * @param image path to the .bin image file
+     * @param major if non-null, receives the image's major version, when encoded in the image
+     * @param minor if non-null, receives the image's minor version, when encoded in the image
+     * @return an eImageSignature bitmask of the target(s) the image is valid for, or IS_IMAGE_SIGN_ERROR/IS_IMAGE_SIGN_NONE
+     */
     static eImageSignature get_bin_image_signature(std::string image, uint8_t* major = NULL, char* minor = NULL);
 };
 

--- a/src/ISBootloaderBase.h
+++ b/src/ISBootloaderBase.h
@@ -37,15 +37,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISUtilities.h"
 #include "protocol/FirmwareUpdate.h"
 
-#define IMX5_FLASH_PAGE_SIZE 65536      // 64K flash page size for IMX-5
-#define IMX5_BOOTLOADER_INCOMPATIBLE_MSG "IMX firmware incompatible with bootloader. Update IMX-5 bootloader to v6i or newer required for selected IMX firmware."
+#define IMX5_FLASH_PAGE_SIZE 65536      //!< 64K flash page size for IMX-5
+#define IMX5_BOOTLOADER_INCOMPATIBLE_MSG "IMX firmware incompatible with bootloader. Update IMX-5 bootloader to v6i or newer required for selected IMX firmware."  //!< error text shown when the IMX-5 bootloader is too old for the selected firmware image
 
 namespace ISBootloader {
 
-static constexpr int IS_DEVICE_LIST_LEN = 256;
-static constexpr int IS_FIRMWARE_PATH_LENGTH = 256;
+static constexpr int IS_DEVICE_LIST_LEN = 256;        //!< maximum number of devices that can be tracked/enumerated at once
+static constexpr int IS_FIRMWARE_PATH_LENGTH = 256;   //!< maximum length, in bytes, of a firmware/bootloader image file path
 
-static constexpr int IS_REBOOT_DELAY_MS = 3000;
+static constexpr int IS_REBOOT_DELAY_MS = 3000;       //!< delay (ms) allowed for a device to complete a reboot before it is considered unresponsive
 
 /** Processor family of the connected device, detected from its bootloader/image signature. */
 typedef enum {

--- a/src/ISBootloaderDFU.h
+++ b/src/ISBootloaderDFU.h
@@ -103,7 +103,12 @@ public:
      * @return IS_OP_OK on success, otherwise IS_OP_ERROR
      */
     is_operation_result reboot_up();
-    /** @return IS_OP_OK always (no level below DFU to reboot into for this transport) */
+    /**
+     * @param major unused
+     * @param minor unused
+     * @param force unused
+     * @return IS_OP_OK always (no level below DFU to reboot into for this transport)
+     */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false) { (void)major; (void)minor; (void)force; return IS_OP_OK; }
 
     /**
@@ -125,9 +130,9 @@ public:
      * @return IS_OP_OK on success, otherwise IS_OP_ERROR
      */
     is_operation_result download_image(std::string image);
-    /** @return IS_OP_OK always (no-op; reading an image back is not supported over DFU) */
+    /** @param image unused @return IS_OP_OK always (no-op; reading an image back is not supported over DFU) */
     is_operation_result upload_image(std::string image) { (void)image; return IS_OP_OK; }
-    /** @return IS_OP_OK always (no-op; verification is not supported over DFU) */
+    /** @param image unused @return IS_OP_OK always (no-op; verification is not supported over DFU) */
     is_operation_result verify_image(std::string image) { (void)image; return IS_OP_OK; }
 
     /** @return the number of STM32 DFU-mode devices currently enumerable via libusb */

--- a/src/ISBootloaderDFU.h
+++ b/src/ISBootloaderDFU.h
@@ -1,9 +1,13 @@
 /**
  * @file ISBootloaderDFU.h
+ * @brief Bootloader-protocol implementation for the STM32 USB DFU (Device Firmware Upgrade)
+ *        interface exposed by the STM32 ROM/DfuSe bootloader (IMX-5). Communicates directly
+ *        over libusb control transfers to enumerate DFU-mode devices, read their serial number
+ *        from OTP, and program an Intel-HEX image into flash.
+ *
  * @author Dave Cutting
- * @brief Inertial Sense routines for updating ISB (Inertial Sense Bootloader)
- *  images using the DFU protocol.
- * 
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
  */
 
 /*
@@ -28,72 +32,116 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace ISBootloader {
 
-static constexpr int IS_DFU_UID_MAX_SIZE = 20;
-static constexpr int IS_DFU_LIST_LEN = 256;
+static constexpr int IS_DFU_UID_MAX_SIZE = 20;    //!< max length (incl. null) of a DFU device UID string
+static constexpr int IS_DFU_LIST_LEN = 256;       //!< max number of DFU devices list_devices() can enumerate at once
 
+/** USB vendor/product ID pair used to recognize an STM32 device in DFU mode. */
 enum
 {
-    STM32_DESCRIPTOR_VENDOR_ID = 0x0483,
-    STM32_DESCRIPTOR_PRODUCT_ID = 0xdf11
+    STM32_DESCRIPTOR_VENDOR_ID = 0x0483,   //!< STMicroelectronics USB vendor ID
+    STM32_DESCRIPTOR_PRODUCT_ID = 0xdf11   //!< USB product ID for the STM32 DFU bootloader interface
 };
 
+/** Identity and connection info for one DFU-mode USB device, filled in by cISBootloaderDFU::list_devices(). */
 typedef struct
 {
     // Recipe for DFU UID number:
     // sprintf(ctx->match_props.uid, "%X%X", manufacturing_info->uid[0] + manufacturing_info->uid[2], (uint16_t)(manufacturing_info->uid[1] >> 16));
-    char uid[IS_DFU_UID_MAX_SIZE];      // DFU device serial number, from descriptors
-    uint32_t sn;                        // Inertial Sense serial number
-    uint16_t vid;
-    uint16_t pid;
-    libusb_device_handle* handle_libusb;
-    uint8_t iSerialNumber;
+    char uid[IS_DFU_UID_MAX_SIZE];      //!< DFU device serial number/UID, derived from descriptors
+    uint32_t sn;                        //!< Inertial Sense serial number, read from OTP
+    uint16_t vid;                       //!< USB vendor ID (expected STM32_DESCRIPTOR_VENDOR_ID)
+    uint16_t pid;                       //!< USB product ID (expected STM32_DESCRIPTOR_PRODUCT_ID)
+    libusb_device_handle* handle_libusb; //!< open libusb handle for this device
+    uint8_t iSerialNumber;               //!< USB string-descriptor index of the serial-number string
 } is_dfu_id;
 
+/** Fixed-capacity list of DFU-mode USB devices, filled in by cISBootloaderDFU::list_devices(). */
 typedef struct
 {
-    is_dfu_id id[IS_DFU_LIST_LEN];
-    size_t present;
+    is_dfu_id id[IS_DFU_LIST_LEN];      //!< discovered devices; entries [0, present) are valid
+    size_t present;                     //!< number of valid entries in id
 } is_dfu_list;
 
+/**
+ * cISBootloaderBase implementation for the STM32 USB DFU (Device Firmware Upgrade) protocol
+ * exposed by the STM32 ROM bootloader in DfuSe mode (IMX-5). Communicates directly over libusb
+ * control transfers (no serial port); enumerates DFU-mode devices, reads the connected device's
+ * Inertial Sense serial number out of OTP, and downloads an Intel-HEX application image by
+ * erasing and programming flash page-by-page.
+ */
 class cISBootloaderDFU : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param handle an open libusb device handle for the DFU-mode device
+     */
     cISBootloaderDFU(
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb,
         libusb_device_handle* handle
-  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb } 
+  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb }
     {
         m_dfu.handle_libusb = handle;
         m_bootloader_type = IS_BL_TYPE_DFU;
     }
 
-    ~cISBootloaderDFU() 
+    /** Destructor; the caller retains ownership of the libusb device handle. */
+    ~cISBootloaderDFU()
     {
         // TODO: Close DFU device?
     }
-    
+
+    /** @return IS_OP_OK on success (resets the USB device to leave DFU mode), otherwise IS_OP_ERROR */
     is_operation_result reboot();
+    /**
+     * @brief Reboots the device down into IS-bootloader (ISB) mode by writing STM32 option bytes
+     *        that leave DFU-on-boot disabled, then resetting.
+     * @return IS_OP_OK on success, otherwise IS_OP_ERROR
+     */
     is_operation_result reboot_up();
+    /** @return IS_OP_OK always (no level below DFU to reboot into for this transport) */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false) { (void)major; (void)minor; (void)force; return IS_OP_OK; }
 
+    /**
+     * @param param a null-terminated DFU UID string to compare against this device's UID
+     * @return IS_OP_OK if param matches this device's UID, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
 
+    /** @return the device's Inertial Sense serial number, read from OTP, or 0 if it could not be read */
     uint32_t get_device_info();
 
+    /** @return IS_IMAGE_SIGN_DFU always (any DFU-mode STM32L4 device accepts a DFU-compatible image) */
     ISBootloader::eImageSignature check_is_compatible();
-    
+
+    /**
+     * @brief Erases and programs the device's flash from an Intel-HEX image via DFU DNLOAD
+     *        control transfers.
+     * @param image path to the Intel-HEX (.hex) image to flash
+     * @return IS_OP_OK on success, otherwise IS_OP_ERROR
+     */
     is_operation_result download_image(std::string image);
+    /** @return IS_OP_OK always (no-op; reading an image back is not supported over DFU) */
     is_operation_result upload_image(std::string image) { (void)image; return IS_OP_OK; }
+    /** @return IS_OP_OK always (no-op; verification is not supported over DFU) */
     is_operation_result verify_image(std::string image) { (void)image; return IS_OP_OK; }
 
+    /** @return the number of STM32 DFU-mode devices currently enumerable via libusb */
     static int get_num_devices();
+    /**
+     * @param list receives up to IS_DFU_LIST_LEN discovered DFU devices (list->present is set to the count found)
+     * @return IS_OP_OK always
+     */
     static is_operation_result list_devices(is_dfu_list* list);
 
+    /** @return false; this implementation communicates over USB/libusb, not a serial port */
     bool is_serial_device() { return false; }
 
-    static std::mutex m_DFUmutex;
+    static std::mutex m_DFUmutex;   //!< guards concurrent libusb device enumeration/claim across DFU instances
 
 private:
     typedef enum    // Internal only, can change as needed

--- a/src/ISBootloaderISB.h
+++ b/src/ISBootloaderISB.h
@@ -1,9 +1,13 @@
 /**
  * @file ISBootloaderISB.h
+ * @brief Bootloader-protocol implementation for the legacy Inertial-Sense-Bootloader (ISB)
+ *        ASCII/hex-record protocol used to update application images over a serial port
+ *        (uINS-3/4, EVB-2, IMX-5), and to navigate up to APP or down to the ROM bootloader
+ *        (SAM-BA/DFU) level.
+ *
  * @author Dave Cutting
- * @brief Inertial Sense routines for updating application images using the ISB
- *  (Inertial Sense Bootloader) protocol.
- * 
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
  */
 
 /*
@@ -25,55 +29,104 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <mutex>
 
+/**
+ * cISBootloaderBase implementation for the legacy Inertial-Sense-Bootloader (ISB) protocol: an
+ * ASCII/hex-record command set sent over a serial port to query device/version info, and to
+ * erase/program/verify application flash. Also drives the reboot chain into APP mode (up) or
+ * into the ROM bootloader (SAM-BA/DFU) mode (down).
+ */
 class cISBootloaderISB : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param port the serial port the ISB-mode device is connected on
+     */
     cISBootloaderISB(
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb,
         port_handle_t port
-  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb } 
+  ) : cISBootloaderBase{ upload_cb, verify_cb, info_cb }
     {
         m_port = port;
         m_bootloader_type = IS_BL_TYPE_ISB;
         m_port_name = std::string(portName(port));
     }
-    
-    ~cISBootloaderISB() 
+
+    /** Destructor; the serial port is owned by the caller, not closed here. */
+    ~cISBootloaderISB()
     {
-        
+
     }
 
+    /**
+     * @param param a null-terminated serial port name to compare against this device's port
+     * @return IS_OP_OK if param matches this device's serial port name, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
-    
+
+    /** @return IS_OP_OK if the device was reset (see reboot_force()), IS_OP_CLOSED if the port had to be closed, otherwise IS_OP_ERROR */
     is_operation_result reboot();
+    /** @return IS_OP_OK if the restart-bootloader command was sent successfully, otherwise IS_OP_ERROR */
     is_operation_result reboot_force();
+    /** @return IS_OP_OK always; sends the "reboot to program mode" command and closes the port */
     is_operation_result reboot_up();
+    /**
+     * Reboots down into the ROM bootloader (SAM-BA/DFU) level if the device's ISB bootloader
+     * version is older than major.minor (or force is set).
+     * @param major if the target level requires a compatible image, its major version (0 = don't care)
+     * @param minor if the target level requires a compatible image, its minor version (0 = don't care)
+     * @param force if true, reboot even though the device's ISB version already appears up to date
+     * @return IS_OP_OK if no update was needed or the reboot command was sent, otherwise IS_OP_ERROR
+     */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false);
 
+    /** @return the device's Inertial Sense serial number and ISB bootloader version, or 0 if they could not be read */
     uint32_t get_device_info();
 
+    /** @return the eImageSignature bitmask of images this device's ISB bootloader will accept, or IS_IMAGE_SIGN_NONE/error if it could not be determined */
     ISBootloader::eImageSignature check_is_compatible();
-    
-    is_operation_result download_image(std::string image);
-    is_operation_result upload_image(std::string image) { return IS_OP_OK; }
-    is_operation_result verify_image(std::string image);
-    
+
     /**
-     * @brief Gets the version (e.g. 6a) from the bootloader file. Should be used in 
-     *  conjunction with the function that gets the signature from the firmware 
+     * @brief Erases and programs the device's flash from an Intel-HEX image, page by page, over
+     *        the ISB ASCII protocol.
+     * @param image path to the Intel-HEX (.hex) image to flash
+     * @return IS_OP_OK on success, otherwise IS_OP_ERROR
+     */
+    is_operation_result download_image(std::string image);
+    /** @return IS_OP_OK always (no-op; reading an image back is not supported over ISB) */
+    is_operation_result upload_image(std::string image) { return IS_OP_OK; }
+    /**
+     * @brief Verifies the device's flash contents against an Intel-HEX image over the ISB protocol.
+     * @param image path to the Intel-HEX (.hex) image to verify against the device
+     * @return IS_OP_OK if the device's contents match image, otherwise IS_OP_ERROR
+     */
+    is_operation_result verify_image(std::string image);
+
+    /**
+     * @brief Gets the version (e.g. 6a) from the bootloader file. Should be used in
+     *  conjunction with the function that gets the signature from the firmware
      *  image.
-     * 
+     *
      * @param filename file name of the bootloader
      * @param major filled with major version
      * @param minor filled with minor version
-     * @return is_operation_result 
+     * @return is_operation_result
      */
     static is_operation_result get_version_from_file(const char* filename, uint8_t* major, char* minor);
 
+    /**
+     * Performs the ISB handshake sequence (repeated 'U' characters) required before the bootloader
+     * will accept commands. A no-op if this instance has already handshaken successfully.
+     * @param port the serial port to handshake over
+     * @return IS_OP_OK once a handshake response is received, otherwise IS_OP_ERROR
+     */
     is_operation_result handshake_sync(port_handle_t port);
 
+    /** Clears the process-wide list of serial numbers already reset by reboot(). */
     static void reset_serial_list() { serial_list_mutex.lock(); serial_list.clear(); serial_list_mutex.unlock(); }
 
 private:

--- a/src/ISBootloaderISB.h
+++ b/src/ISBootloaderISB.h
@@ -97,7 +97,7 @@ public:
      * @return IS_OP_OK on success, otherwise IS_OP_ERROR
      */
     is_operation_result download_image(std::string image);
-    /** @return IS_OP_OK always (no-op; reading an image back is not supported over ISB) */
+    /** @param image unused @return IS_OP_OK always (no-op; reading an image back is not supported over ISB) */
     is_operation_result upload_image(std::string image) { return IS_OP_OK; }
     /**
      * @brief Verifies the device's flash contents against an Intel-HEX image over the ISB protocol.

--- a/src/ISBootloaderSAMBA.h
+++ b/src/ISBootloaderSAMBA.h
@@ -1,8 +1,11 @@
 /**
  * @file ISBootloaderSAMBA.h
+ * @brief Bootloader-protocol implementation for the Atmel SAM-BA ROM bootloader protocol used
+ *        by SAMx70 parts (uINS-3/4, EVB-2) to erase and program the ISB bootloader image itself.
+ *
  * @author Dave Cutting
- * @brief Inertial Sense routines for updating ISB images using SAM-BA protocol.
- * 
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
  */
 
 /*
@@ -22,9 +25,21 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "ISBootloaderBase.h"
 
+/**
+ * cISBootloaderBase implementation for the Atmel SAM-BA ROM bootloader protocol, present on
+ * SAMx70 parts (uINS-3/4, EVB-2). This level sits below ISB in the reboot chain and is used
+ * specifically to erase and reprogram the ISB bootloader image itself (word-level peripheral
+ * reads/writes and page-level flash programming over a serial UART/USB CDC connection).
+ */
 class cISBootloaderSAMBA : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param port the serial port the SAM-BA-mode device is connected on
+     */
     cISBootloaderSAMBA(
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
@@ -36,24 +51,45 @@ public:
         m_port_name = std::string(portName(port));
         m_bootloader_type = IS_BL_TYPE_SAMBA;
     }
-    
-    ~cISBootloaderSAMBA() 
+
+    /** Destructor; the serial port is owned by the caller, not closed here. */
+    ~cISBootloaderSAMBA()
     {
-        
+
     }
 
+    /**
+     * @param param a null-terminated serial port name to compare against this device's port
+     * @return IS_OP_OK if param matches this device's serial port name, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
-    
+
+    /** @return IS_OP_OK always; issues a processor reset via the reset controller register */
     is_operation_result reboot();
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; sets the GPNVM boot-from-flash bit then reboots into IS-bootloader mode */
     is_operation_result reboot_up();
+    /** @return IS_OP_OK always (no level below SAM-BA to reboot into for this transport) */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false) { (void)major; (void)minor; (void)force; return IS_OP_OK; }
 
+    /** @return the device's Inertial Sense serial number, or 0 if it could not be read */
     uint32_t get_device_info();
-    
+
+    /**
+     * @brief Erases and programs the device's flash from an Intel-HEX image, page by page, over
+     *        the SAM-BA protocol.
+     * @param image path to the Intel-HEX (.hex) image to flash (the ISB bootloader image)
+     * @return IS_OP_OK on success, otherwise IS_OP_ERROR
+     */
     is_operation_result download_image(std::string image);
+    /** @return IS_OP_OK always (no-op; reading an image back is not supported over SAM-BA) */
     is_operation_result upload_image(std::string image) { return IS_OP_OK; }
+    /**
+     * @brief Verifies the device's flash contents against an Intel-HEX image over the SAM-BA protocol.
+     * @param image path to the Intel-HEX (.hex) image to verify against the device
+     * @return IS_OP_OK if the device's contents match image, otherwise IS_OP_ERROR
+     */
     is_operation_result verify_image(std::string image);
-    
+
     /**
      * @brief Check if the referenced device is a SAM-BA device, and that the image matches
      *
@@ -63,13 +99,12 @@ public:
 private:
 
     static constexpr int SAMBA_PAGE_SIZE = 512;
-    
+
     is_operation_result erase_flash();
 
     /**
      * @brief Read a single (32-bit) word from the device. Can read from any peripheral or memory
-     * 
-     * @param ctx device context with open serial port registered under `handler`
+     *
      * @param address Address to read at
      * @param word Filled with the read value at return
      */
@@ -77,8 +112,7 @@ private:
 
     /**
      * @brief Write a single (32-bit) word to the device. Can write to any peripheral or memory
-     * 
-     * @param ctx device context with open serial port registered under `handler`
+     *
      * @param address Address to write at
      * @param word Value to write
      */
@@ -86,17 +120,15 @@ private:
 
     /**
      * @brief Wait for the embedded flash controller to be ready or not ready
-     * 
-     * @param ctx device context with open serial port registered under `handler`
+     *
      * @param waitReady if `true`, wait until controller is ready. `false`, wait until not ready
      */
     is_operation_result wait_eefc_ready(bool waitReady);
 
     /**
-     * @brief Write a buffer to the device if connected via UART, minding rules (not 
+     * @brief Write a buffer to the device if connected via UART, minding rules (not
      *  sure where the rules are documented) of the UART connection
-     * 
-     * @param ctx device context with open serial port registered under `handler`
+     *
      * @param buf buffer to send to device
      * @param len length of buffer
      */
@@ -104,8 +136,7 @@ private:
 
    /**
      * @brief Erase, then write a page of flash on the device
-     * 
-     * @param ctx device context with open serial port registered under `handler`
+     *
      * @param offset offset from the base address of the flash memory to write at
      * @param data buffer to write. Must be at least `SAMBA_PAGE_SIZE` long
      * @param isUSB if the device is connected over UART, different rules apply for transmission

--- a/src/ISBootloaderSAMBA.h
+++ b/src/ISBootloaderSAMBA.h
@@ -68,7 +68,12 @@ public:
     is_operation_result reboot();
     /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; sets the GPNVM boot-from-flash bit then reboots into IS-bootloader mode */
     is_operation_result reboot_up();
-    /** @return IS_OP_OK always (no level below SAM-BA to reboot into for this transport) */
+    /**
+     * @param major unused
+     * @param minor unused
+     * @param force unused
+     * @return IS_OP_OK always (no level below SAM-BA to reboot into for this transport)
+     */
     is_operation_result reboot_down(uint8_t major = 0, char minor = 0, bool force = false) { (void)major; (void)minor; (void)force; return IS_OP_OK; }
 
     /** @return the device's Inertial Sense serial number, or 0 if it could not be read */
@@ -81,7 +86,7 @@ public:
      * @return IS_OP_OK on success, otherwise IS_OP_ERROR
      */
     is_operation_result download_image(std::string image);
-    /** @return IS_OP_OK always (no-op; reading an image back is not supported over SAM-BA) */
+    /** @param image unused @return IS_OP_OK always (no-op; reading an image back is not supported over SAM-BA) */
     is_operation_result upload_image(std::string image) { return IS_OP_OK; }
     /**
      * @brief Verifies the device's flash contents against an Intel-HEX image over the SAM-BA protocol.
@@ -92,7 +97,7 @@ public:
 
     /**
      * @brief Check if the referenced device is a SAM-BA device, and that the image matches
-     *
+     * @return the eImageSignature bitmask of images this device's bootloader will accept, or IS_IMAGE_SIGN_ERROR
      */
     ISBootloader::eImageSignature check_is_compatible();
 

--- a/src/ISBootloaderSTM32.h
+++ b/src/ISBootloaderSTM32.h
@@ -1,3 +1,14 @@
+/**
+ * @file ISBootloaderSTM32.h
+ * @brief Bootloader-protocol implementation for the STM32 UART ROM bootloader (the same
+ *        USART-based command set exposed by the chip's built-in bootloader before DFU/ISB is
+ *        available), used to erase/read/write flash and jump to an application entry point.
+ *
+ * @author Dave Cutting
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
+ */
+
 /*
 MIT LICENSE
 
@@ -15,36 +26,63 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "ISBootloaderBase.h"
 
+/**
+ * cISBootloaderBase implementation for the STM32 ROM bootloader's UART command protocol
+ * (GET/GET_VERSION/GET_ID/READ_MEMORY/WRITE_MEMORY/GO/erase, per ST AN3155). Used to identify
+ * the connected STM32 part, and to erase, program, and jump into a flashed application image.
+ */
 class cISBootloaderSTM32 : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param filename path to the firmware image this session will operate on
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param port the serial port the device is connected on
+     */
     cISBootloaderSTM32(
         std::string filename,
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb,
         port_handle_t port
-  ) : cISBootloaderBase{ filename, upload_cb, verify_cb, info_cb } 
+  ) : cISBootloaderBase{ filename, upload_cb, verify_cb, info_cb }
     {
         m_port = port;
     }
-    
-    ~cISBootloaderSTM32() 
+
+    /** Destructor; the serial port is owned by the caller, not closed here. */
+    ~cISBootloaderSTM32()
     {
-        
+
     }
 
+    /**
+     * @param param a null-terminated serial port name to compare against this device's port
+     * @return IS_OP_OK if param matches this device's serial port name, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
-    
+
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR */
     is_operation_result reboot() {}
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; reboots up into the next bootloader/application level */
     is_operation_result reboot_up();
 
+    /** @return the device's Inertial Sense serial number, or 0 if it could not be read */
     uint32_t get_device_info();
-    
+
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; erases and programs flash from the image path passed to the constructor */
     is_operation_result download_image(void);
+    /** @return IS_OP_OK always (no-op; reading an image back is not supported over this transport) */
     is_operation_result upload_image(void) { return IS_OP_OK; }
+    /** @return IS_OP_OK always (no-op; verification is not supported over this transport) */
     is_operation_result verify_image(void) { return IS_OP_OK; }
-    
+
+    /**
+     * @param imgSign the eImageSignature bitmask of the candidate image to check against this device
+     * @return non-zero if the connected STM32 device ID matches a known/supported part and imgSign is compatible with it, otherwise 0
+     */
     uint8_t check_is_compatible(uint32_t imgSign);
 
 private:

--- a/src/ISBootloaderSony.h
+++ b/src/ISBootloaderSony.h
@@ -27,9 +27,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISBootloaderBase.h"
 
 #ifndef MAX_PATH
-#define MAX_PATH_SONY 260
+#define MAX_PATH_SONY 260       //!< maximum path length for Sony bootloader image filenames, when the platform doesn't define MAX_PATH
 #else
-#define MAX_PATH_SONY MAX_PATH
+#define MAX_PATH_SONY MAX_PATH  //!< maximum path length for Sony bootloader image filenames, aliased to the platform's MAX_PATH
 #endif
 
 /**

--- a/src/ISBootloaderSony.h
+++ b/src/ISBootloaderSony.h
@@ -1,8 +1,12 @@
 /**
  * @file ISBootloaderSony.h
+ * @brief Bootloader-protocol implementation for the Sony CXD5610 GNSS receiver's bootloader
+ *        protocol (framed opcode/checksum messages over UART), used to inject and execute the
+ *        chip's updater program and write new SDK/app/lib/cfg firmware images.
+ *
  * @author Dave Cutting
- * @brief Inertial Sense routines for updating ISB images using SAM-BA protocol.
- * 
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
  */
 
 /*
@@ -28,45 +32,74 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #define MAX_PATH_SONY MAX_PATH
 #endif
 
+/**
+ * cISBootloaderBase implementation for the Sony CXD5610 GNSS receiver's bootloader protocol: a
+ * framed, checksummed opcode message set sent over UART (CXD_SET_STATUS/PROGRAM_CODE_INJECTION/
+ * PROGRAM_EXECUTION/WRITE_PROGRAM/etc.) used to restart the chip into bootloader mode, inject and
+ * run its updater program, and write the SDK/app/lib/cfg firmware images that make up a release.
+ */
 class cISBootloaderSONY : public ISBootloader::cISBootloaderBase
 {
 public:
+    /**
+     * @param filename path to the firmware image this session will operate on
+     * @param upload_cb callback invoked to report image-download progress; dummy_update_callback if null
+     * @param verify_cb callback invoked to report image-verify progress; dummy_verify_callback if null
+     * @param info_cb callback invoked to report status/log messages; dummy_info_callback if null
+     * @param port the serial port the device is connected on
+     */
     cISBootloaderSONY(
         std::string filename,
         fwUpdate::pfnProgressCb upload_cb,
         fwUpdate::pfnProgressCb verify_cb,
         fwUpdate::pfnStatusCb info_cb,
         port_handle_t port
-  ) : cISBootloaderBase{ filename, upload_cb, verify_cb, info_cb } 
+  ) : cISBootloaderBase{ filename, upload_cb, verify_cb, info_cb }
     {
         m_port = port;
     }
-    
-    ~cISBootloaderSONY() 
+
+    /** Destructor; the serial port is owned by the caller, not closed here. */
+    ~cISBootloaderSONY()
     {
-        
+
     }
 
+    /**
+     * @param param a null-terminated serial port name to compare against this device's port
+     * @return IS_OP_OK if param matches this device's serial port name, otherwise IS_OP_ERROR
+     */
     is_operation_result match_test(void* param);
-    
+
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR */
     is_operation_result reboot();
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; reboots up into the next bootloader/application level */
     is_operation_result reboot_up();
 
+    /** @return 0 always (not implemented for this transport) */
     uint32_t get_device_info() {return 0; }
-    
+
+    /** @return IS_OP_OK on success, otherwise IS_OP_ERROR; writes the SDK/app/lib/cfg images from m_sony_filenames to the device */
     is_operation_result download_image(void);
+    /** @return IS_OP_OK always (no-op; reading an image back is not supported over this transport) */
     is_operation_result upload_image(void) { return IS_OP_OK; }
+    /** @return IS_OP_OK if the device's contents match the previously-downloaded image, otherwise IS_OP_ERROR */
     is_operation_result verify_image(void);
-    
+
+    /**
+     * @param imgSign the eImageSignature bitmask of the candidate image to check against this device
+     * @return non-zero if the connected CXD5610 device could be restarted into bootloader mode and imgSign is compatible with it, otherwise 0
+     */
     uint8_t check_is_compatible(uint32_t imgSign);
 
-    typedef struct 
+    /** Paths to the individual firmware components that together make up one Sony CXD5610 release. */
+    typedef struct
     {
-        char updater[MAX_PATH_SONY];
-        char app[MAX_PATH_SONY];
-        char sdk[MAX_PATH_SONY];
-        char lib[MAX_PATH_SONY];
-        char cfg[MAX_PATH_SONY];
+        char updater[MAX_PATH_SONY];    //!< path to the bootloader updater program to inject and run on the device
+        char app[MAX_PATH_SONY];        //!< path to the application firmware image
+        char sdk[MAX_PATH_SONY];        //!< path to the Sony GNSS SDK image
+        char lib[MAX_PATH_SONY];        //!< path to the supporting library image
+        char cfg[MAX_PATH_SONY];        //!< path to the configuration image
     } m_sony_filenames;
 
 private:

--- a/src/ISBootloaderThread.h
+++ b/src/ISBootloaderThread.h
@@ -1,8 +1,13 @@
 /**
  * @file ISBootloaderThread.h
+ * @brief Drives one or more cISBootloaderBase bootloader sessions concurrently, one worker
+ *        thread per connected serial port (or per libusb DFU device), so multiple devices can
+ *        be mode-switched and flashed in parallel. See cISBootloaderThread for the thread
+ *        lifecycle (start/poll/cancel/join) and callback contract.
+ *
  * @author Dave Cutting
- * @brief Inertial Sense routines for updating embedded systems in parallel
- * 
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved. See the MIT
+ *            license text below.
  */
 
 /*
@@ -35,22 +40,54 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISUtilities.h"
 #include "ISBootloaderBase.h"
 
+/**
+ * Coordinates one bootloader "pass" across every connected device by fanning work out to a pool
+ * of worker threads -- one thread per serial port (thread_serial_t) or per libusb DFU device
+ * (thread_libusb_t) -- and joining them back together before returning to the caller. All state
+ * (device contexts, thread maps, progress/status callbacks) is static/process-wide: only one
+ * update sequence may be in flight at a time, serialized by m_update_mutex.
+ *
+ * Thread lifecycle:
+ *  - **Start**: set_mode_and_check_devices() and update() each spin up worker threads on demand
+ *    (via create_and_start_serial_thread()/create_and_start_libusb_thread()) as new ports/devices
+ *    are discovered, up to once per port/device per phase.
+ *  - **Poll**: the calling thread polls each worker's `done` flag in a loop, optionally invoking
+ *    a caller-supplied waitAction() callback every iteration (e.g. to pump a UI event loop) so the
+ *    call remains effectively synchronous to the caller despite the internal threading.
+ *  - **Cancel**: cancel_update() (or the progress callbacks returning IS_OP_CANCELLED, checked via
+ *    true_if_cancelled()) sets m_continue_update = false, which the poll loops observe to stop
+ *    launching new work and unwind.
+ *  - **Join**: once every worker's `done` flag is set (or cancellation/timeout is observed), each
+ *    thread is joined and freed with threadJoinAndFree() before the next phase begins or the call
+ *    returns.
+ *
+ * Callback contract: uploadProgress/verifyProgress (fwUpdate::pfnProgressCb) are invoked with the
+ * current step name/index and 0-100 percent complete, and their return value doubles as a cancel
+ * signal -- returning IS_OP_CANCELLED (checked by true_if_cancelled()) aborts the in-progress
+ * update. infoProgress (fwUpdate::pfnStatusCb) receives printf-style status/log messages. All
+ * three callbacks may be invoked from worker threads, not just the calling thread.
+ */
 class cISBootloaderThread
 {
 public:
     cISBootloaderThread() {};
     ~cISBootloaderThread() {};
 
+    /** Per-serial-port worker-thread context used while mode-switching or updating one device. */
     class thread_serial_t{
     public:
-        void* thread;
-        serial_port_t serialPort;
-        ISBootloader::cISBootloaderBase* ctx;
-        is_operation_result opResult;
-        bool done;
-        bool reuse_port;
-        bool force_isb;
+        void* thread;                                //!< opaque handle to the running worker thread, or NULL once joined
+        serial_port_t serialPort;                    //!< serial port state owned by this worker
+        ISBootloader::cISBootloaderBase* ctx;         //!< the bootloader session created for this device, once identified (NULL until then)
+        is_operation_result opResult;                 //!< result of the worker's most recent operation
+        bool done;                                    //!< true once the worker thread has finished and can be joined
+        bool reuse_port;                              //!< true if the port should be reopened and reused in the next phase rather than treated as new
+        bool force_isb;                                //!< true if an ISB bootloader update should be forced even if the version already appears compatible
 
+        /**
+         * @param port_name the serial port name (e.g. "/dev/ttyACM0") this worker will operate on
+         * @param force_isb_update true to force an ISB bootloader update regardless of version
+         */
         thread_serial_t(const std::string& port_name, bool force_isb_update = false) {
             // FIXME: This is pretty jank... and ridiculous.  I can do better!
             port_handle_t port = (port_handle_t)&(serialPort);
@@ -61,6 +98,7 @@ public:
             done = false;
             force_isb = force_isb_update;
         }
+        /** Closes the serial port and marks the worker done. */
         virtual ~thread_serial_t() {
             serialPortClose((port_handle_t)&serialPort);
             thread = NULL;
@@ -68,24 +106,41 @@ public:
         }
     };
 
+    /** Per-libusb-device worker-thread context used while updating one DFU device. */
     class thread_libusb_t {
     public:
-        void* thread;
-        libusb_device_handle* handle;
-        char uid[100];
-        ISBootloader::cISBootloaderBase* ctx;
-        is_operation_result opResult;
-        bool done;
+        void* thread;                              //!< opaque handle to the running worker thread, or NULL once joined
+        libusb_device_handle* handle;               //!< open libusb handle for the device this worker operates on
+        char uid[100];                              //!< the device's DFU UID string, used to avoid double-dispatching the same device
+        ISBootloader::cISBootloaderBase* ctx;        //!< the bootloader session created for this device, once identified (NULL until then)
+        is_operation_result opResult;                //!< result of the worker's most recent operation
+        bool done;                                   //!< true once the worker thread has finished and can be joined
     };
 
+    /** Identifies one ISB-mode device whose bootloader version is older than the supplied image and would be updated if the update proceeds. */
     typedef struct
     {
-        uint32_t sn;
-        uint8_t major;
-        char minor;
-        port_handle_t port;
+        uint32_t sn;         //!< the device's Inertial Sense serial number
+        uint8_t major;       //!< the device's current ISB bootloader major version
+        char minor;          //!< the device's current ISB bootloader minor version
+        port_handle_t port;  //!< the serial port the device is connected on
     } confirm_bootload_t;
 
+    /**
+     * Puts every device on the given ports into the correct mode to begin an update (APP devices
+     * are rebooted into ISB, ISB devices are queried for their bootloader version) and reports
+     * which ones would actually be updated, without performing the update itself. Intended to be
+     * called before update() so the caller can confirm with the user first.
+     * @param comPorts the serial ports to consider; ports not connected at call time are ignored
+     * @param baudRate the serial baud rate to use once devices are in ISB mode
+     * @param firmware candidate firmware/bootloader image paths for every supported target
+     * @param uploadProgress callback invoked to report download progress; also polled for cancellation
+     * @param verifyProgress callback invoked to report verify progress
+     * @param infoProgress callback invoked to report status/log messages
+     * @param waitAction optional callback invoked on every poll iteration (e.g. to pump a UI event loop); may be NULL
+     * @param updatesPending if non-null, receives one confirm_bootload_t per ISB device that would be updated
+     * @return true on success, false if the update was aborted (bad firmware paths, incompatible bootloader, or cancellation)
+     */
     static bool set_mode_and_check_devices(
         std::vector<std::string>&               comPorts,
         int                                     baudRate,
@@ -97,6 +152,20 @@ public:
         std::vector<confirm_bootload_t>*        updatesPending = NULL
     );
 
+    /**
+     * Drives every device on the given ports (and any DFU devices found via libusb) through
+     * however many reboot/flash steps are needed to reach an up-to-date application image,
+     * running one worker thread per device/port and joining them all before returning.
+     * @param comPorts the serial ports to consider; ports not connected at call time are ignored
+     * @param force_isb_update if true, force an ISB bootloader update even if the version already appears compatible
+     * @param baudRate the serial baud rate to use for the update
+     * @param firmware candidate firmware/bootloader image paths for every supported target
+     * @param uploadProgress callback invoked to report download progress; also polled for cancellation
+     * @param verifyProgress callback invoked to report verify progress
+     * @param infoProgress callback invoked to report status/log messages
+     * @param waitAction optional callback invoked on every poll iteration (e.g. to pump a UI event loop); may be NULL
+     * @return IS_OP_OK if at least one device updated successfully and none failed, IS_OP_CANCELLED if cancelled via a progress callback, otherwise the first error encountered
+     */
     static is_operation_result update(
         std::vector<std::string>&               comPorts,
         bool                                    force_isb_update,
@@ -108,13 +177,14 @@ public:
         void                                    (*waitAction)()
     );
 
+    /** Requests that the in-progress update() or set_mode_and_check_devices() call stop launching new work and unwind as soon as possible. */
     static void cancel_update();
-    
-    static std::vector<ISBootloader::cISBootloaderBase*> ctx;
-    static std::mutex m_ctx_mutex;
 
-    static bool m_update_in_progress;
-    
+    static std::vector<ISBootloader::cISBootloaderBase*> ctx;   //!< bootloader sessions created for devices identified during the current/most recent update pass
+    static std::mutex m_ctx_mutex;                                //!< guards concurrent access to ctx across worker threads
+
+    static bool m_update_in_progress;   //!< true while update() or set_mode_and_check_devices() is running
+
 private:
     static void create_and_start_serial_thread(const std::string& port, void(*function)(void*), bool force_isb_update = false);
     static void create_and_start_libusb_thread(void(*function)(void*), libusb_device_handle* handle);

--- a/src/ISDFUFirmwareUpdater.h
+++ b/src/ISDFUFirmwareUpdater.h
@@ -1,6 +1,9 @@
 /**
- * @file ISDFUFirmwareUpdater.h 
- * @brief ${BRIEF_DESC}
+ * @file ISDFUFirmwareUpdater.h
+ * @brief USB DFU (Device Firmware Update) support: DFUDevice wraps a single libusb DFU device
+ *        (open/erase/write/verify/finalize over STM32's DfuSe extensions), and
+ *        ISDFUFirmwareUpdater adapts that to the fwUpdate::FirmwareUpdateDevice interface used
+ *        by the rest of the firmware update stack, plus static device enumeration/discovery.
  *
  * @author Kyle Mallory on 11/28/23.
  * @copyright Copyright (c) 2023 Inertial Sense, Inc. All rights reserved.
@@ -73,43 +76,45 @@ const md5hash_t DFU_FINGERPRINT_STM32L4    = { { 0xFA, 0x45, 0x85, 0x0B, 0xE6, 0
 const md5hash_t DFU_FINGERPRINT_STM32U5_1M = { { 0x82, 0x03, 0x64, 0x70, 0x21, 0x65, 0x55, 0x2A, 0xA2, 0x8B, 0xE7, 0x9D, 0x69, 0xBB, 0xA6, 0x2F } };
 const md5hash_t DFU_FINGERPRINT_STM32U5_2M = { { 0xB5, 0xCE, 0xEA, 0xEB, 0xEE, 0xA7, 0x53, 0x3C, 0x4D, 0xCC, 0xBF, 0x30, 0x71, 0x9B, 0xE2, 0xAB } };
 
-typedef enum    // From DFU manual, do not change
+/** USB DFU class bStatus values (DFU spec §6.1.2), reported by DFU_GETSTATUS. Values are fixed by the spec -- do not change. */
+typedef enum
 {
-    DFU_STATUS_OK = 0,
-    DFU_STATUS_ERR_TARGET,
-    DFU_STATUS_ERR_FILE,
-    DFU_STATUS_ERR_WRITE,
-    DFU_STATUS_ERR_ERASED,
-    DFU_STATUS_ERR_CHECK_ERASED,
-    DFU_STATUS_ERR_PROG,
-    DFU_STATUS_ERR_VERIFY,
-    DFU_STATUS_ERR_ADDRESS,
-    DFU_STATUS_ERR_NOTDONE,
-    DFU_STATUS_ERR_FIRMWARE,
-    DFU_STATUS_ERR_VENDOR,
-    DFU_STATUS_ERR_USBR,
-    DFU_STATUS_ERR_POR,
-    DFU_STATUS_ERR_UNKNOWN,
-    DFU_STATUS_ERR_STALLEDPKT,
+    DFU_STATUS_OK = 0,             //!< no error condition is present
+    DFU_STATUS_ERR_TARGET,         //!< file is not targeted for use by this device
+    DFU_STATUS_ERR_FILE,           //!< file failed a device-specific verification test
+    DFU_STATUS_ERR_WRITE,          //!< device is unable to write memory
+    DFU_STATUS_ERR_ERASED,         //!< memory erase function failed
+    DFU_STATUS_ERR_CHECK_ERASED,   //!< memory erase check failed
+    DFU_STATUS_ERR_PROG,           //!< program memory function failed
+    DFU_STATUS_ERR_VERIFY,         //!< programmed memory failed verification
+    DFU_STATUS_ERR_ADDRESS,        //!< cannot program memory due to received address that is out of range
+    DFU_STATUS_ERR_NOTDONE,        //!< received DFU_DNLOAD with wLength = 0, but device does not think it has all of the data yet
+    DFU_STATUS_ERR_FIRMWARE,       //!< device's firmware is corrupt and cannot return to run-time (non-DFU) operations
+    DFU_STATUS_ERR_VENDOR,         //!< iString indicates a vendor-specific error
+    DFU_STATUS_ERR_USBR,           //!< device detected unexpected USB reset signaling
+    DFU_STATUS_ERR_POR,            //!< device detected unexpected power on reset
+    DFU_STATUS_ERR_UNKNOWN,        //!< something went wrong, but the device does not know what it was
+    DFU_STATUS_ERR_STALLEDPKT,     //!< device stalled an unexpected request
 
-    DFU_STATUS_NUM,
+    DFU_STATUS_NUM,                //!< number of defined status values; must be last
 } dfu_status;
 
-typedef enum    // From DFU manual, do not change
+/** USB DFU class state machine states (DFU spec §6.1.2), reported by DFU_GETSTATE. Values are fixed by the spec -- do not change. */
+typedef enum
 {
-    DFU_STATE_APP_IDLE = 0,
-    DFU_STATE_APP_DETACH,
-    DFU_STATE_IDLE,
-    DFU_STATE_DNLOAD_SYNC,
-    DFU_STATE_DNBUSY,
-    DFU_STATE_DNLOAD_IDLE,
-    DFU_STATE_MANIFEST_SYNC,
-    DFU_STATE_MANIFEST,
-    DFU_STATE_MANIFEST_WAIT_RESET,
-    DFU_STATE_UPLOAD_IDLE,
-    DFU_STATE_ERROR,
+    DFU_STATE_APP_IDLE = 0,         //!< device is running its normal (non-DFU) application
+    DFU_STATE_APP_DETACH,           //!< device has received DFU_DETACH and is waiting for a USB reset
+    DFU_STATE_IDLE,                 //!< device is operating in the DFU mode and is waiting for requests
+    DFU_STATE_DNLOAD_SYNC,          //!< device has received a block and is waiting for the host to solicit its status
+    DFU_STATE_DNBUSY,               //!< device is programming a control-write block into its nonvolatile memory
+    DFU_STATE_DNLOAD_IDLE,          //!< device is processing a download operation and is expecting more data
+    DFU_STATE_MANIFEST_SYNC,        //!< device has received the final block and is waiting for the host to solicit its status
+    DFU_STATE_MANIFEST,             //!< device is in the manifestation phase, programming the received image
+    DFU_STATE_MANIFEST_WAIT_RESET,  //!< device has programmed its memory and is waiting for a USB reset or power-on reset
+    DFU_STATE_UPLOAD_IDLE,          //!< device is processing an upload operation and is expecting more requests
+    DFU_STATE_ERROR,                //!< an error has occurred; device is waiting for DFU_CLRSTATUS
 
-    DFU_STATE_NUM,
+    DFU_STATE_NUM,                  //!< number of defined states; must be last
 } dfu_state;
 
 /**
@@ -140,48 +145,68 @@ typedef enum    // From DFU manual, do not change
     path="3-11.4", alt=0, name="@Internal Flash   /0x08000000/128*08Kg"
 **/
 
+/** One accessible memory segment/region reported by a DfuSe alternate-setting descriptor. */
 typedef struct {
-    uint64_t address;                       // the base address of the accessible memory, reported by the DFU descriptor
-    uint16_t pages;                         // the number of pages for this descriptor, reported by the DFU descriptor
-    uint32_t pageSize;                      // the size of each page related to this descriptor, reported by the DFU descriptor
-    uint8_t pageType;                       // the page type (readable/writable/erasable, etc)
+    uint64_t address;                       //!< the base address of the accessible memory, reported by the DFU descriptor
+    uint16_t pages;                          //!< the number of pages for this descriptor, reported by the DFU descriptor
+    uint32_t pageSize;                       //!< the size of each page related to this descriptor, reported by the DFU descriptor
+    uint8_t pageType;                        //!< the page type (readable/writable/erasable, etc)
 } dfu_memory_t;
 
+/** STM32 DfuSe alternate-setting indices, identifying which memory region an interface's altsetting addresses. */
 typedef enum : uint16_t {
-    STM32_DFU_INTERFACE_FLASH = 0, // @Internal Flash
-    STM32_DFU_INTERFACE_OPTIONS = 1, // @Option Bytes
-    STM32_DFU_INTERFACE_OTP = 2, // @OTP Memory
-    STM32_DFU_INTERFACE_FEATURES = 3  // @Device Feature
+    STM32_DFU_INTERFACE_FLASH = 0,    //!< "@Internal Flash" -- main program flash
+    STM32_DFU_INTERFACE_OPTIONS = 1,  //!< "@Option Bytes" -- STM32 option byte region (RDP, boot config, etc.)
+    STM32_DFU_INTERFACE_OTP = 2,      //!< "@OTP Memory" -- one-time-programmable region (Inertial Sense serial/HW id)
+    STM32_DFU_INTERFACE_FEATURES = 3  //!< "@Device Feature" -- vendor-specific DfuSe command interface
 } dfu_interface_alternatives;
 
-typedef enum    // Internal only, can change as needed
+/**
+ * Result/error code for DFUDevice operations. Internal to this header (not part of the wire
+ * protocol), so values can change as needed.
+ */
+typedef enum
 {
-    DFU_ERROR_NONE = 0,
-    DFU_ERROR_DEVICE_NOTFOUND = -1,
-    DFU_ERROR_DEVICE_BUSY = -2,
-    DFU_ERROR_TIMEOUT = -3,
-    DFU_ERROR_LIBUSB = -4,
-    DFU_ERROR_STATUS = -5,
-    DFU_ERROR_INVALID_ARG = -6,
-    DFU_ERROR_FILE_NOTFOUND = -7,
-    DFU_ERROR_FILE_INVALID = -8,
-    DFU_ERROR_RDP_LOCKED = -9,              // SN-8043: chip at RDP Level 1 (RDP > 0xAA); flash writes are silently dropped. Recoverable via erase/RDP-regress.
-    DFU_ERROR_RDP_PERMANENT_LOCKED = -10,   // SN-8043: chip at RDP Level 2 (RDP == 0xCC); permanently locked, cannot be recovered.
-    DFU_ERROR_WRITE_VERIFY_FAILED = -11,    // SN-8043: post-write readback did not match the source image; the write did not land.
+    DFU_ERROR_NONE = 0,                    //!< operation succeeded
+    DFU_ERROR_DEVICE_NOTFOUND = -1,        //!< no matching DFU device was found
+    DFU_ERROR_DEVICE_BUSY = -2,            //!< device is already open/in-use
+    DFU_ERROR_TIMEOUT = -3,                //!< a USB transfer or state wait timed out
+    DFU_ERROR_LIBUSB = -4,                 //!< a libusb call failed; see getLastLibusbError()/getLastLibusbErrorName()
+    DFU_ERROR_STATUS = -5,                 //!< the device reported a DFU error status (dfu_status != DFU_STATUS_OK)
+    DFU_ERROR_INVALID_ARG = -6,            //!< an invalid argument was passed (e.g. bad address/length)
+    DFU_ERROR_FILE_NOTFOUND = -7,          //!< the firmware image file could not be opened
+    DFU_ERROR_FILE_INVALID = -8,           //!< the firmware image file failed validation
+    DFU_ERROR_RDP_LOCKED = -9,             //!< SN-8043: chip at RDP Level 1 (RDP > 0xAA); flash writes are silently dropped. Recoverable via erase/RDP-regress.
+    DFU_ERROR_RDP_PERMANENT_LOCKED = -10,  //!< SN-8043: chip at RDP Level 2 (RDP == 0xCC); permanently locked, cannot be recovered.
+    DFU_ERROR_WRITE_VERIFY_FAILED = -11,   //!< SN-8043: post-write readback did not match the source image; the write did not land.
 } dfu_error;
 
+/** Processor family detected from a DFU device's USB fingerprint (see DFUDevice::getProcessorType). */
 typedef enum {
-    IS_PROCESSOR_UNKNOWN = -1,
-    IS_PROCESSOR_SAMx70 = 0,        // uINS-3/4, EVB-2
-    IS_PROCESSOR_STM32L4,           // IMX-5
-    IS_PROCESSOR_STM32U5,           // GPX-1, IMX-6
+    IS_PROCESSOR_UNKNOWN = -1,      //!< not yet identified / unrecognized fingerprint
+    IS_PROCESSOR_SAMx70 = 0,        //!< uINS-3/4, EVB-2
+    IS_PROCESSOR_STM32L4,           //!< IMX-5
+    IS_PROCESSOR_STM32U5,           //!< GPX-1, IMX-6
 
-    IS_PROCESSOR_NUM,               // Must be last
+    IS_PROCESSOR_NUM,               //!< number of known processor types; must be last
 } eProcessorType;
 
+/**
+ * Wraps a single USB DFU device (identified by a libusb_device) and drives an STM32 DfuSe-style
+ * firmware update over it: open/claim -> erase -> write -> verify -> finalize, plus descriptor-based
+ * device identification (processor type, flash size, fingerprint) used to match a physical module
+ * against a target and firmware image.
+ */
 class DFUDevice {
 public:
 
+    /**
+     * Wraps the given (already-referenced) libusb device; does not open it. Reads USB descriptors
+     * to populate identification fields (see fetchDeviceInfo()).
+     * @param device the libusb device to wrap; this object takes ownership (unref'd in the destructor)
+     * @param cbProgress optional callback invoked to report upload/erase/verify progress
+     * @param cbStatus optional callback invoked to report status/log messages
+     */
     DFUDevice(libusb_device *device, fwUpdate::pfnProgressCb cbProgress = nullptr, fwUpdate::pfnStatusCb  cbStatus = nullptr) {
         usbDevice = device;
         progressCb = cbProgress;
@@ -190,6 +215,7 @@ public:
         fetchDeviceInfo();
     }
 
+    /** Closes the USB handle (if open) and releases the wrapped libusb device. */
     ~DFUDevice() {
         if (usbHandle) {
             libusb_release_interface(usbHandle, 0);
@@ -202,6 +228,7 @@ public:
         }
     }
 
+    /** @return true if the device is currently open and still present on the bus. */
     bool isConnected() { return (usbHandle != nullptr) && (libusb_get_device(usbHandle) != nullptr); }
 
     /**
@@ -214,11 +241,36 @@ public:
      * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure (open/claim/state)
      */
     dfu_error open(bool resetDevice = true);
+
+    /**
+     * Erases, writes, and verifies the given Intel-HEX firmware file to this device, then finalizes.
+     * @param filename path to an Intel-HEX (.hex) firmware image
+     * @param baseAddress base flash address to write the image at (0 = the image's own addressing)
+     * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure
+     */
     dfu_error updateFirmware(std::string filename, uint64_t baseAddress = 0);
+
+    /**
+     * Erases, writes, and verifies an Intel-HEX firmware image read from the given stream, then finalizes.
+     * @param stream an input stream over Intel-HEX (.hex) firmware image text
+     * @param baseAddress base flash address to write the image at (0 = the image's own addressing)
+     * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure
+     */
     dfu_error updateFirmware(std::istream& stream, uint64_t baseAddress = 0);
     // dfu_error updateFirmware(std::queue<uint8_t>, uint32_t imgSize, uint64_t baseAddress = 0);
+
+    /**
+     * Finalizes a completed firmware write (e.g. writing option bytes / leaving DFU mode so the
+     * device reboots into the new application). A resulting USB disconnect is generally the
+     * expected, successful outcome -- see isExpectedOptionByteResetError().
+     * @return DFU_ERROR_NONE on success (including the expected reset-disconnect), or a dfu_error otherwise
+     */
     dfu_error finalizeFirmware();
+
+    /** Closes the USB handle, if open. @return DFU_ERROR_NONE on success, or a dfu_error otherwise */
     dfu_error close();
+
+    /** Issues a USB port reset on the device. @return 0 on success, or a libusb error code */
     int reset();
 
     /**
@@ -233,12 +285,19 @@ public:
      */
     dfu_error sendDfuCommand(int cmd);
 
+    /** @return a human-readable description of the device (manufacturer/product strings), or "" if unavailable */
     const char *getDescription();
 
+    /** @return the MD5 fingerprint computed from this device's descriptors, used to match it against a known firmware image */
     md5hash_t getFingerprint() { return fingerprint.state; }
 
+    /** @return the fwUpdate target type this device corresponds to (derived from its fingerprint/processor type), or TARGET_UNKNOWN */
     fwUpdate::target_t getTargetType();
+
+    /** @return the Inertial Sense hardware id (type/version) read from OTP data, or 0xFFFF if unavailable */
     uint16_t getHardwareId() { return hardwareId; }
+
+    /** @return the Inertial Sense serial number read from OTP data, or UINT32_MAX if unavailable */
     uint32_t getSerialNo() { return sn; }
 
     /**
@@ -265,13 +324,26 @@ public:
      */
     const char* getLastLibusbErrorName() const { return libusb_error_name(lastLibusbError); }
 
+    /** @return the processor family detected from this device's USB fingerprint */
     eProcessorType getProcessorType() const { return processorType; }
+
+    /** @return the total flash size (bytes) reported by this device's memory segment descriptors */
     uint32_t getTotalFlashSize() const;
+
+    /**
+     * @param procType the processor family (see getProcessorType())
+     * @param totalFlashSize the total flash size (bytes, see getTotalFlashSize())
+     * @return a human-readable device type name (e.g. "IMX-5"), derived from procType and totalFlashSize
+     */
     static const char* getDeviceTypeName(eProcessorType procType, uint32_t totalFlashSize);
 
+    /** @param cbProgress callback invoked to report upload/erase/verify progress */
     void setProgressCb(fwUpdate::pfnProgressCb cbProgress){ progressCb = cbProgress;}
+
+    /** @param cbStatus callback invoked to report status/log messages */
     void setStatusCb(fwUpdate::pfnStatusCb cbStatus) { statusCb = cbStatus;}
 
+    /** @param errNo a dfu_error value @return the enumerator name of errNo (e.g. "DFU_ERROR_TIMEOUT") */
     static const char* getErrorName(int errNo);
 
     /**
@@ -280,6 +352,8 @@ public:
      *   RDP == 0xAA -> DFU_ERROR_NONE (Level 0, unprotected; flash programming allowed)
      *   RDP == 0xCC -> DFU_ERROR_RDP_PERMANENT_LOCKED (Level 2, permanent)
      *   otherwise   -> DFU_ERROR_RDP_LOCKED (Level 1; flash writes silently dropped by the ROM bootloader)
+     * @param rdpByte the raw STM32 FLASH_OPTR RDP byte read from the device
+     * @return a dfu_error verdict for the RDP level (see mapping above)
      */
     static dfu_error rdpVerdict(uint8_t rdpByte);
 
@@ -304,6 +378,12 @@ public:
      */
     static const char* libusbErrorName(int libusbCode);
 
+    /**
+     * Populates devInfo from this device's identification data (hardware id, serial number,
+     * processor type/flash size derived device name, etc).
+     * @param devInfo the dev_info_t struct to fill
+     * @return 0 on success, or a negative error code if identification data was unavailable
+     */
     int fillDeviceInfo(dev_info_t &devInfo);
 
 protected:
@@ -318,14 +398,49 @@ protected:
      */
     dfu_error libusbError(int libusbCode);
 
+    /**
+     * Opens the wrapped device (if not already open), reads its USB descriptors (vendor/product
+     * strings, DFU functional descriptor, alternate-setting memory segments), computes its
+     * fingerprint, and reads OTP data (serial number, hardware id) if accessible.
+     * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure
+     */
     dfu_error fetchDeviceInfo();
 
+    /**
+     * Reads and decodes a USB string descriptor to plain ASCII.
+     * @param desc_index the string descriptor index (from another descriptor's iXxx field)
+     * @param data buffer to receive the decoded ASCII string
+     * @param length size of data, in bytes
+     * @return the number of bytes written to data, or a negative libusb error code
+     */
     int get_string_descriptor_ascii(uint8_t desc_index, char *data, int length);
 
+    /**
+     * Selects the memory segment containing [address, address+data_len) and validates the write is
+     * in-bounds, before a download (erase/write) operation proceeds.
+     * @param address the target flash address
+     * @param data_len the number of bytes to be written starting at address
+     * @return DFU_ERROR_NONE if the range is valid and selected, or a dfu_error otherwise
+     */
     dfu_error prepAndValidateBeforeDownload(uint32_t address, uint32_t data_len);
 
+    /**
+     * Erases the page(s) of mem covering [address, address+data_len).
+     * @param mem the memory segment descriptor covering address
+     * @param address the flash address to begin erasing from
+     * @param data_len the number of bytes that will subsequently be written (determines page count)
+     * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure
+     */
     dfu_error eraseFlash(const dfu_memory_t& mem, uint32_t& address, uint32_t data_len);
 
+    /**
+     * Writes data_len bytes of data to mem starting at address.
+     * @param mem the memory segment descriptor covering address
+     * @param address the flash address to begin writing at
+     * @param data_len the number of bytes to write
+     * @param data the bytes to write
+     * @return DFU_ERROR_NONE on success, or a dfu_error describing the failure
+     */
     dfu_error writeFlash(const dfu_memory_t& mem, uint32_t& address, uint32_t data_len, uint8_t *data);
 
     /**
@@ -334,6 +449,7 @@ protected:
      * regardless of RDP level) and returns rdpVerdict() of the RDP byte. At RDP Level 1 the ROM
      * bootloader ACKs every DNLOAD but silently drops the underlying flash programming, so we must
      * refuse to proceed rather than report a false success.
+     * @return DFU_ERROR_NONE if unprotected (or not applicable to this processor), or a dfu_error otherwise
      */
     dfu_error checkReadProtection();
 
@@ -342,6 +458,10 @@ protected:
      * region and compares them against the source image. Returns DFU_ERROR_WRITE_VERIFY_FAILED on
      * mismatch (the classic RDP-silent-drop signature is an all-0xFF / all-0x00 readback). A readback
      * transport failure is logged but NOT treated as fatal, to avoid false negatives on good devices.
+     * @param address the flash address the just-completed write started at
+     * @param expected the source image bytes that should now be present at address
+     * @param verifyLen the number of bytes to read back and compare
+     * @return DFU_ERROR_NONE if the readback matches (or could not be performed), or DFU_ERROR_WRITE_VERIFY_FAILED on mismatch
      */
     dfu_error verifyFlashWrite(uint32_t address, const uint8_t *expected, uint32_t verifyLen);
 
@@ -411,15 +531,23 @@ private:
     static const char *dfuDeviceErrors[];
 };
 
+/**
+ * Adapts a DFUDevice to the fwUpdate::FirmwareUpdateDevice interface, so a USB-DFU-mode target
+ * (e.g. an STM32-based IMX/GPX module) can be driven through the same firmware update state
+ * machine used for in-application (wire-protocol) updates. Also provides static libusb
+ * initialization and DFU device enumeration/discovery helpers used before a device is claimed.
+ */
 class ISDFUFirmwareUpdater : public fwUpdate::FirmwareUpdateDevice {
 public:
     /**
-     * Constructor to establish a connected to the specified device, and optionally validating against hdwId and serialNo
-     * @param device the libusb device which identifies the connected device to update. This is NOT a libusb_device_handle! If null, this function will use to first detected DFU device which matches the hdwId and/or serialNo
-     * @param hdwId the hardware id (from manufacturing info) used to identify which specific hdwType + hdwVer we should be targeting (used in validation)
-     * @param serialNo the device-specific unique Id (or serial number) that is used to uniquely identify a particular device (used in validation)
+     * Constructor to establish a connection to the specified device, and optionally validate against serialNo.
+     * @param target the fwUpdate target device this updater instance is responsible for
+     * @param device the libusb device which identifies the connected device to update. This is NOT a libusb_device_handle! If null, this function will use the first detected DFU device which matches serialNo
+     * @param serialNo the device-specific unique Id (or serial number) that is used to uniquely identify a particular device (used in validation); UINT32_MAX to skip validation
      */
     ISDFUFirmwareUpdater(fwUpdate::target_t target, libusb_device *device = nullptr, uint32_t serialNo = UINT32_MAX);
+
+    /** Trivial destructor; owned DFUDevice/buffers are released elsewhere (see cleanup in the .cpp). */
     ~ISDFUFirmwareUpdater() { };
 
     /** Initialize the libusb context. Call once at application startup before any DFU operations. */
@@ -456,12 +584,35 @@ public:
     static size_t getAvailableDevices(std::vector<DFUDevice *> &devices, uint16_t vid = 0x0000, uint16_t pid = 0x0000,
                                       pfnDfuDeviceFoundCb onDeviceFound = nullptr);
 
+    /**
+     * @param vid USB vendor id filter (0 = any)
+     * @param pid USB product id filter (0 = any)
+     * @return the number of currently-attached DFU devices matching vid/pid
+     */
     static int getNumDevices(uint16_t vid = 0x0000, uint16_t pid = 0x0000);
 
+    /**
+     * Removes (and deletes) every device in devices whose fingerprint does not match fingerprint.
+     * @param devices the device list to filter in place
+     * @param fingerprint the fingerprint to match against (see DFUDevice::getFingerprint())
+     * @return the number of devices remaining in devices after filtering
+     */
     static size_t filterDevicesByFingerprint(std::vector<DFUDevice *> &devices, md5hash_t fingerprint);
 
+    /**
+     * Removes (and deletes) every device in devices whose fwUpdate target type does not match target.
+     * @param devices the device list to filter in place
+     * @param target the fwUpdate target type to match against (see DFUDevice::getTargetType())
+     * @return the number of devices remaining in devices after filtering
+     */
     static size_t filterDevicesByTargetType(std::vector<DFUDevice *> &devices, fwUpdate::target_t target);
 
+    /**
+     * @param usbDevice the libusb device to check
+     * @param vid USB vendor id filter (0 = any)
+     * @param pid USB product id filter (0 = any)
+     * @return true if usbDevice matches vid/pid and exposes a USB DFU functional descriptor
+     */
     static bool isDFUDevice(libusb_device *usbDevice, uint16_t vid, uint16_t pid);
 
     // ---- DFU discovery state machine (step-driven; no internal thread) ----------------------------
@@ -508,31 +659,47 @@ public:
     static bool discoveryStep(DfuDiscoveryContext &ctx, uint32_t elapsedMs);
 
 
-    // this is called internally by processMessage() to do the things; it should also be called periodically to send status updated, etc.
+    /**
+     * Drives the DFU update state machine forward by one step; called internally by
+     * processMessage() when a message is received, and should also be called periodically
+     * (independent of message reception) so timeouts and erase/write/verify progress continue
+     * to advance.
+     * @param msg_type the type of message that was last processed, or MSG_UNKNOWN
+     * @param processed true if msg_type was already handled by the caller (additional/optional
+     *        processing may still occur here), false if it was not yet handled
+     * @return true if some action was taken as a result of this step, otherwise false
+     */
     bool fwUpdate_step(fwUpdate::msg_types_e msg_type = fwUpdate::MSG_UNKNOWN, bool processed = false) override;
 
-    // called by the Port receiver when we've received and parse a DID_FIRMWARE_UPDATE message; this handles parsing the internal payload.
+    /**
+     * Called by the port receiver when a DID_FIRMWARE_UPDATE message has been received, to parse
+     * the internal fwUpdate payload out of the raw port buffer.
+     * @param rxPort the port the message was received on
+     * @param buffer the raw received message buffer
+     * @param buf_len the number of bytes in buffer
+     * @return true if the message was successfully parsed and processed, otherwise false
+     */
     bool fwUpdate_processMessage(int rxPort, const uint8_t* buffer, int buf_len);
 
-    // called internally to perform a system reset of various severity per reset_flags (HARD, SOFT, etc)
     /**
      * Performs a system reset of various severity per reset_flags, (ie, RESET_SOFT by informing the OS/MCU to restart the system,
      * vs RESET_HARD, usually by pulling interfacing pins into the MCU either HIGH or LOW to force a reset state on the hardware).
      * Note that some systems may not always be able to respond with a success before the system is reset.
      * If a system is NOT able to perform a reset (ie UNSUPPORTED, etc), this MUST return false.
      * @param target_id the device to reset
+     * @param reset_flags the severity/style of reset to perform (e.g. RESET_SOFT, RESET_HARD)
      * @return true if successful, otherwise false
      */
     bool fwUpdate_performReset(fwUpdate::target_t target_id, fwUpdate::reset_flags_e reset_flags) override;
 
-    // called internally (by the receiving device) to populate the dev_info_t struct for the requested device
     /**
      * Internally called by fwUpdate_processMessage() when a REQ_VERSION_INFO message is received, to request version info for the target device.
      * This is to be implemented by the concrete class.  If the target/requested device can not provide version info, this should return false.
      * If this call returns false, the API will respond with a MSG_VERSION_INFO_RESP, with the message filled with 0xFF, indicating not-supported.
      * NOTE that this call is passed a reference to a const dev_info_t; the base-class provides the instance which is referenced. As the implementer
      * of this class, it is your responsibility to fill it with the appropriate data.
-     * @param a reference to a dev_info_t struct that contains the necessary version information to be returned back to the querying host.
+     * @param target_id the device whose version info is being requested
+     * @param dev_info reference to a dev_info_t struct to fill with the version information to be returned back to the querying host
      * @return true if the message was received and parsed without error, false otherwise.
      */
     bool fwUpdate_queryVersionInfo(fwUpdate::target_t target_id, dev_info_t& dev_info) override;
@@ -543,7 +710,6 @@ public:
      * @return an update_status_e indicating the continued state of the update process, or an error. For fwUpdate_startUpdate
      * this should return "GOOD_TO_GO" on success.
      */
-    // this initializes the system to begin receiving firmware image chunks for the target device, image slot and image size
     fwUpdate::update_status_e fwUpdate_startUpdate(const fwUpdate::payload_t& msg) override;
 
     /**
@@ -556,26 +722,25 @@ public:
      * @return an update_status_e indicating the continued state of the update process, or an error. For fwUpdate_writeImageChunk
      * this should return "WAITING_FOR_DATA" if more chunks are expected, or an error.
      */
-    // writes the indicated block of data (of len bytes) to the target and device-specific image slot, and with the specified offset
     fwUpdate::update_status_e fwUpdate_writeImageChunk(fwUpdate::target_t target_id, int slot_id, int offset, int len, uint8_t *data) override;
 
     /**
-     * Validated and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
+     * Validates and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
      * @param target_id the target_id
      * @param slot_id the image slot, if applicable (otherwise 0)
-     * @return
+     * @param flags additional flags controlling finalization behavior
+     * @return an update_status_e indicating the continued state of the update process, or an error
      */
-    // this marks the finish of the upgrade, that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization
     fwUpdate::update_status_e fwUpdate_finishUpdate(fwUpdate::target_t target_id, int slot_id, int flags) override;
 
     /**
-     * Writes the requested data (usually a packed payload_t) out to the specified device
+     * Writes the requested data (usually a packed payload_t) out to the specified device.
      * Note that the implementation between a target and an actual interface is device-specific. In most cases,
      * for a Device-implementation, this will typically specify TARGET_HOST, which will direct back to the
      * controlling host.
-     * @param target
-     * @param buffer
-     * @param buff_len
+     * @param target the target this message is directed to
+     * @param buffer the encoded buffer to send
+     * @param buff_len the number of bytes in the encoded buffer to send
      * @return true if the data was successfully sent to the underlying communication system, otherwise false
      */
     bool fwUpdate_writeToWire(fwUpdate::target_t target, uint8_t* buffer, int buff_len) override;

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -1,6 +1,13 @@
-//
-// Created by kylemallory on 8/18/23.
-//
+/**
+ * @file ISFirmwareUpdater.h
+ * @brief High-level firmware update policy/orchestration: parses manifest-driven update
+ *        scripts (a sequence of target/upload/waitfor/policy steps), applies per-target update
+ *        policy (skip/if-newer/force), and drives the underlying device-specific updater
+ *        (ISBFirmwareUpdater or ISDFUFirmwareUpdater) through the fwUpdate wire protocol.
+ *
+ * @author Kyle Mallory on 8/18/23.
+ * @copyright Copyright (c) 2023 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef SDK_ISFIRMWAREUPDATER_H
 #define SDK_ISFIRMWAREUPDATER_H
@@ -249,6 +256,12 @@ private:
 static ISFwUpdaterCmd nullCmd = ISFwUpdaterCmd();
 static ISFwUpdateState nullState = ISFwUpdateState();
 
+/**
+ * Manages a firmware update session for a single device: parses a manifest into a queue of
+ * ISFwUpdaterCmd steps, applies update policy per target, and drives step() to advance the
+ * queue -- delegating the actual chunked upload to the fwUpdate::FirmwareUpdateHost base and,
+ * for USB-DFU or ISB-protocol targets, to an owned device-specific updater instance.
+ */
 class ISFirmwareUpdater : private fwUpdate::FirmwareUpdateHost {
 public:
 
@@ -264,8 +277,14 @@ public:
      */
     ISFirmwareUpdater(port_handle_t port, const dev_info_t *devInfo, ISFwUpdateState& state) : FirmwareUpdateHost(), port(port), devInfo(devInfo), updateState(state), activeCmd(&nullCmd) { }
 
+    /**
+     * Constructor to initiate and manage updating a firmware image of the specified device
+     * @param device handle to the device to be updated
+     * @param state the shared state object this updater reports progress/status into
+     */
     explicit ISFirmwareUpdater(device_handle_t device, ISFwUpdateState& state);
 
+    /** @param cb callback invoked with formatted status/progress messages as the update proceeds */
     void setInfoProgressCb(fwUpdate::pfnStatusCb cb) { pfnStatus_cb = cb; }
 
     ~ISFirmwareUpdater() override {
@@ -283,44 +302,75 @@ public:
         devInfo = nullptr;
     };
 
+    /** Re-derives updateState's aggregate state/status/hasErrors/hasNotifications fields from the current command queue. */
     void refreshUpdateState();
 
+    /** @param _target the fwUpdate target to direct subsequent commands/steps at */
     void setTarget(fwUpdate::target_t _target);
 
+    /**
+     * Parses a manifest-style command script into the queued command list, replacing any existing queue.
+     * @param cmds the list of command strings to parse (e.g. "target=IMX5", "upload,filename=...")
+     * @return true if all commands were parsed successfully, otherwise false
+     */
     bool setCommands(std::vector<std::string> cmds);
 
+    /**
+     * Advances the update session by one step: runs the next queued command (or continues the
+     * active one) and drives the underlying fwUpdate protocol. Call repeatedly (e.g. once per
+     * main loop iteration) until hasPendingCommands() returns false.
+     * @return true if some action was taken this step, otherwise false
+     */
     bool step();
 
+    /** @return true if any queued or in-process command remains, otherwise false */
     bool hasPendingCommands() { for (auto& c :commands) { if ((c.status == ISFwUpdaterCmd::CMD_QUEUED) || (c.status == ISFwUpdaterCmd::CMD_IN_PROCESS)) return true; } return false; }
 
+    /** @return true if any command in the queue is in the CMD_ERROR state, otherwise false */
     bool hasErrors() { for (auto& c :commands) { if (c.status == ISFwUpdaterCmd::CMD_ERROR) return true; } return false; }
 
+    /** @param level the minimum severity of messages this updater will report */
     void setLogLevel(eLogLevel level) { logLevel = level; }
 
+    /** @return the minimum severity of messages this updater will report */
     eLogLevel getLogLevel() { return logLevel; }
 
+    /** @return a copy of all messages recorded during this update session */
     std::vector<ISFwUpdateState::message> getMessages() { return updateState.messages; }
 
+    /** @return a reference to the currently-executing command (or a static no-op command if none is active) */
     ISFwUpdaterCmd& getActiveCommand() { return *activeCmd; };
 
+    /**
+     * @param steps if non-null, receives the number of chunks/steps completed for the active upload
+     * @param total if non-null, receives the total number of chunks/steps for the active upload
+     * @return the completion percentage (0-100) of the active upload
+     */
     float getProgress(int* steps = nullptr, int* total=nullptr) {
         if (steps) *steps = fwUpdate_getProgressNum();
         if (total) *total = fwUpdate_getProgressTotal();
         return fwUpdate_getProgressPercent();
     }
 
+    /** @return the fwUpdate target currently being updated */
     fwUpdate::target_t getActiveTarget() { return fwUpdate_getSessionTarget(); }
 
+    /** @return the human-readable name of the target currently being updated */
     const char* getActiveTargetName() { return fwUpdate_getSessionTargetName(); }
 
+    /** @return the image slot currently being uploaded to (0 if not applicable) */
     int getActiveSlot() { return fwUpdate_getSessionImageSlot(); }
 
+    /** @return the current/last update_status_e of the active upload session */
     fwUpdate::update_status_e getUploadStatus() { return fwUpdate_getSessionStatus(); }
 
+    /** @return a human-readable name for getUploadStatus() */
     const char* getUploadStatusName() { return fwUpdate_getNiceStatusName(getUploadStatus()); }
 
+    /** @param msg a received p_data_t message to be processed by the fwUpdate protocol handler @return true if the message was recognized and processed, otherwise false */
     bool processMessage(p_data_t* msg) { return fwUpdate_processMessage(msg->ptr, msg->hdr.size); }
 
+    /** Clears the command queue, discarding any queued/in-process/completed commands. */
     void clearAllCommands() { commands.clear(); }
 
     /**
@@ -369,8 +419,10 @@ public:
      * Called when an error occurs while processing a command, to perform corrective actions (if possible).
      * Primarily, this checks if there is a failLabel defined and looks for the corresponding command label.
      * Otherwise it logs the message/errorcode, and clears the command stack.
-     * @param errCode
-     * @param errMsg
+     * @param cmd the command that was being processed when the error occurred
+     * @param errCode a numerical error code
+     * @param errMmsg a printf-style format string for a human-readable message corresponding to errCode
+     * @param ... format arguments for errMmsg
      */
     void handleCommandError(ISFwUpdaterCmd& cmd, int errCode, const char *errMmsg, ...);
 
@@ -382,6 +434,7 @@ public:
      */
     fwUpdate::update_status_e cancel(bool immediately = false);
 
+    /** @return true if the active command/session is in a state where cancel() can be honored, otherwise false */
     bool isCancelable();
 
     /**
@@ -543,13 +596,13 @@ private:
      * @param offset the offset into the image file to pull data from
      * @param len the number of bytes to pull from the image file
      * @param buffer a provided buffer to store the data into.
-     * @return
+     * @return the number of bytes actually written to buffer, or a negative value on error
      */
     int fwUpdate_getImageChunk(uint32_t offset, uint32_t len, void **buffer) override;
 
     /**
-     * @param msg
-     * @return
+     * @param msg the received version-info response payload
+     * @return true if the response was recognized and processed, otherwise false
      */
     bool fwUpdate_handleVersionResponse(const fwUpdate::payload_t &msg) override;
 
@@ -584,15 +637,20 @@ private:
      * Parses a YAML tree containing the manifest of the firmware package
      * @param manifest YAML::Node of the manifests parsed YAML file/text
      * @param archive a pointer to the archive which contains this manifest (or null-ptr if parsed from a file).
-     * @return
+     * @return PKG_SUCCESS on success, otherwise a PKG_ERR_* code describing the parse failure
      */
     pkg_error_e processPackageManifest(YAML::Node &manifest, mz_zip_archive *archive);
 
+    /**
+     * Opens and parses the manifest from a standalone (non-archived) manifest file.
+     * @param manifest_file path to the manifest YAML file
+     * @return PKG_SUCCESS on success, otherwise a PKG_ERR_* code describing the failure
+     */
     pkg_error_e processPackageManifest(const std::string &manifest_file);
 
     /**
      * Performs any necessary cleanup of memory, file handles, or temporary files after all tasks associated with a firmware package have finished (or from an unrecoverable error).
-     * @return
+     * @return PKG_SUCCESS on success, otherwise a PKG_ERR_* code describing the failure
      */
     pkg_error_e cleanupFirmwarePackage();
 

--- a/src/ISFirmwareUpdater.h
+++ b/src/ISFirmwareUpdater.h
@@ -46,7 +46,7 @@ extern "C"
 
 #if !defined(ISDevice)
     class ISDevice;
-    typedef std::shared_ptr<ISDevice> device_handle_t;
+    typedef std::shared_ptr<ISDevice> device_handle_t;  //!< fallback forward-declaration if ISDevice.h wasn't already included
 #endif
 
 
@@ -64,14 +64,20 @@ enum update_policy_e : int8_t {
  * Stores the update policy and image version metadata for a single step/target.
  */
 struct step_policy_t {
-    update_policy_e policy = UPDATE_POLICY_DEFAULT;
+    update_policy_e policy = UPDATE_POLICY_DEFAULT;  //!< the resolved update policy for this step/target
     uint8_t imageVersion[4] = {};  //!< parsed from manifest "version: x.y.z.w"
     bool hasImageVersion = false;  //!< true if imageVersion was explicitly set
 };
 
 
+/**
+ * A single queued/executing/completed step in a firmware update session's command queue
+ * (parsed from a manifest step, e.g. "target=IMX5", "upload,filename=..."). Tracks the
+ * command's arguments, status, and timing.
+ */
 class ISFwUpdaterCmd {
 public:
+    /** Execution status of a queued command. */
     enum cmd_status_e : int8_t {
         CMD_CANCELLED = -3,                                 //!< command was canceled (by the user) before it could complete
         CMD_NOT_EXECUTED = -2,                              //!< command was queued, but ultimately never executed (was skipped due to jumps, etc)
@@ -81,6 +87,7 @@ public:
         CMD_SUCCESS = 2,                                    //!< command had successfully completed
         CMD_SUSPENDED = 3,                                  //!< command has been suspended (by the user) - must be moved back into IN_PROCESS to resume
     };
+    /** Bitmask of capabilities common to all commands. */
     enum cmd_flags_e : int16_t {
         CMD_FLAGS__PAUSABLE = 1 << 0,                       //!< command can be paused/suspended
         CMD_FLAGS__CANCELABLE = 1 << 1,                     //!< command can be canceled (by the user)
@@ -98,13 +105,27 @@ public:
     std::chrono::system_clock::time_point timeStarted;      //!< wall-clock time when this command started execution
     std::chrono::system_clock::time_point timeFinished;     //!< wall-clock time when this command finished execution (error or success)
 
+    /** Constructs an empty, unlabeled command (used as a static "null" placeholder command). */
     explicit ISFwUpdaterCmd() { }
 
+    /**
+     * @param _step the step label this command executes under
+     * @param _cmd the name of the command
+     */
     ISFwUpdaterCmd(const std::string& _step, const std::string& _cmd) : step(_step), cmd(_cmd) {
         status = CMD_QUEUED;
         timeQueued = std::chrono::system_clock::now();
     }
 
+    /**
+     * Constructs a command and parses its comma-separated argument string into named args,
+     * either as explicit "key=value" pairs, positionally against _keyNames, or (if neither
+     * applies) against a built-in default key list for well-known command names.
+     * @param _step the step label this command executes under
+     * @param _cmd the name of the command
+     * @param _args a comma-separated argument string, e.g. "filename=fw.hex,slot=0"
+     * @param _keyNames positional argument names to assign to bare (non "key=value") values, in order
+     */
     ISFwUpdaterCmd(const std::string& _step, const std::string& _cmd, const std::string& _args, std::deque<std::string> _keyNames = {}) : ISFwUpdaterCmd(_step, _cmd) {
         static std::map<std::string, std::vector<std::string>> defaultKeys = {
                 {"target",     {"target","timeout", "interval", "on-timeout"}},
@@ -138,13 +159,17 @@ public:
         }
     }
 
+    /** @param other the command to compare against @return true if other has the same cmd name and step label as this command */
     bool operator==(const ISFwUpdaterCmd& other) const {
         return (cmd == other.cmd) && (step == other.step);
     }
+
+    /** @param k the argument name @return the value of argument k, or "" if not present */
     inline std::string operator[](const std::string& k) {
         return args[k];
     }
 
+    /** @param i the positional index of the argument to retrieve, in map iteration order @return the i-th argument's value, or "" if out of range */
     inline std::string operator[](int i) {
         for (auto& [k, v] : args) {
             if (i-- <= 0)
@@ -153,17 +178,25 @@ public:
         return "";
     }
 
+    /** @param k the argument name @return true if this command has an argument named k */
     inline bool hasArg(const std::string& k) {
         return (args.find(k) != args.end());
     }
 
+    /** @param k the argument name @param def the value to return if k is not present @return the value of argument k, or def if not present */
     inline std::string getArg(const std::string& k, const std::string& def = "") {
         return (hasArg(k) ? args[k] : def);
     }
 };
 
+/**
+ * Shared, thread-safe state for a firmware update session: overall updater state/status, the
+ * current target/slot/progress, and the accumulated log of messages. Owned by the caller and
+ * passed by reference to ISFirmwareUpdater; use lock()/getSnapshot() for thread-safe access.
+ */
 class ISFwUpdateState {
 public:
+    /** Overall state of an update session, aggregated across all queued commands. */
     enum updater_state_e : int8_t {
         UPDATER_CANCELED = -3,                              //!< no longer running, user cancelled, and not all steps were completed.
         UPDATER_DONE_WITH_ERRORS = -2,                      //!< no longer running, errors occurred during the update
@@ -176,24 +209,35 @@ public:
         SUCCESS_WITH_NOTIFICATIONS = 5,                     //!< no more queued commands, but there were notifications/messages reported (but not errors)
     };
 
+    /** A single reported message (status/error/notification) associated with a command's execution. */
     struct message {
         std::string target;                                 //!< the target (if any) which was active, if any
         ISFwUpdaterCmd cmd;                                 //!< the command that generated this message
-        eLogLevel severity;                                 //!< the severity level of the message - use one of IS_LOG_LEVEL_*
+        eLogLevel severity;                                 //!< the severity level of the message (one of the IS_LOG_LEVEL_ constants)
         std::string msg;                                    //!< the fully-formatted message
 
+        /**
+         * @param _target the target which was active when this message was generated, if any
+         * @param _cmd the command that generated this message
+         * @param _severity the severity level of the message, one of the IS_LOG_LEVEL_ constants
+         * @param _msg the fully-formatted message text
+         */
         message(const std::string& _target, const ISFwUpdaterCmd& _cmd, eLogLevel _severity, const std::string& _msg) : target(_target), cmd(_cmd), severity(_severity), msg(_msg) { };
     };
 
     ISFwUpdateState() = default;
 
-    // Copy constructor — copies all data fields but creates a fresh mutex (mutexes are non-copyable).
-    // The source is NOT locked here; callers should use getSnapshot() for thread-safe copies.
+    /**
+     * Copy constructor — copies all data fields but creates a fresh mutex (mutexes are non-copyable).
+     * The source is NOT locked here; callers should use getSnapshot() for thread-safe copies.
+     * @param other the instance to copy fields from
+     */
     ISFwUpdateState(const ISFwUpdateState& other)
         : lastMessage(other.lastMessage), state(other.state), status(other.status),
           target(other.target), slot(other.slot), progress(other.progress),
           messages(other.messages), hasErrors(other.hasErrors), hasNotifications(other.hasNotifications) { }
 
+    /** @param other the instance to copy fields from @return *this */
     ISFwUpdateState& operator=(const ISFwUpdateState& other) {
         if (this != &other) {
             lastMessage = other.lastMessage;
@@ -212,12 +256,14 @@ public:
     /**
      * Acquire a lock on this state object. All reads and writes to this state should be done while holding this lock,
      * to prevent cross-thread data races (e.g., GUI thread reading while IOManager thread writes).
+     * @return a lock owning this state object's mutex
      */
     std::unique_lock<std::recursive_mutex> lock() const { return std::unique_lock<std::recursive_mutex>(mtx); }
 
     /**
      * Returns a thread-safe snapshot (copy) of the current state. The caller can safely read from the copy
      * without holding a lock. Prefer this over direct field access from non-owner threads.
+     * @return a copy of this state object, taken under lock
      */
     ISFwUpdateState getSnapshot() const {
         auto lk = lock();
@@ -225,6 +271,7 @@ public:
         return snapshot;
     }
 
+    /** Clears messages/errors and resets target/status/slot/progress to their initial values. */
     void resetState() {
         auto lk = lock();
         lastMessage.clear();
@@ -253,8 +300,8 @@ private:
 
 
 
-static ISFwUpdaterCmd nullCmd = ISFwUpdaterCmd();
-static ISFwUpdateState nullState = ISFwUpdateState();
+static ISFwUpdaterCmd nullCmd = ISFwUpdaterCmd();      //!< static "no active command" placeholder, pointed to by activeCmd when nothing is running
+static ISFwUpdateState nullState = ISFwUpdateState();  //!< static placeholder update-state instance, unused by default-constructed updaters
 
 /**
  * Manages a firmware update session for a single device: parses a manifest into a queue of
@@ -272,8 +319,9 @@ public:
 
     /**
      * Constructor to initiate and manage updating a firmware image of a device connected on the specified port
-     * @param portHandle handle to the port (typically serial) to which the device is connected
-     * @param portName a named reference to the connected port handle (ie, COM1 or /dev/ttyACM0)
+     * @param port handle to the port (typically serial) to which the device is connected
+     * @param devInfo the root device info connected on this port
+     * @param state the shared state object this updater reports progress/status into
      */
     ISFirmwareUpdater(port_handle_t port, const dev_info_t *devInfo, ISFwUpdateState& state) : FirmwareUpdateHost(), port(port), devInfo(devInfo), updateState(state), activeCmd(&nullCmd) { }
 
@@ -386,11 +434,14 @@ public:
      * Returns a summary of unique firmware update targets from the queued commands.
      * Deduplicates by target name — each target appears once with all associated step labels.
      * Thread-safe: locks the internal mutex.
+     * @return one StepInfo per unique target referenced by the queued commands
      */
     std::vector<StepInfo> getStepSummary() const;
 
     /**
      * Sets an explicit update policy for a specific step (by exact label name).
+     * @param stepLabel the exact step label to set the policy for
+     * @param policy the update policy to apply to this step
      */
     void setStepPolicy(const std::string& stepLabel, update_policy_e policy);
 
@@ -398,11 +449,14 @@ public:
      * Stores a deferred pattern-based policy override. The pattern is matched (case-insensitive
      * substring) against step labels during manifest parsing, and against target names at step
      * transition time. First matching pattern wins.
+     * @param pattern a case-insensitive substring to match against step labels/target names
+     * @param policy the update policy to apply when pattern matches
      */
     void setPolicyPattern(const std::string& pattern, update_policy_e policy);
 
     /**
      * Sets the updater-wide default policy, used when no step-specific or pattern-matched policy applies.
+     * @param policy the default update policy
      */
     void setDefaultPolicy(update_policy_e policy);
 
@@ -412,6 +466,8 @@ public:
      *   2. defaultPolicy (if not DEFAULT)
      *   3. forceUpdate bool (legacy)
      *   4. IF_NEWER fallback
+     * @param stepLabel the step label to resolve a policy for
+     * @return the effective update_policy_e for stepLabel
      */
     update_policy_e getEffectivePolicy(const std::string& stepLabel) const;
 

--- a/src/ihex.h
+++ b/src/ihex.h
@@ -1,8 +1,10 @@
 /**
  * @file ihex.h
  * @author Dave Cutting
- * @brief Intel HEX file read routines for embedded firmware
- * 
+ * @brief Intel HEX file read routines for embedded firmware. Provides a minimal
+ *        C API for loading the sections (contiguous data blocks) of an Intel
+ *        HEX firmware image into memory, and for releasing that memory again.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
  */
 
 /*
@@ -27,35 +29,34 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 extern "C" { 
 #endif
 
-#define MAX_NUM_IHEX_SECTIONS   1024        
-#define MAX_IHEX_SECTION_LEN    0x020000    // 128K TODO: Reduce to 64k if possible
+#define MAX_NUM_IHEX_SECTIONS   1024         //!< maximum number of image sections that can be tracked at once
+#define MAX_IHEX_SECTION_LEN    0x020000     //!< maximum length, in bytes, of a single image section (128K; may be reduced to 64K in the future)
 
+/**
+ * Represents a single contiguous section of an Intel HEX image, as loaded
+ * into memory by ihex_load_sections().
+ */
 typedef struct
 {
-    /* Address the image section needs to be programmed to */
-    uint32_t address;
-
-    /* Pointer to the section data */
-    uint8_t* image;
-
-    /* Length of this section*/
-    uint32_t len;
+    uint32_t address;    //!< address the image section needs to be programmed to
+    uint8_t* image;      //!< pointer to the section data (heap-allocated; owned by this struct)
+    uint32_t len;        //!< length of this section, in bytes
 } ihex_image_section_t;
 
 /**
  * @brief Load an intel hex file into a struct representing the full image
- * 
- * @param ihex_filename a string representing the filename, including path, where the hex file resides at. 
+ *
+ * @param ihex_filename a string representing the filename, including path, where the hex file resides at.
  * @param image array of ihex_image_section_t that will be filled with the image
  * @param num_slots the maximum number of sections to read from the file
- * @return int the number of sections actually read
+ * @return the number of sections actually read, or 0 if the file could not be opened
  */
 size_t ihex_load_sections(const char* ihex_filename, ihex_image_section_t* image, size_t num_slots);
 
 /**
  * @brief Free the memory associated with an image
- * 
- * @param image the struct containing the full image 
+ *
+ * @param image the struct containing the full image
  * @param num number of populated sections in the image. Obtained from return value of ihex_load_sections
  */
 void ihex_unload_sections(ihex_image_section_t* image, size_t num);

--- a/src/intel_hex_utils.h
+++ b/src/intel_hex_utils.h
@@ -1,3 +1,11 @@
+/**
+ * @file intel_hex_utils.h
+ * @brief Utility functions for working with Intel HEX firmware files: existence
+ *        checks, flash-page usage calculation, structural/content validation,
+ *        and extraction of an embedded STM32 bootloader version signature.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -252,12 +252,12 @@ namespace fwUpdate {
     typedef union {
         struct {                     //!< requests that the target device perform a reset (see msg_types_e::MSG_REQ_RESET)
             uint16_t reset_flags;    //!< a reset_flags_e bitmask controlling how the reset is performed
-        } req_reset;
+        } req_reset;                 //!< payload for MSG_REQ_RESET
 
         struct {                    //!< a response to a reset request (usually this isn't sent, but sometimes, like asking a GNSS receiver to reset, it could send back a reply, since that doesn't originate on the GNSS receiver).
             target_t target;        //!< responding target
             uint16_t status;        //!< response status (0 == success)
-        } rpl_reset;
+        } rpl_reset;                 //!< payload for MSG_RESET_RESP
 
         struct {
         } req_version;              //!< requests the version info for the target device
@@ -270,26 +270,26 @@ namespace fwUpdate {
             uint16_t chunk_size;    //!< the maximum size of each chunk
             uint16_t progress_rate; //!< the rate (millis) at which the device should publish progress reports back to the host.
             md5hash_t md5_hash;     //!< the md5 hash for the original firmware file.  If the delivered MD5 hash doesn't match this, after receiving the final chunk, the firmware file will be discarded.
-        } req_update;
+        } req_update;                //!< payload for MSG_REQ_UPDATE
 
         struct {
             uint16_t session_id;    //!< random 16-bit identifier used to validate/associate the data stream.
             uint16_t totl_chunks;   //!< the total number of chunks that are necessary to transmit the entire firmware file
             update_status_e status; //!< a status code (OK, ERROR, etc). Any error reported invalidates the session_id, and a new request with a new session_id must be made
-        } update_resp;
+        } update_resp;               //!< payload for MSG_UPDATE_RESP
 
         struct {
             uint16_t session_id;    //!< random 16-bit identifier used to validate/associate the data stream.
             uint16_t chunk_id;      //!< the chunk number identifying this portion of the firmware
             uint16_t data_len;      //!< the number of bytes of accompanying data
             uint8_t data;           //!< the first byte of data (cast to a uint8_t * to access the rest...)
-        } chunk;
+        } chunk;                     //!< payload for MSG_UPDATE_CHUNK
 
         struct {
             uint16_t session_id;    //!< random 16-bit identifier used to validate/associate the data stream.
             uint16_t chunk_id;      //!< the chunk number identifying this portion of the firmware which should be resent
             resend_reason_e reason; //!< an indicator of why this chunk was requested. This is optional, but is useful for debugging purposes. Regardless of the reason, the requested chunk, and all subsequent chunks must be resent.
-        } req_resend;
+        } req_resend;                //!< payload for MSG_REQ_RESEND_CHUNK
 
         struct {
             uint16_t session_id;    //!< random 16-bit identifier used to validate/associate the data stream.
@@ -299,12 +299,12 @@ namespace fwUpdate {
             uint8_t msg_level;      //!< a numerical indication of the criticality of this message, 0 being the highest. Best practive is to associate syslog type levels here (CRITICAL, ERROR, WARN, INFO, DEBUG, etc).
             uint8_t msg_len;        //!< the length of the following string (in bytes)
             uint8_t message;        //!< an arbitrary human-readable string, that is intended to be consumed by the user to give status about the update process
-        } progress;
+        } progress;                  //!< payload for MSG_UPDATE_PROGRESS
 
         struct {
             uint16_t session_id;    //!< random 16-bit identifier used to validate/associate the data stream.
             update_status_e status; //!< a status code (OK, ERROR, etc). Any error reported invalidates the session_id, and a new request with a new session_id must be made
-        } resp_done;
+        } resp_done;                 //!< payload for MSG_UPDATE_DONE
 
         struct {
             target_t resTarget;     //!< the target identifier of the responding device (for which this data represents)
@@ -328,7 +328,7 @@ namespace fwUpdate {
             uint8_t buildMillis;    //!< Build time millisecond
 
             uint8_t buildFlags;     //!< Build flags (preserves debug/dirty and related build-state flags)
-        } version_resp;
+        } version_resp;              //!< payload for MSG_VERSION_INFO_RESP
 
     } msg_data_t;
 
@@ -445,7 +445,7 @@ namespace fwUpdate {
         uint32_t timeout_duration = 20000;                      //!< the number of millis without any messages, by which we determine a timeout has occurred.  TODO: Should we prod the device (with a required response) at regular multiples of this to effect a keep-alive?
         uint32_t resend_count = 0;                              //!< the number of times a request was sent/received to resend a chunk. This provides an error rate mechanism; Ideal is < 1% of total packets.
 
-        target_t session_target = TARGET_HOST;
+        target_t session_target = TARGET_HOST;                  //!< the target device this session is communicating with
         update_status_e session_status = NOT_STARTED;           //!< last known state of this session
         uint16_t session_id = 0;                                //!< the current session id - all received messages with a session_id must match this value.  O == no session set (invalid)
         uint16_t session_chunk_size = 0;                        //!< the negotiated maximum size for each chunk.
@@ -596,6 +596,7 @@ namespace fwUpdate {
          * Note that some systems may not always be able to respond with a success before the system is reset.
          * If a system is NOT able to perform a reset (ie UNSUPPORTED, etc), this MUST return false.
          * @param target_id the device to reset
+         * @param reset_flags the severity/style of reset to perform (e.g. RESET_SOFT, RESET_HARD)
          * @return true if successful, otherwise false
          */
         virtual bool fwUpdate_performReset(target_t target_id, reset_flags_e reset_flags) = 0;
@@ -743,6 +744,11 @@ namespace fwUpdate {
         int32_t last_chunk_id = -1;                          //!< the last received chunk id from a CHUNK message. -1 = no chunk yet received; the next received chunk must be 0.
     };
 
+    /**
+     * FirmwareUpdateHost is the SDK-side (controlling host PC) implementation of the
+     * fwUpdate protocol: requests updates, sends image chunks, and processes responses/progress
+     * from a remote target device.
+     */
     class FirmwareUpdateHost : public FirmwareUpdateBase {
     public:
         /**
@@ -757,6 +763,13 @@ namespace fwUpdate {
          * @return true if this message was consumed by this interface, or false if the message was not intended for us, and should be passed along to other ports/interfaces.
          */
         bool fwUpdate_processMessage(const payload_t& msg_payload);
+
+        /**
+         * Unpacks buffer into a payload_t and processes it; see fwUpdate_processMessage(const payload_t&).
+         * @param buffer the raw received message buffer
+         * @param buf_len the number of bytes in buffer
+         * @return true if this message was consumed by this interface, or false if the message was not intended for us, and should be passed along to other ports/interfaces.
+         */
         bool fwUpdate_processMessage(const uint8_t* buffer, int buf_len);
 
         /**

--- a/src/protocol/FirmwareUpdate.h
+++ b/src/protocol/FirmwareUpdate.h
@@ -1,6 +1,12 @@
-//
-// Created by kylemallory on 7/26/23.
-//
+/**
+ * @file FirmwareUpdate.h
+ * @brief On-wire DID_FIRMWARE_UPDATE packet protocol: message types, session/status codes, and
+ *        the packed wire structs, plus the FirmwareUpdateBase/Device/Host class hierarchy that
+ *        implements the chunked-transfer state machine described in the comment block below.
+ *
+ * @author Kyle Mallory on 7/26/23.
+ * @copyright Copyright (c) 2023 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef IS_FIRMWAREUPDATE_H
 #define IS_FIRMWAREUPDATE_H
@@ -93,129 +99,159 @@ namespace fwUpdate {
  *
  */
 
+    /**
+     * Progress-report callback for a single upload/verify step.
+     * @param obj implementation-specific context object identifying the caller
+     * @param percent completion percentage (0-100) of the current step
+     * @param stepName human-readable name of the current step
+     * @param stepNo the index of the current step
+     * @param totalSteps the total number of steps
+     * @return IS_OP_OK to continue, or an error to abort
+     */
     typedef is_operation_result (*pfnProgressCb)(const std::any& obj, float percent, const std::string& stepName, int stepNo, int totalSteps);
+
+    /**
+     * Status/log message callback.
+     * @param obj implementation-specific context object identifying the caller
+     * @param level the severity of the message (one of eLogLevel)
+     * @param infoString a printf-style format string
+     * @param ... format arguments for infoString
+     */
     typedef void (*pfnStatusCb)(const std::any& obj, eLogLevel level, const char* infoString, ...);
 
 
-#define FWUPDATE__MAX_CHUNK_SIZE   512
-#define FWUPDATE__MAX_PAYLOAD_SIZE (FWUPDATE__MAX_CHUNK_SIZE + 92)
+#define FWUPDATE__MAX_CHUNK_SIZE   512                                  //!< maximum number of firmware-image bytes carried in a single UPDATE_CHUNK message
+#define FWUPDATE__MAX_PAYLOAD_SIZE (FWUPDATE__MAX_CHUNK_SIZE + 92)       //!< maximum total payload_t size (chunk data plus header/message overhead)
 
-    static constexpr uint32_t TARGET_TYPE_MASK = 0x0000FFF0;
-    static constexpr uint32_t TARGET_DFU_FLAG  = 0x80000000;
-    static constexpr uint32_t TARGET_ISB_FLAG  = 0x40000000;
-    static constexpr uint32_t TARGET_SMP_FLAG  = 0x20000000;
+    static constexpr uint32_t TARGET_TYPE_MASK = 0x0000FFF0;  //!< mask isolating a target_t's base product/type bits, stripping instance and protocol flags
+    static constexpr uint32_t TARGET_DFU_FLAG  = 0x80000000;  //!< bit 31: target is addressed via the USB DFU bootloader protocol
+    static constexpr uint32_t TARGET_ISB_FLAG  = 0x40000000;  //!< bit 30: target is addressed via the legacy ISB (Inertial Sense Bootloader) protocol
+    static constexpr uint32_t TARGET_SMP_FLAG  = 0x20000000;  //!< bit 29: target is addressed via the SMP (Simple Management Protocol / MCUmgr) bootloader protocol
 
+    /**
+     * Identifies the device (and, for multi-instance targets, the specific instance/mask) a
+     * fwUpdate message is directed to. Values < 0xFF are Inertial-Sense products; > 0xFF are
+     * 3rd-party. The high nibble of the low byte selects the product; the low nibble is a mask
+     * selecting which of up to 4 identical devices to address (e.g. TARGET_SONY_CXD5610__1 |
+     * TARGET_SONY_CXD5610__2 updates both receivers with one payload). TARGET_DFU_FLAG/
+     * TARGET_ISB_FLAG/TARGET_SMP_FLAG mark which bootloader protocol addresses that target.
+     */
     enum target_t : uint32_t {
-        TARGET_HOST = 0x00,
+        TARGET_HOST = 0x00,                                    //!< the controlling host PC/application itself (not a remote device)
 
-        TARGET_IMX5 = 0x10,
-        TARGET_DFU_IMX5 = (TARGET_DFU_FLAG | TARGET_IMX5),
-        TARGET_ISB_IMX5 = (TARGET_ISB_FLAG | TARGET_IMX5), // note that the IMX5 ONLY support ISB mode (it doesn't directly support ISv2)
+        TARGET_IMX5 = 0x10,                                     //!< IMX-5 IMU/INS module
+        TARGET_DFU_IMX5 = (TARGET_DFU_FLAG | TARGET_IMX5),       //!< IMX-5, addressed via USB DFU
+        TARGET_ISB_IMX5 = (TARGET_ISB_FLAG | TARGET_IMX5),       //!< IMX-5, addressed via ISB (the IMX-5 ONLY supports ISB mode, not ISv2)
 
-        TARGET_GPX1 = 0x20,
-        TARGET_DFU_GPX1 = (TARGET_DFU_FLAG | TARGET_GPX1),
-        TARGET_SMP_GPX1 = (TARGET_SMP_FLAG | TARGET_GPX1),
+        TARGET_GPX1 = 0x20,                                     //!< GPX-1 GNSS/positioning module
+        TARGET_DFU_GPX1 = (TARGET_DFU_FLAG | TARGET_GPX1),       //!< GPX-1, addressed via USB DFU
+        TARGET_SMP_GPX1 = (TARGET_SMP_FLAG | TARGET_GPX1),       //!< GPX-1, addressed via SMP
 
-        TARGET_IMX6 = 0x30,
-        TARGET_DFU_IMX6 = (TARGET_DFU_FLAG | TARGET_IMX6),
-        TARGET_SMP_IMX6 = (TARGET_SMP_FLAG | TARGET_IMX6),
+        TARGET_IMX6 = 0x30,                                     //!< IMX-6 IMU/INS module
+        TARGET_DFU_IMX6 = (TARGET_DFU_FLAG | TARGET_IMX6),       //!< IMX-6, addressed via USB DFU
+        TARGET_SMP_IMX6 = (TARGET_SMP_FLAG | TARGET_IMX6),       //!< IMX-6, addressed via SMP
 
-        TARGET_UBLOX_F9P = 0x110,
-        TARGET_UBLOX_F9P__1 = 0x111,
-        TARGET_UBLOX_F9P__2 = 0x112,
-        TARGET_UBLOX_F9P__ALL = 0x11F,
+        TARGET_UBLOX_F9P = 0x110,             //!< u-blox F9P GNSS receiver (base target; use a masked variant to address a specific instance)
+        TARGET_UBLOX_F9P__1 = 0x111,          //!< u-blox F9P GNSS receiver, instance 1
+        TARGET_UBLOX_F9P__2 = 0x112,          //!< u-blox F9P GNSS receiver, instance 2
+        TARGET_UBLOX_F9P__ALL = 0x11F,        //!< u-blox F9P GNSS receiver, all instances (mask covering both)
 
-        TARGET_SONY_CXD5610 = 0x120,
-        TARGET_SONY_CXD5610__1 = 0x121,
-        TARGET_SONY_CXD5610__2 = 0x122,
-        TARGET_SONY_CXD5610__ALL = 0x12F,
+        TARGET_SONY_CXD5610 = 0x120,          //!< Sony CXD5610 GNSS receiver (base target; use a masked variant to address a specific instance)
+        TARGET_SONY_CXD5610__1 = 0x121,       //!< Sony CXD5610 GNSS receiver, instance 1
+        TARGET_SONY_CXD5610__2 = 0x122,       //!< Sony CXD5610 GNSS receiver, instance 2
+        TARGET_SONY_CXD5610__ALL = 0x12F,     //!< Sony CXD5610 GNSS receiver, all instances (mask covering both)
 
-        TARGET_SEPTENTRIO = 0x130,
+        TARGET_SEPTENTRIO = 0x130,            //!< Septentrio GNSS receiver
 
-        TARGET_MAXNUM,
-        TARGET_UNKNOWN = 0xFFFFFFFF,
+        TARGET_MAXNUM,                        //!< sentinel; must be last among assigned target values
+        TARGET_UNKNOWN = 0xFFFFFFFF,          //!< target has not been identified / is invalid
     };
 
+    /** Identifies the kind of DID_FIRMWARE_UPDATE message a payload_t carries (see msg_header_t::msg_type). */
     enum msg_types_e : uint32_t {
-        MSG_UNKNOWN = 0,            // an unknown or undefined message type.
-        MSG_REQ_RESET = 1,          // a host is requesting that the device perform a reset.
-        MSG_RESET_RESP = 2,         // response to the requesting host, that a reset was performed (but not guarantee that it was successful).
-        MSG_REQ_UPDATE = 3,         // a host is requesting that the device enter update mode - in essense, initiate the update state-machine that is responsible for getting the target device into a state where it can receive an update.
-        // The payload is a total of 12 bytes, the first 8 bytes, representing in little-endian, the overall size of the payload. The last 4 are the size of each payload chunk.
-        // The payload max_chnks should be the total number of chunks, of overall payload size / the size of the payload chunk (rounded up).
-        MSG_UPDATE_RESP = 4,        // communicates back to the host that the device is ready to update (in bootloader mode, etc) (the state machine has finished setup and is ready for data).
-        MSG_UPDATE_CHUNK = 5,       // this message contains data which is a portion of the new firmware.  The chnk_id, and num_chunks represent the location of the payload within the overall firmware image
-        MSG_UPDATE_PROGRESS = 6,    // this is a message sent back to the host at regular intervals to communicate to the user the status of the update process.  This message can be sent at any time
-        MSG_REQ_RESEND_CHUNK = 7,   // this is a message send by the device back to the host, requesting that a particular chunk be resent.  The device should send this when there is an issue with the last received "UPDATE_PAYLOAD",
-        // either in a checksum error, invalid/missing chunk id, etc.  When this message is received by the host, the host MUST resend the requested chunk, and all subsequent chunks that follow it, regardless
-        // if they were previously sent.  Likewise, on the device, as soon as a received chunk is deemed invalid, forcing this message to be sent back to the host, all subsequent payload chunks received which
-        // are NOT this requested chunk MUST BE ignored.
-        MSG_UPDATE_DONE = 8,        // this message is sent when the device-side has completed receiving file chunks, regardless of the status of those chunks, or the reception of all available chunks.  In essense, this is a notice
-        // to the host that no more chunks of data will be accepted, regardless of state. Included in this message is a status indicating whether the image transfer was successful, of not. When this message
-        // is sent, the associated session_id is invalidated ensuring that no further messages can be processed. If there is an error, a new session will need to be started.
-        MSG_REQ_VERSION_INFO = 9,   // this message is sent by the host to request information about the current target's firmware
-        MSG_VERSION_INFO_RESP = 10, // this message is the response from a device, which details the target devices hardware and firmware version and also firmware build info.
+        MSG_UNKNOWN = 0,            //!< an unknown or undefined message type.
+        MSG_REQ_RESET = 1,          //!< a host is requesting that the device perform a reset.
+        MSG_RESET_RESP = 2,         //!< response to the requesting host, that a reset was performed (but not guarantee that it was successful).
+        MSG_REQ_UPDATE = 3,         //!< a host is requesting that the device enter update mode -- initiates the state-machine that readies the target to receive an update (see msg_data_t::req_update).
+        MSG_UPDATE_RESP = 4,        //!< communicates back to the host that the device is ready to update (in bootloader mode, etc) (the state machine has finished setup and is ready for data).
+        MSG_UPDATE_CHUNK = 5,       //!< this message contains data which is a portion of the new firmware.  The chnk_id, and num_chunks represent the location of the payload within the overall firmware image
+        MSG_UPDATE_PROGRESS = 6,    //!< this is a message sent back to the host at regular intervals to communicate to the user the status of the update process.  This message can be sent at any time
+        MSG_REQ_RESEND_CHUNK = 7,   //!< sent by the device back to the host to request that a chunk be resent (checksum/sequence error, etc); host MUST resend that chunk and all that follow, in order.
+        MSG_UPDATE_DONE = 8,        //!< sent when the device has finished receiving chunks (success or failure, via an included status); invalidates the session_id -- a new session is required to retry.
+        MSG_REQ_VERSION_INFO = 9,   //!< this message is sent by the host to request information about the current target's firmware
+        MSG_VERSION_INFO_RESP = 10, //!< this message is the response from a device, which details the target devices hardware and firmware version and also firmware build info.
     };
 
+    /**
+     * Status/error code for a firmware update session, reported by both host and device sides
+     * (see FirmwareUpdateHost::fwUpdate_getSessionStatus() / FirmwareUpdateDevice equivalent).
+     * Values >= 0 are non-error session states progressing toward FINISHED; negative values are
+     * errors, all of which return the session to NOT_STARTED after a short timeout.
+     */
     enum update_status_e : int16_t {
-        FINISHED = 5,               // indicates that all operations are completed and device reports success (generally ready for a reset)
-        FINALIZING = 4,             // indicates that all chunks have been received, and checksum is valid, but still waiting on internal operations to complete
-        IN_PROGRESS = 3,            // indicates that the update status has started, and at least 1 chunk has been sent, but more chunks are still expected
-        READY = 2,                  // indicates that the update status has finished initializing and is waiting for the first chunk of firmware data
-        INITIALIZING = 1,           // indicates that an update has been received, but the subsystem is waiting on completion of the bootloader or other back-end mechanism to initialize before data transfer can begin.
-        NOT_STARTED = 0,            // indicates that the update process has not been initiated (it will fall back to this after an error, and a short timeout).
-        ERR_INVALID_SESSION = -1,   // indicates that the requested session ID is invalid.
-        ERR_INVALID_SLOT = -2,      // indicates that the request slot does not exist. Different targets have different number of slots which can be written to.
-        ERR_NOT_ALLOWED = -3,       // indicates that writing to the requested slot is not allowed, usually due to security constrains such as a locked firmware, Read-Only FLASH, etc.
-        ERR_NOT_ENOUGH_MEMORY = -4, // indicates that the requested firmware file size would exceed the available slot size.
-        ERR_OLDER_FIRMWARE = -5,    // indicates that the new firmware is an older (or earlier) version, and performing this would result in a downgrade.
-        ERR_MAX_CHUNK_SIZE = -6,    // indicates that the maximum chunk size requested in the original upload request is too large.  The host is expected to begin a new session with a smaller chunk size.
-        ERR_TIMEOUT = -7,           // indicates that the update process timed-out waiting for data (either a request, response, or chunk data that never arrived)
-        ERR_CHECKSUM_MISMATCH = -8, // indicates that the final checksum didn't match the checksum specified at the start of the process
-        ERR_COMMS = -9,             // indicates that an error in the underlying comms system
-        ERR_NOT_SUPPORTED = -10,    // indicates that the target device doesn't support this protocol
-        ERR_FLASH_WRITE_FAILURE = -11,    // indicates that writing of the chunk to flash/nvme storage failed (this can be retried)
-        ERR_FLASH_OPEN_FAILURE = -12,   // indicates that an attempt to "open" a particular flash location failed for unknown reasons.
-        ERR_FLASH_INVALID = -13,    // indicates that the image, after writing to flash failed to validate.
-        ERR_UPDATER_CLOSED = -14,   //
-        ERR_INVALID_IMAGE = -15,    // indicates that the specified image file is invalid; this can also be reported directly by the host if the image file is not found.
-        ERR_INVALID_CHUNK = -16,    // indicates a repeated failure to deliver the correct chunk id or size
-        ERR_INVALID_TARGET = -17,   // indicates that the target is invalid - this could mean that the target 'index' doesn't exist, or that the target + target_flags are unsupported, etc.
-        ERR_INTERRUPTED = -18,      // indicates that the process was artificially interrupted (by the user, etc), and not from an internal error condition
-        ERR_UNKNOWN = -19,          // indicates an unknown error, this should *always* be the last (lower) value
+        FINISHED = 5,               //!< indicates that all operations are completed and device reports success (generally ready for a reset)
+        FINALIZING = 4,             //!< indicates that all chunks have been received, and checksum is valid, but still waiting on internal operations to complete
+        IN_PROGRESS = 3,            //!< indicates that the update status has started, and at least 1 chunk has been sent, but more chunks are still expected
+        READY = 2,                  //!< indicates that the update status has finished initializing and is waiting for the first chunk of firmware data
+        INITIALIZING = 1,           //!< indicates that an update has been received, but the subsystem is waiting on completion of the bootloader or other back-end mechanism to initialize before data transfer can begin.
+        NOT_STARTED = 0,            //!< indicates that the update process has not been initiated (it will fall back to this after an error, and a short timeout).
+        ERR_INVALID_SESSION = -1,   //!< indicates that the requested session ID is invalid.
+        ERR_INVALID_SLOT = -2,      //!< indicates that the request slot does not exist. Different targets have different number of slots which can be written to.
+        ERR_NOT_ALLOWED = -3,       //!< indicates that writing to the requested slot is not allowed, usually due to security constrains such as a locked firmware, Read-Only FLASH, etc.
+        ERR_NOT_ENOUGH_MEMORY = -4, //!< indicates that the requested firmware file size would exceed the available slot size.
+        ERR_OLDER_FIRMWARE = -5,    //!< indicates that the new firmware is an older (or earlier) version, and performing this would result in a downgrade.
+        ERR_MAX_CHUNK_SIZE = -6,    //!< indicates that the maximum chunk size requested in the original upload request is too large.  The host is expected to begin a new session with a smaller chunk size.
+        ERR_TIMEOUT = -7,           //!< indicates that the update process timed-out waiting for data (either a request, response, or chunk data that never arrived)
+        ERR_CHECKSUM_MISMATCH = -8, //!< indicates that the final checksum didn't match the checksum specified at the start of the process
+        ERR_COMMS = -9,             //!< indicates that an error in the underlying comms system
+        ERR_NOT_SUPPORTED = -10,    //!< indicates that the target device doesn't support this protocol
+        ERR_FLASH_WRITE_FAILURE = -11,  //!< indicates that writing of the chunk to flash/nvme storage failed (this can be retried)
+        ERR_FLASH_OPEN_FAILURE = -12,   //!< indicates that an attempt to "open" a particular flash location failed for unknown reasons.
+        ERR_FLASH_INVALID = -13,    //!< indicates that the image, after writing to flash failed to validate.
+        ERR_UPDATER_CLOSED = -14,   //!< indicates that the updater was closed/torn down while a session was active
+        ERR_INVALID_IMAGE = -15,    //!< indicates that the specified image file is invalid; this can also be reported directly by the host if the image file is not found.
+        ERR_INVALID_CHUNK = -16,    //!< indicates a repeated failure to deliver the correct chunk id or size
+        ERR_INVALID_TARGET = -17,   //!< indicates that the target is invalid - this could mean that the target 'index' doesn't exist, or that the target + target_flags are unsupported, etc.
+        ERR_INTERRUPTED = -18,      //!< indicates that the process was artificially interrupted (by the user, etc), and not from an internal error condition
+        ERR_UNKNOWN = -19,          //!< indicates an unknown error, this should *always* be the last (lower) value
         // TODO: IF YOU ADD NEW ERROR MESSAGES, don't forget to update fwUpdate::status_names, and fwUpdate_getStatusName()
     };
 
+    /** Why the device is requesting a chunk be resent (see msg_data_t::req_resend). Informational only -- the resend behavior is the same regardless of reason. */
     enum resend_reason_e : int16_t {
-        REASON_NONE = 0,
-        REASON_INVALID_SEQID = 1,   // the last received chunk was out of order, so we're requesting the correct chunk id.
-        REASON_WRITE_ERROR = 2,     // there was an error writing the data to FLASH (perhaps it took too long?)
-        REASON_INVALID_SIZE = 3,    // unless the chunk id is the last chunk, the size of the chunk should always be the negotiated session_chunk_size;
+        REASON_NONE = 0,            //!< no reason given / not applicable
+        REASON_INVALID_SEQID = 1,   //!< the last received chunk was out of order, so we're requesting the correct chunk id.
+        REASON_WRITE_ERROR = 2,     //!< there was an error writing the data to FLASH (perhaps it took too long?)
+        REASON_INVALID_SIZE = 3,    //!< unless the chunk id is the last chunk, the size of the chunk should always be the negotiated session_chunk_size;
     };
 
+    /** Bitmask flags controlling how a device reset is performed (see msg_data_t::req_reset, fwUpdate_requestReset()/fwUpdate_performReset()). */
     enum reset_flags_e : uint16_t {
-        RESET_SOFT = 0,             // typically, a software reset (start the program over, but don't remove power or clear RAM)
-        RESET_HARD = 1,             // a hard reset, in which the device is power-cycled; this may not always be possible since generally software on a device can't remove its own power
-        RESET_INTO_BOOTLOADER = 2,  // indicates that the device should reset into the bootloader (this may not always be possible)
-        RESET_CONFIG = 4,           // indicates that the device should clear its configuration before performing the reset (Ie, factory restart?)
-        RESET_UPSTREAM = 8,         // indicates that this device should reset all of its upstream devices, in addition to itself
+        RESET_SOFT = 0,             //!< typically, a software reset (start the program over, but don't remove power or clear RAM)
+        RESET_HARD = 1,             //!< bit 0: a hard reset, in which the device is power-cycled; this may not always be possible since generally software on a device can't remove its own power
+        RESET_INTO_BOOTLOADER = 2,  //!< bit 1: indicates that the device should reset into the bootloader (this may not always be possible)
+        RESET_CONFIG = 4,           //!< bit 2: indicates that the device should clear its configuration before performing the reset (Ie, factory restart?)
+        RESET_UPSTREAM = 8,         //!< bit 3: indicates that this device should reset all of its upstream devices, in addition to itself
     };
 
+    /** Bit positions within image_flagsMask_e / msg_data_t::req_update.image_flags. */
     enum image_flagsPos_e : uint8_t {
-        IMG_FLAG_POS__imageNotEncrypted = 0,  // position of bit that informs firmware that sony image is not encrypted
-        IMG_FLAG_POS__useAlternateMD5 = 7,    // position of bit that informs firmware to use the alternate (obsolete) MD5 algorithm
+        IMG_FLAG_POS__imageNotEncrypted = 0,  //!< bit 0: position of bit that informs firmware that sony image is not encrypted
+        IMG_FLAG_POS__useAlternateMD5 = 7,     //!< bit 7: position of bit that informs firmware to use the alternate (obsolete) MD5 algorithm
     };
 
+    /** Bitmask values for msg_data_t::req_update.image_flags, built from image_flagsPos_e bit positions. */
     enum image_flagsMask_e : uint8_t {
-        IMG_FLAG_imageNotEncrypted = 0x01 << IMG_FLAG_POS__imageNotEncrypted,   // bit mask that informs firmware that sony image is not encrypted
-        IMG_FLAG_useAlternateMD5 = 1 << IMG_FLAG_POS__useAlternateMD5           // bit mask that informs firmware to use the alternate (obsolete) MD5 algo
+        IMG_FLAG_imageNotEncrypted = 0x01 << IMG_FLAG_POS__imageNotEncrypted,  //!< bit 0 set: informs firmware that sony image is not encrypted
+        IMG_FLAG_useAlternateMD5 = 1 << IMG_FLAG_POS__useAlternateMD5          //!< bit 7 set: informs firmware to use the alternate (obsolete) MD5 algo
     };
 
     PUSH_PACK_1
 
+    /** Per-message-type payload data for a DID_FIRMWARE_UPDATE packet; msg_header_t::msg_type selects the active member. */
     typedef union {
-        struct {
-            uint16_t reset_flags;
+        struct {                     //!< requests that the target device perform a reset (see msg_types_e::MSG_REQ_RESET)
+            uint16_t reset_flags;    //!< a reset_flags_e bitmask controlling how the reset is performed
         } req_reset;
 
         struct {                    //!< a response to a reset request (usually this isn't sent, but sometimes, like asking a GNSS receiver to reset, it could send back a reply, since that doesn't originate on the GNSS receiver).
@@ -296,13 +332,15 @@ namespace fwUpdate {
 
     } msg_data_t;
 
+    /** Fixed-size header prefixing every DID_FIRMWARE_UPDATE payload_t. */
     typedef struct {
         target_t target_device;     //!< the target type and instance which this message is intended for
         msg_types_e msg_type;       //!< msg_type enum used to indicate how to parse the subsequent data in this message
     } msg_header_t;
 
+    /** A complete DID_FIRMWARE_UPDATE message: header plus the msg_type-selected payload data. */
     typedef struct {
-        msg_header_t hdr;
+        msg_header_t hdr;           //!< identifies the target and message type
         msg_data_t data;            //!< the actual message data
     } payload_t;
 
@@ -320,36 +358,39 @@ namespace fwUpdate {
     class FirmwareUpdateBase {
     public:
 
-        static const size_t MaxChunkSize = FWUPDATE__MAX_CHUNK_SIZE;
-        static const size_t MaxPayloadSize = FWUPDATE__MAX_PAYLOAD_SIZE;
+        static const size_t MaxChunkSize = FWUPDATE__MAX_CHUNK_SIZE;      //!< maximum number of firmware-image bytes carried in a single UPDATE_CHUNK message
+        static const size_t MaxPayloadSize = FWUPDATE__MAX_PAYLOAD_SIZE;  //!< maximum total payload_t size (chunk data plus header/message overhead)
 
         /**
-         * Packs a byte buffer that can be sent out onto the wire, using data from a passed msg_payload_t.
+         * Packs a byte buffer that can be sent out onto the wire, using data from a passed payload_t.
          * Note that this results in at least one copy, and possibly multiple assignments. Where possible, you
          * should opt to cast the payload directly into a uint8_t pointer and use directly. This is not always
          * possible (particularly with strings/chunk data).
-         * @param msg_payload
-         * @param buffer
-         * @param max_len
-         * @return
+         * @param buffer the destination buffer to pack into
+         * @param max_len the size of buffer, in bytes
+         * @param payload the message to pack
+         * @param aux_data auxiliary data (e.g. chunk bytes) to append after the fixed payload, or nullptr if none
+         * @return the number of bytes written to buffer, or a negative value on error (e.g. buffer too small)
          */
         static int fwUpdate_packPayload(uint8_t* buffer, int max_len, const payload_t& payload, const void *aux_data= nullptr);
 
         /**
-         * Unpacks a DID payload byte buffer (from the comms system) into a firmware_update msg_payload_t struct
+         * Unpacks a DID payload byte buffer (from the comms system) into a firmware_update payload_t struct
          * Note that this results in at least one copy, and possibly multiple assignments. Where possible, you
-         * should opt to cast the pointer into a msg_payload_t, and use directly, but that isn't always possible.
+         * should opt to cast the pointer into a payload_t, and use directly, but that isn't always possible.
          * @param buffer a pointer to the start of the byte buffer containing the raw data
          * @param buf_len the number of bytes the unpack from the byte buffer
-         * @param msg_payload the payload_t struct that the data will be unpacked into.
-         * @return true on success, otherwise false
+         * @param payload the payload_t struct that the data will be unpacked into.
+         * @param aux_data if non-null, receives any auxiliary data (e.g. chunk bytes) following the fixed payload
+         * @param max_aux the size of aux_data, in bytes
+         * @return the number of bytes consumed from buffer on success, or a negative value on error
          */
         static int fwUpdate_unpackPayload(const uint8_t* buffer, int buf_len, payload_t& payload, void *aux_data= nullptr, uint16_t max_aux= 0);
 
         /**
          * maps a DID payload byte buffer (from the comms system) into a fwUpdate::payload_t struct, and extracts aux_data if any.
          * @param buffer a pointer to the raw byte buffer
-         * @param msg_payload a double-pointer which on return will point to the start of the buffer (this is a simple cast)
+         * @param payload a double-pointer which on return will point to the start of the buffer (this is a simple cast)
          * @param aux_data a double-pointer which on return will point to any auxilary data in the payload, or nullptr if there is none
          * @return returns the total number of bytes in the packet, including aux data if any
          */
@@ -357,21 +398,21 @@ namespace fwUpdate {
 
         /**
          * Returns the string representation of the passed status
-         * @param status
+         * @param status the status to look up
          * @return a constant char * to a string representing the specified status
          */
         static const char *fwUpdate_getStatusName(update_status_e status);
 
         /**
          * Returns a human-friendly string describing the update status, used for UIs
-         * @param status
+         * @param status the status to look up
          * @return a constant char * to a string representing the specified status
          */
         static const char *fwUpdate_getNiceStatusName(update_status_e status);
 
         /**
          * Returns the string representation of the passed target
-         * @param target
+         * @param target the target to look up
          * @return a constant char * to a string representing the specified target
          */
         static const char *fwUpdate_getTargetName(target_t target);
@@ -422,7 +463,7 @@ namespace fwUpdate {
         /**
          * packages and sends the specified payload, including any auxillary data.
          * Note that the payload must already specify the amount of aux data the be included.
-         * @param payload
+         * @param payload the message to send
          * @param aux_data the auxillary data to include, or nullptr if none.
          * @return true if the specified payload was successfully sent, otherwise false
          */
@@ -431,21 +472,21 @@ namespace fwUpdate {
         /**
          * Virtual function that must be implemented in the concrete implementations, responsible for writing buffer out to the wire (serial, or otherwise).
          * @param target a reference to the target for which this data is intended
-         * @param buffer
-         * @param buff_len
+         * @param buffer the data to send
+         * @param buff_len the number of bytes in buffer
          * @return true if the buffer was sent to the target device, otherwise false
          */
         virtual bool fwUpdate_writeToWire(target_t target, uint8_t* buffer, int buff_len) = 0;
 
         /**
          * Sets the duration (in milliseconds) which will trigger a Timeout status if a session has been started, but no further communications has been received for this target (host or device).
-         * @param timeout
+         * @param timeout the new timeout duration, in milliseconds
          */
         void fwUpdate_setTimeoutDuration(uint32_t timeout) { timeout_duration = timeout; }
 
         /**
          * Returns the elapsed time since the last message was received by this target, meant for this target.  Use this value > timeoutDuration to detect a timeout condition.
-         * @return
+         * @return the elapsed time, in milliseconds, since the last message was received
          */
         uint32_t fwUpdate_getLastMessageAge() { return current_timeMs() - last_message; }
 
@@ -454,12 +495,18 @@ namespace fwUpdate {
          */
         void fwUpdate_resetTimeout() { last_message = current_timeMs(); }
 
+        /**
+         * Formats a payload_t as a human-readable string, for logging/diagnostics.
+         * @param payload the message to format
+         * @return a newly-allocated string describing payload; caller takes ownership
+         */
         static char* fwUpdate_payloadToString(const payload_t* payload);
 
     private:
         /**
          * returns the total size of the passed payload msg, including any variable length data included in the message.
-         * @param msg
+         * @param payload the message to measure
+         * @param include_aux if true, include any auxiliary (e.g. chunk) data following the fixed payload
          * @return the number of bytes that this entire message contains, including headers, etc.
          */
         static size_t fwUpdate_getPayloadSize(const payload_t* payload, bool include_aux= false);
@@ -489,19 +536,42 @@ namespace fwUpdate {
          * Note: Internally, this method calls fwUpdate_step(), so even if you don't call fwUpdate_step(), but it can still operate with just inbound messages, but interval updates/etc won't run.
          */
         bool fwUpdate_processMessage(const payload_t& msg_payload);
+
+        /**
+         * Unpacks buffer into a payload_t and processes it; see fwUpdate_processMessage(const payload_t&).
+         * @param buffer the raw received message buffer
+         * @param buf_len the number of bytes in buffer
+         * @return true if this message was consumed by this interface, or false if the message was not intended for us, and should be passed along to other ports/interfaces.
+         */
         bool fwUpdate_processMessage(const uint8_t* buffer, int buf_len);
 
         /**
          * @return the target type for this instance.
          */
         target_t fwUpdate_getCurrentTarget() { return session_target; }
+
+        /** @return the current/last update_status_e of this device's session */
         update_status_e fwUpdate_getSessionStatus() { return session_status; }
+
+        /** @return the current session id, or 0 if no session has been started */
         uint16_t fwUpdate_getSessionID() { return session_id; }
+
+        /** @return the fraction of chunks (0.0-1.0) that had to be resent, as an error-rate indicator */
         float fwUpdate_getResendRate() { return ((float)resend_count / (float)last_chunk_id); }
+
+        /** @return the chunk id of the most recently received chunk, or -1 if none has been received yet */
         uint16_t fwUpdate_getLastChunkID() { return last_chunk_id; }
+
+        /** @return the negotiated chunk size for this session */
         uint16_t fwUpdate_getChunkSize() { return session_chunk_size; }
+
+        /** @return the total number of chunks negotiated for this session, determined by the image size */
         uint16_t fwUpdate_getTotalChunks() { return session_total_chunks; }
+
+        /** @return the size (bytes) of the firmware image for this session */
         uint16_t fwUpdate_getImageSize() { return session_image_size; }
+
+        /** @return the image slot this session is writing to */
         uint16_t fwUpdate_getImageSlot() { return session_image_slot; }
 
 
@@ -509,13 +579,13 @@ namespace fwUpdate {
         //===========  Functions which MUST be implemented ===========//
 
         /**
-         * Writes the requested data (usually a packed payload_t) out to the specified device
+         * Writes the requested data (usually a packed payload_t) out to the specified device.
          * Note that the implementation between a target and an actual interface is device-specific. In most cases,
          * for a Device-implementation, this will typically specify TARGET_HOST, which will direct back to the
          * controlling host.
-         * @param target
-         * @param buffer
-         * @param buff_len
+         * @param target the target this message is directed to
+         * @param buffer the encoded buffer to send
+         * @param buff_len the number of bytes in the encoded buffer to send
          * @return true if the data was successfully sent to the underlying communication system, otherwise false
          */
         virtual bool fwUpdate_writeToWire(target_t target, uint8_t* buffer, int buff_len) override = 0;
@@ -536,7 +606,8 @@ namespace fwUpdate {
          * If this call returns false, the API will respond with a MSG_VERSION_INFO_RESP, with the message filled with 0xFF, indicating not-supported.
          * NOTE that this call is passed a reference to a const dev_info_t; the base-class provides the instance which is referenced. As the implementer
          * of this class, it is your responsibility to fill it with the appropriate data.
-         * @param a reference to a dev_info_t struct that contains the necessary version information to be returned back to the querying host.
+         * @param target_id the device whose version info is being requested
+         * @param dev_info reference to a dev_info_t struct to fill with the version information to be returned back to the querying host
          * @return true if the message was received and parsed without error, false otherwise.
          */
         virtual bool fwUpdate_queryVersionInfo(target_t target_id, dev_info_t& dev_info) = 0;
@@ -562,18 +633,19 @@ namespace fwUpdate {
         virtual update_status_e fwUpdate_writeImageChunk(target_t target_id, int slot_id, int offset, int len, uint8_t *data) = 0;
 
         /**
-         * Validated and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
+         * Validates and finishes writing of the firmware image; that all image bytes have been received, the md5 sum passed, and the device can complete the requested upgrade, and perform any device-specific finalization.
          * @param target_id the target_id
          * @param slot_id the image slot, if applicable (otherwise 0)
-         * @return
+         * @param flags additional flags controlling finalization behavior
+         * @return an update_status_e indicating the continued state of the update process, or an error
          */
         virtual update_status_e fwUpdate_finishUpdate(target_t target_id, int slot_id, int flags) = 0;
 
 
     protected:
         /**
-         * This is an internal method used to send an update message to the host system regarding the status of the update process
-         * This message only include the number of chunks sent, and the total expected (sufficient for a percentage) and the
+         * This is an internal method used to send an update message to the host system regarding the status of the update process.
+         * This message only includes the number of chunks sent, and the total expected (sufficient for a percentage).
          * @return true if the message was sent, false if there was an error
          */
         virtual bool fwUpdate_sendProgress();
@@ -590,8 +662,8 @@ namespace fwUpdate {
          * This is an internal method used to send an update message to the host system regarding the status of the update process
          * This variation allows for printf-based string formatting
          * @param level the criticality/severity of this message (0 = Critical, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug, etc)
-         * @param message the actual message to be sent to the host
-         * @
+         * @param message a printf-style format string
+         * @param ... format arguments for message
          * @return true if the message was sent, false if there was an error
          */
         virtual bool fwUpdate_sendProgressFormatted(int level, const char *message, ...);
@@ -632,7 +704,7 @@ namespace fwUpdate {
         /**
          * Internally called by fwUpdate_processMessage() when a UPDATE_CHUNK message is received.
          * @param payload the DID payload
-         * @return
+         * @return true if the chunk was received and processed without error, false otherwise.
          */
         bool fwUpdate_handleChunk(const payload_t& payload);
 
@@ -664,11 +736,11 @@ namespace fwUpdate {
          */
         bool fwUpdate_validateSessionId(uint16_t sessionId);
 
-        static constexpr uint8_t MAX_SESSION_HISTORY = 10;  // the maximum number of session Ids to retain for historical purposes.
-        uint16_t sessionHistory[MAX_SESSION_HISTORY] = {0}; // a history of the previously observed session ids.
-        uint32_t progress_interval = 500;                   // we'll send progress updates at 2hz.
-        uint32_t nextProgressReport = 0;                    // the next system
-        int32_t last_chunk_id = -1;                         // the last received chunk id from a CHUNK message. -1 = no chunk yet received; the next received chunk must be 0.
+        static constexpr uint8_t MAX_SESSION_HISTORY = 10;   //!< the maximum number of session Ids to retain for historical purposes.
+        uint16_t sessionHistory[MAX_SESSION_HISTORY] = {0};  //!< a history of the previously observed session ids.
+        uint32_t progress_interval = 500;                    //!< the interval (ms) between progress updates; default sends at 2Hz.
+        uint32_t nextProgressReport = 0;                     //!< the next system time (ms) at which a progress update should be sent
+        int32_t last_chunk_id = -1;                          //!< the last received chunk id from a CHUNK message. -1 = no chunk yet received; the next received chunk must be 0.
     };
 
     class FirmwareUpdateHost : public FirmwareUpdateBase {
@@ -691,33 +763,33 @@ namespace fwUpdate {
          * Called by the host application to initiate a request by the SDK to update a target device.
          * @param target_id the target device to update
          * @param image_slot the "slot" on the target device which this image should be written to (device specific, if supported, otherwise 0)
+         * @param image_flags an image_flagsMask_e bitmask of additional flags to communicate to the device
          * @param chunk_size the size of each chunk used to transmit the image (smaller sizes take longer, larger sizes consume more memory and risk buffer overflows)
          * @param image_size the total number of bytes of the firmware image
          * @param image_md5 the md5 checksum of the firmware image
          * @param progress_rate the rate (in millis) which the device should send out progress updates
-         * @return
+         * @return true if the request was successfully sent, otherwise false
          */
         bool fwUpdate_requestUpdate(target_t target_id, int image_slot, int image_flags, uint16_t chunk_size, uint32_t image_size, md5hash_t image_md5, int32_t progress_rate = 500);
 
         /**
          * Called by the host application to resend a previous "fwUpdate_requestUpdate" with a full parameter set.
          * @param new_session if true, reinitializes the session id to a new random value and retains all other arguments (default = false).
-         * @return
+         * @return true if the request was successfully sent, otherwise false
          */
         bool fwUpdate_requestUpdate(bool new_session = false);
 
         /**
          * Requests that the remote device perform a reset. Note that this request does not need a session, or any other pre-negotiated state.
-         * @param target
-         * @param reset_flags
+         * @param target the target device to reset
+         * @param reset_flags a reset_flags_e bitmask controlling how the reset is performed
          * @return true if the request was successfully sent
          */
         bool fwUpdate_requestReset(target_t target, uint16_t reset_flags);
 
         /**
          * Requests that the remote device respond with the devices current firmware and hardware version information.
-         * @param target
-         * @param dev_info
+         * @param target the target device to query
          * @return true if the request was successfully sent
          */
         bool fwUpdate_requestVersionInfo(target_t target);
@@ -819,8 +891,8 @@ namespace fwUpdate {
          * @return the calculated progress as a percentage (0-1.0) from progressNum() / progressTotal()
          */
         float fwUpdate_getProgressPercent() {
-            /// return (session_status < fwUpdate::READY) ? 0.f : (session_status >=  fwUpdate::FINALIZING) ? 100.f : percentComplete;
-            /// return msg.data.progress.num_chunks/(float)(msg.data.progress.totl_chunks)*100.f
+            // return (session_status < fwUpdate::READY) ? 0.f : (session_status >=  fwUpdate::FINALIZING) ? 100.f : percentComplete;
+            // return msg.data.progress.num_chunks/(float)(msg.data.progress.totl_chunks)*100.f
             return (session_status < fwUpdate::READY) ? 0.f : (session_status >=  fwUpdate::FINALIZING) ? 1.f : (float)fwUpdate_getProgressNum() / (float)fwUpdate_getProgressTotal();
         }
 
@@ -855,6 +927,8 @@ namespace fwUpdate {
          * To be implemented by the concrete class, this method provides the response to a VERSION_INFO requests for a target
          * device. Note that this is not session dependent, and can be received at any time (though usually before an UPDATE_REQ
          * is made).
+         * @param msg the version-info response payload
+         * @return true if this message was properly handled (regardless of error, etc), otherwise false
          */
         virtual bool fwUpdate_handleVersionResponse(const payload_t& msg) = 0;
 

--- a/src/protocol/usb_dfu.h
+++ b/src/protocol/usb_dfu.h
@@ -1,3 +1,16 @@
+/**
+ * @file usb_dfu.h
+ * @brief Protocol definitions for the USB Device Firmware Update (DFU) class,
+ *        as adapted from the OpenPCD project's USB DFU implementation. Covers
+ *        the DFU functional descriptor, class-specific request codes, status/
+ *        state codes, and related wire-protocol constants per the USB DFU
+ *        Specification, Revision 1.1.
+ *
+ * @author Harald Welte <hwelte@hmw-consulting.de> (original OpenPCD implementation, 2006)
+ * @copyright Copyright (c) 2006 Harald Welte. Licensed under the GNU General
+ *            Public License, version 2 or later — see full license text below.
+ */
+
 #ifndef USB_DFU_H
 #define USB_DFU_H
 /* USB Device Firmware Update Implementation for OpenPCD
@@ -25,23 +38,28 @@
 
 #include <stdint.h>
 
-#define USB_DT_DFU            0x21
+#define USB_DT_DFU            0x21    //!< USB descriptor type value identifying a DFU functional descriptor
 
 #ifdef _MSC_VER
 # pragma pack(push)
 # pragma pack(1)
 #endif /* _MSC_VER */
+/**
+ * DFU functional descriptor, as defined in Section 4.1.3 of the USB DFU
+ * Specification, Revision 1.1. Describes the DFU-specific capabilities of
+ * the interface it is attached to.
+ */
 struct usb_dfu_func_descriptor {
-    uint8_t                     bLength;
-    uint8_t                     bDescriptorType;
-    uint8_t                     bmAttributes;
-#define USB_DFU_CAN_DOWNLOAD    (1 << 0)
-#define USB_DFU_CAN_UPLOAD      (1 << 1)
-#define USB_DFU_MANIFEST_TOL    (1 << 2)
-#define USB_DFU_WILL_DETACH     (1 << 3)
-    uint16_t                    wDetachTimeOut;
-    uint16_t                    wTransferSize;
-    uint16_t                    bcdDFUVersion;
+    uint8_t                     bLength;            //!< size of this descriptor, in bytes (USB_DT_DFU_SIZE)
+    uint8_t                     bDescriptorType;     //!< descriptor type (USB_DT_DFU)
+    uint8_t                     bmAttributes;        //!< bitmask of DFU capability/behavior flags, see USB_DFU_* bits below
+#define USB_DFU_CAN_DOWNLOAD    (1 << 0)    //!< bit 0: device supports DFU_DNLOAD (host-to-device firmware download)
+#define USB_DFU_CAN_UPLOAD      (1 << 1)    //!< bit 1: device supports DFU_UPLOAD (device-to-host firmware upload)
+#define USB_DFU_MANIFEST_TOL    (1 << 2)    //!< bit 2: device is manifestation-tolerant (can communicate after manifestation without a reset)
+#define USB_DFU_WILL_DETACH     (1 << 3)    //!< bit 3: device will perform a bus detach-attach sequence on receipt of DFU_DETACH, host need not issue a USB reset
+    uint16_t                    wDetachTimeOut;      //!< maximum time, in milliseconds, the device waits after a DFU_DETACH before giving up on the reset
+    uint16_t                    wTransferSize;       //!< maximum number of bytes the device can accept per control-write transaction (DFU_DNLOAD/DFU_UPLOAD block size)
+    uint16_t                    bcdDFUVersion;       //!< BCD-encoded version of the DFU specification this descriptor conforms to (e.g. 0x0110 for v1.1)
 #ifdef _MSC_VER
     };
 # pragma pack(pop)
@@ -55,53 +73,58 @@ struct usb_dfu_func_descriptor {
     #warning "No way to pack struct on this compiler? This will break!"
 #endif /* _MSC_VER */
 
-#define USB_DT_DFU_SIZE            9
+#define USB_DT_DFU_SIZE            9    //!< size, in bytes, of a usb_dfu_func_descriptor
 
-#define USB_TYPE_DFU            (LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE)
+#define USB_TYPE_DFU            (LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE)    //!< libusb request-type/recipient bits for a DFU class request targeting an interface
 
 /* DFU class-specific requests (Section 3, DFU Rev 1.1) */
-#define USB_REQ_DFU_DETACH          0x00
-#define USB_REQ_DFU_DNLOAD          0x01
-#define USB_REQ_DFU_UPLOAD          0x02
-#define USB_REQ_DFU_GETSTATUS       0x03
-#define USB_REQ_DFU_CLRSTATUS       0x04
-#define USB_REQ_DFU_GETSTATE        0x05
-#define USB_REQ_DFU_ABORT           0x06
+#define USB_REQ_DFU_DETACH          0x00    //!< requests the device leave run-time mode and enter DFU mode (or vice versa in DFU mode, per state)
+#define USB_REQ_DFU_DNLOAD          0x01    //!< requests the device receive a block of firmware data from the host (host-to-device transfer)
+#define USB_REQ_DFU_UPLOAD          0x02    //!< requests the device send a block of firmware data to the host (device-to-host transfer)
+#define USB_REQ_DFU_GETSTATUS       0x03    //!< requests the device's current status (bStatus, bwPollTimeout, bState, iString)
+#define USB_REQ_DFU_CLRSTATUS       0x04    //!< clears an error condition and returns the device to the dfuIDLE state
+#define USB_REQ_DFU_GETSTATE        0x05    //!< requests the device's current state (a single dfu_state byte)
+#define USB_REQ_DFU_ABORT           0x06    //!< aborts the current download/upload operation and returns the device to the dfuIDLE state
 
 /* DFU_GETSTATUS bStatus values (Section 6.1.2, DFU Rev 1.1) */
-#define DFU_STATUS_OK               0x00
-#define DFU_STATUS_errTARGET        0x01
-#define DFU_STATUS_errFILE          0x02
-#define DFU_STATUS_errWRITE         0x03
-#define DFU_STATUS_errERASE         0x04
-#define DFU_STATUS_errCHECK_ERASED  0x05
-#define DFU_STATUS_errPROG          0x06
-#define DFU_STATUS_errVERIFY        0x07
-#define DFU_STATUS_errADDRESS       0x08
-#define DFU_STATUS_errNOTDONE       0x09
-#define DFU_STATUS_errFIRMWARE      0x0a
-#define DFU_STATUS_errVENDOR        0x0b
-#define DFU_STATUS_errUSBR          0x0c
-#define DFU_STATUS_errPOR           0x0d
-#define DFU_STATUS_errUNKNOWN       0x0e
-#define DFU_STATUS_errSTALLEDPKT    0x0f
+#define DFU_STATUS_OK               0x00    //!< no error condition is present
+#define DFU_STATUS_errTARGET        0x01    //!< file is not targeted for use by this device
+#define DFU_STATUS_errFILE          0x02    //!< file failed a vendor-specific verification test
+#define DFU_STATUS_errWRITE         0x03    //!< device is unable to write memory
+#define DFU_STATUS_errERASE         0x04    //!< memory erase function failed
+#define DFU_STATUS_errCHECK_ERASED  0x05    //!< memory erase check failed
+#define DFU_STATUS_errPROG          0x06    //!< program memory function failed
+#define DFU_STATUS_errVERIFY        0x07    //!< programmed memory failed verification
+#define DFU_STATUS_errADDRESS       0x08    //!< cannot program memory due to a received address that is out of range
+#define DFU_STATUS_errNOTDONE       0x09    //!< received DFU_DNLOAD with wLength = 0, but device does not think it has all of the data yet
+#define DFU_STATUS_errFIRMWARE      0x0a    //!< device's firmware is corrupt; it cannot return to run-time (non-DFU) operations
+#define DFU_STATUS_errVENDOR        0x0b    //!< iString indicates a vendor-specific error
+#define DFU_STATUS_errUSBR          0x0c    //!< device detected an unexpected USB reset
+#define DFU_STATUS_errPOR           0x0d    //!< device detected an unexpected power-on reset
+#define DFU_STATUS_errUNKNOWN       0x0e    //!< something went wrong, but the device does not know what it was
+#define DFU_STATUS_errSTALLEDPKT    0x0f    //!< device stalled an unexpected request
 
+/**
+ * DFU device state machine states, as defined in Section 6.1.2 / Figure A.1
+ * of the USB DFU Specification, Revision 1.1. Reported in the bState field
+ * returned by DFU_GETSTATUS and DFU_GETSTATE.
+ */
 enum dfu_state {
-    DFU_STATE_appIDLE               = 0,
-    DFU_STATE_appDETACH             = 1,
-    DFU_STATE_dfuIDLE               = 2,
-    DFU_STATE_dfuDNLOAD_SYNC        = 3,
-    DFU_STATE_dfuDNBUSY             = 4,
-    DFU_STATE_dfuDNLOAD_IDLE        = 5,
-    DFU_STATE_dfuMANIFEST_SYNC      = 6,
-    DFU_STATE_dfuMANIFEST           = 7,
-    DFU_STATE_dfuMANIFEST_WAIT_RST  = 8,
-    DFU_STATE_dfuUPLOAD_IDLE        = 9,
-    DFU_STATE_dfuERROR              = 10
+    DFU_STATE_appIDLE               = 0,    //!< device is running its normal application; DFU capable but not yet requested
+    DFU_STATE_appDETACH             = 1,    //!< device is running its normal application, has received DFU_DETACH, and is waiting for a USB reset
+    DFU_STATE_dfuIDLE               = 2,    //!< device is in DFU mode, idle, and waiting for a download/upload request
+    DFU_STATE_dfuDNLOAD_SYNC        = 3,    //!< device has received a download block and is synchronizing with the host before continuing
+    DFU_STATE_dfuDNBUSY             = 4,    //!< device is busy programming a received download block into memory and cannot communicate
+    DFU_STATE_dfuDNLOAD_IDLE        = 5,    //!< device has programmed a block and is idle, waiting for more DFU_DNLOAD data
+    DFU_STATE_dfuMANIFEST_SYNC      = 6,    //!< device has received the final download block and is waiting for DFU_GETSTATUS before entering manifestation
+    DFU_STATE_dfuMANIFEST           = 7,    //!< device is in the manifestation phase, programming the received image into its final location
+    DFU_STATE_dfuMANIFEST_WAIT_RST  = 8,    //!< manifestation is complete but the device is not manifestation-tolerant and is waiting for a USB reset
+    DFU_STATE_dfuUPLOAD_IDLE        = 9,    //!< device is in DFU mode, idle, with an upload in progress and waiting for further DFU_UPLOAD requests
+    DFU_STATE_dfuERROR              = 10    //!< device has encountered an error and is waiting for a DFU_CLRSTATUS request
 };
 
 /* USB string descriptor should contain max 126 UTF-16 characters
  * but 253 would even accomodate any UTF-8 encoding */
-#define MAX_DESC_STR_LEN 253
+#define MAX_DESC_STR_LEN 253    //!< maximum length, in bytes, of a USB string descriptor buffer used when reading DFU-related string descriptors
 
 #endif /* USB_DFU_H */


### PR DESCRIPTION
## Summary

Doxygen documentation pass over the firmware-update and bootloader stack, per `code-style-guide.md` §2 (JavaDoc `/** */` preceding blocks, `//!<` trailing member/enumerator docs, `@`-tag vocabulary only).

Files documented (15, per the story's file list):
- `ISFirmwareUpdater.h`, `ISBFirmwareUpdater.h`, `ISDFUFirmwareUpdater.h` — high-level update-policy orchestration + device-side ISB/DFU updaters
- `ISBootloaderBase.h` — the common bootloader contract (every virtual method gets full `@param`/`@return`)
- `ISBootloaderAPP/DFU/ISB/SAMBA/STM32/Sony.h` — derived classes, each class brief naming the target hardware/transport it implements
- `ISBootloaderThread.h` — thread lifecycle (start/poll/cancel/join) and callback contract
- `protocol/FirmwareUpdate.h` — wire message/status/reset-flag enums with bitmask bit-position annotations, `msg_data_t` union members, full class hierarchy docs
- `protocol/usb_dfu.h`, `ihex.h`, `intel_hex_utils.h` — utility/protocol headers

Also fixes a number of pre-existing doc/signature mismatches found while auditing (stale `@param` names for parameters that no longer exist, e.g. a constructor's docs referencing `hdwId`/`serialNo` when the actual params are `target`/`device`/`toHost`).

## Notes

- `protocol/usb_dfu.h` is third-party OpenPCD code (Harald Welte, 2006, GPLv2+). Added an accurate `@file`/`@author`/`@copyright` block attributing it correctly; the original GPL license text is preserved unmodified — no Inertial Sense copyright was added to vendored code.
- Verified via a scoped `doxygen` run with `WARN_IF_UNDOCUMENTED=YES` (off by default in the committed `Doxyfile`) against just these 15 files. One residual class of warning remains: `usb_dfu.h` and `ISDFUFirmwareUpdater.h`'s local copy of the DFU functional-descriptor struct report "macro not documented" despite being fully documented. Root-caused via isolated repro to a doxygen 1.9.1 parser bug triggered by the `__attribute__((__packed__))` GNU extension trailing the struct — confirmed the identical content without the packed attribute produces zero warnings. Not fixable from the documentation side without touching struct packing (out of scope, and risks embedded ABI on affected targets). Doesn't affect the real build, since the shipped Doxyfile ships with `WARN_IF_UNDOCUMENTED=NO`.
- Confirmed `python3 scripts/generate_doxygen.py --pdf` still builds both HTML and PDF (1071 pages) cleanly against the current `Doxyfile` + `src/` tree.

## Test plan

- [x] `InertialSenseSDK` target builds clean (no new warnings) after every commit
- [x] Scoped `doxygen` run (`WARN_IF_UNDOCUMENTED=YES`) against the 15 story files — zero real gaps (see PR notes for the one tool-bug exception)
- [x] `python3 scripts/generate_doxygen.py --pdf` — HTML + PDF both generate successfully
- [ ] Reviewer pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)