### PR TITLE
SN-8298: SDK Docs — Transport layer, utilities, and display

### DIFF
--- a/src/ChronoStat.h
+++ b/src/ChronoStat.h
@@ -1,6 +1,11 @@
 /**
- * @file PeriodStat.h 
- * @brief ${BRIEF_DESC}
+ * @file ChronoStat.h
+ * @brief Chronometry/timing-statistics helper: given a stream of sample() calls (either
+ *        externally-timestamped or using an internal clock), incrementally computes the
+ *        inter-sample interval (dt) and its min/max/average/variance, the second-order
+ *        variation between successive intervals (ddt), the resulting sample rate, and a
+ *        user-driven accrual counter/rate -- all via Welford's online algorithm so no history
+ *        of samples needs to be retained.
  *
  * @author Kyle Mallory on 9/17/25.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -20,12 +25,18 @@
 // #define ADDITIONAL_DEBUGGING     // Use this if you are troubleshooting the ChronoStat calculations in sample();
 
 #ifdef ADDITIONAL_DEBUGGING
+/** Begins building a per-sample debug log line (label + timestamp prefix); active only when ADDITIONAL_DEBUGGING is defined. */
 #define START_DEBUG_MSG()           std::string logMsg = utils::string_format("%-20s ts:%6.3f :: ", label.c_str(), time)
+/** Appends a printf-style-formatted fragment to the in-progress debug log line started by START_DEBUG_MSG(). @param ... a printf-style format string and its arguments */
 #define APPEND_DEBUG_MSG(...)       logMsg += utils::string_format(__VA_ARGS__)
+/** Emits the debug log line built by START_DEBUG_MSG()/APPEND_DEBUG_MSG() via the given log macro. @param msg_level the log_* macro (e.g. log_debug) to emit the line with */
 #define END_DEBUG_MSG(msg_level)    msg_level(IS_LOG_CHRONO_STATS, "%s", logMsg.c_str())
 #else
+/** No-op when ADDITIONAL_DEBUGGING is not defined. */
 #define START_DEBUG_MSG()           {}
+/** No-op when ADDITIONAL_DEBUGGING is not defined. @param ... unused */
 #define APPEND_DEBUG_MSG(...)       {}
+/** No-op when ADDITIONAL_DEBUGGING is not defined. @param msg_level unused */
 #define END_DEBUG_MSG(msg_level)    {}
 #endif
 
@@ -44,8 +55,8 @@ private:
     constexpr static double INVALID_DDT_MIN_STAT = 99999.0;
     int cnt = 0;
     double timeLast = NAN;                  //!< the last time that a sample was taken
-    std::chrono::high_resolution_clock::time_point localTimeTs;     // this should initialize to the clocks epoch
-    std::string label;
+    std::chrono::high_resolution_clock::time_point localTimeTs;     //!< local-clock timestamp of the most recent sample; default-initializes to the clock's epoch
+    std::string label;                      //!< optional label/name for this stat instance, used only by toString()
     double dtM2 = 0;                        //!< Welford's algorithm running sum of squared differences from the mean, used to derive dtVariance
 
 public:
@@ -60,39 +71,42 @@ public:
     double duration = 0;                    //!< the sum of all dt's - effectively the total time between the first and last sample.
 
     double dtLast = NAN;                    //!< timestamp of the last dt sample, used for ddt calculations
-    double ddt = 0;
-    double ddtMin = 0;
-    double ddtMax = 0;
-    double ddtMinTime = 0;
-    double ddtMaxTime = 0;
-    double ddtAvg = 0;
-    int ddtCnt = 0;
+    double ddt = 0;                         //!< the delta between the two most recent dt values (the "second derivative" of the sample times), in seconds
+    double ddtMin = 0;                      //!< the lowest ddt from all samples, in seconds (0 until first ddt)
+    double ddtMax = 0;                      //!< the largest ddt from all samples, in seconds (0 until first ddt)
+    double ddtMinTime = 0;                  //!< the sample time of the lowest ddt
+    double ddtMaxTime = 0;                  //!< the sample time of the largest ddt
+    double ddtAvg = 0;                      //!< the average ddt across all samples (in seconds)
+    int ddtCnt = 0;                         //!< the number of ddt samples (should always be dtCnt - 1)
 
     double rate = 0;                //!< the rate/second of samples
     uint64_t accrual = 0;           //!< a general purpose, user counter - call accrue()
     double accrualRate = 0;         //!< the rate/second of the accrual counter
 
     /**
-     * @returns the number of times this stat has been sampled
+     * @return the number of times this stat has been sampled
      */
     inline int count() { return cnt; }
 
     /**
-     * @returns true indicating that more than one sample has been taken and that stats are available, otherwise false
+     * @return true indicating that more than one sample has been taken and that stats are available, otherwise false
      */
     inline bool hasData() { return cnt > 1; }
 
+    /**
+     * @return the value of time (either externally supplied or from the local clock) passed to the most recent call to sample(), or NAN if sample() has never been called.
+     */
     inline double lastSampleTime() { return timeLast; }
 
     /**
-     * @returns the current timestamp (chrono::time_point) of the most recent sample.
+     * @return the current timestamp (chrono::time_point) of the most recent sample.
      *   If sample has never been called, this should return the Epoch of the source
-     *   (std::chrono::hish_resolution_clock) clock, which is typically Jan 1, 1970.
+     *   (std::chrono::high_resolution_clock) clock, which is typically Jan 1, 1970.
      */
     inline std::chrono::high_resolution_clock::time_point lastLocalTs() { return localTimeTs; }
 
     /**
-     * @returns a timestamp in milliseconds at the time the last sample was taken.
+     * @return a timestamp in milliseconds at the time the last sample was taken.
      * NOTE: this is a milliseconds since epoch, cast to a uint32_t which will truncate the upper bits and thus
      *   does not represent an actual wall-clock/system time, as it will rollover approximately every 49 days
      */
@@ -103,7 +117,7 @@ public:
     }
 
     /**
-     * @returns the time elapsed (milliseconds) since the last sample (derived from the local system clock).
+     * @return the time elapsed (milliseconds) since the last sample (derived from the local system clock).
      * NOTE that this uses the local time when the sample was made, and is independent of the time provided
      * to the call to sample() (if any). If there is no previous sample, returns UINT32_MAX.
      */
@@ -121,12 +135,12 @@ public:
     void setLabel(const std::string& newLabel) { label = newLabel; }
 
     /**
-     * @returns the current label associated with this stat instance.
+     * @return the current label associated with this stat instance.
      */
     std::string getLabel() { return label; }
 
     /**
-     * @returns true if a label has been assigned, otherise false.
+     * @return true if a label has been assigned, otherise false.
      */
     bool hasLabel() { return !label.empty(); }
 
@@ -227,7 +241,7 @@ public:
 
 
     /**
-     * @returns the (population) standard deviation of dt across all samples, in the same units as dt.
+     * @return the (population) standard deviation of dt across all samples, in the same units as dt.
      */
     inline double dtStdDev() { return std::sqrt(dtVariance); }
 

--- a/src/ISClient.h
+++ b/src/ISClient.h
@@ -10,12 +10,21 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISClient.h
+ * @brief Factory that opens a cISStream (TCP or serial) client from a colon-delimited connection string.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef __IS_CLIENT__H__
 #define __IS_CLIENT__H__
 
 #include "ISStream.h"
 
 
+/** Factory for opening a cISStream connection (TCP/NTRIP or serial) from a single connection string. */
 class cISClient
 {
 private:
@@ -28,7 +37,7 @@ public:
 
     /**
     * Opens an ISStream (TCP or Serial Port) client
-    * @param connectionString Colon delimited string containing connection info, 
+    * @param connectionString Colon delimited string containing connection info,
     * [type]:[protocol]:[ip/url]:[port]:[mountpoint]:[username]:[password]
     *    type:        TCP, SERIAL
     *    protocol:    RTCM3, UBLOX, IS
@@ -36,7 +45,7 @@ public:
     *    [TCP]:[RTCM3]:[ip/url]:[port]:[mountpoint]:[username]:[password]
     *    [TCP]:[RTCM3]:[ip/url]:[port]
     *    [SERIAL]:[RTCM3]:[serial port]:[baudrate]
-    * @param enableGpggaForwarding Return value indicating that GPGGA GNSS messages should sent for VRS base stations. 
+    * @param enableGpggaForwarding Return value indicating that GPGGA GNSS messages should sent for VRS base stations.
     * @return cISStream pointer if successful, otherwise NULLPTR
     */
     static cISStream* OpenConnectionToServer(const std::string& connectionString, bool *enableGpggaForwarding=NULL);

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -44,14 +44,14 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 #ifndef CHAR_BIT
-#define CHAR_BIT 8
+#define CHAR_BIT 8   //!< number of bits in a char, for platforms whose climits header doesn't define it
 #endif
 
 #if defined(INCLUDE_LUNA_DATA_SETS)
 #include "luna_data_sets.h"
 #endif
 
-#define IS_DATA_MAPPING_MAX_STRING_LENGTH 2048
+#define IS_DATA_MAPPING_MAX_STRING_LENGTH 2048   //!< capacity, in bytes, of a data_mapping_string_t rendering buffer
 
 /** The primitive wire/storage type of a mapped field (see data_info_t::type). */
 typedef enum
@@ -306,7 +306,7 @@ template <typename Dtype>
 class DataMapper
 {
 public:
-    typedef Dtype MAP_TYPE;
+    typedef Dtype MAP_TYPE;  //!< the concrete DID struct type this mapper populates fields for
 
     /**
      * @param data_set the SDK-wide array of data sets; data_set[did] is the entry this mapper populates
@@ -795,30 +795,37 @@ public:
 
     /**
     * Get the data set for a data id
+    * @param did the data id
     * @return the data set for the data id, or NULL if none found
     */
     static data_set_t* DataSet(uint32_t did);
 
     /**
     * Get the info for a data id
+    * @param did the data id
     * @return the info for the data id, or NULL if none found
     */
     static const map_name_to_info_t* NameToInfoMap(uint32_t did);
 
     /**
     * Get map pointer for a data id
+    * @param did the data id
     * @return map pointer for the data id, or NULL if none found
     */
     static const map_index_to_info_t* IndexToInfoMap(uint32_t did);
 
     /**
     * Get map pointer for a data id
+    * @param did the data id
+    * @param element the flattened element index
+    * @param arrayIndex receives the array index (within its field) of the returned element
     * @return map pointer for the data id (or NULL if none found) and array index
     */
     static const data_info_t* ElementToInfo(uint32_t did, uint32_t element, uint32_t &arrayIndex);
 
     /**
     * Get map pointer for a data id
+    * @param dataId the data id
     * @return map pointer for the data id, or NULL if none found
     */
     static const map_index_to_info_t* GetIndexMapInfo(uint32_t dataId);
@@ -840,6 +847,7 @@ public:
     * SN-8068: Array-of-struct members of a DID (additive). These expose inner struct
     * fields once as "<struct>.<field>" and carry the metadata needed to fan a field out
     * across every populated element, keyed by identity.
+    * @param did the data id
     * @return pointer to the DID's array-struct descriptors, or NULL if the DID has none.
     */
     static const std::vector<array_struct_info_t>* ArrayStructFields(uint32_t did);
@@ -908,8 +916,8 @@ public:
     * @param datasetBuffer packet buffer
     * @param info metadata about the field to convert
     * @param arrayIndex index into array
-    * @param elementSize size of elements in array
     * @param json true if json, false if csv
+    * @param useConversion if true, multiply the parsed value by info.conversion before storing
     * @return true if success, false if error
     */
     static bool StringToData(const char* stringBuffer, int stringLength, const p_data_hdr_t* hdr, uint8_t* datasetBuffer, const data_info_t& info, unsigned int arrayIndex = 0, bool json = false, bool useConversion = true);
@@ -920,6 +928,7 @@ public:
     * @param stringLength the number of chars in stringBuffer
     * @param dataBuffer data buffer pointer
     * @param dataType data type
+    * @param dataSize size, in bytes, of the field at dataBuffer
     * @param radix (10 = base 10 for decimal, 16 = base 16 for hexidecimal) if the field is a number field, ignored otherwise
     * @param conversion conversion of value (i.e. rad2deg)
     * @param json true if json, false if csv
@@ -935,6 +944,7 @@ public:
     * @param stringBuffer the buffer to hold the converted string
     * @param arrayIndex index into array
     * @param json true if json, false if csv
+    * @param useConversion if true, divide the raw value by info.conversion before rendering
     * @return true if success, false if error
     */
     static bool DataToString(const data_info_t& info, const p_data_hdr_t* hdr, const uint8_t* datasetBuffer, data_mapping_string_t stringBuffer, unsigned int arrayIndex = 0, bool json = false, bool useConversion = true);

--- a/src/ISDataMappings.h
+++ b/src/ISDataMappings.h
@@ -1,3 +1,15 @@
+/**
+ * @file ISDataMappings.h
+ * @brief Runtime field-level reflection for every DID data struct: per-field metadata
+ *        (data_info_t: offset/size/type/units/description/render functions), the DataMapper
+ *        builder classes used to populate that metadata for a struct, and cISDataMappings'
+ *        static lookup/conversion API (name<->DID, string<->binary field conversion, YAML
+ *        round-tripping) built on top of it.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 /*
 MIT LICENSE
 
@@ -41,54 +53,54 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #define IS_DATA_MAPPING_MAX_STRING_LENGTH 2048
 
+/** The primitive wire/storage type of a mapped field (see data_info_t::type). */
 typedef enum
 {
-    DATA_TYPE_INT8,     // 8-bit  signed    integer
-    DATA_TYPE_UINT8,    // 8-bit  unsigned  integer
-    DATA_TYPE_INT16,    // 16-bit signed    integer
-    DATA_TYPE_UINT16,   // 16-bit unsigned  integer
-    DATA_TYPE_INT32,    // 32-bit signed    integer
-    DATA_TYPE_UINT32,   // 32-bit unsigned  integer
-    DATA_TYPE_INT64,    // 64-bit signed    integer
-    DATA_TYPE_UINT64,   // 64-bit unsigned  integer
-    DATA_TYPE_F32,      // 32-bit float 
-    DATA_TYPE_F64,      // 64-bit float
-    DATA_TYPE_STRING,
-    DATA_TYPE_BINARY,
+    DATA_TYPE_INT8,     //!< 8-bit  signed    integer
+    DATA_TYPE_UINT8,    //!< 8-bit  unsigned  integer
+    DATA_TYPE_INT16,    //!< 16-bit signed    integer
+    DATA_TYPE_UINT16,   //!< 16-bit unsigned  integer
+    DATA_TYPE_INT32,    //!< 32-bit signed    integer
+    DATA_TYPE_UINT32,   //!< 32-bit unsigned  integer
+    DATA_TYPE_INT64,    //!< 64-bit signed    integer
+    DATA_TYPE_UINT64,   //!< 64-bit unsigned  integer
+    DATA_TYPE_F32,      //!< 32-bit float
+    DATA_TYPE_F64,      //!< 64-bit float
+    DATA_TYPE_STRING,   //!< variable-length text; size is caller-supplied (not in s_eDataTypeSize)
+    DATA_TYPE_BINARY,   //!< variable-length raw bytes; size is caller-supplied (not in s_eDataTypeSize)
 
-    DATA_TYPE_COUNT
+    DATA_TYPE_COUNT     //!< number of defined data types; must be last
 } eDataType;
 
+/** Bitmask of rendering/behavior flags for a mapped field (see data_info_t::flags). */
 typedef enum
 {
-    DATA_FLAGS_FIXED_DECIMAL_MASK        = 0x0000000F,
-    DATA_FLAGS_FIXED_DECIMAL_0           = 0x00000001,
-    DATA_FLAGS_FIXED_DECIMAL_1           = 0x00000002,
-    DATA_FLAGS_FIXED_DECIMAL_2           = 0x00000003,
-    DATA_FLAGS_FIXED_DECIMAL_3           = 0x00000004,
-    DATA_FLAGS_FIXED_DECIMAL_4           = 0x00000005,
-    DATA_FLAGS_FIXED_DECIMAL_5           = 0x00000006,
-    DATA_FLAGS_FIXED_DECIMAL_6           = 0x00000007,
-    DATA_FLAGS_FIXED_DECIMAL_7           = 0x00000008,
-    DATA_FLAGS_FIXED_DECIMAL_8           = 0x00000009,
-    DATA_FLAGS_FIXED_DECIMAL_9           = 0x0000000A,
-    DATA_FLAGS_FIXED_DECIMAL_10          = 0x0000000B,
-    DATA_FLAGS_FIXED_DECIMAL_11          = 0x0000000C,
-    DATA_FLAGS_FIXED_DECIMAL_12          = 0x0000000D,
-    DATA_FLAGS_FIXED_DECIMAL_13          = 0x0000000E,
-    DATA_FLAGS_FIXED_DECIMAL_14          = 0x0000000F,
-    DATA_FLAGS_READ_ONLY                 = 0x00000010,
-    DATA_FLAGS_HIDDEN                    = 0x00000020,  // Do not print to screen
-    DATA_FLAGS_DISPLAY_HEX               = 0x00000100,
-    DATA_FLAGS_ANGLE                     = 0x00000200,  // Supports unwrapping angle
-    DATA_FLAGS_DECOR_ROLL_MASK           = 0x000F0000,  // Decoration roll
-    DATA_FLAGS_INS_STATUS                = 0x00010000,  // "
-    DATA_FLAGS_GNSS_STATUS                = 0x00020000,  // "
+    DATA_FLAGS_FIXED_DECIMAL_MASK        = 0x0000000F,  //!< bits 0-3: mask isolating the fixed-decimal-place count below
+    DATA_FLAGS_FIXED_DECIMAL_0           = 0x00000001,  //!< render with 0 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_1           = 0x00000002,  //!< render with 1 decimal place
+    DATA_FLAGS_FIXED_DECIMAL_2           = 0x00000003,  //!< render with 2 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_3           = 0x00000004,  //!< render with 3 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_4           = 0x00000005,  //!< render with 4 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_5           = 0x00000006,  //!< render with 5 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_6           = 0x00000007,  //!< render with 6 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_7           = 0x00000008,  //!< render with 7 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_8           = 0x00000009,  //!< render with 8 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_9           = 0x0000000A,  //!< render with 9 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_10          = 0x0000000B,  //!< render with 10 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_11          = 0x0000000C,  //!< render with 11 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_12          = 0x0000000D,  //!< render with 12 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_13          = 0x0000000E,  //!< render with 13 decimal places
+    DATA_FLAGS_FIXED_DECIMAL_14          = 0x0000000F,  //!< render with 14 decimal places
+    DATA_FLAGS_READ_ONLY                 = 0x00000010,  //!< bit 4: field is read-only; StringToData()/StringToVariable() should refuse to write it
+    DATA_FLAGS_HIDDEN                    = 0x00000020,  //!< bit 5: do not print to screen
+    DATA_FLAGS_DISPLAY_HEX               = 0x00000100,  //!< bit 8: render the value in hexadecimal
+    DATA_FLAGS_ANGLE                     = 0x00000200,  //!< bit 9: field is an angle; supports unwrapping
+    DATA_FLAGS_DECOR_ROLL_MASK           = 0x000F0000,  //!< bits 16-19: mask isolating the "decoration roll" flags below
+    DATA_FLAGS_INS_STATUS                = 0x00010000,  //!< bit 16: field is an insStatus bitmask; render with INS-status decoration
+    DATA_FLAGS_GNSS_STATUS                = 0x00020000,  //!< bit 17: field is a gnssStatus bitmask; render with GNSS-status decoration
 } eDataFlags;
 
-/*
-* Metadata about a specific field
-*/
+/** Forward declaration; see the full definition below for field documentation. */
 struct data_info_t;
 
 /**
@@ -102,6 +114,12 @@ struct data_info_t;
  */
 using RenderFunction = std::function<std::string(const data_info_t& info, std::any value, int arrayIdx, int flags)>;
 
+/**
+ * Metadata about a single field of a DID struct: where it lives in memory, its wire type,
+ * display units/description, and the render callbacks used to convert its raw value to text.
+ * One instance exists per registered field, built by DataMapper::AddMember()/AddArray() (or the
+ * offset-based AddMember2()/AddArray2()) and owned by the enclosing data_set_t.
+ */
 struct data_info_t
 {
     uint32_t    offset;                         //!< Offset in to the data struct where this specific field resides
@@ -120,6 +138,12 @@ struct data_info_t
             [](const data_info_t& info, std::any val, int arrayIdx, int flags) -> std::string { (void)info; (void)val; (void)arrayIdx; (void)flags; return ""; };
 };
 
+/**
+ * Table schema: one entry per eDataType enumerator (indexed by the enum value), giving the
+ * fixed size in bytes of that primitive type. DATA_TYPE_STRING and DATA_TYPE_BINARY are
+ * variable-length, so their entries are 0 -- the actual size must be supplied by the caller
+ * (e.g. via DataMapper::AddMember2()'s typeSize parameter) rather than looked up here.
+ */
 CONST_EXPRESSION uint32_t s_eDataTypeSize[DATA_TYPE_COUNT] =
 {
     (uint32_t)sizeof(int8_t),
@@ -136,6 +160,12 @@ CONST_EXPRESSION uint32_t s_eDataTypeSize[DATA_TYPE_COUNT] =
     (uint32_t)0  // binary, must be set to actual size by caller
 };
 
+/**
+ * Table schema: one entry per eDataType enumerator (indexed by the enum value), giving the
+ * number of characters (including the "0x" prefix) needed to render that type in hexadecimal
+ * (see DATA_FLAGS_DISPLAY_HEX). Variable-length types (DATA_TYPE_STRING/DATA_TYPE_BINARY) are
+ * not hex-rendered, so their entries are 0.
+ */
 CONST_EXPRESSION uint32_t s_eDataTypeHexStringSize[DATA_TYPE_COUNT] =
 {   // Number of characters in hexidecimal string including prefix "0x"
     (uint32_t)4,    // 0x00
@@ -153,23 +183,31 @@ CONST_EXPRESSION uint32_t s_eDataTypeHexStringSize[DATA_TYPE_COUNT] =
 };
 
 #if !PLATFOM_IS_EMBEDDED
-extern const unsigned char g_asciiToLowerMap[256];
+extern const unsigned char g_asciiToLowerMap[256];  //!< lookup table mapping each byte value to its ASCII-lowercased equivalent, indexed by the byte itself
 #endif
 
 /**
-* Case-insensitive comparator for std::find and other functions
-*/
+ * Case-insensitive comparator for std::find and other functions
+ */
 struct sCaseInsensitiveCompare
 {
+    /** Case-insensitive less-than comparator for a single character, using g_asciiToLowerMap. */
     struct nocase_compare
     {
+        /** @param c1 the first character @param c2 the second character @return true if the lowercased c1 is less than the lowercased c2 */
         bool operator() (const unsigned char& c1, const unsigned char& c2) const
         {
             return g_asciiToLowerMap[c1] < g_asciiToLowerMap[c2];
         }
     };
 
-    // less than, not equal
+    /**
+     * Case-insensitive less-than comparison, hand-coded for NMEA-style ASCII strings (no
+     * unicode/locale handling) for roughly 3x the speed of std::lexicographical_compare.
+     * @param s1 the first string
+     * @param s2 the second string
+     * @return true if s1 is lexicographically less than s2, ignoring case
+     */
     bool operator() (const std::string& s1, const std::string& s2) const
     {
         // return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), nocase_compare());
@@ -201,38 +239,85 @@ struct sCaseInsensitiveCompare
     }
 };
 
-typedef std::map<std::string, data_info_t, sCaseInsensitiveCompare>     map_name_to_info_t;             // map of field name to data info
-typedef std::map<uint32_t, data_info_t*>                                map_index_to_info_t;            // map of field index to data info pointer
-typedef std::map<uint32_t, data_info_t*>                                map_element_to_info_t;          // map of element index to data info pointer
-typedef std::map<uint32_t, uint32_t>                                    map_element_to_array_size_t;    // map of element index to array size
-typedef char data_mapping_string_t[IS_DATA_MAPPING_MAX_STRING_LENGTH];
+typedef std::map<std::string, data_info_t, sCaseInsensitiveCompare>     map_name_to_info_t;             //!< map of field name to data info
+typedef std::map<uint32_t, data_info_t*>                                map_index_to_info_t;            //!< map of field index to data info pointer
+typedef std::map<uint32_t, data_info_t*>                                map_element_to_info_t;          //!< map of element index to data info pointer
+typedef std::map<uint32_t, uint32_t>                                    map_element_to_array_size_t;    //!< map of element index to array size
+typedef char data_mapping_string_t[IS_DATA_MAPPING_MAX_STRING_LENGTH];  //!< fixed-capacity buffer used by DataToString()/VariableToString() for a single rendered field value
 
+/**
+ * The complete field-mapping table for one DID: every registered field, indexed by name,
+ * sequential field index, and flattened array-element index. Populated by a DataMapper<Dtype>
+ * bound to this entry in cISDataMappings::m_data_set[did], and queried via cISDataMappings'
+ * static NameToInfoMap()/IndexToInfoMap()/ElementToInfo() etc.
+ */
 typedef struct
 {
-    uint32_t                    size;
-    map_name_to_info_t          nameToInfo;
-    map_index_to_info_t         indexToInfo;
-    map_element_to_info_t       elementToInfo;
-    map_element_to_array_size_t elementToArraySize;
-    uint32_t                    elementCount;
-    const data_info_t*          timestampFields;
+    uint32_t                    size;                  //!< sizeof the mapped DID struct (set by DataMapper's constructor)
+    map_name_to_info_t          nameToInfo;             //!< every registered field, keyed by field name (case-insensitive)
+    map_index_to_info_t         indexToInfo;            //!< every registered field, keyed by its sequential registration index
+    map_element_to_info_t       elementToInfo;          //!< every registered field, keyed by flattened element index (arrays contribute one entry per element)
+    map_element_to_array_size_t elementToArraySize;      //!< for each flattened element index, the array index (0 for scalar fields) within its field
+    uint32_t                    elementCount;           //!< total number of flattened elements across all registered fields
+    const data_info_t*          timestampFields;        //!< the field(s), if any, used to derive a record's timestamp (see cISDataMappings::Timestamp())
 } data_set_t;
 
+/**
+ * Default data_info_t::renderBasic implementation: converts value to a simple string with no
+ * newlines/formatting (per data_info_t::renderBasic's contract). Used by VariableToString().
+ * @param info metadata for the field being rendered
+ * @param value the raw value to render, as extracted by dataToStdAny()
+ * @param arrayIdx the array index (0 for scalar fields) of the specific value being rendered
+ * @param flags renderer-specific flags, interpreted by this function
+ * @return the rendered string
+ */
 std::string renderVariableToString(const data_info_t& info, std::any value, int arrayIdx, int flags);
+
+/**
+ * Default data_info_t::renderExtended implementation: renders value with additional
+ * statistics/formatting (may include newlines/HTML), for tooltips and advanced display contexts.
+ * @param info metadata for the field being rendered
+ * @param value the raw value to render, as extracted by dataToStdAny()
+ * @param arrayIdx the array index (0 for scalar fields) of the specific value being rendered
+ * @param flags renderer-specific flags, interpreted by this function
+ * @return the rendered string
+ */
 std::string renderVariableAndStatsToString(const data_info_t& info, std::any value, int arrayIdx, int flags);
+
+/**
+ * Specialized renderExtended implementation for RTK configuration bitmask fields, decoding
+ * individual bits into a human-readable description.
+ * @param info metadata for the field being rendered
+ * @param value the raw value to render, as extracted by dataToStdAny()
+ * @param arrayIdx the array index (0 for scalar fields) of the specific value being rendered
+ * @param flags renderer-specific flags, interpreted by this function
+ * @return the rendered string
+ */
 std::string renderRTKCfgBits(const data_info_t& info, std::any value, int arrayIdx, int flags);
 
+/**
+ * Builder used to populate one data_set_t entry with per-field data_info_t metadata for a
+ * concrete DID struct (Dtype). Typically constructed on the stack for the duration of a single
+ * DID's registration; each AddMember()/AddArray()/etc. call appends one field, and the
+ * destructor asserts that the total size of all registered fields equals sizeof(Dtype), catching
+ * a struct/mapping mismatch immediately rather than at first use.
+ */
 template <typename Dtype>
 class DataMapper
 {
 public:
     typedef Dtype MAP_TYPE;
 
+    /**
+     * @param data_set the SDK-wide array of data sets; data_set[did] is the entry this mapper populates
+     * @param did the DID being registered
+     */
     DataMapper(data_set_t data_set[DID_COUNT], uint32_t did) : ds(data_set[did]), totalSize(0), memberCount(0)
     {
         data_set[did].size = structSize = sizeof(MAP_TYPE);
     }
 
+    /** Asserts (and logs to stderr) if the total size of all registered fields doesn't equal sizeof(MAP_TYPE). */
     ~DataMapper()
     {
         if (totalSize != structSize)
@@ -243,14 +328,26 @@ public:
         }
     }
 
+    /**
+     * Registers a single (non-array) scalar field, located via a pointer-to-member so the offset
+     * is computed by the compiler rather than passed by hand.
+     * @param name the field's name, used for name-based lookup
+     * @param member pointer-to-member (e.g. &MAP_TYPE::fieldName) identifying the field's location
+     * @param type the field's wire/storage type
+     * @param units the display units for this field, if any
+     * @param description a human-readable description of the field
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to the raw value before display
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     template <typename MemberType>
     data_info_t& AddMember(const std::string& name,
         MemberType member,
         eDataType type,
-        const std::string& units = "", 
+        const std::string& units = "",
         const std::string& description = "",
-        int flags = 0, 
-        double conversion = 1.0)     
+        int flags = 0,
+        double conversion = 1.0)
     {
         using FieldType = typename std::remove_cv<typename std::remove_reference<decltype(((MAP_TYPE*)nullptr)->*member)>::type>::type;
         uint32_t offset = (uint32_t)(uintptr_t)&(((MAP_TYPE*)nullptr)->*member);
@@ -309,6 +406,19 @@ public:
         return *dinfo;
     }
 
+    /**
+     * Registers an array field, located via a pointer-to-member so the offset is computed by the
+     * compiler rather than passed by hand.
+     * @param name the field's name, used for name-based lookup
+     * @param member pointer-to-member (e.g. &MAP_TYPE::fieldName) identifying the array's location
+     * @param type the wire/storage type of each element
+     * @param arraySize the number of elements in the array
+     * @param units per-element display units (extended to arraySize entries if shorter)
+     * @param description per-element descriptions (extended to arraySize entries if shorter)
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to each raw value before display
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     template <typename MemberType>
     data_info_t& AddArray(const std::string& name,
         MemberType member,
@@ -317,7 +427,7 @@ public:
         const std::vector<std::string>& units = {},
         const std::vector<std::string>& description = {},
         int flags = 0,
-        double conversion = 1.0)     
+        double conversion = 1.0)
     {
         using FieldType = typename std::remove_cv<typename std::remove_reference<decltype(((MAP_TYPE*)nullptr)->*member)>::type>::type;
         uint32_t offset = (uint32_t)(uintptr_t)&(((MAP_TYPE*)nullptr)->*member);
@@ -376,12 +486,25 @@ public:
         return *dinfo;
     }
 
+    /**
+     * Registers a single (non-array) scalar field by explicit byte offset, for cases where a
+     * pointer-to-member isn't available or convenient (e.g. offsets computed programmatically).
+     * @param name the field's name, used for name-based lookup
+     * @param offset the field's byte offset within the mapped struct
+     * @param type the field's wire/storage type
+     * @param units the display units for this field, if any
+     * @param description a human-readable description of the field
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to the raw value before display
+     * @param typeSize explicit field size in bytes; required for DATA_TYPE_STRING/DATA_TYPE_BINARY (0 = look up s_eDataTypeSize[type])
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     data_info_t& AddMember2(const std::string& name,
         uint32_t offset,
         eDataType type,
-        const std::string& units = "", 
+        const std::string& units = "",
         const std::string& description = "",
-        int flags = 0, 
+        int flags = 0,
         double conversion = 1.0,
         uint32_t typeSize = 0)
     {
@@ -427,6 +550,20 @@ public:
         return *dinfo;
     }
 
+    /**
+     * Registers an array field by explicit byte offset, for cases where a pointer-to-member
+     * isn't available or convenient (e.g. offsets computed programmatically).
+     * @param name the field's name, used for name-based lookup
+     * @param offset the array's starting byte offset within the mapped struct
+     * @param type the wire/storage type of each element
+     * @param arraySize the number of elements in the array
+     * @param units per-element display units (extended to arraySize entries if shorter)
+     * @param description per-element descriptions (extended to arraySize entries if shorter)
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to each raw value before display
+     * @param typeSize explicit per-element size in bytes; required for DATA_TYPE_STRING/DATA_TYPE_BINARY (0 = look up s_eDataTypeSize[type])
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     data_info_t& AddArray2(const std::string& name,
         uint32_t offset,
         eDataType type,
@@ -491,6 +628,16 @@ public:
         return *dinfo;
     }
 
+    /**
+     * Registers a 3-element [lat, lon, alt] array field (degrees, degrees, meters) with
+     * per-element units/descriptions and fixed 8-decimal precision pre-applied.
+     * @param name the field's name, used for name-based lookup
+     * @param offset the array's starting byte offset within the mapped struct
+     * @param description base description, prefixed onto "latitude"/"longitude"/altitude
+     * @param descriptionAltitude description suffix for the altitude element
+     * @param flags an eDataFlags bitmask controlling rendering/behavior (fixed-decimal bits are overridden)
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     data_info_t& AddLlaDegM(const std::string& name,
         uint32_t offset,
         const std::string& description = "",
@@ -502,6 +649,18 @@ public:
         return AddArray2(name, offset, type, 3, {"°", "°", "m"}, {description + " latitude", description + " longitude", description + " " + descriptionAltitude}, flags | DATA_FLAGS_FIXED_DECIMAL_8);
     }
 
+    /**
+     * Registers a 3-element [X, Y, Z] vector array field, with per-element descriptions derived
+     * from description.
+     * @param name the field's name, used for name-based lookup
+     * @param offset the array's starting byte offset within the mapped struct
+     * @param type the wire/storage type of each element
+     * @param units the display units, applied to all three elements
+     * @param description base description, prefixed with "X "/"Y "/"Z " per element
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to each raw value before display
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     data_info_t& AddVec3Xyz(const std::string& name,
         uint32_t offset,
         eDataType type,
@@ -513,6 +672,18 @@ public:
         return AddArray2(name, offset, type, 3, {units}, {"X "+description, "Y "+description, "Z "+description}, flags, conversion);
     }
 
+    /**
+     * Registers a 3-element [Roll, Pitch, Yaw] vector array field, with per-element descriptions
+     * derived from description.
+     * @param name the field's name, used for name-based lookup
+     * @param offset the array's starting byte offset within the mapped struct
+     * @param type the wire/storage type of each element
+     * @param units the display units, applied to all three elements
+     * @param description base description, prefixed with "Roll "/"Pitch "/"Yaw " per element
+     * @param flags an eDataFlags bitmask controlling rendering/behavior
+     * @param conversion a scalar divisor applied to each raw value before display
+     * @return a reference to the newly-registered data_info_t, for further customization (e.g. overriding renderBasic)
+     */
     data_info_t& AddVec3Rpy(const std::string& name,
         uint32_t offset,
         eDataType type,
@@ -569,6 +740,13 @@ struct array_struct_info_t
 };
 
 
+/**
+ * Owns the field-mapping table (data_set_t m_data_set[DID_COUNT]) for every DID and exposes it
+ * through a static lookup/conversion API: name<->DID, field lookup by name/index/offset/element,
+ * and string<->binary field conversion (including YAML round-tripping). A process-wide singleton
+ * (see s_map) built once and never destroyed, so other statics can safely query it during their
+ * own static destruction.
+ */
 class cISDataMappings
 {
 public:
@@ -576,11 +754,13 @@ public:
 
     virtual ~cISDataMappings() {}
 
+    /** A single contiguous heap allocation tracked for later validation/leak-checking (see AppendMemoryUsage()). */
     struct MemoryUsage
     {
-        uint8_t* ptr;
-        size_t size;
+        uint8_t* ptr;    //!< pointer to the start of the allocation
+        size_t size;     //!< size of the allocation, in bytes
 
+        /** @return a pointer one-past-the-end of the allocation */
         uint8_t* end() const { return ptr + size; }
     };
 
@@ -689,6 +869,15 @@ public:
     */
     static uint32_t DefaultPeriodMultiple(uint32_t did);
 
+    /**
+     * Extracts a single field value (or one array element) out of a raw record buffer into a
+     * type-erased std::any, per info's type/offset/elementSize. Only numeric types are supported;
+     * DATA_TYPE_STRING/DATA_TYPE_BINARY and out-of-range array indices yield an empty std::any.
+     * @param dataBuff pointer to the start of the decoded DID struct for one record
+     * @param info metadata for the field to extract
+     * @param arrayIndex the array index to extract (0 for scalar fields)
+     * @return the extracted value, or an empty std::any if info.type/arrayIndex is not supported
+     */
     static std::any dataToStdAny(const uint8_t* dataBuff, const data_info_t& info, unsigned int arrayIndex = 0) {
         std::any value;
 
@@ -838,28 +1027,41 @@ public:
      */
     static const data_info_t* FieldInfoByOffset(uint32_t did, uint16_t offset);
 
+    /**
+     * Records a heap allocation in usageVec, for later validation/leak-checking of YamlToData()'s
+     * dynamically-allocated fields (e.g. variable-length strings/arrays).
+     * @param usageVec the vector to append the new allocation record to
+     * @param newPtr pointer to the start of the allocation
+     * @param newSize size of the allocation, in bytes
+     */
     static void AppendMemoryUsage(std::vector<MemoryUsage>& usageVec, void* newPtr, size_t newSize);
 
 protected:
 
+    /**
+     * Parses and removes a trailing "[N]" array-index suffix from str, if present.
+     * @param str the field-name string to parse; the "[N]" suffix, if found, is erased from it
+     * @return the parsed array index N, or -1 if str had no array-index suffix
+     */
     static int ExtractArrayIndex(std::string &str);
 
+    /** Table schema: human-readable name for each DID, indexed by the DID value (see DataName()/Did()). */
     static const char* const m_dataIdNames[];
 
-    data_set_t m_data_set[DID_COUNT];
+    data_set_t m_data_set[DID_COUNT];    //!< the field-mapping table for every DID, populated by this instance's constructor
 
 #if PLATFORM_IS_EMBEDDED
     // on embedded we cannot new up C++ runtime until after free rtos has started
-    static cISDataMappings* s_map;
+    static cISDataMappings* s_map;    //!< the process-wide singleton instance, lazily constructed on first use
 #else
     // Heap-allocated pointer (never deleted) to avoid static destruction order fiasco:
     // other static objects (e.g. cDeviceLog containers) may call NameToInfoMap() during
     // their own destructors, after a value-typed s_map would have already been destroyed.
-    static cISDataMappings* s_map;
+    static cISDataMappings* s_map;    //!< the process-wide singleton instance, lazily constructed on first use and never deleted
 #endif
 
 private:
-    #define PROTECT_UNALIGNED_ASSIGNS
+    #define PROTECT_UNALIGNED_ASSIGNS    //!< when defined, protectUnalignedAssign() copies via memcpy instead of a direct pointer cast, avoiding unaligned-access faults on strict-alignment platforms
     template<typename T>
     static inline void protectUnalignedAssign(void* out, T in) {
         // This gets called from cISDataMappings::StringToVariable

--- a/src/ISDisplay.h
+++ b/src/ISDisplay.h
@@ -10,6 +10,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISDisplay.h
+ * @brief Console/terminal display and formatting helper for cltool-style host applications:
+ *        renders received device data sets as human-readable text, tracks per-DID receive
+ *        statistics, and drives an interactive terminal UI for viewing/editing a data set.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef IS_DISPLAY_H
 #define IS_DISPLAY_H
 
@@ -33,128 +43,494 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 /**
-* Utility functions for displaying data
-*/
+ * Console/terminal front-end used by cltool (and similar host tools) to render incoming device
+ * data. Owns the terminal mode (raw keyboard input, cursor positioning), formats every DID's
+ * data set into human-readable strings (the DataToString*() family), tracks per-DID receive
+ * statistics for the "stats" display mode, and drives an interactive field-editing UI for
+ * uploading modified values back to the device.
+ */
 class cInertialSenseDisplay
 {
 public:
+    /** State for the interactive single-field editor (see SelectEditDataset()/GetKeyboardInput()). Named (rather than anonymous) to keep MSVC happy with the default member initializer on pData. */
     typedef struct edit_data_s // we need to name this to make MSVC happy, since we make default assignments in the struct below (pData)
     {
-        const map_name_to_info_t            *mapInfo;
-        map_name_to_info_t::const_iterator  mapInfoSelection;
-        map_name_to_info_t::const_iterator  mapInfoBegin;
-        map_name_to_info_t::const_iterator  mapInfoEnd;
-        uint32_t                            selectionArrayIdx;
+        const map_name_to_info_t            *mapInfo;             //!< data mapping table for the dataset currently being edited
+        map_name_to_info_t::const_iterator  mapInfoSelection;      //!< currently selected field within mapInfo
+        map_name_to_info_t::const_iterator  mapInfoBegin;          //!< begin iterator of mapInfo, cached for wraparound navigation
+        map_name_to_info_t::const_iterator  mapInfoEnd;            //!< end iterator of mapInfo, cached for wraparound navigation
+        uint32_t                            selectionArrayIdx;    //!< array index selected, for fields that are arrays
 
-        bool                                readOnlyMode;
-        bool                                editEnabled;
-        std::string                         field;
-        uint32_t                            did;
-        bool                                uploadNeeded;
-        uint8_t                             data[MAX_DATASET_SIZE];
-        data_info_t                         info;
-        uint8_t                             pDataBuf[MAX_DATASET_SIZE];
-        p_data_t                            pData = {{}, pDataBuf};
+        bool                                readOnlyMode;          //!< true if editing is disabled and the dataset is only being displayed
+        bool                                editEnabled;           //!< true while the user is actively editing the selected field
+        std::string                         field;                 //!< text currently being typed for the selected field's new value
+        uint32_t                            did;                   //!< data set ID being edited
+        bool                                uploadNeeded;           //!< true once an edited value is ready to be uploaded to the device
+        uint8_t                             data[MAX_DATASET_SIZE]; //!< last-received copy of the dataset being edited
+        data_info_t                         info;                   //!< data mapping info for the currently selected field
+        uint8_t                             pDataBuf[MAX_DATASET_SIZE]; //!< backing buffer for pData
+        p_data_t                            pData = {{}, pDataBuf};     //!< packet data descriptor wrapping pDataBuf, used to stage an upload
     } edit_data_t;
 
+    /** Top-level rendering mode for PrintData()/PrintStats(). */
     enum eDisplayMode
     {
-        DMODE_QUIET = 0,
-        DMODE_PRETTY,
-        DMODE_SCROLL,
-        DMODE_EDIT,
-        DMODE_STATS,
-        DMODE_RAW_PARSE,
+        DMODE_QUIET = 0,    //!< no console output
+        DMODE_PRETTY,       //!< human-readable, formatted multi-line output
+        DMODE_SCROLL,       //!< one line of output per received message, scrolling
+        DMODE_EDIT,         //!< interactive field-editing UI
+        DMODE_STATS,        //!< per-DID receive statistics summary
+        DMODE_RAW_PARSE,    //!< raw hex dump of received packets
     };
 
+    /**
+     * Constructs the display and initializes terminal state.
+     * @param displayMode the initial display mode
+     */
     cInertialSenseDisplay(eDisplayMode displayMode = DMODE_QUIET);
+
+    /** Restores the terminal to its original mode. */
     ~cInertialSenseDisplay();
 
+    /** Sets the current display mode. @param mode the new display mode */
     void SetDisplayMode(eDisplayMode mode) { m_displayMode = mode; };
+
+    /** @return the current display mode */
     eDisplayMode GetDisplayMode() { return m_displayMode; };
+
+    /** Enables or disables printing of received data as raw hex. @param enable true to show raw hex, false to show formatted data */
     void showRawData(bool enable) { m_showRawHex = enable; };
+
+    /** Shows or hides the terminal cursor. @param visible true to show the cursor, false to hide it */
     void ShowCursor(bool visible);
+
+    /** Restores the terminal to its normal (non-raw, cursor-visible) mode. */
     void ShutDown();
+
+    /** Clears the terminal screen. */
     void Clear(void);
+
+    /** Moves the cursor to the terminal's home position (top-left). */
     void Home(void);
+
+    /**
+     * Moves the cursor to a given row, column 0.
+     * @param y the target row
+     */
     void GoToRow(int y);
+
+    /**
+     * Moves the cursor to a given column and row.
+     * @param x the target column
+     * @param y the target row
+     */
     void GoToColumnAndRow(int x, int y);
+
+    /** @return the column header string describing the fields printed in scroll mode */
     std::string Header();
+
+    /** @return a greeting banner string printed at startup */
     std::string Hello();
+
+    /** @return a string describing the connected device */
     std::string Connected();
+
+    /**
+     * @param speed replay speed multiplier being used
+     * @return a string describing the active log-replay session
+     */
     std::string Replay(double speed=1.0);
+
+    /** @return a farewell banner string printed at shutdown */
     std::string Goodbye();
 
+    /** Puts the keyboard into non-blocking, unbuffered raw mode so KeyboardHit()/GetChar() work without waiting for Enter. */
     void SetKeyboardNonBlocking();
+
+    /** Restores the keyboard/terminal to its original (buffered, echoing) mode. */
     void ResetTerminalMode();
+
+    /** @return non-zero if a key is currently available to be read, 0 otherwise */
     int KeyboardHit();
+
+    /** @return the next character from the keyboard (blocking) */
     int GetChar();
+
+    /** @return true if the user has requested the program exit (e.g. pressed 'q' or Ctrl-C) */
     bool ExitProgram();
+
+    /** Flags that the program should exit, causing subsequent ExitProgram() calls to return true. */
     void SetExitProgram();
 
-    // for the binary protocol, this processes a packet of data
+    /**
+     * Updates per-DID statistics and buffers a formatted string for the given packet, for the binary protocol.
+     * @param data the received packet data (raw buffer form)
+     * @param enableReplay true if this data originates from log replay
+     * @param replaySpeedX replay speed multiplier, used when enableReplay is true
+     */
     void ProcessData(p_data_buf_t* data, bool enableReplay = false, double replaySpeedX = 1.0);
+
+    /**
+     * Updates per-DID statistics and buffers a formatted string for the given packet.
+     * @param data the received packet data
+     * @param enableReplay true if this data originates from log replay
+     * @param replaySpeedX replay speed multiplier, used when enableReplay is true
+     */
     void ProcessData(p_data_t *data, bool enableReplay = false, double replaySpeedX = 1.0);
+
+    /**
+     * Renders the current display mode's output to the console, throttled to refreshPeriodMs.
+     * @param refreshPeriodMs minimum time, in milliseconds, between successive screen redraws (100ms = 10Hz)
+     * @return true if the screen was actually redrawn, false if throttled/skipped
+     */
     bool PrintData(unsigned int refreshPeriodMs = 100); // 100ms = 10Hz
+
+    /**
+     * @param comm the comm instance whose parse status/error counters are to be reported
+     * @return a string summarizing the is_comm_instance_t's parse status
+     */
     static std::string PrintIsCommStatus(is_comm_instance_t *comm);
+
+    /**
+     * Updates the per-DID receive statistics (count, time delta) used by DMODE_STATS.
+     * @param data the received packet data
+     */
     void DataToStats(const p_data_t* data);
+
+    /** Prints the accumulated per-DID receive statistics to the console (DMODE_STATS). */
     void PrintStats();
+
+    /**
+     * @param data the received packet data
+     * @return a formatted, human-readable string describing the data set, dispatched by DID
+     */
     std::string DataToString(const p_data_t* data);
+
+    /**
+     * Appends a human-readable decode of insStatus/hdwStatus flag bits to a buffer.
+     * @param ptr current write position in the destination buffer
+     * @param ptrEnd end of the destination buffer (exclusive), used to bound writes
+     * @param insStatus INS status flags to decode
+     * @param hdwStatus hardware status flags to decode
+     * @return the updated write position (ptr advanced past the appended text)
+     */
     char* StatusToString(char* ptr, char* ptrEnd, const uint32_t insStatus, const uint32_t hdwStatus);
+
+    /**
+     * Appends a human-readable decode of the INS solution status bits of insStatus to a buffer.
+     * @param ptr current write position in the destination buffer
+     * @param ptrEnd end of the destination buffer (exclusive), used to bound writes
+     * @param insStatus INS status flags to decode
+     * @return the updated write position (ptr advanced past the appended text)
+     */
     char* InsStatusToSolStatusString(char* ptr, char* ptrEnd, const uint32_t insStatus);
+
+    /**
+     * @param ins1 the INS1 data set to format
+     * @param hdr the packet header associated with ins1 (used for timestamp)
+     * @return a formatted, human-readable string describing ins1
+     */
     std::string DataToStringINS1(const ins_1_t &ins1, const p_data_hdr_t& hdr);
+
+    /**
+     * @param ins2 the INS2 data set to format
+     * @param hdr the packet header associated with ins2 (used for timestamp)
+     * @return a formatted, human-readable string describing ins2
+     */
     std::string DataToStringINS2(const ins_2_t &ins2, const p_data_hdr_t& hdr);
+
+    /**
+     * @param ins3 the INS3 data set to format
+     * @param hdr the packet header associated with ins3 (used for timestamp)
+     * @return a formatted, human-readable string describing ins3
+     */
      std::string DataToStringINS3(const ins_3_t &ins3, const p_data_hdr_t& hdr);
+
+    /**
+     * @param ins4 the INS4 data set to format
+     * @param hdr the packet header associated with ins4 (used for timestamp)
+     * @return a formatted, human-readable string describing ins4
+     */
     std::string DataToStringINS4(const ins_4_t &ins4, const p_data_hdr_t& hdr);
+
+    /**
+     * @param imus the multi-IMU data set to format
+     * @param hdr the packet header associated with imus (used for timestamp)
+     * @return a formatted, human-readable string describing imus
+     */
     std::string DataToStringIMUs(const imus_t &imus, const p_data_hdr_t& hdr);
+
+    /**
+     * @param imus the multi-IMU data set to format
+     * @param numDevices the number of IMU devices present in imus to format
+     * @param full if true, includes additional detail fields
+     * @return a formatted, human-readable string describing imus
+     */
     static std::string DataToStringIMUs(const imus_t &imus, int numDevices, bool full=false);
+
+    /**
+     * @param imu the IMU data set to format
+     * @param hdr the packet header associated with imu (used for timestamp)
+     * @return a formatted, human-readable string describing imu
+     */
     std::string DataToStringIMU(const imu_t &imu, const p_data_hdr_t& hdr);
+
+    /**
+     * @param imu the IMU data set to format
+     * @param full if true, includes additional detail fields
+     * @return a formatted, human-readable string describing imu
+     */
     static std::string DataToStringIMU(const imu_t &imu, bool full=false);
+
+    /**
+     * @param imu the preintegrated IMU data set to format
+     * @param hdr the packet header associated with imu (used for timestamp)
+     * @return a formatted, human-readable string describing imu
+     */
     std::string DataToStringPreintegratedImu(const pimu_t &imu, const p_data_hdr_t& hdr);
+
+    /**
+     * @param baro the barometer data set to format
+     * @param hdr the packet header associated with baro (used for timestamp)
+     * @return a formatted, human-readable string describing baro
+     */
     std::string DataToStringBarometer(const barometer_t& baro, const p_data_hdr_t& hdr);
+
+    /**
+     * @param mag the magnetometer data set to format
+     * @param hdr the packet header associated with mag (used for timestamp)
+     * @return a formatted, human-readable string describing mag
+     */
     std::string DataToStringMagnetometer(const magnetometer_t &mag, const p_data_hdr_t& hdr);
+
+    /**
+     * @param mag the magnetometer calibration data set to format
+     * @param hdr the packet header associated with mag (used for timestamp)
+     * @return a formatted, human-readable string describing mag
+     */
     std::string DataToStringMagCal(const mag_cal_t &mag, const p_data_hdr_t& hdr);
+
+    /**
+     * @param ver the GNSS receiver version data set to format
+     * @param hdr the packet header associated with ver (used for timestamp)
+     * @return a formatted, human-readable string describing ver
+     */
     std::string DataToStringGnssVersion(const gnss_version_t &ver, const p_data_hdr_t& hdr);
+
+    /**
+     * @param gnss the GNSS position data set to format
+     * @param hdr the packet header associated with gnss (used for timestamp)
+     * @return a formatted, human-readable string describing gnss
+     */
     std::string DataToStringGnssPos(const gnss_pos_t &gnss, const p_data_hdr_t& hdr);
+
+    /**
+     * @param gnss the GNSS position data set to format
+     * @param full if true, includes additional detail fields
+     * @return a formatted, human-readable string describing gnss
+     */
     static std::string DataToStringGnssPos(const gnss_pos_t &gnss, bool full=false);
+
+    /**
+     * @param gnss the GNSS RTK relative-positioning data set to format
+     * @param hdr the packet header associated with gnss (used for timestamp)
+     * @return a formatted, human-readable string describing gnss
+     */
     std::string DataToStringRtkRel(const gnss_rtk_rel_t &gnss, const p_data_hdr_t& hdr);
+
+    /**
+     * @param sol the GNSS RTK miscellaneous data set to format
+     * @param hdr the packet header associated with sol (used for timestamp)
+     * @return a formatted, human-readable string describing sol
+     */
     std::string DataToStringRtkMisc(const gnss_rtk_misc_t& sol, const p_data_hdr_t& hdr);
+
+    /**
+     * @param raw the raw GNSS observation/ephemeris data set to format
+     * @param hdr the packet header associated with raw (used for timestamp)
+     * @return a formatted, human-readable string describing raw
+     */
     std::string DataToStringRawGNSS(const gnss_raw_t& raw, const p_data_hdr_t& hdr);
+
+    /**
+     * @param gnss the GNSS satellite-info data set to format
+     * @param hdr the packet header associated with gnss (used for timestamp)
+     * @return a formatted, human-readable string describing gnss
+     */
     std::string DataToStringGnssSat(const gnss_sat_t &gnss, const p_data_hdr_t& hdr);
+
+    /**
+     * @param gnss the GNSS satellite-info data set to format
+     * @param full if true, includes additional detail fields
+     * @return a formatted, human-readable string describing gnss
+     */
     static std::string DataToStringGnssSat(const gnss_sat_t &gnss, bool full=false);
+
+    /**
+     * @param survey the survey-in data set to format
+     * @param hdr the packet header associated with survey (used for timestamp)
+     * @return a formatted, human-readable string describing survey
+     */
     std::string DataToStringSurveyIn(const survey_in_t &survey, const p_data_hdr_t& hdr);
+
+    /**
+     * @param sys the system parameters data set to format
+     * @param hdr the packet header associated with sys (used for timestamp)
+     * @return a formatted, human-readable string describing sys
+     */
     std::string DataToStringSysParams(const sys_params_t& sys, const p_data_hdr_t& hdr);
+
+    /**
+     * @param sensors the system sensors data set to format
+     * @param hdr the packet header associated with sensors (used for timestamp)
+     * @return a formatted, human-readable string describing sensors
+     */
     std::string DataToStringSysSensors(const sys_sensors_t& sensors, const p_data_hdr_t& hdr);
+
+    /**
+     * @param info the IMX RTOS task-info data set to format
+     * @param hdr the packet header associated with info (used for timestamp)
+     * @return a formatted, human-readable string describing info
+     */
     std::string DataToStringRTOS(const rtos_info_t& info, const p_data_hdr_t& hdr);
+
+    /**
+     * @param info the GPX RTOS task-info data set to format
+     * @param hdr the packet header associated with info (used for timestamp)
+     * @return a formatted, human-readable string describing info
+     */
     std::string DataToStringGRTOS(const gpx_rtos_info_t& info, const p_data_hdr_t& hdr);
+
+    /**
+     * @param info the device info data set to format
+     * @param hdr the packet header associated with info (used for timestamp)
+     * @return a formatted, human-readable string describing info
+     */
     std::string DataToStringDevInfo(const dev_info_t &info, const p_data_hdr_t& hdr);
+
+    /**
+     * @param info the device info data set to format
+     * @param flags formatting flags controlling which fields are included
+     * @return a formatted, human-readable string describing info
+     */
     static std::string DataToStringDevInfo(const dev_info_t &info, int flags=0);
+
+    /**
+     * @param sensorsADC the raw ADC sensor sample data set to format
+     * @param hdr the packet header associated with sensorsADC (used for timestamp)
+     * @return a formatted, human-readable string describing sensorsADC
+     */
     std::string DataToStringSensorsADC(const sys_sensors_adc_t &sensorsADC, const p_data_hdr_t& hdr);
+
+    /**
+     * @param enc the wheel encoder data set to format
+     * @param hdr the packet header associated with enc (used for timestamp)
+     * @return a formatted, human-readable string describing enc
+     */
     std::string DataToStringWheelEncoder(const wheel_encoder_t &enc, const p_data_hdr_t& hdr);
+
+    /**
+     * @param gpxStatus the GPX status data set to format
+     * @param hdr the packet header associated with gpxStatus (used for timestamp)
+     * @return a formatted, human-readable string describing gpxStatus
+     */
     std::string DataToStringGPXStatus(const gpx_status_t &gpxStatus, const p_data_hdr_t& hdr);
+
+    /**
+     * @param debug the debug array data set to format
+     * @param hdr the packet header associated with debug (used for timestamp)
+     * @return a formatted, human-readable string describing debug
+     */
     std::string DataToStringDebugArray(const debug_array_t &debug, const p_data_hdr_t& hdr);
+
+    /**
+     * @param portMon the port monitor data set to format
+     * @param hdr the packet header associated with portMon (used for timestamp)
+     * @return a formatted, human-readable string describing portMon
+     */
     std::string DataToStringPortMonitor(const port_monitor_t &portMon, const p_data_hdr_t& hdr);
+
+    /**
+     * @param event the device event data set to format
+     * @param hdr the packet header associated with event (used for timestamp)
+     * @return a formatted, human-readable string describing event
+     */
     std::string DataToStringEvent(const did_event_t &event, const p_data_hdr_t& hdr);
+
+    /**
+     * @param raw_data pointer to the raw packet bytes to dump
+     * @param hdr the packet header associated with raw_data (used for timestamp)
+     * @param bytesPerLine number of bytes to print per output line
+     * @return a hex-dump string of raw_data
+     */
     std::string DataToStringRawHex(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine);
+
+    /**
+     * @param raw_data pointer to the raw packet bytes to dump
+     * @param hdr the packet header associated with raw_data (used for timestamp)
+     * @param bytesPerLine number of bytes to print per output line
+     * @param colorize if true, colorizes the hex dump output using ANSI escape codes
+     * @return a hex-dump string of raw_data
+     */
     std::string DataToStringPacket(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine, bool colorize);
+
+    /**
+     * @param data the received packet data
+     * @return a generic, mapping-driven, human-readable string describing data (used as a fallback for DIDs without a dedicated formatter)
+     */
     std::string DataToStringGeneric(const p_data_t* data);
+
+    /**
+     * Appends ", " to the buffer if comma is already true, then sets comma to true. Used to separate list items when building comma-separated output.
+     * @param[in,out] comma tracks whether a preceding item has already been written; updated to true
+     * @param[in,out] ptr current write position in the destination buffer; advanced past the appended text
+     * @param ptrEnd end of the destination buffer (exclusive), used to bound writes
+     */
     static void AddCommaToString(bool &comma, char* &ptr, char* &ptrEnd){ if (comma) { ptr += SNPRINTF(ptr, ptrEnd - ptr, ", "); } comma = true; };
 
+    /**
+     * @param data the received packet data
+     * @return a formatted, human-readable string describing the data set (top-level entry point dispatched by display mode)
+     */
     std::string DatasetToString(const p_data_t* data);
 
+    /** Reads and processes any pending keyboard input, driving the interactive editor's navigation/typing. */
     void GetKeyboardInput();
+
+    /**
+     * Begins interactively editing the dataset for the given DID.
+     * @param did the data set ID to edit
+     * @param readOnlyMode if true, the dataset is displayed but cannot be modified
+     */
     void SelectEditDataset(int did, bool readOnlyMode=false);
+
+    /** Advances the field-editor selection to the next field. */
     void VarSelectIncrement();
+
+    /** Moves the field-editor selection to the previous field. */
     void VarSelectDecrement();
+
+    /** Ends the current field-editing session, discarding an in-progress edit. */
     void StopEditing();
+
+    /** @return true if an edited value is ready to be uploaded; clears the pending flag as a side effect */
     bool UploadNeeded() { bool uploadNeeded = m_editData.uploadNeeded; m_editData.uploadNeeded = false; return uploadNeeded; };
+
+    /** @return a pointer to the current editor state, for staging an upload */
     edit_data_t *EditData() { return &m_editData; }
-    void setOutputOnceDid(std::vector<uint32_t> did) 
-    { 
-        m_outputOnceDid = did; m_interactiveMode = did.empty(); 
+
+    /**
+     * Restricts output to a specific set of DIDs, printed once and then exits (used by cltool's non-interactive "print and quit" mode).
+     * @param did the list of DIDs to print; if empty, interactive mode is re-enabled
+     */
+    void setOutputOnceDid(std::vector<uint32_t> did)
+    {
+        m_outputOnceDid = did; m_interactiveMode = did.empty();
     }
     // void SetSerialPort(serial_port_t* port) { m_port = port; }
     // void SetCommInstance(is_comm_instance_t* comm) { m_comm = comm; }
+
+    /** Sets the device associated with this display, used for device-specific formatting. @param activeDevice handle of the active device */
     void setDevice(device_handle_t activeDevice) { m_device = activeDevice; }
 
 private:
@@ -179,9 +555,9 @@ private:
 
     struct sDidStats
     {
-        int lastTimeMs;
-        int dtMs;
-        int count;
+        int lastTimeMs;    //!< the timestamp (ms) of the previous sample used to compute dtMs
+        int dtMs;          //!< the time delta (ms) between the two most recent samples
+        int count;         //!< the number of samples received for this DID
     };
 
     std::vector<sDidStats> m_didStats;
@@ -199,9 +575,32 @@ private:
 
 };
 
+/**
+ * Turns on bold text for subsequent output to the stream, using an ANSI escape code.
+ * @param os the output stream to modify
+ * @return the same stream, for chaining with operator<<
+ */
 std::ostream& boldOn(std::ostream& os);
+
+/**
+ * Turns off bold text for subsequent output to the stream, using an ANSI escape code.
+ * @param os the output stream to modify
+ * @return the same stream, for chaining with operator<<
+ */
 std::ostream& boldOff(std::ostream& os);
-std::ostream& endlbOn(std::ostream& os);  // Bold on with newline
-std::ostream& endlbOff(std::ostream& os); // Bold off with newline
+
+/**
+ * Turns on bold text and appends a newline (bold on with newline).
+ * @param os the output stream to modify
+ * @return the same stream, for chaining with operator<<
+ */
+std::ostream& endlbOn(std::ostream& os);
+
+/**
+ * Turns off bold text and appends a newline (bold off with newline).
+ * @param os the output stream to modify
+ * @return the same stream, for chaining with operator<<
+ */
+std::ostream& endlbOff(std::ostream& os);
 
 #endif // IS_DISPLAY_H

--- a/src/ISHttpRequest.h
+++ b/src/ISHttpRequest.h
@@ -18,19 +18,22 @@ extern "C"
     #include "core/base_port.h"
 }
 
+/** Lightweight, blocking HTTP/1.1 client built on the tcpPort transport; supports GET/POST/PUT and multipart PUT. */
 class ISHttpRequest {
 public:
+    /** Result of an HTTP request performed by ISHttpRequest. */
     struct Response {
-        int statusCode = -1;
-        std::string statusMessage;
-        std::string body;
-        std::map<std::string, std::string> headers;
+        int statusCode = -1;                        //!< HTTP status code (e.g. 200), or -1 if the request failed before a response was received
+        std::string statusMessage;                   //!< HTTP status reason phrase (e.g. "OK")
+        std::string body;                             //!< response body, with any chunked/length framing already removed
+        std::map<std::string, std::string> headers;   //!< response headers, keyed by header name
     };
 
+    /** One field of a multipart/form-data body sent via putMultipart(). */
     struct MultipartField {
-        std::string name;
-        std::string contentType;   // e.g., "application/json", "application/zip"
-        std::string data;
+        std::string name;          //!< form field name
+        std::string contentType;   //!< MIME type of data, e.g. "application/json", "application/zip"
+        std::string data;          //!< raw field content
     };
 
     /**
@@ -69,11 +72,18 @@ public:
     static Response putMultipart(const std::string& url, const std::vector<MultipartField>& fields, int timeoutMs = 10000);
 
 private:
+    /** Builds a raw HTTP/1.1 GET request line and headers for host/path. */
     static std::string buildGetRequest(const std::string& host, const std::string& path);
+
+    /** Builds a raw HTTP/1.1 request (any method) with optional content type and body. */
     static std::string buildRequest(const std::string& method, const std::string& host, const std::string& path,
                                     const std::string& contentType, const std::string& body);
+
+    /** Parses url, opens a tcpPort connection, sends the request, and returns the parsed Response. */
     static Response sendRequest(const std::string& url, const std::string& method,
                                 const std::string& contentType, const std::string& body, int timeoutMs);
+
+    /** Reads and parses an HTTP status line, headers, and body from an already-connected port. */
     static Response parseResponse(port_handle_t port, int timeoutMs);
 };
 

--- a/src/ISLogStats.h
+++ b/src/ISLogStats.h
@@ -10,6 +10,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISLogStats.h
+ * @brief Per-DID receive statistics tracking (count, error count, inter-arrival timing, bitrate)
+ *        and a diagnostic-DID cache used to render a device-health summary alongside a log's
+ *        stats file.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef IS_LOG_STATS_H
 #define IS_LOG_STATS_H
 
@@ -23,60 +33,124 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISComm.h"
 
 
-typedef void (*FuncLogDataAndTimestamp)(uint32_t dataId, double timeMs);
+typedef void (*FuncLogDataAndTimestamp)(uint32_t dataId, double timeMs);   //!< callback signature for logging a data ID with an associated timestamp (ms)
 
+/** Receive statistics tracked for a single message/data ID: counts, error counts, inter-arrival timing, and bitrate. */
 class cLogStatMsgId
 {
 public:
-    unsigned int count = 0;         // count for this data id
-    unsigned int errors = 0;        // error count for this data id
-    unsigned int meanDtMs = 0;      // average time delta for the data id
-    unsigned int accumDtMs = 0;     // sum of all time deltas
-    unsigned int lastTimeMs = 0;
-    unsigned int lastDtMs = 0;
-    unsigned int minDtMs = 0;
-    unsigned int maxDtMs = 0;
-    unsigned int dtMsCount = 0;
-    unsigned int timeIrregCount = 0; // count of irregularities in delta timestamps (> 50% different from previous delta timestamp)
+    unsigned int count = 0;         //!< count for this data id
+    unsigned int errors = 0;        //!< error count for this data id
+    unsigned int meanDtMs = 0;      //!< average time delta for the data id
+    unsigned int accumDtMs = 0;     //!< sum of all time deltas
+    unsigned int lastTimeMs = 0;    //!< timestamp (ms) of the most recent sample, used to compute the next dt
+    unsigned int lastDtMs = 0;      //!< the most recently computed time delta (ms)
+    unsigned int minDtMs = 0;       //!< the smallest time delta (ms) observed
+    unsigned int maxDtMs = 0;       //!< the largest time delta (ms) observed
+    unsigned int dtMsCount = 0;     //!< number of time deltas accumulated into meanDtMs/accumDtMs (periodically halved to bound the running average's window)
+    unsigned int timeIrregCount = 0; //!< count of irregularities in delta timestamps (> 50% different from previous delta timestamp)
 
-    unsigned int bpsBytes = 0;
-    unsigned int bpsStartTimeMs = 0;
-    unsigned int bytesPerSec = 0;
+    unsigned int bpsBytes = 0;         //!< bytes accumulated in the current bitrate measurement window
+    unsigned int bpsStartTimeMs = 0;   //!< timestamp (ms) at the start of the current bitrate measurement window
+    unsigned int bytesPerSec = 0;      //!< most recently computed bytes-per-second rate for this data id
 
+    /** Constructs a stat with counters zeroed (minDtMs seeded high so the first sample always sets it). */
     cLogStatMsgId();
+
+    /**
+     * Records a new sample timestamp, updating dt/min/max/mean and timeIrregCount.
+     * @param timeMs the timestamp (ms) of the new sample; a value of 0 is ignored
+     */
     void LogTimestamp(unsigned int timeMs);
+
+    /**
+     * Records bytes received for this data id, updating bytesPerSec once the current 1-second window has elapsed.
+     * @param timeMs the timestamp (ms) of the new sample
+     * @param bytes the number of bytes received in this sample
+     */
     void LogByteSize(unsigned int timeMs, int bytes);
 };
 
+/** Aggregate receive statistics for all data ids belonging to a single protocol type (see protocol_type_t). */
 struct sLogStatPType
 {
-    std::map<int, cLogStatMsgId> stats;     // ID, cLogStatMsgId
-    unsigned int count;                     // count of all message ids
-    unsigned int errors;                    // total error count
+    std::map<int, cLogStatMsgId> stats;     //!< per-data-id statistics, keyed by data id
+    unsigned int count;                     //!< count of all message ids
+    unsigned int errors;                    //!< total error count
 };
 
+/** Cached copy of the most recently observed data for one diagnostic DID, used to build DiagnosticSummary(). */
 struct DiagnosticDIDCache {
-    std::vector<uint8_t> data;
-    double timestamp = 0.0;
-    bool observed = false;
+    std::vector<uint8_t> data;      //!< buffer holding the most recently observed (possibly partially merged) copy of the data set
+    double timestamp = 0.0;         //!< timestamp of the most recent update to data
+    bool observed = false;          //!< true once at least one update has been received
 };
 
+/** Aggregates per-protocol/per-DID receive statistics and a diagnostic-DID cache, and renders both to a stats summary. */
 class cLogStats
 {
 public:
-    std::map<protocol_type_t, sLogStatPType> msgs;
-    cISLogFileBase* statsFile;
+    std::map<protocol_type_t, sLogStatPType> msgs;     //!< per-protocol-type statistics, keyed by protocol type
+    cISLogFileBase* statsFile;                          //!< log file the stats summary is written to by WriteToFile()
 
+    /** Constructs the stats tracker with all counters cleared. */
     cLogStats();
+
+    /** Resets all per-protocol/per-DID statistics to their initial state. */
     void Clear();
+
+    /**
+     * Records a parse/receive error for a given protocol type and (if known) data id.
+     * @param hdr the packet header identifying the data id in error, or nullptr if unknown
+     * @param ptype the protocol type the error occurred on
+     */
     void LogError(const p_data_hdr_t* hdr, protocol_type_t ptype=_PTYPE_INERTIAL_SENSE_DATA);
+
+    /**
+     * Records a successfully received message, updating its protocol-type and per-id statistics.
+     * @param ptype the protocol type of the received message
+     * @param id the data id of the received message
+     * @param bytes the size, in bytes, of the received message
+     * @param timeMs the timestamp, in seconds, of the received message (converted to ms internally); 0 disables timing/bitrate updates for this sample
+     */
     void LogData(protocol_type_t ptype, int id, int bytes, double timeMs=0.0);
+
+    /**
+     * Merges a (possibly partial) update into the cached copy of a diagnostic DID's data, for later inclusion in DiagnosticSummary().
+     * Data ids not in the diagnostic set (see s_diagnosticDIDs) are ignored.
+     * @param did the data id being cached
+     * @param data pointer to the received bytes to merge in
+     * @param size the number of bytes pointed to by data
+     * @param timestamp the timestamp of this update
+     * @param offset byte offset within the full data set where data should be merged (0 for a full update)
+     */
     void CacheDiagnosticData(uint32_t did, const uint8_t* data, uint32_t size, double timestamp, uint32_t offset=0);
+
+    /** @return the total count of all messages received across all protocol types */
     unsigned int Count();
+
+    /** @return the total count of all errors recorded across all protocol types */
     unsigned int Errors();
+
+    /**
+     * @param ptype the protocol type msg belongs to, used to select id-to-name formatting
+     * @param msg the per-protocol-type statistics to format
+     * @param showDeltaTime if true, includes the per-id inter-arrival timing/bitrate columns
+     * @param showErrors if true, includes the per-id error-count column
+     * @return a formatted, human-readable table of msg's per-id statistics
+     */
     std::string MessageStats(protocol_type_t ptype, sLogStatPType &msg, bool showDeltaTime=true, bool showErrors=false);
+
+    /** @return a formatted, human-readable summary of statistics for all tracked protocol types */
     std::string Stats();
+
+    /** @return a formatted, human-readable device-health summary derived from the cached diagnostic DID data (device info, non-default flash config, BIT/status fields) */
     std::string DiagnosticSummary();
+
+    /**
+     * Writes the diagnostic summary (if any) and full stats summary to the given file.
+     * @param fileName path of the file to write
+     */
     void WriteToFile(const std::string& fileName);
 
 private:

--- a/src/ISSerialPort.h
+++ b/src/ISSerialPort.h
@@ -10,6 +10,14 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISSerialPort.h
+ * @brief cISStream implementation backed by a native OS serial (COM) port.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef __ISSERIALPORT_H__
 #define __ISSERIALPORT_H__
 
@@ -21,19 +29,23 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "serialPortPlatform.h"
 
 
+/**
+ * cISStream implementation that reads and writes a native serial/COM port using the
+ * C serialPort/serialPortPlatform API declared in serialPort.h.
+ */
 class cISSerialPort : serial_port_t, public cISStream
 {
 private:
     cISSerialPort(const cISSerialPort& copy) = delete; // disable copy constructor
 
-    port_handle_t port= this;
-    int m_timeout;
-    bool m_blocking;
+    port_handle_t port= this;  //!< handle used with the C serialPort API; points at an externally-owned port, or at this object's own serial_port_t base when constructed with NULL
+    int m_timeout;              //!< read timeout in milliseconds, 0 for none
+    bool m_blocking;             //!< whether reads/writes block until data is transferred
 
 public:
     /**
     * Constructor
-    * @param serial inner serial port implementation or NULL for default, if not NULL, it will be copied
+    * @param port inner serial port handle to use, or NULL to initialize and own this object's own serial_port_t base
     */
     cISSerialPort(port_handle_t port = NULL);
 

--- a/src/ISTcpClient.h
+++ b/src/ISTcpClient.h
@@ -10,6 +10,14 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISTcpClient.h
+ * @brief cISStream implementation of a TCP client socket, plus free functions wrapping the raw socket API.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef __ISTCPCLIENT__H__
 #define __ISTCPCLIENT__H__
 
@@ -19,9 +27,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include "ISConstants.h"
 #include "ISStream.h"
 
-#define IS_SOCKET_DEFAULT_TIMEOUT_MS 5000
+#define IS_SOCKET_DEFAULT_TIMEOUT_MS 5000  //!< default socket connect/read timeout, in milliseconds
 
 
+/** cISStream implementation of a TCP client socket. Deprecated in favor of tcpPort/TcpPortFactory. */
 class [[deprecated("Use tcpPort/TcpPortFactory instead. cISTcpClient will be removed with SDK 3.0.")]] cISTcpClient : public cISStream
 {
 public:
@@ -89,6 +98,7 @@ public:
 
     /**
     * Sets whether the client socket is blocking. Default is false.
+    * @param blocking true to make the socket blocking, false to make it non-blocking
     * @return 0 if success otherwise an error code
     */
     int SetBlocking(bool blocking);
@@ -102,10 +112,10 @@ public:
 private:
     cISTcpClient(const cISTcpClient& copy); // Disable copy constructor
 
-    is_socket_t m_socket;
-    std::string m_host;
-    int m_port;
-    bool m_blocking;
+    is_socket_t m_socket;    //!< underlying OS socket handle, 0 when not connected
+    std::string m_host;      //!< host or ip address passed to the most recent Open()
+    int m_port;              //!< port number passed to the most recent Open()
+    bool m_blocking;         //!< whether the socket is currently in blocking mode
 };
 
 /**

--- a/src/ISTcpServer.h
+++ b/src/ISTcpServer.h
@@ -10,6 +10,14 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISTcpServer.h
+ * @brief cISStream implementation of a simple multi-client TCP server, plus its connection delegate interface.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef _ISTCPSERVER__H__
 #define _ISTCPSERVER__H__
 
@@ -21,6 +29,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 class cISTcpServer;
 
+/**
+ * Delegate interface notified of client connect/disconnect/data events on a cISTcpServer.
+ * Override the callbacks of interest; all have no-op default implementations.
+ */
 class [[deprecated("Use tcpPort/TcpPortFactory instead. cISTcpClient will be removed with SDK 3.0.")]] iISTcpServerDelegate
 {
 protected:
@@ -82,11 +94,17 @@ protected:
     friend class cISTcpServer;
 };
 
+/**
+ * cISStream implementation of a listening TCP server that accepts and manages multiple client
+ * sockets. Update() must be polled to accept new connections and to prune disconnected clients.
+ * Deprecated in favor of tcpPort/TcpPortFactory.
+ */
 class [[deprecated("Use tcpPort/TcpPortFactory instead. cISTcpClient will be removed with SDK 3.0.")]] cISTcpServer : public cISStream
 {
 public:
     /**
     * Constructor
+    * @param delegate optional delegate notified of client connect/disconnect/data events, or NULL for none
     */
     cISTcpServer(iISTcpServerDelegate* delegate = NULL);
 
@@ -143,11 +161,11 @@ public:
 private:
     cISTcpServer(const cISTcpServer& copy); // Disable copy constructor
 
-    is_socket_t m_socket;
-    std::vector<is_socket_t> m_clients;
-    std::string m_ipAddress;
-    int32_t m_port;
-    iISTcpServerDelegate* m_delegate;
+    is_socket_t m_socket;                    //!< listening socket handle, 0 when not open
+    std::vector<is_socket_t> m_clients;       //!< currently connected client sockets
+    std::string m_ipAddress;                  //!< ip address bound in the most recent Open()
+    int32_t m_port;                           //!< port number bound in the most recent Open()
+    iISTcpServerDelegate* m_delegate;         //!< optional delegate notified of client events, may be NULL
 };
 
 #endif

--- a/src/ISUtilities.h
+++ b/src/ISUtilities.h
@@ -10,6 +10,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file ISUtilities.h
+ * @brief General-purpose SDK utility grab-bag: base64/string helpers, a C++ mutex wrapper,
+ *        cross-platform time/timer/uptime functions, a C-ABI thread/mutex abstraction, and
+ *        GPS/MJD date-conversion helpers.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef IS_UTILITIES_H
 #define IS_UTILITIES_H
 
@@ -26,10 +36,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 /**
-* Encode data as base64 
+* Encode data as base64
 * @param bytes_to_encode the data to encode
 * @param in_len the number of bytes to encode
-* @param return the base64 encoded data
+* @return the base64 encoded data
 */
 std::string base64Encode(const unsigned char* bytes_to_encode, unsigned int in_len);
 
@@ -51,10 +61,9 @@ size_t splitString(const std::string str, const char delimiter, std::vector<std:
 
 /**
 * Join vector of strings with character
-* @param s the string to split
-* @param delimiter the delimiter to split on
-* @param result cleared and then filled with split strings
-* @return the number of items in result
+* @param v the vector of strings to join
+* @param c the delimiter to insert between joined strings
+* @param result cleared and then filled with the joined string
 */
 void joinStrings(const std::vector<std::string>& v, const char c, std::string& result);
 
@@ -118,13 +127,15 @@ extern "C" {
 
 #if PLATFORM_IS_WINDOWS
     void usleep(__int64 usec);
-    #define DEFAULT_COM_PORT "COM4"
+    #define DEFAULT_COM_PORT "COM4"   //!< default serial port name to try when none is specified (Windows)
 
     #ifndef SLEEP_MS
+        /** @param milliseconds duration to sleep, in milliseconds */
         #define SLEEP_MS(milliseconds) Sleep(milliseconds);
     #endif
 
     #ifndef SLEEP_US
+        /** @param timeUs duration to sleep, in microseconds */
         #define SLEEP_US(timeUs) usleep(timeUs);
     #endif
 #else // LINUX
@@ -132,45 +143,90 @@ extern "C" {
     #include <sys/time.h>
     #include <stdarg.h>
 
-    #define DEFAULT_COM_PORT "/dev/ttyUSB0"
+    #define DEFAULT_COM_PORT "/dev/ttyUSB0"   //!< default serial port name to try when none is specified (Linux)
 
     #ifndef SLEEP_MS
+        /** @param timeMs duration to sleep, in milliseconds */
         #define SLEEP_MS(timeMs) usleep(timeMs * 1000);
     #endif
 
     #ifndef SLEEP_US
+        /** @param timeUs duration to sleep, in microseconds */
         #define SLEEP_US(timeUs) usleep(timeUs);
     #endif
 
     // 0 for no output, 1 for verbose, 2 for spinning cursor
     #if PLATFORM_IS_EMBEDDED
-        #define LOG_DEBUG_GEN            0
+        #define LOG_DEBUG_GEN            0   //!< debug-output verbosity: 0 = no output (embedded default)
     #elif !defined(LOG_DEBUG_GEN)
-        #define LOG_DEBUG_GEN            2
+        #define LOG_DEBUG_GEN            2   //!< debug-output verbosity: 0 = no output, 1 = verbose, 2 = spinning cursor (desktop default)
     #else
         // Nothing to do here...
     #endif
 #endif
 
+/** @return the current system time, in seconds, as a double (platform-specific epoch: week-start on Windows, Unix epoch elsewhere) */
 double current_timeSecD();
+
+/** @return the current system time, in whole seconds (platform-specific epoch) */
 unsigned int current_timeSec();
+
+/** System time in milliseconds. @return the current system time, in milliseconds (platform-specific epoch) */
 unsigned int current_timeMs();
+
+/** System time in microseconds. @return the current system time, in microseconds (platform-specific epoch) */
 uint64_t current_timeUs();
 
+/**
+ * Returns the number of milliseconds since the host processor was started (most commonly).
+ * This is uses the monotonic clock, which is guaranteed NOT to go back in time (such as if setting the system clock after startup)
+ * @return number of milliseconds
+ */
 uint32_t current_uptimeMs();
 
+/** @return an opaque starting timestamp (microsecond resolution) to be passed to timerUsEnd() */
 uint64_t timerUsStart();
+
+/**
+ * @param start a timestamp previously returned by timerUsStart()
+ * @return the elapsed time, in microseconds, since start
+ */
 uint64_t timerUsEnd(uint64_t start);
+
+/** @return an opaque starting timestamp (raw, platform-native resolution) to be passed to timerRawEnd() */
 uint64_t timerRawStart();
+
+/**
+ * @param start a timestamp previously returned by timerRawStart()
+ * @return the elapsed time since start, in the same units used by timerRawStart()
+ */
 uint64_t timerRawEnd(uint64_t start);
 
+/** Prints and advances a simple spinning-cursor character ('/','-','\\','|') to stdout, throttled to update no more than once every 50ms. */
 void advance_cursor(void);
 
+/** @return a monotonically increasing tick count, in milliseconds, suitable for measuring elapsed time */
 uint64_t getTickCount(void);
 
+/**
+ * Advances a sine-wave signal generator by one time step.
+ * @param[in,out] sig_gen current phase angle (radians) of the generator; advanced and unwrapped to (-PI, PI] in place
+ * @param freqHz the signal frequency, in Hz
+ * @param amplitude the desired output amplitude
+ * @param periodSec the elapsed time, in seconds, to advance the phase by
+ * @return the generated signal value, amplitude * sin(sig_gen)
+ */
 float step_sinwave(float *sig_gen, float freqHz, float amplitude, float periodSec);
 
+/**
+ * Opens a file, using the secure fopen_s() on MSVC and fopen() elsewhere.
+ * @param path the path of the file to open
+ * @param mode the fopen()-style mode string (e.g. "rb", "wb")
+ * @return the opened file handle, or nullptr on failure
+ */
 FILE* openFile(const char* path, const char* mode);
+
+/** @return the platform's temporary-directory path, ending with a directory separator */
 const char* tempPath(); // ends with dir separator
 
 /**
@@ -190,6 +246,7 @@ uint8_t getHexValue(unsigned char hex);
 * Create a thread and execute a function
 * @param function the function to execute in a background thread
 * @param info the parameter to pass to the thread function
+* @param threadName an optional name to assign to the thread, for debugging (may be ignored on some platforms)
 * @return the thread handle
 */
 void* threadCreateAndStart(void(*function)(void*), void* info, const char* threadName);
@@ -200,7 +257,7 @@ void* threadCreateAndStart(void(*function)(void*), void* info, const char* threa
 */
 void threadJoinAndFree(void* handle);
 
-/*
+/**
 * Create a mutex which allows exclusive access to a shared resource
 * @return the mutex handle
 */
@@ -225,10 +282,49 @@ void mutexUnlock(void* handle);
 void mutexFree(void* handle);
 
 // taken from http://www.leapsecond.com/tools/gpsdate.c, uses UTC time
+
+/**
+ * Converts a calendar date (UTC) to a Modified Julian Date.
+ * @param year the calendar year (e.g. 2025)
+ * @param month the calendar month (1-12)
+ * @param day the calendar day of month (1-31)
+ * @return the Modified Julian Date
+ */
 int32_t convertDateToMjd(int32_t year, int32_t month, int32_t day);
+
+/**
+ * Converts a GPS week/seconds-of-week pair to a Modified Julian Date.
+ * @param gpsWeek the GPS week number
+ * @param gpsSeconds the number of seconds into gpsWeek
+ * @return the Modified Julian Date
+ */
 int32_t convertGpsToMjd(int32_t gpsWeek, int32_t gpsSeconds);
+
+/**
+ * Converts a Modified Julian Date to a calendar date (UTC).
+ * @param mjd the Modified Julian Date to convert
+ * @param[out] year the calendar year
+ * @param[out] month the calendar month (1-12)
+ * @param[out] day the calendar day of month (1-31)
+ */
 void convertMjdToDate(int32_t mjd, int32_t* year, int32_t* month, int32_t* day);
+
+/**
+ * Converts GPS seconds-of-week to hours/minutes/seconds of the current day.
+ * @param gpsSeconds the number of seconds into the current GPS week
+ * @param[out] hour the hour of the day (0-23)
+ * @param[out] minutes the minute of the hour (0-59)
+ * @param[out] seconds the second of the minute (0-59)
+ */
 void convertGpsToHMS(int32_t gpsSeconds, int32_t* hour, int32_t* minutes, int32_t* seconds);
+
+/**
+ * Computes the day of the week for a given calendar date (UTC).
+ * @param ul_year the calendar year (e.g. 2025)
+ * @param ul_month the calendar month (1-12)
+ * @param ul_day the calendar day of month (1-31)
+ * @return the day of the week as an index from 1 to 7
+ */
 uint32_t dateToWeekDay(uint32_t ul_year, uint32_t ul_month, uint32_t ul_day);
 
 #ifdef __cplusplus

--- a/src/ISmDnsPortFactory.h
+++ b/src/ISmDnsPortFactory.h
@@ -9,17 +9,18 @@
 #ifndef IS_SDK__IS_MDNS_PORT_FACTORY_H
 #define IS_SDK__IS_MDNS_PORT_FACTORY_H
 
-#define IS_MDNS_PORT_FACTORY_TIME_BETWEEN_QUERIES_MS 200 // How long to wait between sending MDNS queries
+#define IS_MDNS_PORT_FACTORY_TIME_BETWEEN_QUERIES_MS 200   //!< How long to wait between sending MDNS queries, in milliseconds
 
 #include <chrono>
 #include "core/tcpPort.h"
 #include "PortFactory.h"
 
+/** Bitmask flags controlling which resolved address form(s) locatePorts() will emit for a discovered device. */
 enum MdnsResolveFlags : uint8_t {
     MDNS_RESOLVE_IPV4     = 0x01,   //!< Prefer resolved IPv4 address (e.g. tcp://192.168.1.5:port)
     MDNS_RESOLVE_IPV6     = 0x02,   //!< Prefer resolved IPv6 address (e.g. tcp://[fdc2::1]:port)
     MDNS_RESOLVE_HOSTNAME = 0x04,   //!< Use mDNS hostname (e.g. tcp://hostname.local:port)
-    MDNS_RESOLVE_DEFAULT  = MDNS_RESOLVE_IPV4 | MDNS_RESOLVE_IPV6 | MDNS_RESOLVE_HOSTNAME,
+    MDNS_RESOLVE_DEFAULT  = MDNS_RESOLVE_IPV4 | MDNS_RESOLVE_IPV6 | MDNS_RESOLVE_HOSTNAME,  //!< try every resolved form, in IPv4 > IPv6 > hostname precedence
 };
 
 /**
@@ -30,11 +31,13 @@ enum MdnsResolveFlags : uint8_t {
  */
 class ISmDnsPortFactory : public PortFactory {
 public:
+    /** Default options applied to ports created by this factory. */
     struct {
-        bool defaultBlocking = false;
+        bool defaultBlocking = false;                        //!< default blocking mode applied to ports bound by this factory
         uint8_t resolvePreference = MDNS_RESOLVE_DEFAULT;   //!< Bitmask of MdnsResolveFlags; precedence: IPv4 > IPv6 > hostname
-    } portOptions = {};
+    } portOptions = {};   //!< default options applied to ports created by this factory
 
+    /** @return the process-wide singleton ISmDnsPortFactory instance. */
     static ISmDnsPortFactory& getInstance() {
         static ISmDnsPortFactory instance;
         return instance;
@@ -43,10 +46,42 @@ public:
     ISmDnsPortFactory(ISmDnsPortFactory const &) = delete;
     ISmDnsPortFactory& operator=(ISmDnsPortFactory const&) = delete;
 
+    /**
+     * Refreshes the mDNS cache (via tick()) and emits a "tcp://host:port" URL, via @p portCallback,
+     * for every advertised device port whose mDNS URL or resolved TCP URL matches the @p pattern regex.
+     * Deduplicates devices advertised on multiple interfaces before emitting.
+     * @param portCallback function to call for each matching port (TcpPortFactory instance, port-type, tcp:// URL)
+     * @param pattern regex matched against each candidate's mDNS URL and resolved tcp:// URL
+     * @param pType OR'd into the port-type flags passed to portCallback
+     */
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
+
+    /**
+     * Validates that @p pName is a well-formed "is-mdns://" port name that resolves to a currently
+     * known device/port in the mDNS cache (refreshed via tick() first).
+     * @param pName the URL to validate, starting with is-mdns://
+     * @param pType must include PORT_TYPE__TCP (PORT_TYPE__COMM is also expected but not enforced)
+     * @return true if a port can be created from pName, otherwise false
+     */
     bool validatePort(const std::string& pName, uint16_t pType = 0) override;
+
+    /**
+     * Parses and creates a new port_handle_t representing a TCP port for a URL in the format
+     * is-mdns://hostname/port, resolved to a concrete address via the mDNS cache.
+     * @param pName the URL and name of the new port to bind a port_handle_t to
+     * @param pType the port type requested to be generated
+     * @return a port_handle_t bound to the newly created TCP port for the connection pName represents, or nullptr on failure
+     */
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
+
+    /**
+     * Releases and frees the memory used by this port.
+     * @param port the TCP port handle to deinitialize
+     * @return true if successful, false otherwise
+     */
     bool releasePort(port_handle_t port) override;
+
+    /** Sends a periodic mDNS PTR query (rate-limited to IS_MDNS_PORT_FACTORY_TIME_BETWEEN_QUERIES_MS) and pumps mdns::tick() to process responses. */
     static void tick();
 
     /**
@@ -58,6 +93,7 @@ public:
      */
     static void queryNow(uint32_t timeoutMs = 1000);
 
+    /** Maps a Linux tty major device number to its driver name prefix, for devices whose advertised hostname encodes major:minor rather than a friendly name. */
     static inline const std::unordered_map<uint16_t, std::string> majorAtlas = {
         {166, "ttyACM"}
     };
@@ -67,8 +103,8 @@ private:
     ~ISmDnsPortFactory() = default;
 
     typedef struct {
-        uint32_t devid;
-        uint16_t port;
+        uint32_t devid;   //!< numeric device id encoded in the advertised mDNS hostname
+        uint16_t port;    //!< TCP port advertised for this device
     } port_t;
 
     inline static std::chrono::time_point<std::chrono::steady_clock> lastQueryTime;

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -1,6 +1,7 @@
 /**
- * @file PortLocator.h 
- * @brief ${BRIEF_DESC}
+ * @file PortFactory.h
+ * @brief Abstract PortFactory interface, plus the SerialPortFactory and SpiPortFactory
+ *  implementations for discovering and binding local (non-networked) ports.
  *
  * @author Kyle Mallory on 2/20/25.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -34,7 +35,10 @@ public:
     // virtual ~PortFactory() = default;
 
     /**
-     * @param portCallback - A function to be called when this Factory identifies a possible port; callback parameters are port-type and name
+     * Scans for ports discoverable by this factory and invokes @p portCallback for each one found.
+     * @param portCallback a function to be called when this factory identifies a possible port; callback parameters are the factory, port-type, and name
+     * @param pattern an optional, implementation-specific filter (e.g. a regex) matched against candidate port names/URLs; empty matches all
+     * @param pType an optional port-type filter/hint (PORT_TYPE__* flags); defaults to PORT_TYPE__UNKNOWN
      */
     virtual void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern = "", uint16_t pType = PORT_TYPE__UNKNOWN) = 0;
 
@@ -53,8 +57,8 @@ public:
     /**
      * A function responsible for allocating the underlying port type and returning a port_handle_t to it
      * This function should NOT manipulate the underlying port, such as opening, etc.
-     * @param pType the type of the port being allocated
      * @param pName the binding name of the port to be allocated.
+     * @param pType the type of the port being allocated
      * @return a port_handle_t to the allocated port
      */
     virtual port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) = 0;
@@ -84,13 +88,18 @@ public:
     }
 };
 
+/**
+ * PortFactory implementation for local serial (UART) devices. Uses OS-specific enumeration
+ * (e.g. /sys/class/tty on Linux, QueryDosDeviceA on Windows) to discover COM/TTY ports.
+ */
 class SerialPortFactory : public PortFactory {
 public:
     struct {
-        int defaultBaudRate = BAUDRATE_921600;
-        bool defaultBlocking = false;
+        int defaultBaudRate = BAUDRATE_921600;  //!< default baud rate applied to ports bound by this factory
+        bool defaultBlocking = false;           //!< default blocking mode applied to ports bound by this factory
     } portOptions = {};
 
+    /** Returns the process-wide singleton SerialPortFactory instance. */
     static SerialPortFactory& getInstance() {
         static SerialPortFactory instance;
         return instance;
@@ -99,15 +108,41 @@ public:
     SerialPortFactory(SerialPortFactory const &) = delete;
     SerialPortFactory& operator=(SerialPortFactory const&) = delete;
 
+    /**
+     * Enumerates serial ports known to the host OS and invokes @p portCallback for each one that
+     * matches @p pattern (a regex) and validates.
+     * @param portCallback function to call for each matching port (factory, port-type, name)
+     * @param pattern regex matched against candidate port names
+     * @param pType ignored by the matching logic; PORT_TYPE__UART is always reported to the callback
+     */
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
 
+    /**
+     * Returns true if @p pName refers to an existing, OS-recognized serial/TTY device.
+     * @param pName the serial device name/path to validate
+     * @param pType the port type to validate against (platform-specific use)
+     * @return true if the port exists and is usable, otherwise false
+     */
     bool validatePort(const std::string& pName, uint16_t pType = 0) override;
 
+    /**
+     * Allocates and initializes a serial_port_t for the given port name. Does NOT open the device.
+     * @param pName the serial device name/path to bind
+     * @param pType additional port-type flags OR'd with PORT_TYPE__UART | PORT_TYPE__COMM
+     * @return the allocated port handle, or nullptr if validatePort fails
+     */
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
 
+    /**
+     * Frees the serial_port_t allocated by bindPort(). Does NOT close the device first.
+     * @param port the port handle to release
+     * @return true if @p port was non-null and successfully freed
+     */
     bool releasePort(port_handle_t port) override;
 
+    /** Sets the default baud rate used when a port is bound without an explicit override. */
     SerialPortFactory& setBaudRate(uint32_t baud) { portOptions.defaultBaudRate = baud; return *this; }
+    /** Sets the default blocking mode used when a port is bound without an explicit override. */
     SerialPortFactory& setBlocking(bool block) { portOptions.defaultBlocking = block; return *this; }
 
 private:
@@ -119,7 +154,7 @@ private:
      * @param port the port the error occurred on
      * @param errCode the error code (usually errno) of the error that occurred
      * @param errMsg an optional string message which describes the error the occurred
-     * @return
+     * @return always 0 (reserved for future use); the port is closed and/or invalidated as a side effect for certain errCode values
      */
     static int onPortError(port_handle_t port, int errCode, const char *errMsg);
 
@@ -172,9 +207,9 @@ class SpiPortFactory : public PortFactory {
 public:
     /** Default SPI parameters applied when binding a new port. Per-port bracket opts override these. */
     struct {
-        uint32_t defaultSpeedHz  = SPI_PORT_DEFAULT_SPEED_HZ; ///< SPI clock speed in Hz
-        uint8_t  defaultMode     = SPI_PORT_DEFAULT_MODE;     ///< SPI mode 0-3 (CPOL/CPHA)
-        int      dataReadyGpio   = -1;                        ///< data-ready GPIO number, -1 = disabled
+        uint32_t defaultSpeedHz  = SPI_PORT_DEFAULT_SPEED_HZ; //!< SPI clock speed in Hz
+        uint8_t  defaultMode     = SPI_PORT_DEFAULT_MODE;     //!< SPI mode 0-3 (CPOL/CPHA)
+        int      dataReadyGpio   = -1;                        //!< data-ready GPIO number, -1 = disabled
     } portOptions = {};
 
     /** Returns the process-wide singleton SpiPortFactory instance. */

--- a/src/RelayPortFactory.h
+++ b/src/RelayPortFactory.h
@@ -61,6 +61,7 @@ class RelayPortFactory : public PortFactory {
 public:
 
     // -- Singleton --
+    /** @return the process-wide singleton RelayPortFactory instance. */
     static RelayPortFactory& getInstance() {
         static RelayPortFactory instance;
         return instance;
@@ -70,6 +71,7 @@ public:
     RelayPortFactory& operator=(RelayPortFactory const&) = delete;
 
     // -- Per-device record parsed from the relay's HTTP response --
+    /** A single device entry parsed from a relay host's /api/availableDevices response or SSE snapshot. */
     struct DeviceRecord {
         std::string  portUrl;       //!< tcp://host:port — the actual port to bind/connect
         dev_info_t   hint = {};     //!< bridgeboard-authoritative device info for seedDeviceHint()
@@ -86,6 +88,7 @@ public:
     };
 
     // -- Per-host status snapshot (returned by getRelayHosts()) --
+    /** A point-in-time snapshot of a single relay host's configuration and connection status. */
     struct RelayHostStatus {
         std::string  url;                                           //!< http://host:port (canonical base URL; no path)
         bool         enabled = false;                               //!< whether this host contributes ports
@@ -211,6 +214,7 @@ public:
      * @param interval polling period (default 1 second)
      */
     void setPollInterval(std::chrono::milliseconds interval) { pollInterval_ = interval; }
+    /** @return the currently configured HTTP polling interval for enabled hosts. */
     std::chrono::milliseconds getPollInterval() const { return pollInterval_; }
 
     /** Default HTTP port assumed for mDNS-discovered hosts (bridgeboard default). */
@@ -265,10 +269,11 @@ private:
     ~RelayPortFactory();
 
     // -- Internal per-host state --
+    /** Full internal state tracked for one relay host, including SSE worker state. */
     struct RelayHost {
         std::string  url;                                           //!< canonical "http://host:port" (no path)
-        bool         enabled = false;
-        bool         viaMdns = false;
+        bool         enabled = false;                               //!< whether this host currently contributes ports
+        bool         viaMdns = false;                               //!< true if discovered via mDNS, false if manually added
         std::vector<DeviceRecord> devices;                          //!< latest poll/snapshot result (metadata + hints)
         std::set<std::string> knownPortUrls;                        //!< high-water mark of tcp:// URLs ever seen from this host.
                                                                     //!< Only cleared on host disable/remove. Ports persist across
@@ -280,7 +285,7 @@ private:
                                                                     //!< successful poll. Drives offline port eviction + reconnect backoff.
                                                                     //!< Seeded to "now" on enable so a never-reachable host starts its grace then.
         std::chrono::steady_clock::time_point lastAttemptTime = {}; //!< last poll ATTEMPT (success or failure) — gates the backoff cadence.
-        std::string  lastError;
+        std::string  lastError;                                     //!< empty on success; descriptive string on the most recent failure
         uint32_t     consecutiveFailures = 0;                       //!< polling failure counter (resets on success)
 
         // -- SSE worker state (populated while feedType == SSE) --
@@ -293,7 +298,7 @@ private:
         uint32_t     sseConsecutiveFailures = 0;                    //!< drives fallback to Polling after DEFAULT_MAX_SSE_RETRIES
 
         // -- Transport mode --
-        RelayFeedType activeTransport = RelayFeedType::Auto;
+        RelayFeedType activeTransport = RelayFeedType::Auto;        //!< the transport currently in use for this host
 
         RelayHost() = default;
         // Non-copyable/movable because of the thread member.

--- a/src/TcpPortFactory.h
+++ b/src/TcpPortFactory.h
@@ -28,10 +28,12 @@
  */
 class TcpPortFactory : public PortFactory {
 public:
+    /** Default options applied to ports created by this factory. */
     struct {
-        bool defaultBlocking = false;
-    } portOptions = {};
+        bool defaultBlocking = false;   //!< default blocking mode applied to ports bound by this factory
+    } portOptions = {};   //!< default options applied to ports created by this factory
 
+    /** @return the process-wide singleton TcpPortFactory instance. */
     static TcpPortFactory& getInstance() {
         static TcpPortFactory instance;
         return instance;
@@ -40,12 +42,37 @@ public:
     TcpPortFactory(TcpPortFactory const &) = delete;
     TcpPortFactory& operator=(TcpPortFactory const&) = delete;
 
+    /**
+     * This factory doesn't provide device discovery; it only reports whether @p pattern itself
+     * is a valid "tcp://host:port" URL, invoking @p portCallback with it if so (a one-port stub).
+     * @param portCallback function invoked with (this factory, PORT_TYPE__TCP, pattern) if pattern validates
+     * @param pattern the "tcp://host:port" URL to validate and "discover"
+     * @param pType ignored
+     */
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
 
+    /**
+     * Validates that @p pName is a well-formed "tcp://host:port" URL whose host resolves.
+     * @param pName the URL to validate, starting with tcp://
+     * @param pType must include PORT_TYPE__TCP
+     * @return true if a port can be created from pName, otherwise false
+     */
     bool validatePort(const std::string& pName, uint16_t pType = 0) override;
 
+    /**
+     * Parses and creates a new port_handle_t representing a TCP port for a URL in the format
+     * tcp://ipAddr:port.
+     * @param pName the URL and name of the new port to bind a port_handle_t to
+     * @param pType the port type requested to be generated
+     * @return a port_handle_t bound to the newly created TCP port for the connection pName represents, or nullptr on failure
+     */
     port_handle_t bindPort(const std::string& pName, uint16_t pType = 0) override;
 
+    /**
+     * Releases and frees the memory used by this port.
+     * @param port the TCP port handle to deinitialize
+     * @return true if successful, false otherwise
+     */
     bool releasePort(port_handle_t port) override;
 
 private:

--- a/src/TcpServerPortFactory.h
+++ b/src/TcpServerPortFactory.h
@@ -55,14 +55,25 @@ enum eTcpListenErrorContext {
  */
 class TcpServerPortFactory : public PortFactory {
 public:
+    /** Configuration for this factory's listener, set by the constructor. */
     struct {
         uint16_t listenerPort = 4321;       //!< the tcp port to listen for incoming connections on
-        struct sockaddr_in listeningAddr;   //!< listening address (this binds to a specific interface, defaults to 127.0.0.1
+        struct sockaddr_in listeningAddr;   //!< listening address (this binds to a specific interface, defaults to 127.0.0.1)
         bool backgroundListener = false;    //!< if true, we'll setup a thread to process incoming connections -- note that this doesn't service those connections, just the listener
         int maxConnections = 10;            //!< the maximum number of connections that can be kept open - additional connection requests will be rejected
         bool portDefaultBlocking = false;   //!< if true, created tcpPorts will be configured for blocking by default (usually, we don't want that).
-    } factoryOptions = {};
+    } factoryOptions = {};   //!< configuration for this factory's listener, set by the constructor
 
+    /**
+     * Constructs and configures a listener; does not start listening (call startListening() or
+     * drive it via locatePorts()). Performs one-time platform setup (ignores SIGPIPE on Linux,
+     * calls WSAStartup on Windows).
+     * @param listenPort the tcp port to listen for incoming connections on
+     * @param listenAddr the local interface address to bind to; accepts "<address>" or "<address> (<name>)", defaults to 127.0.0.1
+     * @param maxConnections the maximum number of connections that can be kept open
+     * @param portDefaultBlocking if true, created tcpPorts will be configured for blocking by default
+     * @param backgroundListener if true, a thread will be set up to process incoming connections (the listener only, not the connections themselves)
+     */
     explicit TcpServerPortFactory(uint16_t listenPort = 4321, const std::string& listenAddr = "127.0.0.1", int maxConnections = 10, bool portDefaultBlocking = false, bool backgroundListener = false) {
 #ifdef PLATFORM_IS_LINUX
         signal(SIGPIPE, SIG_IGN); // ignore broken pipes
@@ -99,14 +110,41 @@ public:
     // TcpServerPortFactory(TcpServerPortFactory const &) = delete;
     // TcpServerPortFactory& operator=(TcpServerPortFactory const&) = delete;
 
+    /**
+     * Services pending incoming connections on the listening socket (starting it if not already
+     * started) and invokes @p portCallback for each accepted connection whose auto-generated
+     * "tcp://ip:port" name validates.
+     * @param portCallback the function to call back into to indicate that this port has been "found"
+     * @param pattern the URL to validate and "discover"
+     * @param pType ignored
+     */
     void locatePorts(std::function<void(PortFactory*, uint16_t, std::string)> portCallback, const std::string& pattern, uint16_t pType) override;
 
+    /**
+     * Validates that @p pName is a well-formed "tcp://host:port" URL whose host resolves.
+     * @param pName the URL to validate, starting with tcp://
+     * @param pType must be PORT_TYPE__TCP
+     * @return true if a port can be created from pName, otherwise false
+     */
     bool validatePort(const std::string& pName, uint16_t pType) override;
 
+    /**
+     * Parses and creates a new port_handle_t representing a TCP port for a URL in the format
+     * tcp://ipAddr:port.
+     * @param pName the URL and name of the new port to bind a port_handle_t to
+     * @param pType the port type requested to be generated
+     * @return a port_handle_t bound to the newly created TCP port for the connection pName represents, or nullptr on failure
+     */
     port_handle_t bindPort(const std::string& pName, uint16_t pType) override;
 
+    /**
+     * Releases and frees the memory used by this port.
+     * @param port the TCP port handle to deinitialize
+     * @return true if successful, false otherwise
+     */
     bool releasePort(port_handle_t port) override;
 
+    /** Shuts down (SHUT_RDWR) and closes every currently-accepted client socket, without removing them from knownSockets. */
     void shutdownAllClients();
 
     /**
@@ -121,20 +159,39 @@ public:
     std::pair<eTcpListenErrorContext, int> getLastListenError() const { return lastListenError; }
 
 protected:
+    /** A single accepted client connection: its raw socket, auto-generated "tcp://ip:port" name, and (once bound) its port handle. */
     struct socket_entry_t {
-        int socket = 0;
-        std::string portName;
-        mutable port_handle_t port = nullptr;
+        int socket = 0;                        //!< the accepted client's raw socket descriptor
+        std::string portName;                  //!< auto-generated "tcp://ip:port" name for this connection
+        mutable port_handle_t port = nullptr;   //!< the bound port handle for this connection, once created
 
+        /**
+         * @param _s the accepted client's raw socket descriptor
+         * @param _n auto-generated "tcp://ip:port" name for this connection
+         * @param _p the bound port handle for this connection, if already created
+         */
         socket_entry_t(int _s, std::string _n, port_handle_t _p = nullptr) : socket(_s), portName(std::move(_n)), port(_p) {};
 
-        // Overload operator< for strict weak ordering
+        /**
+         * Strict weak ordering by socket, falling back to portName so entries with the same
+         * (reused) socket value on different names remain distinguishable in the containing std::set.
+         * @param other the socket_entry_t to compare against
+         * @return true if this entry sorts before @p other
+         */
         bool operator<(const socket_entry_t& other) const {
             return (socket != other.socket) ? socket < other.socket : portName < other.portName; // Secondary sorting criterion
         }
 
     };
 
+    /**
+     * Applies the listener configuration used by startListening(); does not itself open a socket.
+     * @param listenPort the tcp port to listen for incoming connections on
+     * @param listenAddr the local interface address to bind to; accepts "<address>" or "<address> (<name>)", defaults to 127.0.0.1
+     * @param maxConnections the maximum number of connections that can be kept open
+     * @param portDefaultBlocking if true, created tcpPorts will be configured for blocking by default
+     * @param backgroundListener if true, a thread will be set up to process incoming connections (the listener only, not the connections themselves)
+     */
     void configure(uint16_t listenPort = 4321, const std::string& listenAddr = "127.0.0.1", int maxConnections = 10, bool portDefaultBlocking = false, bool backgroundListener = false) {
         factoryOptions.listenerPort = listenPort;
         factoryOptions.maxConnections = maxConnections;
@@ -154,14 +211,24 @@ protected:
         factoryOptions.listeningAddr.sin_addr = addr;
     }
 
+    /**
+     * Creates, configures (non-blocking, SO_REUSEADDR), binds, and listens on the socket described
+     * by factoryOptions. Idempotent — if a listener is already open, returns true immediately without
+     * creating a second socket. On failure, records the failing step and platform error via
+     * recordListenError() and tears the half-open socket back down (see getLastListenError()).
+     * @return true if a listener is open (already was, or was just created), false on failure
+     */
     bool startListening();
 
+    /** Closes the listening socket (if open) and resets it to the not-listening state. */
     void stopListening();
 
+    /** @return the number of currently-accepted client connections. */
     int getClientConnectionCount() {
         return (int)knownSockets.size();
     }
 
+    /** @return a snapshot copy of all currently-accepted client connections. */
     std::vector<socket_entry_t> getClientSockets() {
         std::vector<socket_entry_t> out;
         for (const auto& ks : knownSockets)
@@ -172,6 +239,8 @@ protected:
     /**
      * The primary service routine - this should be called periodically (and frequently) to service incoming connections.
      * If this is not called, no ports will ever be discovered/created
+     * @param cb callback invoked once per newly-accepted connection, with the socket_entry_t describing it
+     * @return true if at least one connection was accepted during this call; false if none were (including when no listener is active)
      */
     bool processPendingConnections(std::function<void(const socket_entry_t&)> cb);
 

--- a/src/core/ISFilePort.h
+++ b/src/core/ISFilePort.h
@@ -1,6 +1,8 @@
 /**
- * @file ISFilePort.h 
- * @brief ${BRIEF_DESC}
+ * @file ISFilePort.h
+ * @brief Stream-backed base_port_t implementations: ISStreamPort adapts an arbitrary
+ *        %std::istream/%std::ostream pair to the base_port_t interface, and ISFilePort is a
+ *        concrete specialization of it that opens a single file for both reading and writing.
  *
  * @author Kyle Mallory on 1/16/25.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -16,6 +18,13 @@
 #include "core/types.h"
 #include "core/base_port.h"
 
+/**
+ * Adapts an arbitrary %std::istream/%std::ostream pair to the base_port_t interface, so that the
+ * generic port I/O helpers (portRead(), portWrite(), etc. from base_port.h) can operate on any
+ * C++ stream as if it were a hardware port. The port's name/free/available/read/write callbacks
+ * are implemented as static member functions that reinterpret the port_handle_t back into an
+ * ISStreamPort*, per the base_port_t "vtable" convention.
+ */
 class ISStreamPort : base_port_t {
 private:
     // static std::map<port_handle_t, ISStreamPort> m_streamPortMappings;
@@ -41,10 +50,16 @@ private:
 
 
 public:
-    const std::string m_portName;
-    std::ostream& m_ostream;
-    std::istream& m_istream;
+    const std::string m_portName;  //!< display name for this port, returned by ISStreamPort::name()
+    std::ostream& m_ostream;       //!< the output stream data is written to (portWrite)
+    std::istream& m_istream;       //!< the input stream data is read from (portRead)
 
+    /**
+     * Constructs a stream-backed port bound to the given input/output streams.
+     * @param name display name for this port (returned by ISStreamPort::name())
+     * @param in   the input stream to read from
+     * @param out  the output stream to write to
+     */
     ISStreamPort(const std::string& name, std::istream& in, std::ostream& out) : m_portName(name), m_ostream(out), m_istream(in) {
         pnum = 128; // FIXME unique ID?  maybe an index value or hash?
         ptype = PORT_TYPE__FILE;
@@ -57,10 +72,20 @@ public:
     }
 };
 
+/**
+ * Concrete ISStreamPort that opens a single file for both reading and writing, using the same
+ * path for the underlying std::ifstream and std::ofstream. Useful for capturing/replaying raw
+ * port traffic to/from disk using the generic base_port_t helpers.
+ */
 class ISFilePort : ISStreamPort {
-    std::ofstream m_out;
-    std::ifstream m_in;
+    std::ofstream m_out;  //!< output stream opened on the file passed to the constructor
+    std::ifstream m_in;   //!< input stream opened on the file passed to the constructor
 
+    /**
+     * Opens fname for both reading and writing, and binds the resulting streams to the
+     * underlying ISStreamPort.
+     * @param fname path of the file to open for read/write access
+     */
     ISFilePort(const std::string& fname) : ISStreamPort(fname, m_in, m_out){
         m_out.open(fname);
         m_in.open(fname);

--- a/src/core/base_port.h
+++ b/src/core/base_port.h
@@ -1,6 +1,9 @@
 /**
- * @file base_port.h 
- * @brief ${BRIEF_DESC}
+ * @file base_port.h
+ * @brief Common port abstraction shared by every transport (UART/USB/SPI/CAN/TCP/UDP/file/
+ *        loopback): the base_port_t vtable-style struct, the PORT_TYPE__/PORT_FLAG__/
+ *        PORT_ERROR__ constant families, and the inline portRead()/portWrite()/portOpen()/etc.
+ *        wrappers that dispatch through it with integrity-checking and stats bookkeeping.
  *
  * @author Kyle Mallory on 5/9/25.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -55,22 +58,23 @@
 
 #define PORT_DEFAULT_TIMEOUT        1000        //!< A default timeout period (in milliseconds) for READ and other operations.
 
-typedef void* port_handle_t;
+typedef void* port_handle_t;    //!< opaque handle to a base_port_t-compatible port; cast internally via BASE_PORT()
 
-typedef const char*(*pfnPortName)(port_handle_t port);
-typedef int(*pfnPortValidate)(port_handle_t port);
-typedef int(*pfnPortOpen)(port_handle_t port);
-typedef int(*pfnPortClose)(port_handle_t port);
-typedef int(*pfnPortFree)(port_handle_t port);
-typedef int(*pfnPortAvailable)(port_handle_t port);
-typedef int(*pfnPortFlush)(port_handle_t port);
-typedef int(*pfnPortDrain)(port_handle_t port, uint32_t timeout);
-typedef int(*pfnPortRead)(port_handle_t port, uint8_t* buf, unsigned int len);
-typedef int(*pfnPortReadTimeout)(port_handle_t port, uint8_t* buf, unsigned int len, uint32_t timeout);
-typedef int(*pfnPortWrite)(port_handle_t port, const uint8_t* buf, unsigned int len);
-typedef int(*pfnPortLogger)(port_handle_t port, uint8_t op, const uint8_t* buf, unsigned int len, void* userData);
+typedef const char*(*pfnPortName)(port_handle_t port);                                                          //!< returns an optional name uniquely identifying the port, or "" if unsupported
+typedef int(*pfnPortValidate)(port_handle_t port);                                                               //!< confirms the port is viable, without opening/connecting it; returns non-zero if viable
+typedef int(*pfnPortOpen)(port_handle_t port);                                                                   //!< opens/connects the port; returns a PORT_ERROR__* code, or PORT_ERROR__NONE on success
+typedef int(*pfnPortClose)(port_handle_t port);                                                                  //!< closes/disconnects the port; returns a PORT_ERROR__* code, or PORT_ERROR__NONE on success
+typedef int(*pfnPortFree)(port_handle_t port);                                                                   //!< returns the number of bytes that can currently be written without dropping data
+typedef int(*pfnPortAvailable)(port_handle_t port);                                                              //!< returns the number of bytes currently available to be read
+typedef int(*pfnPortFlush)(port_handle_t port);                                                                  //!< discards all data currently waiting to be read; returns the number of bytes flushed, or a PORT_ERROR__* code
+typedef int(*pfnPortDrain)(port_handle_t port, uint32_t timeout);                                                //!< blocks up to timeout ms for queued TX data to be sent; returns bytes dropped (if any), or a PORT_ERROR__* code
+typedef int(*pfnPortRead)(port_handle_t port, uint8_t* buf, unsigned int len);                                   //!< reads up to len bytes into buf; returns the actual number of bytes read
+typedef int(*pfnPortReadTimeout)(port_handle_t port, uint8_t* buf, unsigned int len, uint32_t timeout);          //!< reads up to len bytes into buf, waiting up to timeout ms; returns the actual number of bytes read
+typedef int(*pfnPortWrite)(port_handle_t port, const uint8_t* buf, unsigned int len);                            //!< writes len bytes from buf; returns the number of bytes actually written, or a PORT_ERROR__* code
+typedef int(*pfnPortLogger)(port_handle_t port, uint8_t op, const uint8_t* buf, unsigned int len, void* userData); //!< invoked on every portRead()/portWrite() to monitor/copy data flowing through the port
 // typedef int(*pfnPortSetName)(port_handle_t port, const char* name, unsigned int len);
 
+/** Traffic/error counters optionally attached to a port (see base_port_t::stats), reset via portStatsReset(). */
 PUSH_PACK_1
 typedef struct
 {
@@ -92,6 +96,12 @@ typedef struct
 POP_PACK
 
 
+/**
+ * Common "vtable" header every concrete port implementation (UART/USB/SPI/CAN/TCP/UDP/file/
+ * loopback) embeds as its first member, so a port_handle_t can be reinterpreted via BASE_PORT()
+ * regardless of the concrete port type. The chksum field lets portCheckIntegrity() detect a
+ * stale/invalid handle before dereferencing the function pointers below.
+ */
 typedef struct base_port_s {
     uint16_t pnum;                          //!< an identifier for a specific port that belongs to this device
     uint16_t ptype;                         //!< an indicator of the type of port
@@ -115,29 +125,142 @@ typedef struct base_port_s {
     uint32_t chksum;                        //!< to be valid:  chksum == ^~((pflags << 16) | ptype) - this is a validation mechanism to help ensure that this is a valid port
     port_stats_t* stats;                    //!< if not-null, contains the stats associated with this port (bytes sent/received, etc)
 } base_port_t;
-#define BASE_PORT(n)        ((base_port_t*)(n))
+#define BASE_PORT(n)        ((base_port_t*)(n))    //!< reinterprets a port_handle_t (or any compatible concrete port pointer) as a base_port_t*
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * Fallback software-timeout implementation of portReadTimeout(), used when a port implementation
+ * doesn't provide its own pfnPortReadTimeout. Internal use only -- DO NOT EXPORT / call directly.
+ * @param port the port to read from
+ * @param buffer the buffer to place a copy of the data into
+ * @param readCount the maximum number of bytes to read
+ * @param timeoutMs the maximum time, in milliseconds, to wait for readCount bytes to be received
+ * @return the number of actual bytes read, or a PORT_ERROR__* code
+ */
 int portReadTimeout_internal(port_handle_t port, uint8_t *buffer, unsigned int readCount, unsigned int timeoutMs);     // DO NOT EXPORT
+
+/**
+ * Reads and discards bytes from port until the waitFor sequence is matched or timeoutMs elapses.
+ * @param port the port to read from
+ * @param waitFor the byte sequence to wait for
+ * @param waitForLength the number of bytes in waitFor
+ * @param timeoutMs the maximum time, in milliseconds, to wait for a match
+ * @return the number of bytes consumed (including the match) if found, or a PORT_ERROR__* code (e.g. PORT_ERROR__TIMEOUT)
+ */
 int portWaitForTimeout(port_handle_t port, const uint8_t* waitFor, unsigned int waitForLength, unsigned int timeoutMs);
+
+/**
+ * Reads and discards bytes from port until the waitFor sequence is matched, using PORT_DEFAULT_TIMEOUT.
+ * @param port the port to read from
+ * @param waitFor the byte sequence to wait for
+ * @param waitForLength the number of bytes in waitFor
+ * @return the number of bytes consumed (including the match) if found, or a PORT_ERROR__* code (e.g. PORT_ERROR__TIMEOUT)
+ */
 int portWaitFor(port_handle_t port, const uint8_t* waitFor, unsigned int waitForLength);
 
+/**
+ * Reads a single character, waiting up to timeoutMs for it to become available.
+ * @param port the port to read from
+ * @param c receives the read character
+ * @param timeoutMs the maximum time, in milliseconds, to wait
+ * @return 1 if a character was read, or a PORT_ERROR__* code (e.g. PORT_ERROR__TIMEOUT)
+ */
 int portReadCharTimeout(port_handle_t port, unsigned char* c, unsigned int timeoutMs);
+
+/**
+ * Reads a single character, using PORT_DEFAULT_TIMEOUT.
+ * @param port the port to read from
+ * @param c receives the read character
+ * @return 1 if a character was read, or a PORT_ERROR__* code (e.g. PORT_ERROR__TIMEOUT)
+ */
 int portReadChar(port_handle_t port, unsigned char* c);
 
+/**
+ * Reads a single line (terminated by newline) into buffer, waiting up to timeoutMs.
+ * @param port the port to read from
+ * @param buffer the buffer to place the line into
+ * @param bufferLength the size of buffer, in bytes
+ * @param timeoutMs the maximum time, in milliseconds, to wait for a complete line
+ * @return the number of bytes read (the line, excluding the terminator), or a PORT_ERROR__* code
+ */
 int portReadLineTimeout(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, unsigned int timeoutMs);
+
+/**
+ * Reads a single line (terminated by newline) into buffer, using PORT_DEFAULT_TIMEOUT.
+ * @param port the port to read from
+ * @param buffer the buffer to place the line into
+ * @param bufferLength the size of buffer, in bytes
+ * @return the number of bytes read (the line, excluding the terminator), or a PORT_ERROR__* code
+ */
 int portReadLine(port_handle_t port, unsigned char* buffer, unsigned int bufferLength);
 
+/**
+ * Reads a line of ASCII text into buffer, waiting up to timeoutMs, and locates the start of the
+ * ASCII payload within it.
+ * @param port the port to read from
+ * @param buffer the buffer to read raw line data into
+ * @param bufferLength the size of buffer, in bytes
+ * @param timeoutMs the maximum time, in milliseconds, to wait for a complete line
+ * @param asciiData receives a pointer into buffer at which the ASCII payload begins
+ * @return the number of bytes read, or a PORT_ERROR__* code
+ */
 int portReadAsciiTimeout(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, unsigned int timeoutMs, unsigned char** asciiData);
+
+/**
+ * Reads a line of ASCII text into buffer, using PORT_DEFAULT_TIMEOUT, and locates the start of the
+ * ASCII payload within it.
+ * @param port the port to read from
+ * @param buffer the buffer to read raw line data into
+ * @param bufferLength the size of buffer, in bytes
+ * @param asciiData receives a pointer into buffer at which the ASCII payload begins
+ * @return the number of bytes read, or a PORT_ERROR__* code
+ */
 int portReadAscii(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, unsigned char** asciiData);
 
+/**
+ * Writes writeCount bytes from buffer, followed by a line terminator.
+ * @param port the port to write to
+ * @param buffer the data to write
+ * @param writeCount the number of bytes in buffer
+ * @return the number of bytes written, or a PORT_ERROR__* code
+ */
 int portWriteLine(port_handle_t port, const unsigned char* buffer, unsigned int writeCount);
+
+/**
+ * Writes a null-terminated ASCII string.
+ * @param port the port to write to
+ * @param buffer the null-terminated string to write
+ * @param bufferLength the maximum number of bytes to write from buffer
+ * @return the number of bytes written, or a PORT_ERROR__* code
+ */
 int portWriteAscii(port_handle_t port, const char* buffer, unsigned int bufferLength);
 
+/**
+ * Writes writeCount bytes from buffer, then waits up to timeoutMs for the waitFor sequence to be
+ * received in response.
+ * @param port the port to write to and read the response from
+ * @param buffer the data to write
+ * @param writeCount the number of bytes in buffer
+ * @param waitFor the byte sequence to wait for in the response
+ * @param waitForLength the number of bytes in waitFor
+ * @param timeoutMs the maximum time, in milliseconds, to wait for a match
+ * @return the number of response bytes consumed (including the match) if found, or a PORT_ERROR__* code
+ */
 int portWriteAndWaitForTimeout(port_handle_t port, const unsigned char* buffer, unsigned int writeCount, const unsigned char* waitFor, unsigned int waitForLength, const unsigned int timeoutMs);
+
+/**
+ * Writes writeCount bytes from buffer, then waits (using PORT_DEFAULT_TIMEOUT) for the waitFor
+ * sequence to be received in response.
+ * @param port the port to write to and read the response from
+ * @param buffer the data to write
+ * @param writeCount the number of bytes in buffer
+ * @param waitFor the byte sequence to wait for in the response
+ * @param waitForLength the number of bytes in waitFor
+ * @return the number of response bytes consumed (including the match) if found, or a PORT_ERROR__* code
+ */
 int portWriteAndWaitFor(port_handle_t port, const unsigned char* buffer, unsigned int writeCount, const unsigned char* waitFor, unsigned int waitForLength);
 
 /**
@@ -185,7 +308,7 @@ static inline int portCheckIntegrity(port_handle_t port) {
     return (port && (BASE_PORT(port)->chksum == ~(uint32_t)((BASE_PORT(port)->pnum << 16) | BASE_PORT(port)->ptype)));
 }
 
-#define NOT_GNSS_PORT(port) ((portType(port) & PORT_TYPE__GNSS) == 0)
+#define NOT_GNSS_PORT(port) ((portType(port) & PORT_TYPE__GNSS) == 0)    //!< true if port does not have the PORT_FLAG__GNSS bit set
 
 /**
  * @brief sets the specified bit-flags on the port, without modifying previously set flags

--- a/src/core/msg_logger.h
+++ b/src/core/msg_logger.h
@@ -1,6 +1,8 @@
 /**
  * @file msg_logger.h
- * @brief ${BRIEF_DESC}
+ * @brief Facility- and level-gated logging macros (log_error()/log_warn()/log_info()/etc.), the
+ *        eLogLevel run-time level control (IS_SET_LOG_LEVEL()/IS_GET_LOG_LEVEL()), and the
+ *        static_log_msg()/static_log_buffer() backends they expand to.
  *
  * @author Kyle Mallory on 4/7/25.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -23,61 +25,165 @@ extern "C" {
 
 
 // --- Compile-time configuration ---
-// Define the default log level to show messages at or above this level.
+/** Default run-time log level; messages below this eLogLevel are suppressed unless IS_SET_LOG_LEVEL() raises it. */
 #ifndef IS_LOG_LEVEL
 #define IS_LOG_LEVEL  IS_LOG_LEVEL_INFO // Default to INFO
 #endif
 
-// Define the highest (most verbose) level that will be compiled into the binary
-// IE, if this is set to IS_LOG_LEVEL_WARN, you will never see IS_LOG_LEVEL_INFO
-// without changing this and recompiling the SDK/binaries.  This is useful to
-// reduce executable size, if necessary, but generally should be left alone.
+/**
+ * The highest (most verbose) eLogLevel that will be compiled into the binary. IE, if this is set
+ * to IS_LOG_LEVEL_WARN, you will never see IS_LOG_LEVEL_INFO messages without changing this and
+ * recompiling the SDK/binaries. This is useful to reduce executable size, if necessary, but
+ * generally should be left alone.
+ */
 #ifndef IS_LOG_LEVEL_COMPILER
 #define IS_LOG_LEVEL_COMPILER  IS_LOG_LEVEL_MORE_DEBUG // Default to MORE_DEBUG
 #endif
 
-// Define the facilities you want to enable.
-// Combine multiple facilities using the bitwise OR operator.
+/**
+ * Bitmask of the IS_LOG_ facilities (see types.h) enabled at compile time. Combine multiple
+ * facilities using the bitwise OR operator; only enabled facilities pass IS_FACILITY_ENABLED().
+ */
 #ifndef IS_ENABLED_FACILITIES
 #define IS_ENABLED_FACILITIES (IS_LOG_PORT | IS_LOG_PORT_FACTORY | IS_LOG_PORT_MANAGER | IS_LOG_DEVICE_FACTORY | IS_LOG_DEVICE_MANAGER | IS_LOG_ISDEVICE | IS_LOG_FN_PROFILER | IS_LOG_FWUPDATE | IS_LOG_ISLOG | IS_LOG_APP_LOGALYZER)
 #endif
 
-// Macro to check if a facility is enabled
+/**
+ * Checks whether the given facility bit(s) are enabled in IS_ENABLED_FACILITIES.
+ * @param facility a facility bitmask (or combination) to test, e.g. IS_LOG_PORT
+ * @return non-zero if every bit in facility is enabled, otherwise zero
+ */
 #define IS_FACILITY_ENABLED(facility) ((IS_ENABLED_FACILITIES & (facility)) == (facility))
 
 // --- Macros for different log levels and facilities ---
+/**
+ * Core expansion used by all log_*() convenience macros below: expands to a no-op unless
+ * facility is enabled and IS_LOG_LEVEL_COMPILER allows level_code, in which case it forwards to
+ * static_log_msg().
+ * @param facility      bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param facility_name string form of facility, normally supplied via the # stringizing operator
+ * @param level_code    the eLogLevel of this message
+ * @param ...           printf-style format string and arguments
+ */
 #define IS_LOG_MSG(facility, facility_name, level_code, ...) { do { \
     if (IS_FACILITY_ENABLED(facility) && (IS_LOG_LEVEL_COMPILER >= level_code)) {        \
         static_log_msg(facility, level_code, facility_name, __VA_ARGS__); \
     } \
 } while (0); }
 
+/**
+ * Logs a message at an arbitrary level.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param level    the eLogLevel of this message
+ * @param ...      printf-style format string and arguments
+ */
 #define log_msg(facility, level, ...)       IS_LOG_MSG(facility, #facility, level, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_ERROR.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_error(facility, ...)            IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_ERROR, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_WARN.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_warn(facility, ...)             IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_WARN, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_INFO.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_info(facility, ...)             IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_INFO, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_MORE_INFO.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_more_info(facility, ...)        IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_MORE_INFO, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_DEBUG.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_debug(facility, ...)            IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_DEBUG, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_MORE_DEBUG.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_more_debug(facility, ...)       IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_MORE_DEBUG, __VA_ARGS__)
+
+/**
+ * Logs a message at IS_LOG_LEVEL_BOMBASTIC.
+ * @param facility bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param ...      printf-style format string and arguments
+ */
 #define log_bombastic(facility, ...)        IS_LOG_MSG(facility, #facility, IS_LOG_LEVEL_BOMBASTIC, __VA_ARGS__)
 
+/**
+ * Sets the current run-time log level.
+ * @param new_level the eLogLevel to switch to
+ */
 #define IS_SET_LOG_LEVEL(new_level)         static_set_log_level(new_level)
+
+/** Returns the current run-time log level. */
 #define IS_GET_LOG_LEVEL()                  static_get_log_level()
 
 // --- Internal static inline functions ---
-extern eLogLevel log_level;
+extern eLogLevel log_level;    //!< current run-time log level; messages below this are suppressed
+
+/** @return the current run-time log level. */
 static inline eLogLevel static_get_log_level() { return log_level; }
+
+/**
+ * Sets the current run-time log level.
+ * @param new_level the eLogLevel to switch to
+ */
 static inline void static_set_log_level(eLogLevel new_level) { log_level = new_level; }
 
 #if defined(PLATFORM_IS_WINDOWS) || defined(PLATFORM_IS_LINUX)
-    extern FILE* log_file;
+    extern FILE* log_file;    //!< destination stream for log output; set via IS_LOG_OUTPUT()
+
+    /**
+     * Redirects log output to the given stream.
+     * @param out destination stream that log messages will be written to
+     */
     #define IS_LOG_OUTPUT(out)                  static_log_output(out)
     static inline void static_log_output(FILE* out) { log_file = out; }
 #endif
 
+/**
+ * Backend that formats and emits a single log message; invoked by the log_*() macros above.
+ * Prefer the log_*() macros over calling this directly.
+ * @param facility_code bitmask identifying the log facility (see IS_LOG_ constants in types.h)
+ * @param msg_log_level the eLogLevel of this message
+ * @param facility_name string form of facility_code, included in the rendered output
+ * @param format        printf-style format string
+ * @param ...            format arguments
+ */
 void static_log_msg(int facility_code, int msg_log_level, const char *facility_name, const char *format, ...);
+
+/**
+ * Emits a hex/ASCII dump of buffer, prefixed by prefix, to the log output.
+ * @param prefix short label printed before the dump
+ * @param buffer the bytes to dump
+ * @param len    the number of bytes in buffer
+ */
 void static_log_buffer(const char* prefix, const unsigned char* buffer, int len);
 
+/**
+ * Checks whether n is within the printable ASCII range (0x20..0x7E).
+ * @param n the character/byte value to test
+ * @return non-zero if n is printable ASCII, otherwise zero
+ */
 #define IS_PRINTABLE(n) (((n >= 0x20) && (n <= 0x7E)) ) //  || ((n >= 0xA1) && (n <= 0xDF)))
 
 #ifdef __cplusplus

--- a/src/core/tcpPort.h
+++ b/src/core/tcpPort.h
@@ -1,6 +1,11 @@
-//
-// Created by firiusfoxx on 6/5/25.
-//
+/**
+ * @file tcpPort.h
+ * @brief TCP-socket implementation of the base_port_t/comm_port_t interface (tcp_port_t), plus
+ *        the init/delete/blocking-mode entry points used to create and manage it.
+ *
+ * @author firiusfoxx on 6/5/25.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
 
 #ifndef __IS_TCPPORT_H
 #define __IS_TCPPORT_H
@@ -23,62 +28,90 @@ extern "C" {
     #endif
 #endif
 
-#define MAX_TCP_PORT_NAME_LENGTH 63
+#define MAX_TCP_PORT_NAME_LENGTH 63     //!< maximum length (excluding the null terminator) of a tcp_port_t name
 
-// Allows communicating over a TCP Socket
+/**
+ * Concrete base_port_t/comm_port_t implementation backed by a TCP socket. Embeds base_port_t (or
+ * comm_port_t, when the PORT_TYPE__COMM bit is set) as its first member so a tcp_port_t* can be
+ * reinterpreted and driven through the generic port helpers in base_port.h.
+ */
 struct tcp_port_s
 {
     // base "implementation"
     union {
-        base_port_t base;
-        comm_port_t comm;
+        base_port_t base;      //!< base_port_t view of this port
+        comm_port_t comm;      //!< comm_port_t view of this port, valid when PORT_TYPE__COMM is set
     };
 
-    port_monitor_set_t stats;
+    port_monitor_set_t stats;  //!< traffic/error counters for this port, referenced by base.stats
 
     // the port name (do not modify directly)
-    char name[MAX_TCP_PORT_NAME_LENGTH + 1];
+    char name[MAX_TCP_PORT_NAME_LENGTH + 1];   //!< display name for this port, set via tcpPortInit()/tcpPortInitWithSocket()
 
     // Actual socket
-    int socket;
+    int socket;                 //!< native socket descriptor, or a negative -errno value if not open/invalid
 
     // Store an Address type that can connect via TCP
     union {
 #if PLATFORM_IS_WINDOWS
-        ADDRESS_FAMILY domain;
+        ADDRESS_FAMILY domain;          //!< address family of the socket (Windows)
 #elif !PLATFORM_IS_EMBEDDED
-        sa_family_t domain; // Type of socket to use
+        sa_family_t domain;             //!< address family of the socket (Linux/POSIX), e.g. AF_INET/AF_INET6/AF_UNIX
 #endif
-        struct sockaddr generic;
-        struct sockaddr_in ipv4;
-        struct sockaddr_in6 ipv6;
+        struct sockaddr generic;        //!< generic view of the peer/bind address
+        struct sockaddr_in ipv4;        //!< IPv4 view of the peer/bind address
+        struct sockaddr_in6 ipv6;       //!< IPv6 view of the peer/bind address
 #ifdef __unix__
-        struct sockaddr_un UNIX;
+        struct sockaddr_un UNIX;        //!< Unix-domain-socket-file view of the peer/bind address
 #endif
-        struct sockaddr_storage storage;
-    } addr;
+        struct sockaddr_storage storage; //!< generic storage, large enough for any supported address family
+    } addr;                              //!< remote (or, for a Unix socket file, local) address this port connects to
 
-    bool blocking;
-    bool blocking_internal;
+    bool blocking;           //!< caller-requested blocking mode for read/write operations
+    bool blocking_internal;  //!< actual current blocking mode of the underlying socket (may transiently differ from blocking)
 };
 
-typedef struct tcp_port_s tcp_port_t;
-#define TCP_PORT(n)  ((tcp_port_t*)n)
+typedef struct tcp_port_s tcp_port_t;   //!< see struct tcp_port_s
+#define TCP_PORT(n)  ((tcp_port_t*)n)    //!< reinterprets a port_handle_t (or any compatible pointer) as a pointer to tcp_port_t
 
+/**
+ * Initializes a new tcp port bound to the given remote address, without opening it. Call
+ * portOpen() (or portOpenRetry()) afterward to actually connect.
+ * @param port  the port handle to initialize
+ * @param id    the id of the new port handle (a unique id)
+ * @param name  the name to be associated with the new port
+ * @param ip    the remote address (and port) to connect to over TCP
+ * @param flags port-specific bit-flags to associate with this port
+ */
 void tcpPortInit(port_handle_t port, int id, const char* name, const struct sockaddr_storage* ip, int flags);
 
 /**
- * Initializes a tcp port with the specified name and socket
+ * Initializes a tcp port with the specified name and an existing, already-connected socket.
  * @param port The port handle to initialize
  * @param id The id of the new port handle (a unique id)
  * @param type The type modifier (OR'd with PORT_TYPE__TCP | PORT_FLAG__VALID)
  * @param name The name to be associated with the new port
  * @param socket a socket handle describing an existing and valid tcp socket
- * @param flags port-specific bit-flags to associated with this port (defaults to PORT_FLAG__COMM)
+ * @param flags port-specific bit-flags to associate with this port
+ *
+ * Note that initializing a TCP Port with a valid socket implies that the underlying socket is
+ * already connected. As a result, the PORT_FLAG__OPENED will also be set, and there is no need
+ * to call portOpen()
  */
 void tcpPortInitWithSocket(port_handle_t port, int id, int type, const char* name, const int socket, int flags);
 
+/**
+ * Deinitializes a tcp port, closing it if still open, and zeros its underlying memory.
+ * @param port The port handle to deinitialize
+ */
 void tcpPortDelete(port_handle_t port);
+
+/**
+ * Sets the blocking mode used for socket I/O on this port.
+ * @param port     the tcp port to configure
+ * @param blocking true to use blocking I/O, false for non-blocking
+ * @return 0 on success, or a negative ioctl() error code on failure
+ */
 int tcpPortSetBlocking(port_handle_t port, bool blocking);
 
 #ifdef __cplusplus

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -1,6 +1,8 @@
 /**
- * @file types.h 
- * @brief ${BRIEF_DESC}
+ * @file types.h
+ * @brief Foundational enums and log-facility bitmask constants shared across the SDK core: the
+ *        IS_LOG_ facility bits consumed by msg_logger.h, the eLogLevel severity enum, and the
+ *        eBootLoaderType bootloader-mode enum.
  *
  * @author Kyle Mallory on 7/3/24.
  * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
@@ -12,29 +14,30 @@
 #include <inttypes.h>
 
 // Define facility bitmasks. Use powers of 2 for unique bits.
-#define IS_LOG_FACILITY_NONE       0x0000                          // This facility is ALWAYS enabled (but still followed LOG_LEVEL)
-#define IS_LOG_PORT                0x0001
-#define IS_LOG_ISCOMM              ((IS_LOG_PORT << 1))
-#define IS_LOG_FWUPDATE            ((IS_LOG_ISCOMM << 1))
-#define IS_LOG_ISDEVICE            ((IS_LOG_FWUPDATE << 1))
-#define IS_LOG_PORT_FACTORY        ((IS_LOG_ISDEVICE << 1))
-#define IS_LOG_PORT_MANAGER        ((IS_LOG_PORT_FACTORY << 1))
-#define IS_LOG_DEVICE_FACTORY      ((IS_LOG_PORT_MANAGER << 1))
-#define IS_LOG_DEVICE_MANAGER      ((IS_LOG_DEVICE_FACTORY << 1))
-#define IS_LOG_CHRONO_STATS        ((IS_LOG_DEVICE_MANAGER << 1))
-#define IS_LOG_FN_PROFILER         ((IS_LOG_CHRONO_STATS << 1))
-#define IS_LOG_MDNS_CACHE          ((IS_LOG_FN_PROFILER << 1))
-#define IS_LOG_HTTP_REQUEST        ((IS_LOG_MDNS_CACHE << 1))
-#define IS_LOG_CORRECTIONS         ((IS_LOG_HTTP_REQUEST << 1))
-#define IS_LOG_CALIBRATION         ((IS_LOG_CORRECTIONS << 1))
-#define IS_LOG_ISLOG               ((IS_LOG_CALIBRATION << 1))    // ISLog / ISDeviceLog / ISLogReader file parse + load
+#define IS_LOG_FACILITY_NONE       0x0000                          //!< this facility is ALWAYS enabled (but still follows IS_LOG_LEVEL)
+#define IS_LOG_PORT                0x0001                          //!< generic port I/O (base_port_t) logging
+#define IS_LOG_ISCOMM              ((IS_LOG_PORT << 1))            //!< ISComm protocol parsing/framing logging
+#define IS_LOG_FWUPDATE            ((IS_LOG_ISCOMM << 1))          //!< firmware update logging
+#define IS_LOG_ISDEVICE            ((IS_LOG_FWUPDATE << 1))        //!< ISDevice logging
+#define IS_LOG_PORT_FACTORY        ((IS_LOG_ISDEVICE << 1))        //!< port factory/discovery logging
+#define IS_LOG_PORT_MANAGER        ((IS_LOG_PORT_FACTORY << 1))    //!< port manager logging
+#define IS_LOG_DEVICE_FACTORY      ((IS_LOG_PORT_MANAGER << 1))    //!< device factory logging
+#define IS_LOG_DEVICE_MANAGER      ((IS_LOG_DEVICE_FACTORY << 1))  //!< device manager logging
+#define IS_LOG_CHRONO_STATS        ((IS_LOG_DEVICE_MANAGER << 1))  //!< timing/chrono statistics logging
+#define IS_LOG_FN_PROFILER         ((IS_LOG_CHRONO_STATS << 1))    //!< FnProfiler function-timing logging
+#define IS_LOG_MDNS_CACHE          ((IS_LOG_FN_PROFILER << 1))     //!< mDNS cache logging
+#define IS_LOG_HTTP_REQUEST        ((IS_LOG_MDNS_CACHE << 1))      //!< HTTP request logging
+#define IS_LOG_CORRECTIONS         ((IS_LOG_HTTP_REQUEST << 1))    //!< GNSS corrections logging
+#define IS_LOG_CALIBRATION         ((IS_LOG_CORRECTIONS << 1))     //!< calibration logging
+#define IS_LOG_ISLOG               ((IS_LOG_CALIBRATION << 1))     //!< ISLog / ISDeviceLog / ISLogReader file parse + load logging
 // APP-specific stuff here goes here
-#define IS_LOG_APP_EVALTOOL        ((IS_LOG_ISLOG << 1))
-#define IS_LOG_APP_CLTOOL          ((IS_LOG_APP_EVALTOOL << 1))
-#define IS_LOG_APP_LOGALYZER       ((IS_LOG_APP_CLTOOL << 1))
+#define IS_LOG_APP_EVALTOOL        ((IS_LOG_ISLOG << 1))           //!< EvalTool application logging
+#define IS_LOG_APP_CLTOOL          ((IS_LOG_APP_EVALTOOL << 1))    //!< cltool application logging
+#define IS_LOG_APP_LOGALYZER       ((IS_LOG_APP_CLTOOL << 1))      //!< Logalyzer application logging
 
-#define IS_LOG_FACILITY_ALL        0xFFFF
+#define IS_LOG_FACILITY_ALL        0xFFFF     //!< bitmask enabling every defined logging facility
 
+/** Severity levels for the SDK's logging macros (see msg_logger.h); higher values are more verbose. */
 typedef enum {
     IS_LOG_LEVEL_NONE  = 0,         //!< use this to disable all log messages
     IS_LOG_LEVEL_ERROR = 1,         //!< errors - that that prevents the application from proceeding as normal
@@ -46,12 +49,13 @@ typedef enum {
     IS_LOG_LEVEL_BOMBASTIC = 7      //!< excessive on all but the most extreme cases - will definitely be annoying
 } eLogLevel;
 
+/** Identifies which bootloader protocol/mode a device is running, or should be flashed with. */
 typedef enum {
-    IS_BL_TYPE_NONE = 0,
-    IS_BL_TYPE_SAMBA,
-    IS_BL_TYPE_ISB,
-    IS_BL_TYPE_APP,
-    IS_BL_TYPE_DFU,
+    IS_BL_TYPE_NONE = 0,    //!< no bootloader / not applicable
+    IS_BL_TYPE_SAMBA,       //!< Atmel/Microchip SAM-BA bootloader
+    IS_BL_TYPE_ISB,         //!< Inertial Sense proprietary ISB bootloader
+    IS_BL_TYPE_APP,         //!< not a bootloader; the device is running its application firmware
+    IS_BL_TYPE_DFU,         //!< USB DFU (Device Firmware Upgrade) bootloader
 } eBootLoaderType;
 
 #endif //IS_CORE_TYPES_H

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -10,6 +10,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file linked_list.h
+ * @brief Minimal, intrusive, generic doubly-linked list for plain-C data structures: embed a
+ *        linked_list_node_t as the first member of any struct to make it insertable into a
+ *        linked_list_t, without any per-node heap allocation of its own.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef LINKED_LIST_H
 #define LINKED_LIST_H
 
@@ -20,23 +30,48 @@ extern "C" {
 
 //_____ D E F I N I T I O N S ______________________________________________
 
-typedef struct          // Place this structure at the start of any data structure to reference properly
-{
-    void                *prev;                 // Next object in linked list.  0 indicates this is the head.
-    void                *nextCt;                 // Prev object in linked list.  0 indicates this is the tail.
-}linked_list_node_t;
-
+/** Intrusive linked-list link. Place this structure at the start of any data structure to reference properly, so a pointer to that structure can be treated as a linked_list_node_t*. */
 typedef struct
 {
-    linked_list_node_t  *head;                  // Head of linked list
-    linked_list_node_t  *tail;                  // Tail of linked list
+    void                *prev;                  //!< previous object in the linked list; 0 indicates this is the head
+    void                *nextCt;                 //!< next object in the linked list; 0 indicates this is the tail
+}linked_list_node_t;
+
+/** Head/tail handle for a doubly-linked list of linked_list_node_t-derived nodes. */
+typedef struct
+{
+    linked_list_node_t  *head;                  //!< head of the linked list, or 0 if the list is empty
+    linked_list_node_t  *tail;                  //!< tail of the linked list, or 0 if the list is empty
 }linked_list_t;
 
 //_____ P R O T O T Y P E S ________________________________________________
 
+/**
+ * Empties a linked list. Does not free/modify the nodes themselves.
+ * @param ll the linked list to clear
+ */
 void linkedListClear(linked_list_t *ll);
+
+/**
+ * Inserts a node at the head of a linked list.
+ * @param ll the linked list to insert into
+ * @param newNode the node to insert; its prev/nextCt fields are overwritten
+ */
 void linkedListInsertAtHead(linked_list_t *ll, linked_list_node_t *newNode);
+
+/**
+ * Inserts a node immediately before an existing node in a linked list.
+ * @param ll the linked list containing node
+ * @param node the existing node to insert before
+ * @param newNode the node to insert; its prev/nextCt fields are overwritten
+ */
 void linkedListInsertBefore(linked_list_t *ll, linked_list_node_t *node, linked_list_node_t *newNode);
+
+/**
+ * Removes a node from a linked list, relinking its neighbors and updating head/tail as needed.
+ * @param ll the linked list containing node
+ * @param node the node to remove
+ */
 void linkedListRemove(linked_list_t *ll, linked_list_node_t *node);
 
 

--- a/src/pybindMacros.h
+++ b/src/pybindMacros.h
@@ -1,3 +1,19 @@
+/**
+ * @file pybindMacros.h
+ * @brief Registers the NumPy structured-array dtype for every `data_sets.h` struct exposed to the
+ *        Python bindings, via pybind11's `PYBIND11_NUMPY_DTYPE(type, field1, field2, ...)` macro.
+ *
+ * Despite the filename, this file does not define any macros of its own -- `PYBIND11_NUMPY_DTYPE`
+ * is a third-party macro from `<pybind11/numpy.h>`. Each line below is an *invocation* of that
+ * macro: it registers `type` as NumPy-array-compatible, listing (in declaration order) every field
+ * that should be exposed as a dtype member, so Python code can view/construct a NumPy structured
+ * array over the same memory layout as the corresponding C struct. Commented-out lines are structs
+ * intentionally not (yet) exposed to Python -- left in place as a record of what was considered.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2024 Inertial Sense, Inc. All rights reserved.
+ */
+
 #include "data_sets.h"
 
 // support types

--- a/src/serialPort.h
+++ b/src/serialPort.h
@@ -10,6 +10,15 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file serialPort.h
+ * @brief Platform-independent C API for reading and writing a serial port through a pluggable
+ * serial_port_t/base_port_t function-pointer table.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef __IS_SERIALPORT_H
 #define __IS_SERIALPORT_H
 
@@ -24,350 +33,422 @@ extern "C" {
 
 #include "ISComm.h"
 
-extern int SERIAL_PORT_DEFAULT_TIMEOUT;
+extern int SERIAL_PORT_DEFAULT_TIMEOUT;  //!< default read/write timeout, in milliseconds, used when a blocking port is opened without an explicit timeout
 
-#define MAX_SERIAL_PORT_NAME_LENGTH 63
+#define MAX_SERIAL_PORT_NAME_LENGTH 63   //!< maximum length (excluding the null terminator) of a serial_port_t name
 
 // Standard Baud Rates - FTDI Functional.   // Bit period = 1/baudrate, Actual baud (FTDI,AVR,ARM)
-#define BAUDRATE_300        300             // 3333 us
-#define BAUDRATE_600        600             // 1667 us
-#define BAUDRATE_1200       1200            //  833 us
-#define BAUDRATE_2400       2400            //  417 us
-#define BAUDRATE_4800       4800            //  208 us
-#define BAUDRATE_9600       9600            //  104 us
-#define BAUDRATE_19200      19200           //   52 us
-#define BAUDRATE_38400      38400           //   26 us
-#define BAUDRATE_57600      57600           //   17 us
-#define BAUDRATE_115200     115200          // 8680 ns
-#define BAUDRATE_230400     230400          // 4340 ns
-#define BAUDRATE_460800     460800          // 2170 ns
-#define BAUDRATE_921600     921600          // 1085 ns
-#define BAUDRATE_1000000    1000000         // 1000 ns
-#define BAUDRATE_1220000    1220000         //  820 ns
-#define BAUDRATE_1440000    1440000         //  794 ns
-#define BAUDRATE_1500000    1500000         //  667 ns    (FTDI 1520, AFR 1500)
-#define BAUDRATE_2000000    2000000         //  500 ns    (FTDI 2080, AVR/ARM 2016)
-#define BAUDRATE_3000000    3000000         //  333 ns    (FTDI 3150, AVR/ARM 3030)
-#define BAUDRATE_4000000    4000000         //  250 ns    (SN-8239)
+#define BAUDRATE_300        300             //!< 300 baud (3333 us bit period)
+#define BAUDRATE_600        600             //!< 600 baud (1667 us bit period)
+#define BAUDRATE_1200       1200            //!< 1200 baud (833 us bit period)
+#define BAUDRATE_2400       2400            //!< 2400 baud (417 us bit period)
+#define BAUDRATE_4800       4800            //!< 4800 baud (208 us bit period)
+#define BAUDRATE_9600       9600            //!< 9600 baud (104 us bit period)
+#define BAUDRATE_19200      19200           //!< 19200 baud (52 us bit period)
+#define BAUDRATE_38400      38400           //!< 38400 baud (26 us bit period)
+#define BAUDRATE_57600      57600           //!< 57600 baud (17 us bit period)
+#define BAUDRATE_115200     115200          //!< 115200 baud (8680 ns bit period)
+#define BAUDRATE_230400     230400          //!< 230400 baud (4340 ns bit period)
+#define BAUDRATE_460800     460800          //!< 460800 baud (2170 ns bit period)
+#define BAUDRATE_921600     921600          //!< 921600 baud (1085 ns bit period)
+#define BAUDRATE_1000000    1000000         //!< 1,000,000 baud (1000 ns bit period)
+#define BAUDRATE_1220000    1220000         //!< 1,220,000 baud (820 ns bit period)
+#define BAUDRATE_1440000    1440000         //!< 1,440,000 baud (794 ns bit period)
+#define BAUDRATE_1500000    1500000         //!< 1,500,000 baud (667 ns bit period; FTDI 1520, AFR 1500)
+#define BAUDRATE_2000000    2000000         //!< 2,000,000 baud (500 ns bit period; FTDI 2080, AVR/ARM 2016)
+#define BAUDRATE_3000000    3000000         //!< 3,000,000 baud (333 ns bit period; FTDI 3150, AVR/ARM 3030)
+#define BAUDRATE_4000000    4000000         //!< 4,000,000 baud (250 ns bit period; SN-8239)
 
 // SN-8239: maximum baud rate accepted by the SDK serial layer. Standard rates use their termios Bxxx
 // constant; any other rate up to this ceiling is applied via the platform custom-rate path
 // (Linux termios2/BOTHER, macOS IOSSIOSPEED). Actual achievable rate is bounded by the USB-serial
 // bridge/driver, so a successful open does not guarantee the exact line rate.
-#define SERIAL_PORT_BAUDRATE_MAX  10000000
+#define SERIAL_PORT_BAUDRATE_MAX  10000000   //!< maximum baud rate accepted by the SDK serial layer (SN-8239); see comment above
 
+/** Bitfield options for serial line encoding (parity, etc.), combined into serial_port_s::options. */
 enum eSerialPortOptions
 {
-    OPT_PARITY_NONE = 0x0,
-    OPT_PARITY_ODD = 0x1,
-    OPT_PARITY_EVEN = 0x2,
-    OPT_PARITY_MASK = 0x3,
+    OPT_PARITY_NONE = 0x0,          //!< no parity bit
+    OPT_PARITY_ODD = 0x1,           //!< odd parity
+    OPT_PARITY_EVEN = 0x2,          //!< even parity
+    OPT_PARITY_MASK = 0x3,          //!< mask isolating the parity bits above
 
-    SERIAL_PORT_OPTIONS_MASK = OPT_PARITY_MASK,
+    SERIAL_PORT_OPTIONS_MASK = OPT_PARITY_MASK,  //!< mask of all bits recognized by serialPortSetOptions()
 };
 
-typedef int(*pfnSerialPortOpen)(port_handle_t port, const char* portName, int baudRate, int blocking);
-typedef int(*pfnSerialPortIsOpen)(port_handle_t port);
-typedef int(*pfnSerialPortRead)(port_handle_t port, unsigned char* buf, unsigned int len);
-typedef int(*pfnSerialPortReadTimeout)(port_handle_t port, unsigned char* buf, unsigned int len, int timeoutMs);
-typedef void(*pfnSerialPortAsyncReadCompletion)(port_handle_t port, unsigned char* buf, unsigned int len, int errorCode);
-typedef int(*pfnSerialPortAsyncRead)(port_handle_t port, unsigned char* buf, unsigned int len, pfnSerialPortAsyncReadCompletion completion);
-typedef int(*pfnSerialPortWrite)(port_handle_t port, const unsigned char* buf, unsigned int len);
-typedef int(*pfnSerialPortClose)(port_handle_t port);
-typedef int(*pfnSerialPortFlush)(port_handle_t port);
-typedef int(*pfnSerialPortGetByteCountAvailableToRead)(port_handle_t port);
-typedef int(*pfnSerialPortGetByteCountAvailableToWrite)(port_handle_t port);
-typedef int(*pfnSerialPortSleep)(int sleepMilliseconds);
-typedef int(*pfnSerialPortOnErrorCB)(port_handle_t port, int errCode, const char *errMsg);
+typedef int(*pfnSerialPortOpen)(port_handle_t port, const char* portName, int baudRate, int blocking);  //!< function pointer type for opening a port, see serialPortOpen()
+typedef int(*pfnSerialPortIsOpen)(port_handle_t port);  //!< function pointer type for checking whether a port is open, see serialPortIsOpen()
+typedef int(*pfnSerialPortRead)(port_handle_t port, unsigned char* buf, unsigned int len);  //!< function pointer type for a synchronous, non-blocking read, see serialPortRead()
+typedef int(*pfnSerialPortReadTimeout)(port_handle_t port, unsigned char* buf, unsigned int len, int timeoutMs);  //!< function pointer type for a synchronous read with a timeout, see serialPortReadTimeout()
+typedef void(*pfnSerialPortAsyncReadCompletion)(port_handle_t port, unsigned char* buf, unsigned int len, int errorCode);  //!< completion callback invoked when an asynchronous read finishes, see serialPortReadTimeoutAsync()
+typedef int(*pfnSerialPortAsyncRead)(port_handle_t port, unsigned char* buf, unsigned int len, pfnSerialPortAsyncReadCompletion completion);  //!< function pointer type for starting an asynchronous read, see serialPortReadTimeoutAsync()
+typedef int(*pfnSerialPortWrite)(port_handle_t port, const unsigned char* buf, unsigned int len);  //!< function pointer type for a write, see serialPortWrite()
+typedef int(*pfnSerialPortClose)(port_handle_t port);  //!< function pointer type for closing a port, see serialPortClose()
+typedef int(*pfnSerialPortFlush)(port_handle_t port);  //!< function pointer type shared by the flush and drain operations, see serialPortFlush() and serialPortDrain()
+typedef int(*pfnSerialPortGetByteCountAvailableToRead)(port_handle_t port);  //!< function pointer type for querying receive-buffer depth, see serialPortGetByteCountAvailableToRead()
+typedef int(*pfnSerialPortGetByteCountAvailableToWrite)(port_handle_t port);  //!< function pointer type for querying send-buffer headroom, see serialPortGetByteCountAvailableToWrite()
+typedef int(*pfnSerialPortSleep)(int sleepMilliseconds);  //!< function pointer type for a platform sleep, see serialPortSleep()
+typedef int(*pfnSerialPortOnErrorCB)(port_handle_t port, int errCode, const char *errMsg);  //!< error callback invoked by the serialPort implementation when an operation fails, see serialPortSetErrorCB()
 
-// Allows communicating over a serial port
+/**
+ * Represents a serial port, combining the shared base_port_t/comm_port_t state with a
+ * function-pointer table (the pfn* members) that a platform backend (see serialPortPlatform.h)
+ * fills in to provide the actual OS-level implementation.
+ */
 struct serial_port_s
 {
-    // base "implementation"
     union {
-        base_port_t base;
-        comm_port_t comm;
+        base_port_t base;   //!< base "implementation" viewed as a generic port
+        comm_port_t comm;   //!< base "implementation" viewed as a comm port
     };
 
-    port_monitor_set_t stats;
+    port_monitor_set_t stats;              //!< communication statistics for this port
 
-    rmci_t rmci;
-    uint8_t rmciUPMcnt[DID_COUNT];
-    uint8_t rmciNMEAcnt[NMEA_MSG_ID_COUNT];
+    rmci_t rmci;                                       //!< realtime message controller interface state for this port
+    uint8_t rmciUPMcnt[DID_COUNT];                     //!< per-DID broadcast counters used by the realtime message controller
+    uint8_t rmciNMEAcnt[NMEA_MSG_ID_COUNT];            //!< per-NMEA-message-id broadcast counters used by the realtime message controller
 
-    // platform specific handle
-    void* handle;
+    void* handle;                                       //!< platform-specific handle (e.g. file descriptor or OS handle)
 
-    // the port name (do not modify directly)
-    char portName[MAX_SERIAL_PORT_NAME_LENGTH + 1];
+    char portName[MAX_SERIAL_PORT_NAME_LENGTH + 1];     //!< the port name (do not modify directly; use serialPortSetName())
 
-    // the current (or expected) baud rate to communicate at
-    int baudRate;
+    int baudRate;                                       //!< the current (or expected) baud rate to communicate at
 
-    // non-zero if this port is configured for blocking calls
-    int blocking;
+    int blocking;                                       //!< non-zero if this port is configured for blocking calls
 
-    // latest errno that was reported from an operation on this port
-    int errorCode;
+    int errorCode;                                       //!< latest errno that was reported from an operation on this port
 
-    // optional error buffer to store errors
-    char* error;
+    char* error;                                         //!< optional caller-owned buffer used to store the latest error message
 
-    // length of error
-    int errorLength;
+    int errorLength;                                     //!< length, in bytes, of the error buffer above
 
-    // Options for encoding like parity, stop bits, etc. (see eSerialPortOptions)
-    uint32_t options;
+    uint32_t options;                                    //!< options for encoding like parity, stop bits, etc. (see eSerialPortOptions)
 
-    // open the serial port
-    pfnSerialPortOpen pfnOpen;
+    pfnSerialPortOpen pfnOpen;                                                       //!< opens the serial port
+    pfnSerialPortIsOpen pfnIsOpen;                                                   //!< reports whether the serial port is open
+    pfnSerialPortRead pfnRead;                                                       //!< reads data synchronously
+    pfnSerialPortReadTimeout pfnReadTimeout;                                         //!< reads data synchronously with a timeout
+    pfnSerialPortAsyncRead pfnAsyncRead;                                             //!< reads data asynchronously
+    pfnSerialPortWrite pfnWrite;                                                     //!< writes data synchronously
+    pfnSerialPortClose pfnClose;                                                     //!< closes the serial port
+    pfnSerialPortFlush pfnFlush;                                                     //!< discards all data from all buffers
+    pfnSerialPortFlush pfnDrain;                                                     //!< blocks until all queued TX data has been sent
+    pfnSerialPortGetByteCountAvailableToRead pfnGetByteCountAvailableToRead;         //!< gets the number of bytes in the receive buffer that can be read
+    pfnSerialPortGetByteCountAvailableToWrite pfnGetByteCountAvailableToWrite;       //!< gets the number of available bytes in the send buffer
+    pfnSerialPortSleep pfnSleep;                                                     //!< sleeps for a specified number of milliseconds
 
-    // is the serial port open?
-    pfnSerialPortIsOpen pfnIsOpen;
-
-    // read data synchronously
-    pfnSerialPortRead pfnRead;
-
-    // read data synchronously w/ timeout
-    pfnSerialPortReadTimeout pfnReadTimeout;
-
-    // read data asynchronously
-    pfnSerialPortAsyncRead pfnAsyncRead;
-
-    // write data synchronously
-    pfnSerialPortWrite pfnWrite;
-
-    // close the serial port
-    pfnSerialPortClose pfnClose;
-
-    // discard all data from all buffers
-    pfnSerialPortFlush pfnFlush;
-
-    // block until all queued TX data has been sent
-    pfnSerialPortFlush pfnDrain;
-
-    // get number of bytes in the receive buffer that can be read
-    pfnSerialPortGetByteCountAvailableToRead pfnGetByteCountAvailableToRead;
-
-    // get the number of available bytes in the send buffer
-    pfnSerialPortGetByteCountAvailableToWrite pfnGetByteCountAvailableToWrite;
-
-    // sleep for a specified number of milliseconds
-    pfnSerialPortSleep pfnSleep;
-
-    pfnSerialPortOnErrorCB pfnError;
+    pfnSerialPortOnErrorCB pfnError;                                                 //!< optional callback invoked when an operation on this port reports an error
 };
 
-typedef struct serial_port_s serial_port_t;
-#define SERIAL_PORT(n)  ((serial_port_t*)n)
+typedef struct serial_port_s serial_port_t;   //!< see struct serial_port_s
+#define SERIAL_PORT(n)  ((serial_port_t*)n)    //!< reinterprets a port_handle_t (or any compatible pointer) as a pointer to serial_port_t
 
+/**
+ * Initializes a serial_port_t: sets its port number/type/flags, invokes serialPortPlatformInit()
+ * to install the platform function-pointer table, and marks the port valid.
+ * @param port the port to initialize
+ * @param id the port number to assign
+ * @param type the port type flags (see PORT_TYPE__* constants)
+ * @param flags additional port flags to set
+ * @return PORT_ERROR__NONE on success, otherwise a PORT_ERROR__* code
+ */
+int serialPortInit(port_handle_t port, int id, int type, int flags);
 
-int serialPortInit(port_handle_t, int id, int type, int flags);
-
-// set the port name for a serial port, in case you are opening it later
+/**
+ * Sets the port name for a serial port, in case you are opening it later.
+ * @param port the port to update
+ * @param portName the null-terminated port name to store (e.g. "COM1" or "/dev/ttyACM0")
+ * @return PORT_ERROR__NONE on success, otherwise a PORT_ERROR__* code
+ */
 int serialPortSetName(port_handle_t port, const char* portName);
 
 /**
- * returns the name associated with this port (this is usually the OS's identifier)
- * @param port
- * @return returns the name associated with this port (this is usually the OS's identifier)
+ * Returns the name associated with this port (this is usually the OS's identifier).
+ * @param port the port to query
+ * @return the port name (this is usually the OS's identifier)
  */
 const char *serialPortName(port_handle_t port);
 
 /**
- * open a serial port
- * portName is null terminated, i.e. COM1\0, COM2\0, etc.
- * use blocking = 0 when data is being streamed from the serial port rapidly and blocking = 1 for
- * uses such as a boot loader where a write would then require n bytes to be read in a single operation.
- * blocking simply determines the default timeout value of the serialPortRead function
- * @param port
- * @param portName
- * @param baudRate
- * @param blocking
- * @return 1 if success, 0 if failure
+ * Opens a serial port. portName is null terminated, i.e. COM1\0, COM2\0, etc. Use blocking = 0
+ * when data is being streamed from the serial port rapidly and blocking = 1 for uses such as a
+ * boot loader where a write would then require n bytes to be read in a single operation. Blocking
+ * simply determines the default timeout value of the serialPortRead function.
+ * @param port the port to open
+ * @param portName the null-terminated OS port name to open, e.g. "COM1" or "/dev/ttyACM0"
+ * @param baudRate the baud rate to open the port at
+ * @param blocking whether reads on this port default to blocking (non-zero) or non-blocking (zero)
+ * @return PORT_ERROR__NONE (0) on success, otherwise a negative PORT_ERROR__* code (e.g. PORT_ERROR__OPEN_FAILURE)
  */
 int serialPortOpen(port_handle_t port, const char* portName, int baudRate, int blocking);
 
 /**
- * opens the specified serial port, using previously set options for name, baudrate, and flags/options
+ * Opens the specified serial port, using previously set options for name, baudrate, and flags/options.
  * @param port the port to open
- * @return
+ * @return PORT_ERROR__NONE (0) on success, otherwise a negative PORT_ERROR__* code
  */
 int serialPortOpen_internal(port_handle_t port);
 
 /**
- * open a serial port with retry
- * portName is null terminated, i.e. COM1\0, COM2\0, etc.
- * use blocking = 0 when data is being streamed from the serial port rapidly and blocking = 1 for
- * uses such as a boot loader where a write would then require n bytes to be read in a single operation.
- * blocking simply determines the default timeout value of the serialPortRead function
- * @param port
- * @param portName
- * @param baudRate
- * @param blocking
- * @return 1 if success, 0 if failure
+ * Opens a serial port, retrying on failure. portName is null terminated, i.e. COM1\0, COM2\0, etc.
+ * Use blocking = 0 when data is being streamed from the serial port rapidly and blocking = 1 for
+ * uses such as a boot loader where a write would then require n bytes to be read in a single
+ * operation. Blocking simply determines the default timeout value of the serialPortRead function.
+ * @param port the port to open
+ * @param portName the null-terminated OS port name to open, e.g. "COM1" or "/dev/ttyACM0"
+ * @param baudRate the baud rate to open the port at
+ * @param blocking whether reads on this port default to blocking (non-zero) or non-blocking (zero)
+ * @return PORT_ERROR__NONE (0) on success, otherwise a negative PORT_ERROR__* code
  */
 int serialPortOpenRetry(port_handle_t port, const char* portName, int baudRate, int blocking);
 
 /**
- * check if the port is open
- * @param port
+ * Checks if the port is open.
+ * @param port the port to query
  * @return 1 if open, 0 if not open
  */
 int serialPortIsOpen(port_handle_t port);
 
 /**
- * check if the port is open, but avoids an expensive OS/kernel call is possible.
+ * Checks if the port is open, but avoids an expensive OS/kernel call if possible.
  * If the internal handle is NOT null, and there are recent errors on the port
- * this function will return true, indicating that the port is open.  However,
+ * this function will return true, indicating that the port is open. However,
  * it should be noted that the port may still be closed by the OS or another
  * mechanism which may not be reflected in the local state, which could cause
  * this to report incorrectly and then leading to a future error state when
  * operating on the closed port.
- * @param port
+ * @param port the port to query
  * @return 1 if open, 0 if not open
  */
 int serialPortIsOpenQuick(port_handle_t port);
 
 /**
- * close the serial port - this object can be re-used by calling open again
- * @param port
+ * Closes the serial port - this object can be re-used by calling open again.
+ * @param port the port to close
  * @return 1 if closed, 0 if the port was not closed
  */
 int serialPortClose(port_handle_t port);
 
 /**
- * clear all buffers and pending reads and writes
- * @param port
+ * Clears all buffers and pending reads and writes.
+ * @param port the port to flush
  * @return 1 if success, 0 if failure
  */
 int serialPortFlush(port_handle_t port);
 
 /**
- * blocks until all pending TX writes have completed, and the TX buffer is empty.
- * @param port
+ * Blocks until all pending TX writes have completed, and the TX buffer is empty.
+ * @param port the port to drain
  * @param timeoutMs the number of milliseconds to wait, at most before data is discarded
  * @return 1 if success, 0 if failure
  */
 int serialPortDrain(port_handle_t port, uint32_t timeoutMs);
 
 /**
- * read up to readCount bytes into buffer
- * call is forwarded to serialPortReadTimeout with timeoutMilliseconds of 0 for non-blocking, or SERIAL_PORT_DEFAULT_TIMEOUT for blocking.
- * @param port
- * @param buffer
- * @param readCount
- * @return number of bytes read which is less than or equal to readCount.
+ * Reads up to readCount bytes into buffer. Call is forwarded to serialPortReadTimeout with
+ * timeoutMs of 0 for non-blocking, or SERIAL_PORT_DEFAULT_TIMEOUT for blocking.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param readCount the maximum number of bytes to read
+ * @return number of bytes read which is less than or equal to readCount, or a negative PORT_ERROR__* code on failure.
  */
 int serialPortRead(port_handle_t port, unsigned char* buffer, unsigned int readCount);
 
 /**
- * read up to thue number of bytes requested
- * @param port
- * @param buffer
- * @param readCount
- * @param timeoutMilliseconds
- * @return number of bytes read which is less than or equal to readCount
+ * Reads up to the number of bytes requested.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param readCount the maximum number of bytes to read
+ * @param timeoutMs the maximum number of milliseconds to wait for data
+ * @return number of bytes read which is less than or equal to readCount, or a negative PORT_ERROR__* code on failure
  */
 int serialPortReadTimeout(port_handle_t port, unsigned char* buffer, unsigned int readCount, uint32_t timeoutMs);
 
 /**
- * start an async read - not all platforms will support an async read and may call the callback function immediately
- * reads up to readCount bytes into buffer
- * buffer must exist until callback is executed, if it needs to be freed, free it in the callback or later
- * @param port
- * @param buffer
- * @param readCount
- * @param callback
+ * Starts an async read - not all platforms will support an async read and may call the callback
+ * function immediately. Reads up to readCount bytes into buffer. buffer must exist until callback
+ * is executed; if it needs to be freed, free it in the callback or later.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param readCount the maximum number of bytes to read
+ * @param callback function invoked when the read completes
  * @return 1 if success, 0 if failed to start async operation
  */
 int serialPortReadTimeoutAsync(port_handle_t port, unsigned char* buffer, unsigned int readCount, pfnSerialPortAsyncReadCompletion callback);
 
 /**
- * read up until a \r\n sequence has been read
- * buffer will not contain \r\n sequence
- * @param port
- * @param buffer
- * @param bufferLength
+ * Reads up until a CRLF (\\r\\n) sequence has been read. buffer will not contain the CRLF sequence.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param bufferLength the size of buffer, in bytes
  * @return number of bytes read or -1 if timeout or buffer overflow, count does not include the null terminator
  */
 int serialPortReadLine(port_handle_t port, unsigned char* buffer, unsigned int bufferLength);
 
 /**
- * read up until a \r\n sequence has been read
- * result will not contain \r\n sequence
- * @param port
- * @param buffer
- * @param bufferLength
- * @param timeoutMilliseconds
+ * Reads up until a CRLF (\\r\\n) sequence has been read. Result will not contain the CRLF sequence.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param bufferLength the size of buffer, in bytes
+ * @param timeoutMilliseconds the maximum number of milliseconds to wait for the line
  * @return number of bytes read or -1 if timeout or buffer overflow, count does not include the null terminator
  */
 int serialPortReadLineTimeout(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, int timeoutMilliseconds);
 
 /**
- * read ASCII data (starts with $ and ends with \r\n, based on NMEA format)
- * will ignore data that fails checksum
- * asciiData gets set to start of ASCII data
- * @param port
- * @param buffer
- * @param bufferLength
- * @param asciiData
+ * Reads ASCII data (starts with $ and ends with CRLF, based on NMEA format). Will ignore data
+ * that fails checksum. asciiData gets set to the start of the ASCII data.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param bufferLength the size of buffer, in bytes
+ * @param asciiData receives a pointer into buffer at which the validated ASCII data starts
  * @return -1 if timeout or buffer overflow or checksum failure
  */
 int serialPortReadAscii(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, unsigned char** asciiData);
 
 /**
- * read ASCII data (starts with $ and ends with \r\n, based on NMEA format)
- * will ignore data that fails checksum
- * asciiData gets set to start of ASCII data
- * @param port
- * @param buffer
- * @param bufferLength
- * @param timeoutMilliseconds
- * @param asciiData
+ * Reads ASCII data (starts with $ and ends with CRLF, based on NMEA format). Will ignore data
+ * that fails checksum. asciiData gets set to the start of the ASCII data.
+ * @param port the port to read from
+ * @param buffer the buffer to read data into
+ * @param bufferLength the size of buffer, in bytes
+ * @param timeoutMilliseconds the maximum number of milliseconds to wait for the data
+ * @param asciiData receives a pointer into buffer at which the validated ASCII data starts
  * @return -1 if timeout or buffer overflow or checksum failure
  */
 int serialPortReadAsciiTimeout(port_handle_t port, unsigned char* buffer, unsigned int bufferLength, int timeoutMilliseconds, unsigned char** asciiData);
 
-// read one char, waiting SERIAL_PORT_DEFAULT_TIMEOUT milliseconds to get a char
+/**
+ * Reads one char, waiting SERIAL_PORT_DEFAULT_TIMEOUT milliseconds to get a char.
+ * @param port the port to read from
+ * @param c receives the character read
+ * @return 1 if a character was read, 0 on timeout, or a negative PORT_ERROR__* code on failure
+ */
 int serialPortReadChar(port_handle_t port, unsigned char* c);
 
-// read one char, waiting timeoutMilliseconds to get a char, returns number of chars read
+/**
+ * Reads one char, waiting timeoutMilliseconds to get a char.
+ * @param port the port to read from
+ * @param c receives the character read
+ * @param timeoutMilliseconds the maximum number of milliseconds to wait for the character
+ * @return 1 if a character was read, 0 on timeout, or a negative PORT_ERROR__* code on failure
+ */
 int serialPortReadCharTimeout(port_handle_t port, unsigned char* c, int timeoutMilliseconds);
 
-// write, returns the number of bytes written
+/**
+ * Writes data to the port.
+ * @param port the port to write to
+ * @param buffer the data to write
+ * @param writeCount the number of bytes to write
+ * @return the number of bytes written, or a negative PORT_ERROR__* code on failure
+ */
 int serialPortWrite(port_handle_t port, const unsigned char* buffer, unsigned int writeCount);
 
-// write with a \r\n added at the end, \r\n should not be part of buffer, returns the number of bytes written
+/**
+ * Writes data to the port with a CRLF (\\r\\n) added at the end; buffer should not already include it.
+ * @param port the port to write to
+ * @param buffer the data to write (without a trailing CRLF)
+ * @param writeCount the number of bytes in buffer to write
+ * @return the number of bytes written
+ */
 int serialPortWriteLine(port_handle_t port, const unsigned char* buffer, unsigned int writeCount);
 
-// write ascii data - if buffer does not start with $, a $ will be written first, followed by buffer, followed by *xx\r\n, where xx is a two hex character checksum
+/**
+ * Writes ASCII data - if buffer does not start with $, a $ will be written first, followed by
+ * buffer, followed by *xx and a trailing CRLF, where xx is a two hex character checksum.
+ * @param port the port to write to
+ * @param buffer the ASCII data to write
+ * @param bufferLength the number of bytes in buffer to write
+ * @return the number of bytes written
+ */
 int serialPortWriteAscii(port_handle_t port, const char* buffer, unsigned int bufferLength);
 
-// write and wait for a response, returns 1 if success, 0 if failure
+/**
+ * Writes data and waits for a response, using the default timeout.
+ * @param port the port to write to and wait on
+ * @param buffer the data to write
+ * @param writeCount the number of bytes in buffer to write
+ * @param waitFor the byte sequence to wait for in the response
+ * @param waitForLength the number of bytes in waitFor
+ * @return 1 if success, 0 if failure
+ */
 int serialPortWriteAndWaitFor(port_handle_t port, const unsigned char* buffer, unsigned int writeCount, const unsigned char* waitFor, unsigned int waitForLength);
+
+/**
+ * Writes data and waits for a response, with an explicit timeout.
+ * @param port the port to write to and wait on
+ * @param buffer the data to write
+ * @param writeCount the number of bytes in buffer to write
+ * @param waitFor the byte sequence to wait for in the response
+ * @param waitForLength the number of bytes in waitFor
+ * @param timeoutMilliseconds the maximum number of milliseconds to wait for waitFor
+ * @return 1 if success, 0 if failure
+ */
 int serialPortWriteAndWaitForTimeout(port_handle_t port, const unsigned char* buffer, unsigned int writeCount, const unsigned char* waitFor, unsigned int waitForLength, const int timeoutMilliseconds);
 
-// wait for a response, returns 0 if failure, 1 if success
+/**
+ * Waits for a specific byte sequence to be received, using the default timeout.
+ * @param port the port to wait on
+ * @param waitFor the byte sequence to wait for
+ * @param waitForLength the number of bytes in waitFor
+ * @return 0 if failure, 1 if success
+ */
 int serialPortWaitFor(port_handle_t port, const unsigned char* waitFor, unsigned int waitForLength);
+
+/**
+ * Waits for a specific byte sequence to be received, with an explicit timeout.
+ * @param port the port to wait on
+ * @param waitFor the byte sequence to wait for
+ * @param waitForLength the number of bytes in waitFor
+ * @param timeoutMilliseconds the maximum number of milliseconds to wait for waitFor
+ * @return 0 if failure, 1 if success
+ */
 int serialPortWaitForTimeout(port_handle_t port, const unsigned char* waitFor, unsigned int waitForLength, int timeoutMilliseconds);
 
-// get available bytes in the receive buffer
+/**
+ * Gets the number of available bytes in the receive buffer that can be read.
+ * @param port the port to query
+ * @return number of bytes available to read
+ */
 int serialPortGetByteCountAvailableToRead(port_handle_t port);
 
-// get available bytes in the send buffer
+/**
+ * Gets the number of available bytes in the send buffer.
+ * @param port the port to query
+ * @return number of bytes of headroom available in the send buffer
+ */
 int serialPortGetByteCountAvailableToWrite(port_handle_t port);
 
-// sleep for the specified number of milliseconds if supported, returns 1 if success, 0 if failed to sleep
+/**
+ * Sleeps for the specified number of milliseconds, if supported.
+ * @param port the port whose platform sleep implementation to use
+ * @param sleepMilliseconds the number of milliseconds to sleep
+ * @return 1 if success, 0 if failed to sleep
+ */
 int serialPortSleep(port_handle_t port, int sleepMilliseconds);
 
-// Set the port options
+/**
+ * Sets the port options (see eSerialPortOptions).
+ * @param port the port to update
+ * @param options the option bits to set (see eSerialPortOptions)
+ * @return PORT_ERROR__NONE on success, otherwise a PORT_ERROR__* code
+ */
 int serialPortSetOptions(port_handle_t port, uint32_t options);
 
-// Set the port baud rate
+/**
+ * Sets the port baud rate.
+ * @param port the port to update
+ * @param baudRate the baud rate to record for this port
+ * @return PORT_ERROR__NONE on success, otherwise a PORT_ERROR__* code
+ */
 int serialPortSetBaud(port_handle_t port, int baudRate);
 
-// Set callback for error events
+/**
+ * Sets the callback for error events reported by operations on this port.
+ * @param port the port to update
+ * @param onErrorCb callback invoked when an operation on this port reports an error
+ * @return PORT_ERROR__NONE on success, otherwise a PORT_ERROR__* code (e.g. PORT_ERROR__NOT_SUPPORTED)
+ */
 int serialPortSetErrorCB(port_handle_t port, pfnSerialPortOnErrorCB onErrorCb);
 
 

--- a/src/serialPortPlatform.h
+++ b/src/serialPortPlatform.h
@@ -10,6 +10,14 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/**
+ * @file serialPortPlatform.h
+ * @brief Platform-specific initialization and baud-rate helpers backing the serialPort.h function-pointer API.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2014-2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef __IS_SERIALPORT_PLATFORM_H
 #define __IS_SERIALPORT_PLATFORM_H
 
@@ -19,22 +27,44 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 extern "C" {
 #endif
 
-// zero the struct then assign function pointers for common platforms such as Windows
-// returns non-zero if success, 0 if platform not implemented
+/**
+ * Zeros the serial_port_t struct then assigns the function-pointer table for the current
+ * platform (e.g. Windows, Linux, macOS).
+ * @param port the port to initialize
+ * @return non-zero if success, 0 if the current platform is not implemented
+ */
 int serialPortPlatformInit(port_handle_t port);
 
-// SN-8239: baud-rate helpers (POSIX). serialPortStandardBaudRate() returns the termios Bxxx constant
-// for a known standard rate or 0 if the rate must use the custom path; serialPortBaudRateSupported()
-// returns 1 for any rate in (0, SERIAL_PORT_BAUDRATE_MAX]. Exposed (non-static) for unit testing.
-// Declared only off-Windows to match their definitions (the Windows branch of serialPortPlatform.c
-// does not define them), so a stray Windows caller fails at compile time rather than link time.
 #if !defined(_WIN32)
+/**
+ * SN-8239: returns the termios Bxxx constant for a known standard baud rate. Declared only
+ * off-Windows to match its definition (the Windows branch of serialPortPlatform.c does not
+ * define it), so a stray Windows caller fails at compile time rather than link time. Exposed
+ * (non-static) for unit testing.
+ * @param baudRate the baud rate to look up
+ * @return the termios Bxxx constant for baudRate, or 0 if the rate must use the custom baud path
+ */
 int serialPortStandardBaudRate(int baudRate);
+
+/**
+ * SN-8239: reports whether baudRate can be opened, either via a standard termios Bxxx constant or
+ * via the platform custom-rate path. Declared only off-Windows to match its definition (the Windows
+ * branch of serialPortPlatform.c does not define it), so a stray Windows caller fails at compile
+ * time rather than link time. Exposed (non-static) for unit testing.
+ * @param baudRate the baud rate to check
+ * @return 1 if baudRate is in (0, SERIAL_PORT_BAUDRATE_MAX], 0 otherwise
+ */
 int serialPortBaudRateSupported(int baudRate);
 #endif
 
 #if defined(__linux__)
-// SN-8239: set an arbitrary custom baud rate on an open fd via termios2/BOTHER (see serialPortLinuxCustomBaud.c).
+/**
+ * SN-8239: sets an arbitrary custom baud rate on an open fd via termios2/BOTHER (see
+ * serialPortLinuxCustomBaud.c). Used for rates that have no standard termios Bxxx constant.
+ * @param fd the open file descriptor of the serial device
+ * @param baudRate the desired baud rate
+ * @return 0 on success, -1 on failure (errno set by the underlying ioctl)
+ */
 int serialPortSetCustomBaudLinux(int fd, int baudRate);
 #endif
 

--- a/src/util/md5.h
+++ b/src/util/md5.h
@@ -1,3 +1,14 @@
+/**
+ * @file md5.h
+ * @brief MD5 message-digest implementation (md5_init()/md5_update()/md5_final(), plus the
+ *        md5_hash()/md5_stream_details()/md5_file_details() convenience wrappers), the
+ *        md5hash_t/md5Context_t data types, string/char-array conversion helpers, and a
+ *        deprecated alternate implementation (altMD5_*) retained only for legacy compatibility.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef INERTIALSENSE_SDK__MD5_H
 #define INERTIALSENSE_SDK__MD5_H
 
@@ -8,55 +19,103 @@
 #include "ISConstants.h"
 #include <string>
 
+/** 128-bit MD5 digest, viewable as bytes, 16-bit words, 32-bit double-words, or 64-bit long-words. */
 typedef union {
-    uint8_t         bytes[16];
-    uint16_t        words[8];
-    uint32_t        dwords[4];
-    uint64_t        ldwords[2];
+    uint8_t         bytes[16];     //!< digest as 16 individual bytes
+    uint16_t        words[8];      //!< digest as 8 16-bit words
+    uint32_t        dwords[4];     //!< digest as 4 32-bit double-words
+    uint64_t        ldwords[2];    //!< digest as 2 64-bit long-words
 } md5hash_t;
 
-// MD5 context structure
+/** Running-state context for an in-progress MD5 computation; passed to md5_init()/md5_update()/md5_final(). */
 typedef struct {
-    md5hash_t       state;
-    uint32_t        count[2];
-    unsigned char   buffer[64];
+    md5hash_t       state;         //!< current 128-bit intermediate hash state
+    uint32_t        count[2];      //!< number of bits processed so far, as a 64-bit little-endian pair
+    unsigned char   buffer[64];    //!< buffered input bytes not yet forming a complete 512-bit block
 } md5Context_t;
 
 /**
- * Initializes the MD5 hash. Don't forget to call hashMd5() afterwards to actually get your hash
+ * Initializes an MD5 context for a new computation. Follow with one or more calls to
+ * md5_update(), then call md5_final() to retrieve the resulting digest.
+ * @param context the MD5 context to initialize
  */
 void md5_init(md5Context_t& context);
 
 /**
- * Adds the specified data into the running MD5 hash
- * @param len the number of bytes to consume into the hash
- * @param data the bytes to consume into the hash
- * @return a static buffer of 16 unsigned bytes which represent the 128 total bits of the MD5 hash
+ * Feeds the specified data into the running MD5 hash held by context. May be called multiple
+ * times to hash data incrementally, in which case md5_final() should only be called once, after
+ * the last chunk has been fed in.
+ * @param context  the MD5 context previously initialized by md5_init()
+ * @param input    the bytes to consume into the hash
+ * @param inputLen the number of bytes in input
  */
 void md5_update(md5Context_t& context, const unsigned char *input, size_t inputLen);
 
 /**
- * updates the passed reference to an array, the current running md5 sum.
- * @param md5sum the reference to an array of uint32_t[4] where the md5 sum will be stored
+ * Finalizes the MD5 computation held by context and writes the resulting 128-bit digest to hash.
+ * @param context the MD5 context previously initialized by md5_init() and fed via md5_update()
+ * @param hash    receives the final 128-bit MD5 digest
  */
 void md5_final(md5Context_t& context, md5hash_t& hash);
 
 // Hash generation functions
+/**
+ * Computes the MD5 hash for the specified in-memory buffer.
+ * @param md5hash  receives the resulting 128-bit MD5 digest
+ * @param data_len the number of bytes in data
+ * @param data     the buffer to hash
+ */
 void md5_hash(md5hash_t& md5hash, uint32_t data_len, uint8_t* data);
+
+/**
+ * Computes the size and MD5 checksum of the given input stream. Reads the stream in full, then
+ * restores the stream's read position back to the beginning before returning.
+ * @param is       the input stream to hash
+ * @param filesize [out] receives the number of bytes read from the stream
+ * @param md5      [out] receives the resulting 128-bit MD5 digest
+ * @return 0 on success, or a negative -errno value on error
+ */
 int md5_stream_details(std::istream& is, size_t& filesize, md5hash_t& md5);
+
+/**
+ * Computes the size and MD5 checksum of the named file.
+ * @param filename the path of the file to hash
+ * @param filesize [out] receives the size of the file, in bytes
+ * @param md5      [out] receives the resulting 128-bit MD5 digest
+ * @return 0 on success, or a negative -errno value on error
+ */
 int md5_file_details(const std::string& filename, size_t& filesize, md5hash_t& md5);
 
-// Hash match check
+/**
+ * Compares two MD5 digests for equality.
+ * @param a the first digest to compare
+ * @param b the second digest to compare
+ * @return true if a and b represent the same 128-bit digest, otherwise false
+ */
 inline bool md5_matches(const md5hash_t &a, const md5hash_t &b) {
     return (
-        (a.dwords[0] == b.dwords[0]) && 
-        (a.dwords[1] == b.dwords[1]) && 
-        (a.dwords[2] == b.dwords[2]) && 
-        (a.dwords[3] == b.dwords[3])); 
+        (a.dwords[0] == b.dwords[0]) &&
+        (a.dwords[1] == b.dwords[1]) &&
+        (a.dwords[2] == b.dwords[2]) &&
+        (a.dwords[3] == b.dwords[3]));
 }
 
 // Helper functions
+/**
+ * Converts a 32-character MD5 hex-digest string (no null terminator required beyond the 32
+ * hex characters consumed) into its binary md5hash_t representation.
+ * @param md5    receives the decoded 128-bit digest
+ * @param hashStr the hex-digest characters to decode; at least 32 characters are read
+ */
 void md5_from_char_array(md5hash_t& md5, const char hashStr[]);
+
+/**
+ * Converts a binary md5hash_t digest into its 32-character hexadecimal string representation.
+ * @param md5          the digest to convert
+ * @param hashStr      buffer that receives the hex-digest characters (plus a null terminator)
+ * @param hashStrMaxLen the size of hashStr, in bytes; must be greater than 32
+ * @return true on success, or false if hashStrMaxLen is too small
+ */
 bool md5_to_char_array(md5hash_t& md5, char hashStr[], int hashStrMaxLen);
 
 #define USE_ALTERNATE_MD5_IMPL
@@ -70,16 +129,62 @@ bool md5_to_char_array(md5hash_t& md5, char hashStr[], int hashStrMaxLen);
  * you need to.  You have been warned.
  ****************************************************************************/
 
+/** Resets the legacy alternate-implementation's global running hash state. Do not use (see NOTICE above). */
 void altMD5_reset();
+
+/**
+ * Feeds data into the legacy alternate implementation's global running hash and returns the
+ * current digest. Do not use (see NOTICE above).
+ * @param data_len the number of bytes in data
+ * @param data     the bytes to consume into the hash
+ * @return a pointer to the global running digest (not thread-safe; do not retain across calls)
+ */
 md5hash_t* altMD5_hash(size_t data_len, uint8_t* data);
+
+/**
+ * Copies the legacy alternate implementation's current global running digest. Do not use (see
+ * NOTICE above).
+ * @param hash receives a copy of the current 128-bit digest
+ */
 void altMD5_getHash(md5hash_t &hash);
+
+/**
+ * Computes the size and (legacy, incorrect) MD5 checksum of the given input stream, using the
+ * alternate implementation. Do not use (see NOTICE above).
+ * @param is       the input stream to hash
+ * @param filesize [out] receives the number of bytes read from the stream
+ * @param md5      [out] receives the resulting digest
+ * @return 0 on success, or a negative -errno value on error
+ */
 int altMD5_file_details(std::istream* is, size_t& filesize, md5hash_t& md5);
 #endif // USE_ALTERNATE_MD5_IMPL
 
+/**
+ * Parses a 32-character MD5 hex-digest string into its binary md5hash_t representation.
+ * @param hashStr the hex-digest string to parse; must be at least 32 characters
+ * @return the decoded 128-bit digest, or a zeroed md5hash_t if hashStr is too short
+ */
 md5hash_t md5_from_string(std::string hashStr);
+
+/**
+ * Converts a binary md5hash_t digest into its 32-character hexadecimal string representation.
+ * @param md5 the digest to convert
+ * @return the 32-character lowercase hex-digest string
+ */
 std::string md5_to_string(const md5hash_t& md5);
+
+/**
+ * Converts an MD5 digest, given as a raw uint32_t[4] array, into its 32-character hexadecimal
+ * string representation.
+ * @param hash the digest, as 4 uint32_t words (aliased directly to an md5hash_t)
+ * @return the 32-character lowercase hex-digest string
+ */
 std::string md5_to_string_u32(uint32_t hash[4]);
 #ifndef ARM
+/**
+ * Prints the hex-digest string representation of md5 to stdout (no trailing newline).
+ * @param md5 the digest to print
+ */
 void md5_print(md5hash_t& md5);
 #endif
 

--- a/src/util/natsort.h
+++ b/src/util/natsort.h
@@ -1,6 +1,8 @@
 /**
- * @file natsort.h 
- * @brief ${BRIEF_DESC}
+ * @file natsort.h
+ * @brief "Natural order" string comparison (strnatcmp()/natcmp() and case-insensitive variants),
+ *        adapted from Martin Pool's public-domain strnatcmp.c, plus std::sort/%std::map-ready
+ *        comparator functors (nat_cmp, nat_case_cmp).
  *
  * @author Kyle Mallory on 4/27/24.
  * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
@@ -43,21 +45,61 @@ namespace utils {
      *
      * You can change this typedef, but must then also change the inline
      * functions in strnatcmp.c */
-    typedef char nat_char;
+    typedef char nat_char;   //!< character type used by the strnatcmp()/strnatcasecmp() implementation
 
+    /**
+     * Performs a case-sensitive "natural order" comparison of two null-terminated C strings
+     * (runs of digits are compared numerically rather than character-by-character, so "img2" is
+     * ordered before "img10").
+     * @param a the first null-terminated string to compare
+     * @param b the second null-terminated string to compare
+     * @return <0 if a sorts before b, 0 if they are equivalent, >0 if a sorts after b
+     */
     int strnatcmp(nat_char const *a, nat_char const *b);
+
+    /**
+     * Case-insensitive variant of strnatcmp().
+     * @param a the first null-terminated string to compare
+     * @param b the second null-terminated string to compare
+     * @return <0 if a sorts before b, 0 if they are equivalent, >0 if a sorts after b
+     */
     int strnatcasecmp(nat_char const *a, nat_char const *b);
 
+    /**
+     * std::string convenience wrapper around strnatcmp().
+     * @param a the first string to compare
+     * @param b the second string to compare
+     * @return <0 if a sorts before b, 0 if they are equivalent, >0 if a sorts after b
+     */
     int natcmp(const std::string& a, const std::string& b);
+
+    /**
+     * std::string convenience wrapper around strnatcasecmp().
+     * @param a the first string to compare
+     * @param b the second string to compare
+     * @return <0 if a sorts before b, 0 if they are equivalent, >0 if a sorts after b
+     */
     int natcasecmp(const std::string& a, const std::string& b);
 
+    /** Case-sensitive "natural order" std::string comparator functor, e.g. for std::sort()/%std::map<>. */
     struct nat_cmp {
+        /**
+         * @param s1 the first string to compare
+         * @param s2 the second string to compare
+         * @return true if s1 sorts before s2 in natural order, otherwise false
+         */
         bool operator()(const std::string& s1, const std::string& s2) const {
             return (utils::natcmp(s1, s2) < 0);
         }
     };
 
+    /** Case-insensitive "natural order" std::string comparator functor, e.g. for std::sort()/%std::map<>. */
     struct nat_case_cmp {
+        /**
+         * @param s1 the first string to compare
+         * @param s2 the second string to compare
+         * @return true if s1 sorts before s2 in natural order (case-insensitive), otherwise false
+         */
         bool operator()(const std::string& s1, const std::string& s2) const {
             return (utils::natcasecmp(s1, s2) < 0);
         }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -88,16 +88,21 @@ namespace utils {
     std::string trim_copy(std::string s, const char* t = " \t\n\r\f\v");
 
     /**
-     * Performs sprintf-type formatting, using a std:string for the format string, and outputting a std::string
-     * @tparam Args
-     * @param format
-     * @param args
-     * @return
+     * Base case for the variadic string_format() below; returns format unchanged, since there are
+     * no substitutions to perform when no additional arguments are supplied.
+     * @param format the string to return as-is
+     * @return a copy of format
      */
     inline std::string string_format(const std::string& format) {
         return format;
     }
 
+    /**
+     * Performs sprintf-type formatting, using a std::string for the format string, and outputting a std::string.
+     * @param format a printf-style format string
+     * @param args the values to substitute into format, per the usual printf conversion rules
+     * @return the formatted string
+     */
     template<typename ... Args>
     std::string string_format(const std::string& format, Args ... args) {
         int size_s = std::snprintf((char*)nullptr, 0, format.c_str(), args ...) + 1; // Extra space for '\0'
@@ -113,9 +118,8 @@ namespace utils {
 
     /**
      * Combine all elements of a container denoted by the start and ending iterators, to join into a
-     *   single string, using the specified delimiter
-     * @tparam T the type of container/iterator
-     * @param v a copy of the iterator denoting the first element to join
+     *   single string, using the specified delimiter. The iterator type is deduced from the arguments.
+     * @param begin a copy of the iterator denoting the first element to join
      * @param end reference to the iterator denoting the last element to join
      * @param delimiter a delimiter string to be placed between each element in the output string
      * @return a string of all joined elements
@@ -131,8 +135,8 @@ namespace utils {
     }
 
     /**
-     * Combine all elements of a container into a single string, using the specified delimiter
-     * @tparam T the type of container
+     * Combine all elements of a container into a single string, using the specified delimiter.
+     * The container type is deduced from the argument.
      * @param v reference to the container of elements to join
      * @param delimiter a delimiter string to be placed between each element in the output string
      * @return a string of all joined elements
@@ -191,12 +195,11 @@ namespace utils {
 
 
     /**
-     * Returns the index of an entry (type E) within a container (type T)
-     * @tparam E the data type of the collection; defaults to std::string
-     * @tparam T the collection type; defaults to std::vector
+     * Returns the index of an entry (type E, default std::string) within a container (type T,
+     * default std::vector<E>).
      * @param c a reference to the collection containing the element to index
      * @param e a reference to the element to locate in the collection
-     * @returns the index number of the element e within collection c, or -1 if not found.
+     * @return the index number of the element e within collection c, or -1 if not found.
      */
     template <typename E=std::string, typename T=std::vector<E>>
     int indexOf(const T& c, const E& e) {
@@ -205,9 +208,26 @@ namespace utils {
         return (int)pos;
     }
 
+    /**
+     * Formats the passed raw data as a "hexadecimal view". This can be used with any data.
+     * @param raw_data a pointer to the raw byte stream
+     * @param bytesLen the number of bytes following raw_data to output
+     * @param bytesPerLine the number of hexadecimal bytes to print per line
+     * @return a fully formatted string
+     */
     std::string raw_hexdump(const char* raw_data, int bytesLen, int bytesPerLine);
+
+    /**
+     * Formats the specified DID's raw data as a "hexadecimal view". This can be used with any DID
+     * that is not otherwise supported.
+     * @param raw_data a pointer to the raw DID byte stream
+     * @param hdr the DID header
+     * @param bytesPerLine the number of hexadecimal bytes to print per line
+     * @return a fully formatted string
+     */
     std::string did_hexdump(const char *raw_data, const p_data_hdr_t& hdr, int bytesPerLine);
 
+    /** Bitmask selecting which dev_info_t fields devInfoToString()/getBuildAsString() render. */
     enum dev_info_fmt_e : uint16_t {
         DV_BIT_SERIALNO         = 0x0001,        //!< serial number
         DV_BIT_FIRMWARE_VER     = 0x0002,        //!< firmware version w/ optional release type
@@ -259,33 +279,169 @@ namespace utils {
      */
     std::string deviceIdString(uint16_t hdwId, uint64_t serial);
 
+    /**
+     * Renders the hardware type-major-minor portion of devInfo, e.g. "IMX-5.0", optionally
+     * appended with the sub-rev components (hardwareVer[2..3]) when showRev is true and they are
+     * non-zero.
+     * @param devInfo the dev_info_t supplying the hardware type and version bytes
+     * @param showRev if true, append the sub-rev components when present
+     * @return the rendered hardware-id string
+     */
     std::string getHardwareAsString(const dev_info_t& devInfo, bool showRev = true);
+
+    /**
+     * Renders the type-major-minor portion of a packed hardware id, e.g. "IMX-5.0". This is a
+     * legacy-named alias of hdwIdToString() for callers that prefer this historical name; the
+     * packed form cannot carry the sub-rev bytes.
+     * @param hdwId packed hardware id
+     * @return the rendered hardware-id string
+     */
     std::string getHardwareAsString(is_hardware_t hdwId);
+
+    /**
+     * Renders the firmware version portion of devInfo, e.g. "fw2.1.7" or "fw2.1.7-rc.5", including
+     * the build-type suffix (alpha/beta/rc/devel/snap) when set.
+     * @param devInfo the dev_info_t supplying the firmware version and build type
+     * @param prefix  a prefix to prepend to the rendered version (defaults to "fw")
+     * @return the rendered firmware-version string
+     */
     std::string getFirmwareAsString(const dev_info_t& devInfo, const std::string& prefix = "fw");
+
+    /**
+     * Renders the requested build-related fields of devInfo (commit hash, build key/number,
+     * build date, build time) as a single delimited string, per the DV_BIT_ flags requested.
+     * @param devInfo the dev_info_t supplying the build fields
+     * @param flags   a bitmask of dev_info_fmt_e DV_BIT_ values selecting which fields to render
+     * @param sep     the separator placed between each rendered field
+     * @return the rendered build-info string
+     */
     std::string getBuildAsString(const dev_info_t& devInfo, uint16_t flags = -1, const std::string& sep = " ");
 
-    /// Parse a hardware identity string (inverse of getHardwareAsString). Accepts "<TYPE>-<major>.<minor>[.<p2>[.<p3>]]"
-    /// e.g. "IMX-5.0", "GPX-1.0.2", "uINS-3.2". Populates devInfo.hardwareType and hardwareVer[0..3].
-    /// Returns false on unrecognized type prefix or malformed version — caller should leave devInfo unchanged.
+    /**
+     * Parses a hardware identity string (inverse of getHardwareAsString()). Accepts
+     * "<TYPE>-<major>.<minor>[.<p2>[.<p3>]]", e.g. "IMX-5.0", "GPX-1.0.2", "uINS-3.2". Populates
+     * devInfo.hardwareType and hardwareVer[0..3].
+     * @param s       the hardware identity string to parse
+     * @param devInfo the dev_info_t to populate; left unchanged if parsing fails
+     * @return false on unrecognized type prefix or malformed version, otherwise true
+     */
     bool parseHardwareFromString(const std::string& s, dev_info_t& devInfo);
 
-    /// Parse a firmware version string (inverse of getFirmwareAsString). Accepts optional "fw" prefix followed by
-    /// "<M>.<m>.<p>" and an optional build-type suffix "-alpha|-beta|-rc|-devel|-snap" with optional ".<build>".
-    /// Populates devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|0 for production/no suffix).
-    /// The legacy "-r" suffix and unknown suffixes are normalized to 0 (production). Returns false on malformed input.
+    /**
+     * Parses a firmware version string (inverse of getFirmwareAsString()). Accepts an optional
+     * "fw" prefix followed by "<M>.<m>.<p>" and an optional build-type suffix
+     * "-alpha|-beta|-rc|-devel|-snap" with an optional ".<build>". Populates
+     * devInfo.firmwareVer[0..3] and buildType ('a'|'b'|'c'|'d'|'s'|0 for production/no suffix).
+     * The legacy "-r" suffix and unknown suffixes are normalized to 0 (production).
+     * @param s       the firmware version string to parse
+     * @param devInfo the dev_info_t to populate
+     * @return false on malformed input, otherwise true
+     */
     bool parseFirmwareFromString(const std::string& s, dev_info_t& devInfo);
     // semver::version<uint8_t, uint8_t, uint8_t> getSemanticVersion(const dev_info_t& devInfo, uint16_t flags = -1);
 
+    /**
+     * @return the current system clock as a string with millisecond precision
+     */
     std::string getCurrentTimestamp();
+
+    /**
+     * Formats a string representation of devInfo, in the specific format also understood by
+     * devInfoFromString(): "SN[serialNo]: [hdwType]-[hdwVer], fw[fwVersion] b[buildNum][buildType]
+     * [buildDate] [buildTime] (addlInfo)", e.g. "SN102934: IMX-5.0, fw2.1.7 b83c 2024-09-18
+     * 15:35:43 (p12 cmp)". Not all dev_info_t fields are rendered, but the majority are.
+     * @param devInfo the dev_info_t struct that provides the values to render
+     * @param flags   a bitmask of dev_info_fmt_e DV_BIT_ values selecting which fields to render
+     * @return a std::string representation of devInfo
+     */
     std::string devInfoToString(const dev_info_t& devInfo, uint16_t flags = -1);
+
+    /**
+     * Parses and populates a dev_info_t struct from an input string (inverse of
+     * devInfoToString()). Works by attempting to parse a series of "components" from the input
+     * string, removing each successfully parsed component from the string, and then trying again
+     * until the string is fully consumed or fails to match any component patterns.
+     * @param str     the string to parse
+     * @param devInfo the dev_info_t struct to parse into
+     * @return a bitmask of dev_info_fmt_e DV_BIT_ values indicating which components were parsed
+     */
     uint16_t devInfoFromString(const std::string& str, dev_info_t& devInfo);
+
+    /**
+     * Converts the dev_info_t build date/time into a single uint64_t that is still
+     * human-readable, but numerically significant and suitable for sorting, e.g.
+     * [2024, 05, 01, 23, 18, 35] becomes (uint64_t) 20240501231835.
+     * @param a         the dev_info_t whose build date/time will be used
+     * @param useMillis if true, append the build milliseconds as an additional low-order digit group
+     * @return the packed, sortable build date/time value
+     */
     uint64_t intDateTimeFromDevInfo(const dev_info_t& a, bool useMillis = false);
+
+    /**
+     * Generates a potential/expected firmware filename based on the given devInfo. E.g. given a
+     * devInfo describing an IMX-5.0 running firmware 2.5.1, built on 2025-05-31 at 20:10:07, this
+     * returns something like "IS_IMX-5_v2.5.1+2025-05-31-201007.hex" -- typically the firmware
+     * file that was used to load that firmware.
+     * @param devInfo the dev_info_t describing the firmware; passed by value since buildMillisecond
+     *                is zeroed internally before formatting
+     * @return the generated firmware filename
+     */
     std::string firmwareFileFromDevInfo(dev_info_t devInfo);
 
+    /**
+     * Compares the serial number and full hardware version (hardwareVer[0..3]) of two dev_info_t
+     * structs for an exact match.
+     * @param info1 the first dev_info_t to compare
+     * @param info2 the second dev_info_t to compare
+     * @return true if the serial number and hardware version match exactly, otherwise false
+     */
     bool devInfoHdwMatch(const dev_info_t &info1, const dev_info_t &info2);
+
+    /**
+     * Performs a series of tests, based on the flags bitmask, to determine if two dev_info_t
+     * structs are effective matches. This is not a byte-for-byte match, but rather a filter of
+     * specific sets of fields within the dev_info_t struct to make a determination of equality.
+     * For example, this can test whether the main firmware version matches (major, minor, patch),
+     * but disregard whether the build date/time matches, etc.
+     * @param info1 the first dev_info_t to compare
+     * @param info2 the second dev_info_t to compare with
+     * @param flags a bitmask of dev_info_fmt_e DV_BIT_ values identifying the fields to test, and
+     *              other related comparison flags (e.g. DV_BIT_EXACT_MATCH)
+     * @return true if the two match the specified flags, otherwise false
+     */
     bool devInfoVersionMatch(const dev_info_t &info1, const dev_info_t &info2, int flags = DV_BIT_FIRMWARE_VER | DV_BIT_BUILD_COMMIT | DV_BIT_BUILD_DATE | DV_BIT_BUILD_TIME);
+
+    /**
+     * Determines if two dev_info_t structs describe compatible hardware (same hardware type,
+     * major/minor version, and run state). Used primarily to determine if a firmware is
+     * compatible with a target device.
+     * @param a the first dev_info_t to compare
+     * @param b the second dev_info_t to compare
+     * @return true if the two dev_info_t structs are "compatible", otherwise false
+     */
     bool isDevInfoCompatible(const dev_info_t& a, const dev_info_t& b);
+
+    /**
+     * Compares the full firmware version (firmwareVer[0..3], buildType, build date/time, and
+     * build key) of two dev_info_t structs. Equivalent to compareFirmwareVersions(a, b, 0xFFFF).
+     * @param a dev_info_t representing a particular firmware version
+     * @param b dev_info_t representing a particular firmware version
+     * @return an integer representing the difference between a and b; 0 if both are equal, >0 if
+     *   a > b, and <0 if a < b. The magnitude reflects which components differ (each compared
+     *   component occupies its own bit range of the result) but is not itself a meaningful distance.
+     */
     int64_t compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b);
+
+    /**
+     * Compares the firmware version fields of two dev_info_t structs selected by fields. A
+     * comparator suitable for use by std::map<> to order dev_info_t by firmware version.
+     * @param a      dev_info_t representing a particular firmware version
+     * @param b      dev_info_t representing a particular firmware version
+     * @param fields a bitmask of dev_info_fmt_e DV_BIT_ values selecting which components to compare
+     * @return an integer representing the difference between a and b; 0 if both are equal, >0 if
+     *   a > b, and <0 if a < b. The magnitude reflects which components differ (each compared
+     *   component occupies its own bit range of the result) but is not itself a meaningful distance.
+     */
     int64_t compareFirmwareVersions(const dev_info_t& a, const dev_info_t& b, uint16_t fields);
 
     // int parseStringVersion(const std::string& vIn, uint8_t vOut[4]);
@@ -317,6 +473,12 @@ namespace utils {
      */
     uint32_t compareDevInfo(const dev_info_t& info1, const dev_info_t& info2);
 
+    /**
+     * Checks whether domainName is a syntactically valid DNS domain name (RFC-1035-style labels,
+     * with support for punycode "xn--" labels), and no longer than 254 characters.
+     * @param domainName the domain name string to validate
+     * @return true if domainName is a syntactically valid domain name, otherwise false
+     */
     bool validDomainName(const std::string& domainName);
 
     /**
@@ -337,10 +499,14 @@ namespace utils {
         std::string path;       //!< path component (e.g. an NTRIP mountpoint); empty if absent
         std::string query;      //!< query component; empty if absent
 
-        bool hasScheme() const { return !scheme.empty(); }     //!< true if a scheme was present
-        bool hasHost() const { return !host.empty(); }         //!< true if a host was present
-        bool hasPort() const { return port >= 0; }             //!< true if a valid port was present
-        bool hasUserinfo() const { return !user.empty() || !password.empty(); } //!< true if userinfo was present
+        /** @return true if a scheme was present */
+        bool hasScheme() const { return !scheme.empty(); }
+        /** @return true if a host was present */
+        bool hasHost() const { return !host.empty(); }
+        /** @return true if a valid port was present */
+        bool hasPort() const { return port >= 0; }
+        /** @return true if userinfo was present */
+        bool hasUserinfo() const { return !user.empty() || !password.empty(); }
     };
 
     /**
@@ -387,14 +553,31 @@ namespace utils {
     std::string generateUUIDv4();
 };
 
+/**
+ * A fixed-size, in-memory std::streambuf that also tracks which byte ranges have been written
+ * (via insert()), so a caller can later query whether a given range has been populated. Useful
+ * for assembling a buffer out-of-order (e.g. from out-of-order network chunks).
+ */
 class ByteBuffer : public std::streambuf {
 public:
+    /**
+     * Allocates a zero-initialized buffer of the given size and prepares the get/put pointers to
+     * span it.
+     * @param size the fixed size, in bytes, of the buffer
+     */
     ByteBuffer(std::size_t size) : size_(size) {
         buffer_.resize(size_, 0); // Initialize buffer with zeros
         setg(buffer_.data(), buffer_.data(), buffer_.data() + buffer_.size());
         setp(buffer_.data(), buffer_.data() + buffer_.size());
     }
 
+    /**
+     * Copies len bytes from data into the buffer starting at pos, and records [pos, pos+len) as
+     * an initialized range (merging it with any adjacent/overlapping previously-initialized ranges).
+     * @param pos  the byte offset within the buffer to write to
+     * @param data the bytes to copy in
+     * @param len  the number of bytes to copy
+     */
     void insert(std::size_t pos, const uint8_t* data, std::size_t len) {
         if (pos + len > buffer_.size()) {
             throw std::out_of_range("Insert position out of range");
@@ -404,22 +587,36 @@ public:
         merge_initialized_ranges();
     }
 
+    /** @return the current read position, as an offset from the start of the buffer */
     std::size_t tellg() const {
         return gptr() - eback();
     }
 
+    /** @return the current write position, as an offset from the start of the buffer */
     std::size_t tellp() const {
         return pptr() - pbase();
     }
 
+    /** @return the current value of the internal write-position counter */
     std::size_t data_size() const {
         return current_write_pos_;
     }
 
+    /**
+     * Moves the read position to the given offset from the start of the buffer.
+     * @param pos the byte offset to seek the read position to
+     */
     void seekg(std::size_t pos) {
         setg(eback(), eback() + pos, egptr());
     }
 
+    /**
+     * Checks whether the byte range [pos, pos+len) has been fully populated by one or more prior
+     * insert() calls.
+     * @param pos the starting byte offset of the range to check
+     * @param len the length, in bytes, of the range to check
+     * @return true if the entire range has been initialized, otherwise false
+     */
     bool is_initialized(std::size_t pos, std::size_t len) const {
         auto end_pos = pos + len;
         for (const auto& range : initialized_ranges_) {
@@ -453,27 +650,49 @@ private:
     }
 };
 
+/**
+ * A std::iostream front-end for a ByteBuffer, providing the same tellg()/tellp()/seekg()/
+ * data_size()/is_initialized() convenience accessors directly on the stream.
+ */
 class ByteBufferStream : public std::iostream {
 public:
+    /**
+     * Binds this stream to the given ByteBuffer, which must outlive the stream.
+     * @param buffer the ByteBuffer to read/write through this stream
+     */
     ByteBufferStream(ByteBuffer& buffer)
             : std::iostream(&buffer), buffer_(buffer) {}
 
+    /** @return the current read position, as an offset from the start of the underlying buffer */
     std::size_t tellg() const {
         return buffer_.tellg();
     }
 
+    /** @return the current write position, as an offset from the start of the underlying buffer */
     std::size_t tellp() const {
         return buffer_.tellp();
     }
 
+    /** @return the current value of the underlying buffer's internal write-position counter */
     std::size_t data_size() const {
         return buffer_.data_size();
     }
 
+    /**
+     * Moves the read position to the given offset from the start of the underlying buffer.
+     * @param pos the byte offset to seek the read position to
+     */
     void seekg(std::size_t pos) {
         buffer_.seekg(pos);
     }
 
+    /**
+     * Checks whether the byte range [pos, pos+len) of the underlying buffer has been fully
+     * populated by one or more prior ByteBuffer::insert() calls.
+     * @param pos the starting byte offset of the range to check
+     * @param len the length, in bytes, of the range to check
+     * @return true if the entire range has been initialized, otherwise false
+     */
     bool is_initialized(std::size_t pos, std::size_t len) const {
         return buffer_.is_initialized(pos, len);
     }
@@ -484,10 +703,19 @@ private:
 
 
 // #define FN_PROFILER_ENABLED
+/**
+ * RAII scoped function-timing profiler: on destruction, logs (at IS_LOG_FN_PROFILER) the elapsed
+ * time since construction if it exceeds threshold, along with any intermediate mark() timestamps.
+ * Compiles to a complete no-op unless FN_PROFILER_ENABLED is defined.
+ */
 class FnProfiler {
 public:
 #ifdef FN_PROFILER_ENABLED
-    // Constructor records the start time and function name
+    /**
+     * Starts timing, recording the current time and an identifying label for the log output.
+     * @param functionName a label (typically the function name) to identify this timing in the log output
+     * @param threshold    the minimum elapsed microseconds required for the destructor to emit a log message
+     */
     FnProfiler(const std::string& functionName, uint32_t threshold = 100) : m_functionName(functionName), m_threshold(threshold), m_startTime(std::chrono::high_resolution_clock::now()) { }
 
     // Destructor calculates and prints the duration
@@ -507,6 +735,11 @@ public:
         }
     }
 
+    /**
+     * Records an intermediate timestamp, labeled with msg, to be reported (relative to the start
+     * time and the previous mark) alongside the total duration when this FnProfiler is destroyed.
+     * @param msg a label describing this checkpoint
+     */
     void mark(const std::string& msg) {
         markers.emplace_back(std::make_pair(std::chrono::high_resolution_clock::now(), msg));
     }
@@ -517,19 +750,37 @@ private:
     std::chrono::high_resolution_clock::time_point m_startTime;
     std::vector<std::pair<std::chrono::high_resolution_clock::time_point, std::string>> markers;
 #else
+    /**
+     * No-op constructor used when FN_PROFILER_ENABLED is not defined.
+     * @param functionName unused
+     * @param threshold    unused
+     */
     FnProfiler(const std::string& functionName, uint32_t threshold = 100) { (void) functionName; (void) threshold; }
 
     // Destructor calculates and prints the duration
     ~FnProfiler() { }
 
+    /**
+     * No-op when FN_PROFILER_ENABLED is not defined.
+     * @param msg unused
+     */
     void mark(const std::string& msg) { (void) msg; }
 #endif
 };
 
+/**
+ * RAII helper that invokes an arbitrary callable (its type F is deduced from the constructor
+ * argument) when it goes out of scope, regardless of how the scope is exited (normal return,
+ * early return, or exception). Non-copyable and non-movable to prevent the wrapped callable from
+ * accidentally being invoked more than once.
+ */
 template <typename F>
 class Finalizer {
     F f;
 public:
+    /**
+     * @param f the callable to invoke when this Finalizer is destroyed
+     */
     explicit Finalizer(F f) : f(std::move(f)) {}
     ~Finalizer() { f(); }
 

--- a/src/version/version.h
+++ b/src/version/version.h
@@ -1,3 +1,15 @@
+/**
+ * @file version.h
+ * @brief Includes the generated version/build-info headers (repositoryInfo.h and buildInfo.h,
+ *        which define the IS_SDK_REPO_ constants for the actual repo/build) when they can be
+ *        found, or falls back to hard-coded REPO_ placeholder constants otherwise; also defines
+ *        the IS_SDK_VERSION_MAJOR/MINOR/PATCH/REVIS aliases (pulled from the generated
+ *        IS_SDK_REPO_VERSION_ constants) that the rest of the SDK consumes.
+ *
+ * @author Inertial Sense, Inc.
+ * @copyright Copyright (c) 2025 Inertial Sense, Inc. All rights reserved.
+ */
+
 #ifndef SDK_VERSION_H
 #define SDK_VERSION_H
 
@@ -11,31 +23,31 @@
     #include "../../cpp/EvalTool/version/repositoryInfo.h"
     #include "../../cpp/EvalTool/version/buildInfo.h"
 #else
-    #define REPO_VERSION_MAJOR      2
-    #define REPO_VERSION_MINOR      7
-    #define REPO_VERSION_REVIS      0
-    #define REPO_VERSION_PRERELEASE 0
+    #define REPO_VERSION_MAJOR      2       //!< fallback major version, used when repositoryInfo.h/buildInfo.h were not generated
+    #define REPO_VERSION_MINOR      7       //!< fallback minor version, used when repositoryInfo.h/buildInfo.h were not generated
+    #define REPO_VERSION_REVIS      0       //!< fallback revision/patch version, used when repositoryInfo.h/buildInfo.h were not generated
+    #define REPO_VERSION_PRERELEASE 0       //!< fallback prerelease/build number, used when repositoryInfo.h/buildInfo.h were not generated
 
-    #define REPO_NAME               "is-sdk"
-    #define REPO_BRANCH             "<no-git-info>"
-    #define REPO_DESCRIPTION        "<no-git-info>"
-    #define REPO_GIT_COMMIT         0xdeadbeaf
-    #define REPO_VERSION            "<no-git-info>"
-    #define REPO_VERSION_NO_META    "<no-git-info>"
-    #define REPO_VERSION_MAJOR      2
-    #define REPO_VERSION_MINOR      7
-    #define REPO_VERSION_REVIS      0
-    #define REPO_VERSION_PRERELEASE 0
+    #define REPO_NAME               "is-sdk"          //!< fallback repository name
+    #define REPO_BRANCH             "<no-git-info>"   //!< fallback git branch name
+    #define REPO_DESCRIPTION        "<no-git-info>"   //!< fallback git describe output
+    #define REPO_GIT_COMMIT         0xdeadbeaf         //!< fallback git commit hash placeholder
+    #define REPO_VERSION            "<no-git-info>"   //!< fallback full version string (with metadata)
+    #define REPO_VERSION_NO_META    "<no-git-info>"   //!< fallback version string without build metadata
+    #define REPO_VERSION_MAJOR      2       //!< fallback major version (duplicate definition, kept for compatibility)
+    #define REPO_VERSION_MINOR      7       //!< fallback minor version (duplicate definition, kept for compatibility)
+    #define REPO_VERSION_REVIS      0       //!< fallback revision/patch version (duplicate definition, kept for compatibility)
+    #define REPO_VERSION_PRERELEASE 0       //!< fallback prerelease/build number (duplicate definition, kept for compatibility)
 
-    #define QU(x) #x
-    #define QUH(x) QU(x)
-    #define VERSION_STRING
-    #define NSIS_VERSION_NUMBER QUH(REPO_VERSION_MAJOR) "." QUH(REPO_VERSION_MINOR) "." QUH(REPO_VERSION_REVIS) "." QUH(REPO_VERSION_PRERELEASE)
+    #define QU(x) #x                        //!< stringizes x without macro-expanding it first
+    #define QUH(x) QU(x)                    //!< expands x, then stringizes the result (use this for macro arguments)
+    #define VERSION_STRING                  //!< placeholder marker; intentionally empty in the fallback branch
+    #define NSIS_VERSION_NUMBER QUH(REPO_VERSION_MAJOR) "." QUH(REPO_VERSION_MINOR) "." QUH(REPO_VERSION_REVIS) "." QUH(REPO_VERSION_PRERELEASE)   //!< dotted "major.minor.revis.prerelease" string consumed by the NSIS installer script
 #endif
 
-#define IS_SDK_VERSION_MAJOR  IS_SDK_REPO_VERSION_MAJOR
-#define IS_SDK_VERSION_MINOR  IS_SDK_REPO_VERSION_MINOR
-#define IS_SDK_VERSION_PATCH  IS_SDK_REPO_VERSION_REVIS
-#define IS_SDK_VERSION_REVIS  IS_SDK_REPO_VERSION_PRERELEASE
+#define IS_SDK_VERSION_MAJOR  IS_SDK_REPO_VERSION_MAJOR        //!< SDK major version, aliasing IS_SDK_REPO_VERSION_MAJOR from the generated repositoryInfo.h
+#define IS_SDK_VERSION_MINOR  IS_SDK_REPO_VERSION_MINOR        //!< SDK minor version, aliasing IS_SDK_REPO_VERSION_MINOR from the generated repositoryInfo.h
+#define IS_SDK_VERSION_PATCH  IS_SDK_REPO_VERSION_REVIS        //!< SDK patch version, aliasing IS_SDK_REPO_VERSION_REVIS from the generated repositoryInfo.h
+#define IS_SDK_VERSION_REVIS  IS_SDK_REPO_VERSION_PRERELEASE   //!< SDK prerelease/build number, aliasing IS_SDK_REPO_VERSION_PRERELEASE from the generated repositoryInfo.h
 
 #endif // SDK_VERSION_H


### PR DESCRIPTION
## Summary

Final story in the SDK Doxygen epic (SN-8279). Documents the remaining 28 headers per `code-style-guide.md` §2 (JavaDoc `/** */` preceding blocks, `//!<` trailing member/enumerator docs, `@`-tag vocabulary only), completing full Doxygen coverage across the entire SDK `src/` tree.

Files documented:
- **Transport factories**: `PortFactory.h`, `TcpPortFactory.h`, `TcpServerPortFactory.h`, `ISmDnsPortFactory.h`, `RelayPortFactory.h`
- **Concrete ports**: `ISSerialPort.h`, `ISClient.h`, `ISTcpClient.h`, `ISTcpServer.h`, `ISHttpRequest.h`, `serialPort.h`, `serialPortPlatform.h`
- **Core impls + utilities**: `core/base_port.h`, `core/ISFilePort.h`, `core/tcpPort.h`, `core/msg_logger.h`, `core/types.h`, `util/util.h`, `util/md5.h`, `util/natsort.h`, `version/version.h`
- **Data mappings + pybind**: `ISDataMappings.h` (full `@param`/`@return` + table-schema blocks on the mapping-table arrays, per AC), `pybindMacros.h`
- **Display/stats/misc**: `ISDisplay.h`, `ISLogStats.h`, `ISUtilities.h`, `ChronoStat.h` (filled its `${BRIEF_DESC}` placeholder, per AC), `linked_list.h`

Also fixes several pre-existing issues found while auditing: forbidden `///` comment forms, stale/mismatched `@param` names (including a badly wrong doc on `md5_update()`), disallowed `@tparam` tags, and a `\r\n`/autolink markdown-parser landmine in `serialPort.h`'s comments that was corrupting nearby `@param` parsing.

## Notes

- **`pybindMacros.h`**: despite the filename, this file defines no macros of its own — every line is an *invocation* of pybind11's third-party `PYBIND11_NUMPY_DTYPE` macro, registering one `data_sets.h` struct per call as a NumPy-compatible dtype. Documented the file's actual purpose accurately rather than inventing per-line macro docs that wouldn't apply to a macro *use*. Because doxygen doesn't recognize this third-party variadic macro, it misparses ~90 invocation lines as undocumented functions when `WARN_IF_UNDOCUMENTED=YES` — this is the same class of doxygen 1.9.1 tool limitation flagged on SN-8297's `usb_dfu.h` (confirmed via isolated repro), not a real documentation gap, and has no effect on the real build (`WARN_IF_UNDOCUMENTED=NO` by default).
- Verified via a scoped `doxygen -` run (`WARN_IF_UNDOCUMENTED=YES`) against all 28 files: zero real gaps outside the `pybindMacros.h` tool-limitation class above.
- Confirmed `python3 scripts/generate_doxygen.py --pdf` builds both HTML and a 1141-page PDF cleanly against the current Doxyfile + `src/` tree.

## Test plan

- [x] `InertialSenseSDK` target builds clean (no new warnings) after every commit
- [x] Scoped `doxygen` run (`WARN_IF_UNDOCUMENTED=YES`) against all 28 story files — zero real gaps (see notes for the one tool-bug exception)
- [x] `python3 scripts/generate_doxygen.py --pdf` — HTML + PDF both generate successfully
- [ ] Reviewer pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)