### PR TITLE
SN-8381 Fix SIGSEGV in mDNS record cache (assign into uninitialized union member)

### DIFF
--- a/src/protocol/mdns.cpp
+++ b/src/protocol/mdns.cpp
@@ -375,32 +375,30 @@ int mdns::queryCallback(int sock, const struct sockaddr* from, size_t addrlen, m
             // Parse IPv4 from message
             struct sockaddr_in addr;
             mdns_record_parse_a(data, size, record_offset, record_length, &addr);
-            // Copy IPv4 address to new record
-            newRecord.data.a = mdns_record_a_cpp_t(addr);
+            // Construct IPv4 address in the (raw) union storage. The union members are non-trivial and
+            // the storage is not yet holding a live object, so placement-new — not assignment — is required.
+            new (&newRecord.data.a) mdns_record_a_cpp_t(addr);
         } else if (rtype == MDNS_RECORDTYPE_PTR) {
             // Record is a PTR record
             // Parse PTR name from message
             mdns_string_t ptrTxt = mdns_record_parse_ptr(data, size, record_offset, record_length,
                                                       namebuffer, sizeof(namebuffer));
             // Copy PTR name to new record
-            mdns_record_ptr_cpp_t ptrRecord = mdns_record_ptr_cpp_t(std::string(MDNS_STRING_ARGS(ptrTxt)));
-            newRecord.data.ptr = ptrRecord;
+            new (&newRecord.data.ptr) mdns_record_ptr_cpp_t(std::string(MDNS_STRING_ARGS(ptrTxt)));
         } else if (rtype == MDNS_RECORDTYPE_AAAA) {
             // Record is an IPv6 Address
             // Parse IPv6 from message
             struct sockaddr_in6 addr;
             mdns_record_parse_aaaa(data, size, record_offset, record_length, &addr);
             // Copy IPv6 address to new record
-            mdns_record_aaaa_cpp_t aaaaRecord = mdns_record_aaaa_cpp_t(addr);
-            newRecord.data.aaaa = aaaaRecord;
+            new (&newRecord.data.aaaa) mdns_record_aaaa_cpp_t(addr);
         } else if (rtype == MDNS_RECORDTYPE_SRV) {
             // Record is an SRV record
             // Parse data from SRV record
             mdns_record_srv_t srv = mdns_record_parse_srv(data, size, record_offset, record_length,
                                                           namebuffer, sizeof(namebuffer));
             // Copy data in to new record
-            mdns_record_srv_cpp_t srvRecord = mdns_record_srv_cpp_t(srv.priority, srv.weight, srv.port, std::string(MDNS_STRING_ARGS(srv.name)));
-            newRecord.data.srv = srvRecord;
+            new (&newRecord.data.srv) mdns_record_srv_cpp_t(srv.priority, srv.weight, srv.port, std::string(MDNS_STRING_ARGS(srv.name)));
         } else {
             log_warn(IS_LOG_MDNS_CACHE, "Unable to process unknown MDNS record type: Not Supported.");
             return -ENOTSUP;
@@ -428,8 +426,7 @@ int mdns::queryCallback(int sock, const struct sockaddr* from, size_t addrlen, m
             std::vector<unsigned char> value;
             for (std::size_t p = 0; p < txtbuffer[itxt].value.length; p++) { value.push_back(txtbuffer[itxt].value.str[p]); }
 
-            mdns_record_txt_cpp_t txtRecord = mdns_record_txt_cpp_t(key, value);
-            newRecord.data.txt = txtRecord;
+            new (&newRecord.data.txt) mdns_record_txt_cpp_t(key, value);
             newRecord.type = (mdns_record_type)rtype;
             responses.insert_or_assign(newRecord, std::chrono::steady_clock::now()-std::chrono::microseconds(100*backtick));
             backtick++;

--- a/src/protocol/mdns.hpp
+++ b/src/protocol/mdns.hpp
@@ -316,14 +316,18 @@ public:
                 case MDNS_RECORDTYPE_ANY: break;
             }
             // The previous active member was destroyed above, so the union storage no longer holds a
-            // live object. Construct the new active member in place (placement-new) — assigning here
-            // would run operator= over uninitialized memory (UB; the original crash was exactly this).
-            this->name = std::string(other.name);
+            // live object. Mark the union as empty (IGNORE) *before* doing anything that can throw:
+            // if the name assignment or the placement-new below throws, the destructor must not try to
+            // destroy the already-destroyed (or not-yet-constructed) member. type is set to the real
+            // value only after the new active member has been successfully constructed in place.
+            this->type = MDNS_RECORDTYPE_IGNORE;
 
-            this->type = other.type;
+            this->name = other.name;
             this->rclass = other.rclass;
             this->ttl = other.ttl;
 
+            // Construct the new active member in place (placement-new) — assigning would run operator=
+            // over uninitialized memory (UB; the original crash was exactly this).
             if (other.type == MDNS_RECORDTYPE_PTR) {
                 new (&this->data.ptr) mdns_record_ptr_cpp_t(other.data.ptr);
             } else if (other.type == MDNS_RECORDTYPE_SRV) {
@@ -335,6 +339,7 @@ public:
             } else if (other.type == MDNS_RECORDTYPE_TXT) {
                 new (&this->data.txt) mdns_record_txt_cpp_t(other.data.txt);
             }
+            this->type = other.type;
             return *this;
         }
 

--- a/src/protocol/mdns.hpp
+++ b/src/protocol/mdns.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <list>
 #include <utility>
+#include <new>
 #include "mdns.h"
 
 #ifdef _WIN32
@@ -239,13 +240,16 @@ public:
             type = other.type;
             rclass = other.rclass;
             ttl = other.ttl;
+            // The union members are non-trivial (std::string / std::vector) and the union storage
+            // is not yet holding a live object, so each active member must be *constructed*
+            // (placement-new) — assigning would run operator= over uninitialized memory (UB / crash).
             switch (type) {
                 case MDNS_RECORDTYPE_IGNORE: break;
-                case MDNS_RECORDTYPE_A: data.a = other.data.a; break;
-                case MDNS_RECORDTYPE_TXT: data.txt = other.data.txt; break;
-                case MDNS_RECORDTYPE_PTR: data.ptr = other.data.ptr; break;
-                case MDNS_RECORDTYPE_AAAA: data.aaaa = other.data.aaaa; break;
-                case MDNS_RECORDTYPE_SRV: data.srv = other.data.srv; break;
+                case MDNS_RECORDTYPE_A: new (&data.a) mdns_record_a_cpp_t(other.data.a); break;
+                case MDNS_RECORDTYPE_TXT: new (&data.txt) mdns_record_txt_cpp_t(other.data.txt); break;
+                case MDNS_RECORDTYPE_PTR: new (&data.ptr) mdns_record_ptr_cpp_t(other.data.ptr); break;
+                case MDNS_RECORDTYPE_AAAA: new (&data.aaaa) mdns_record_aaaa_cpp_t(other.data.aaaa); break;
+                case MDNS_RECORDTYPE_SRV: new (&data.srv) mdns_record_srv_cpp_t(other.data.srv); break;
                 case MDNS_RECORDTYPE_ANY: break;
             }
         }
@@ -311,9 +315,9 @@ public:
                 case MDNS_RECORDTYPE_SRV: data.srv.~mdns_record_srv_cpp_t(); break;
                 case MDNS_RECORDTYPE_ANY: break;
             }
-            // Zero out the data to prevent any crashes when we try to reassign data
-            memset((void*)&(this->data), 0, sizeof(mdns_record_data));
-
+            // The previous active member was destroyed above, so the union storage no longer holds a
+            // live object. Construct the new active member in place (placement-new) — assigning here
+            // would run operator= over uninitialized memory (UB; the original crash was exactly this).
             this->name = std::string(other.name);
 
             this->type = other.type;
@@ -321,15 +325,15 @@ public:
             this->ttl = other.ttl;
 
             if (other.type == MDNS_RECORDTYPE_PTR) {
-                this->data.ptr = other.data.ptr;
+                new (&this->data.ptr) mdns_record_ptr_cpp_t(other.data.ptr);
             } else if (other.type == MDNS_RECORDTYPE_SRV) {
-                this->data.srv = other.data.srv;
+                new (&this->data.srv) mdns_record_srv_cpp_t(other.data.srv);
             } else if (other.type == MDNS_RECORDTYPE_A) {
-                this->data.a = other.data.a;
+                new (&this->data.a) mdns_record_a_cpp_t(other.data.a);
             } else if (other.type == MDNS_RECORDTYPE_AAAA) {
-                this->data.aaaa = other.data.aaaa;
+                new (&this->data.aaaa) mdns_record_aaaa_cpp_t(other.data.aaaa);
             } else if (other.type == MDNS_RECORDTYPE_TXT) {
-                this->data.txt = other.data.txt;
+                new (&this->data.txt) mdns_record_txt_cpp_t(other.data.txt);
             }
             return *this;
         }


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV in the SDK's mDNS record cache, reproduced under gdb on the `IOManager-COMM` thread in EvalTool while parsing an mDNS PTR answer (`_services._dns-sd._udp.local.`) during device discovery.

Jira: [SN-8381](https://inertialsense.atlassian.net/browse/SN-8381)

## Root cause

`mdns::mdns_record_cpp_t` stores its payload in a `union` (`mdns_record_data`) whose members hold non-trivial types (`std::string`, `std::vector`). The union constructor `memset`s the storage to zero — it does **not** construct any member. The code then copy-**assigned** into those unconstructed members:

```cpp
newRecord.data.ptr = ptrRecord;   // operator= over uninitialized memory
```

`std::string::operator=` writes through the memset'd string's null/garbage internal data pointer → segfault (crash frame: `std::string::_M_assign`). This is UB: a non-trivial object in raw union storage must be **constructed** (placement-new), not assigned to.

`data.a` / `data.aaaa` are trivially copyable (`sockaddr` only), so only PTR/SRV/TXT answers crashed — matching the intermittent, discovery-only nature of the failure.

## Fix

Replace every assignment-into-union with placement-new construction at all union-write sites:
- `queryCallback` (`mdns.cpp`) — A / PTR / AAAA / SRV / TXT records
- `mdns_record_cpp_t` copy constructor
- `mdns_record_cpp_t::operator=` — destructor dispatch still runs first; the redundant/harmful `memset` is removed

All consumers (`ISmDnsPortFactory`, `RelayPortFactory` via `getRecords()`) reach these records exclusively through copy-construction, so no other call sites are affected.

## Compatibility notes (MSVC / CI)

- Uses only standard C++11/17 (`<new>` added for placement-new); no compiler-specific constructs.
- Every copy constructor invoked is the implicitly-generated one — still generated on MSVC (no move members are declared), and none is deleted (all members copy-constructible). No overload ambiguity with the `explicit` value ctors.
- No MSVC C4291 (standard placement-new has a matching placement-delete).
- Note: the `#ifdef _WIN32` copy-**assignment** operators on the string-bearing element types are now dead code (nothing copy-assigns those types anymore). Left in place to keep the fix minimal; can be removed in a follow-up.

## Testing

- Builds clean on Linux/GCC (C++17) via the EvalTool build.
- Manually verified: EvalTool mDNS discovery now runs solid without crashing.
- MSVC build to be confirmed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8381]: https://inertialsense.atlassian.net/browse/SN-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ