### PR TITLE
SN-8339/8383/8340/8105/7901: multi-boot resolver + v2.1 .idx + anchored span + legacy-reader deprecation

### DIFF
--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -10,6 +10,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <chrono>
 #include <ctime>
 #include <string>
 #include <sstream>
@@ -67,6 +68,12 @@ void cDeviceLog::InitDeviceForWriting(const std::string& timestamp, const std::s
     m_logStats.Clear();
     m_indexChunks.clear();
     m_logStartUpTime = current_uptimeMs();
+    // SN-8340: capture the absolute host wall-clock once, at log-open, so the
+    // v2.1 .idx header carries a durable epoch anchor even for logs that never
+    // acquire GPS. Per-record times stay relative (m_logStartUpTime delta).
+    m_captureEpochMs = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
 }
 
 
@@ -357,6 +364,15 @@ void cDeviceLog::addIndexRecord(const p_data_hdr_t* dataHdr, const uint8_t* data
     rec.offset = m_lastIndexOffset;
     rec.reserved = 0;
 
+    // SN-8383 (v2.1): stamp the host-uptime-since-log-start for EVERY record —
+    // the per-record local clock v1 had and the v2 transition dropped. This is
+    // independent of `timestamp` below (which still prefers the payload ToW),
+    // so a downstream resolver can bracket a timeless record between the local
+    // deltas of its timed neighbours instead of guessing by arrival index.
+    const uint32_t localDelta = static_cast<uint32_t>(current_uptimeMs() - m_logStartUpTime);
+    rec.local_uptime_ms = localDelta;
+    rec.reserved2       = 0;
+
     if (dataHdr != nullptr) {
         rec.did = dataHdr->id;
         // cISDataMappings::Timestamp returns 0.0 if the DID doesn't
@@ -367,7 +383,7 @@ void cDeviceLog::addIndexRecord(const p_data_hdr_t* dataHdr, const uint8_t* data
             rec.timestamp = static_cast<uint64_t>(tsSeconds * 1000.0);
             rec.flags = IS_LOG_IDX_REC_FLAG_HAS_TOW;
         } else {
-            rec.timestamp = static_cast<uint64_t>(current_uptimeMs() - m_logStartUpTime);
+            rec.timestamp = localDelta;
             rec.flags = 0;
         }
     } else {
@@ -375,7 +391,7 @@ void cDeviceLog::addIndexRecord(const p_data_hdr_t* dataHdr, const uint8_t* data
         // to host uptime delta so the record still anchors a position
         // in the .raw segment by approximate time.
         rec.did = 0;
-        rec.timestamp = static_cast<uint64_t>(current_uptimeMs() - m_logStartUpTime);
+        rec.timestamp = localDelta;
         rec.flags = 0;
     }
 
@@ -419,7 +435,9 @@ bool cDeviceLog::writeIndexChunk() {
         is_log_idx_header_t hdr = makeDefaultHeader(
             encode_sdk_producer_version(),
             TimestampUnits::HostUptimeMs,
-            HeaderTimeSource::Mixed);
+            HeaderTimeSource::Mixed,
+            m_captureEpochMs);
+        hdr.flags |= IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA;   // SN-8383: every record carries local_uptime_ms
         auto r = writeHeader(indexFile, hdr);
         if (!r) {
             return false;
@@ -463,11 +481,17 @@ bool cDeviceLog::finalizeIndex() {
     is_log_idx_header_t hdr = makeDefaultHeader(
         encode_sdk_producer_version(),
         TimestampUnits::HostUptimeMs,
-        HeaderTimeSource::Mixed);
+        HeaderTimeSource::Mixed,
+        m_captureEpochMs);
     hdr.total_records       = m_idxTotalRecords;
     hdr.first_timestamp_ms  = m_idxFirstTimestampMs;
     hdr.last_timestamp_ms   = m_idxLastTimestampMs;
-    hdr.flags               = IS_LOG_IDX_HDR_FLAG_FINALIZED;
+    // Preserve the v2.1 flags across the finalize header rewrite (the plain
+    // "= FINALIZED" would otherwise drop HAS_LOCAL_DELTA / HAS_CAPTURE_EPOCH).
+    hdr.flags               = static_cast<uint8_t>(
+                                  IS_LOG_IDX_HDR_FLAG_FINALIZED
+                                | IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA
+                                | (m_captureEpochMs ? IS_LOG_IDX_HDR_FLAG_HAS_CAPTURE_EPOCH : 0));
 
     auto r = writeHeader(indexFile, hdr);
     if (!r) {

--- a/src/DeviceLog.h
+++ b/src/DeviceLog.h
@@ -347,6 +347,7 @@ protected:
     uint64_t m_lastIndexOffset = 0;                 //!< running byte offset into the .raw segment; v2 widened from u32 to u64 since segments can exceed 4GB
     uint32_t m_logStartUpTime = 0;                  //!< the system uptime (in millis) at the moment this index was created
     uint32_t m_lastIndexTime = 0;                   //!< system uptime (in ms) of the last index record; v2 still tracks this for the host-uptime fallback path
+    uint64_t m_captureEpochMs = 0;                  //!< SN-8340: absolute host wall-clock (ms since Unix epoch) captured at log-open; written to the v2.1 .idx header so a no-GPS-ever log still has a wall-clock anchor
 
     // D-01 / SN-7879 v2 .idx bookkeeping. The header at offset 0 of
     // the .idx file carries these aggregates; finalizeIndex() seeks(0)

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -76,6 +76,13 @@ bool cDeviceLogRaw::CloseAllFiles()
     // Close file
     CloseISLogFile(m_pFile);
 
+    // SN-8328 (rotation ordering): the current .raw segment is finalized. Reset
+    // the physical-offset accounting so the NEXT segment's records index from 0.
+    // (The base's lazy OpenNewSaveFile() also zeroes m_fileSize, but that fires
+    // only at the next chunk flush — too late for records indexed in between.)
+    m_fileSize       = 0;
+    m_rawIndexCursor = 0;
+
     return true;
 }
 
@@ -98,15 +105,33 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
 {
     cDeviceLog::SaveData(dataSize, dataBuf, globalLogStats);    // call into the super, in case it needs to do something special
 
+    // SN-8328 (rotation ordering): if this input buffer won't fit in the current
+    // chunk, flush + (maybe) rotate FIRST — BEFORE indexing this buffer's
+    // packets below. PushBack() puts the whole buffer into one chunk, so a
+    // record and its data must land in the same segment; flushing after indexing
+    // would emit the record into the closing segment's .idx while its data goes
+    // to the next segment (a trusted sidecar would then double-count it).
+    // Records already indexed for the current chunk are fully placed, so this
+    // flush writes them to the correct segment.
+    if (dataSize > m_chunk.GetBuffFree())
+    {
+        if (!WriteChunkToFile())
+        {
+            return false;   // there was an error writing the chunk to disk
+        }
+        else if (m_fileSize >= m_maxFileSize)
+        {
+            CloseAllFiles();   // rotate; resets m_fileSize + m_rawIndexCursor for the new segment
+        }
+    }
+
     // SN-8328: physical .idx offsets. The .raw segment is pure concatenated
     // packet bytes (chunks are written header-less — see DeviceLogRaw.h), so a
     // record's physical byte offset in the file is simply its position in that
     // stream. `rawFileBase` is the physical position of THIS input buffer's first
     // byte within the current file = (bytes already flushed to the file) +
-    // (bytes buffered in the current chunk before this input). Both terms are
-    // flush-invariant — a chunk flush moves bytes from the buffer to the file,
-    // leaving m_fileSize + GetDataSize() unchanged — so it is valid to capture
-    // here, before the possible chunk flush below.
+    // (bytes buffered in the current chunk before this input). The flush above
+    // has already run, so both terms reflect the segment this buffer lands in.
     const uint64_t rawFileBase = static_cast<uint64_t>(m_fileSize) + static_cast<uint64_t>(m_chunk.GetDataSize());
     if (rawFileBase == 0) {
         m_rawIndexCursor = 0;   // a fresh .raw file -> per-file offsets restart at 0
@@ -208,21 +233,6 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
             // at the following byte. Mirrors ISLogReader's scan cursor; persists
             // across input buffers so a split packet keeps its true start.
             m_rawIndexCursor = rawFileBase + static_cast<uint64_t>(dPtr - dataBuf) + 1;
-        }
-    }
-
-    // Ensure data will fit in chunk.  If not, create new chunk
-    if (dataSize > m_chunk.GetBuffFree())
-    {
-        // Save chunk to file and clear
-        if (!WriteChunkToFile())
-        {
-            return false;   // there was a error writing the chunk to disk
-        }
-        else if (m_fileSize >= m_maxFileSize)
-        {
-            // Close existing file
-            CloseAllFiles();
         }
     }
 

--- a/src/DeviceLogRaw.cpp
+++ b/src/DeviceLogRaw.cpp
@@ -98,6 +98,20 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
 {
     cDeviceLog::SaveData(dataSize, dataBuf, globalLogStats);    // call into the super, in case it needs to do something special
 
+    // SN-8328: physical .idx offsets. The .raw segment is pure concatenated
+    // packet bytes (chunks are written header-less — see DeviceLogRaw.h), so a
+    // record's physical byte offset in the file is simply its position in that
+    // stream. `rawFileBase` is the physical position of THIS input buffer's first
+    // byte within the current file = (bytes already flushed to the file) +
+    // (bytes buffered in the current chunk before this input). Both terms are
+    // flush-invariant — a chunk flush moves bytes from the buffer to the file,
+    // leaving m_fileSize + GetDataSize() unchanged — so it is valid to capture
+    // here, before the possible chunk flush below.
+    const uint64_t rawFileBase = static_cast<uint64_t>(m_fileSize) + static_cast<uint64_t>(m_chunk.GetDataSize());
+    if (rawFileBase == 0) {
+        m_rawIndexCursor = 0;   // a fresh .raw file -> per-file offsets restart at 0
+    }
+
     // Parse messages for statistics and DID_DEV_INFO
     for (const uint8_t *dPtr = dataBuf; dPtr < dataBuf+dataSize; dPtr++)
     {
@@ -132,6 +146,13 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
                     // own DID + payload timestamp + ToW flag — which is
                     // exactly what per-DID time-range queries against the
                     // index need.
+                    // SN-8328: stamp this packet's PHYSICAL .raw byte offset (its
+                    // start position in the file) rather than a chunk-relative
+                    // one, so ISLogReader trusts the sidecar (no offset-driven
+                    // rebuild) and the v2.1 per-record deltas survive.
+                    // m_rawIndexCursor holds the start of the current packet,
+                    // tracked across input-buffer boundaries below.
+                    m_lastIndexOffset = m_rawIndexCursor;
                     addIndexRecord(&m_comm.rxPkt.dataHdr, m_comm.rxPkt.data.ptr);
 
                     dev_info_t tmpInfo = {};
@@ -182,6 +203,11 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
             {
                 m_logStats.CacheDiagnosticData(m_comm.rxPkt.dataHdr.id, m_comm.rxPkt.data.ptr, m_comm.rxPkt.dataHdr.size, timestamp, m_comm.rxPkt.dataHdr.offset);
             }
+
+            // SN-8328: this packet's bytes end at dPtr, so the NEXT packet starts
+            // at the following byte. Mirrors ISLogReader's scan cursor; persists
+            // across input buffers so a split packet keeps its true start.
+            m_rawIndexCursor = rawFileBase + static_cast<uint64_t>(dPtr - dataBuf) + 1;
         }
     }
 
@@ -207,14 +233,9 @@ bool cDeviceLogRaw::SaveData(int dataSize, const uint8_t* dataBuf, cLogStats &gl
         return false;   // unable to push the buffer into the chunk
     }
 
-    // D-01 / SN-7879: advance the index-offset counter for the *next*
-    // chunk-input. The base cDeviceLog::SaveData(int, ...) used to do
-    // this immediately on entry, but that broke per-packet emission
-    // (records inside the parser loop above would have been tagged
-    // with the next-chunk's offset). We defer the bump to here so the
-    // offset captured by per-packet addIndexRecord calls matches the
-    // chunk-input's starting offset.
-    m_lastIndexOffset += dataSize;
+    // SN-8328: m_lastIndexOffset is no longer a chunk-input accumulator — each
+    // .idx record now gets its true physical .raw offset from m_rawIndexCursor
+    // in the parse loop above, so there is no per-buffer bump here.
 
     return true;
 }

--- a/src/DeviceLogRaw.h
+++ b/src/DeviceLogRaw.h
@@ -95,6 +95,14 @@ private:
     p_data_buf_t m_pData;                   //!< scratch buffer for the most recently read data set
     is_comm_instance_t m_comm;              //!< multi-protocol packet parser (IS binary, NMEA, RTCM3, u-blox)
     protocol_type_t m_protocolType;         //!< unused
+
+    //! SN-8328: physical byte offset (within the current .raw file) at which the
+    //! NEXT parsed packet starts. Persists across SaveData() input buffers so a
+    //! packet split across two LogData() calls still gets its true start offset.
+    //! Reset to 0 when a fresh .raw file begins. Stamped into each .idx record so
+    //! ISLogReader trusts the sidecar instead of rebuilding (a rebuild would drop
+    //! the SN-8383 per-record host-uptime deltas).
+    uint64_t m_rawIndexCursor = 0;
 };
 
 #endif // IS_SDK__DEVICE_LOG_RAW_H

--- a/src/ISDeviceLog.cpp
+++ b/src/ISDeviceLog.cpp
@@ -9,9 +9,11 @@
 
 #include "ISDeviceLog.h"
 
+#include "ISTimeResolver.h"   // SN-8105 anchored-span accessors
 #include "core/msg_logger.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <set>
 #include <utility>
 
@@ -140,6 +142,52 @@ TimeStamp ISDeviceLog::spanEnd() const noexcept {
         if (v != 0) return TimeStamp::fromPayloadToW(v, deviceId_);
     }
     return TimeStamp::fromPayloadToW(0, deviceId_);
+}
+
+namespace {
+
+//! SN-8105: single arrival-ordered pass folding the min and max of every
+//! record's resolver-anchored timestamp. Skips zero-raw (no time field) and
+//! `SessionOnly/Unknown` (no shared anchor) records. `any` is false when the
+//! log has no anchorable record. Keyed on arrival index for SN-8339 multi-boot.
+struct AnchoredFold {
+    uint64_t minMs = UINT64_MAX;
+    uint64_t maxMs = 0;
+    bool     any   = false;
+};
+
+AnchoredFold foldAnchoredSpan(const ISDeviceLog& log,
+                              const ISTimeResolver& resolver) {
+    AnchoredFold f;
+    const uint64_t deviceId = log.deviceId();
+    for (ISRecordView v : log.allRecords()) {
+        const uint64_t raw = v.timestamp().value;
+        if (raw == 0) continue;
+        const TimeStamp r = resolver.resolve(raw, deviceId, v.arrivalIndex());
+        if (r.source == TimeSource::SessionOnly &&
+            r.confidence == TimeConfidence::Unknown) {
+            continue;
+        }
+        if (r.value == 0) continue;
+        if (!f.any || r.value < f.minMs) f.minMs = r.value;
+        if (!f.any || r.value > f.maxMs) f.maxMs = r.value;
+        f.any = true;
+    }
+    return f;
+}
+
+}  // namespace
+
+TimeStamp ISDeviceLog::anchoredSpanStart(const ISTimeResolver& resolver) const noexcept {
+    const AnchoredFold f = foldAnchoredSpan(*this, resolver);
+    if (!f.any) return spanStart();
+    return TimeStamp::fromResolvedViaSync(f.minMs, deviceId_, TimeConfidence::Exact);
+}
+
+TimeStamp ISDeviceLog::anchoredSpanEnd(const ISTimeResolver& resolver) const noexcept {
+    const AnchoredFold f = foldAnchoredSpan(*this, resolver);
+    if (!f.any) return spanEnd();
+    return TimeStamp::fromResolvedViaSync(f.maxMs, deviceId_, TimeConfidence::Exact);
 }
 
 ISDeviceLog::Range ISDeviceLog::records(did_t did) const noexcept {

--- a/src/ISDeviceLog.cpp
+++ b/src/ISDeviceLog.cpp
@@ -99,8 +99,10 @@ void ISDeviceLog::buildIndex() {
     total_ = 0;
     all_.clear();
     byDid_.clear();
+    segmentBase_.assign(segments_.size(), 0);
 
     for (std::size_t s = 0; s < segments_.size(); ++s) {
+        segmentBase_[s] = total_;   // SN-8339: global arrival base for this segment
         const std::size_t n = segments_[s].recordCount();
         all_.reserve(all_.size() + n);
         for (std::size_t r = 0; r < n; ++r) {
@@ -188,7 +190,14 @@ ISDeviceLog::RangeIterator
 ISRecordView ISDeviceLog::RangeIterator::operator*() const noexcept {
     if (!parent_ || !locators_ || pos_ >= locators_->size()) return {};
     const Locator& loc = (*locators_)[pos_];
-    return parent_->segments_[loc.segment].recordAt(loc.record);
+    ISRecordView v = parent_->segments_[loc.segment].recordAt(loc.record);
+    // SN-8339: stamp the global arrival index so consumers can key the
+    // multi-boot resolver, regardless of which range (allRecords / records(did)
+    // / seek / in_time) produced this view.
+    if (loc.segment < parent_->segmentBase_.size()) {
+        v.setArrivalIndex(parent_->segmentBase_[loc.segment] + loc.record);
+    }
+    return v;
 }
 
 ISDeviceLog::RangeIterator&

--- a/src/ISDeviceLog.h
+++ b/src/ISDeviceLog.h
@@ -286,6 +286,13 @@ private:
     std::unordered_map<did_t, std::vector<Locator>>   byDid_;
     static const std::vector<Locator>                 kEmptyLocators_;
 
+    //! SN-8339: per-segment base of the global arrival index. A record at
+    //! (segment s, record r) has global arrival index `segmentBase_[s] + r` —
+    //! its 0-based position in cross-segment arrival order. Stamped onto every
+    //! view the range iterator yields so consumers can key the multi-boot
+    //! resolver. Matches `ISTimeResolver`'s own byte-scan arrival numbering.
+    std::vector<std::size_t>                          segmentBase_;
+
     std::function<void(std::size_t)>   onSegmentBoundary_;
 
     friend class RangeIterator;

--- a/src/ISDeviceLog.h
+++ b/src/ISDeviceLog.h
@@ -32,6 +32,10 @@
 
 namespace inertial_sense {
 
+class ISTimeResolver;  // forward — SN-8105 anchored-span accessors take one by
+                       // ref; ISTimeResolver.h includes this header (it builds
+                       // from an ISDeviceLog), so we cannot include it back.
+
 class ISDeviceLog {
 public:
     using did_t = uint32_t;
@@ -116,6 +120,33 @@ public:
      *          empty-composition semantics as `spanStart`.
      */
     TimeStamp spanEnd() const noexcept;
+
+    /**
+     * @brief SN-8105: earliest record timestamp, GPS-anchored via the resolver.
+     *
+     * `spanStart()` returns the raw first/last `TimeStamp::value()` in whatever
+     * time domain the originating record used (session-uptime for radio modules,
+     * GPS-ToW for GPS-anchored devices), so on a GPS-anchored log it can report a
+     * ~0 ms session-uptime value that renders as a 1970 wall-clock. This variant
+     * routes every record's raw timestamp through `resolver` (SN-8339: keyed on
+     * the record's global arrival index, so multi-boot logs bridge per session)
+     * and folds the minimum of the anchored, non-`SessionOnly` results.
+     *
+     * @param resolver  Resolver built from this device log.
+     * @return  Earliest GPS-anchored absolute-ms timestamp, or `spanStart()`
+     *          (raw) if the log has no anchorable records.
+     */
+    TimeStamp anchoredSpanStart(const ISTimeResolver& resolver) const noexcept;
+
+    /**
+     * @brief SN-8105: latest record timestamp, GPS-anchored via the resolver.
+     *        See `anchoredSpanStart`; folds the maximum instead.
+     *
+     * @param resolver  Resolver built from this device log.
+     * @return  Latest GPS-anchored absolute-ms timestamp, or `spanEnd()` (raw)
+     *          if the log has no anchorable records.
+     */
+    TimeStamp anchoredSpanEnd(const ISTimeResolver& resolver) const noexcept;
 
     /** @return  Number of underlying segments composed. */
     std::size_t segmentCount() const noexcept { return segments_.size(); }

--- a/src/ISLogIndex.cpp
+++ b/src/ISLogIndex.cpp
@@ -10,6 +10,7 @@
 
 #include "ISLogFileBase.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace inertial_sense {
@@ -198,17 +199,29 @@ ISExpected<is_log_idx_header_t> readHeader(cISLogFileBase& file) {
 }
 
 ISExpected<is_log_idx_record_v2_t> readRecord(cISLogFileBase& file, std::size_t record_size) {
-    // Legacy pre-v2.1 headers carry record_size 0 ⇒ read the 24-byte prefix;
-    // clamp anything larger than v2.1 (a future v2.2 reader handles the tail).
-    if (record_size < IS_LOG_IDX_RECORD_V2_SIZE)   record_size = IS_LOG_IDX_RECORD_V2_SIZE;
-    if (record_size > IS_LOG_IDX_RECORD_V2_1_SIZE) record_size = IS_LOG_IDX_RECORD_V2_1_SIZE;
+    // Legacy pre-v2.1 headers carry record_size 0 ⇒ 24-byte stride.
+    if (record_size < IS_LOG_IDX_RECORD_V2_SIZE) record_size = IS_LOG_IDX_RECORD_V2_SIZE;
+
+    // Parse only the fields this build understands (the v2.0/v2.1 prefix). A
+    // future format with record_size > 32 is still consumed WHOLE so the file
+    // position advances by the full stride and subsequent reads stay aligned.
+    const std::size_t parseLen = std::min<std::size_t>(record_size, IS_LOG_IDX_RECORD_V2_1_SIZE);
     uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
-    const std::size_t got = file.read(buf, record_size);
-    if (got < record_size) {
+    if (file.read(buf, parseLen) < parseLen) {
         return fail(ISErrorCode::Truncated,
                     "short read on .idx record");
     }
-    return parseRecord(buf, record_size);
+    // Discard any trailing bytes of a larger (future) record.
+    for (std::size_t remaining = record_size - parseLen; remaining > 0;) {
+        uint8_t scratch[64];
+        const std::size_t chunk = std::min<std::size_t>(remaining, sizeof(scratch));
+        if (file.read(scratch, chunk) < chunk) {
+            return fail(ISErrorCode::Truncated,
+                        "short read on .idx record tail");
+        }
+        remaining -= chunk;
+    }
+    return parseRecord(buf, parseLen);
 }
 
 is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,

--- a/src/ISLogIndex.cpp
+++ b/src/ISLogIndex.cpp
@@ -87,7 +87,10 @@ void serializeHeader(uint8_t out[IS_LOG_IDX_HEADER_SIZE],
     out[41] = hdr.ts_source;
     out[42] = hdr.flags;
     out[43] = hdr.reserved8;
-    // out[44..63] left zero from memset.
+    put_u16(out + 44, hdr.record_size);        // SN-8383: on-disk record stride
+    put_u16(out + 46, hdr.reserved16);
+    put_u64(out + 48, hdr.capture_epoch_ms);   // SN-8340: absolute host wall-clock at log-open
+    // out[56..63] left zero from memset.
 }
 
 ISExpected<is_log_idx_header_t> parseHeader(
@@ -117,7 +120,10 @@ ISExpected<is_log_idx_header_t> parseHeader(
     hdr.ts_source           = in[41];
     hdr.flags               = in[42];
     hdr.reserved8           = in[43];
-    std::memcpy(hdr.reserved, in + 44, sizeof(hdr.reserved));
+    hdr.record_size         = get_u16(in + 44);   // 0 on legacy pre-v2.1 headers
+    hdr.reserved16          = get_u16(in + 46);
+    hdr.capture_epoch_ms    = get_u64(in + 48);
+    std::memcpy(hdr.reserved, in + 56, sizeof(hdr.reserved));
 
     if (hdr.version != IS_LOG_IDX_VERSION_V2) {
         return fail(ISErrorCode::Unsupported,
@@ -132,23 +138,30 @@ ISExpected<is_log_idx_header_t> parseHeader(
     return hdr;
 }
 
-void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_SIZE],
+void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_1_SIZE],
                      const is_log_idx_record_v2_t& rec) noexcept {
     put_u64(out +  0, rec.timestamp);
     put_u64(out +  8, rec.offset);
     put_u32(out + 16, rec.did);
     put_u16(out + 20, rec.flags);
     put_u16(out + 22, rec.reserved);
+    put_u32(out + 24, rec.local_uptime_ms);   // v2.1 trailing field (SN-8383)
+    put_u32(out + 28, rec.reserved2);
 }
 
 is_log_idx_record_v2_t parseRecord(
-    const uint8_t in[IS_LOG_IDX_RECORD_V2_SIZE]) noexcept {
+    const uint8_t* in, std::size_t record_size) noexcept {
     is_log_idx_record_v2_t rec{};
     rec.timestamp = get_u64(in +  0);
     rec.offset    = get_u64(in +  8);
     rec.did       = get_u32(in + 16);
     rec.flags     = get_u16(in + 20);
     rec.reserved  = get_u16(in + 22);
+    // v2.1 trailing field present only when the on-disk record is >= 32 bytes.
+    if (record_size >= IS_LOG_IDX_RECORD_V2_1_SIZE) {
+        rec.local_uptime_ms = get_u32(in + 24);
+        rec.reserved2       = get_u32(in + 28);
+    }
     return rec;
 }
 
@@ -165,10 +178,10 @@ ISExpected<void> writeHeader(cISLogFileBase& file, const is_log_idx_header_t& hd
 }
 
 ISExpected<void> writeRecord(cISLogFileBase& file, const is_log_idx_record_v2_t& rec) {
-    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
     serializeRecord(buf, rec);
-    const std::size_t written = file.write(buf, IS_LOG_IDX_RECORD_V2_SIZE);
-    if (written != IS_LOG_IDX_RECORD_V2_SIZE) {
+    const std::size_t written = file.write(buf, IS_LOG_IDX_RECORD_V2_1_SIZE);
+    if (written != IS_LOG_IDX_RECORD_V2_1_SIZE) {
         return fail(ISErrorCode::Io, "short write on .idx record");
     }
     return {};
@@ -184,19 +197,24 @@ ISExpected<is_log_idx_header_t> readHeader(cISLogFileBase& file) {
     return parseHeader(buf);
 }
 
-ISExpected<is_log_idx_record_v2_t> readRecord(cISLogFileBase& file) {
-    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
-    const std::size_t got = file.read(buf, IS_LOG_IDX_RECORD_V2_SIZE);
-    if (got < IS_LOG_IDX_RECORD_V2_SIZE) {
+ISExpected<is_log_idx_record_v2_t> readRecord(cISLogFileBase& file, std::size_t record_size) {
+    // Legacy pre-v2.1 headers carry record_size 0 ⇒ read the 24-byte prefix;
+    // clamp anything larger than v2.1 (a future v2.2 reader handles the tail).
+    if (record_size < IS_LOG_IDX_RECORD_V2_SIZE)   record_size = IS_LOG_IDX_RECORD_V2_SIZE;
+    if (record_size > IS_LOG_IDX_RECORD_V2_1_SIZE) record_size = IS_LOG_IDX_RECORD_V2_1_SIZE;
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
+    const std::size_t got = file.read(buf, record_size);
+    if (got < record_size) {
         return fail(ISErrorCode::Truncated,
                     "short read on .idx record");
     }
-    return parseRecord(buf);
+    return parseRecord(buf, record_size);
 }
 
 is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,
                                       TimestampUnits units,
-                                      HeaderTimeSource source) noexcept {
+                                      HeaderTimeSource source,
+                                      uint64_t capture_epoch_ms) noexcept {
     is_log_idx_header_t hdr{};
     hdr.magic[0] = IS_LOG_IDX_MAGIC[0];
     hdr.magic[1] = IS_LOG_IDX_MAGIC[1];
@@ -213,6 +231,13 @@ is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,
     hdr.ts_source           = static_cast<uint8_t>(source);
     hdr.flags               = 0;  // FINALIZED set on clean close
     hdr.reserved8           = 0;
+    // v2.1: all newly-written .idx use 32-byte records; record_size drives the
+    // reader's stride (legacy v2.0 files carry 0 ⇒ reader treats as 24). The
+    // live writer sets HAS_LOCAL_DELTA once it stamps real per-record deltas.
+    hdr.record_size         = static_cast<uint16_t>(IS_LOG_IDX_RECORD_V2_1_SIZE);
+    hdr.reserved16          = 0;
+    hdr.capture_epoch_ms    = capture_epoch_ms;
+    if (capture_epoch_ms != 0) hdr.flags |= IS_LOG_IDX_HDR_FLAG_HAS_CAPTURE_EPOCH;
     std::memset(hdr.reserved, 0, sizeof(hdr.reserved));
     return hdr;
 }

--- a/src/ISLogIndex.h
+++ b/src/ISLogIndex.h
@@ -48,6 +48,13 @@ inline constexpr uint16_t IS_LOG_IDX_VERSION_V2 = 2;
 inline constexpr std::size_t IS_LOG_IDX_HEADER_SIZE = 64;
 inline constexpr std::size_t IS_LOG_IDX_RECORD_V2_SIZE = 24;
 
+/// SN-8383: v2.1 grows the per-record entry by a trailing `local_uptime_ms`
+/// (+ pad) — appended at the END so the 24-byte v2.0 prefix is byte-identical
+/// and a v2.1 reader can still stride v2.0 files (which lack the trailing
+/// field). The writer stamps v2.1 records; the on-disk record size lives in the
+/// header (`record_size`) so the reader strides correctly for either.
+inline constexpr std::size_t IS_LOG_IDX_RECORD_V2_1_SIZE = 32;
+
 // ----- Timestamp interpretation enums --------------------------------------
 
 /// What `is_log_idx_record_v2_t::timestamp` means in this file. Stored
@@ -85,6 +92,16 @@ inline constexpr uint16_t IS_LOG_IDX_REC_FLAG_HAS_TOW = 1u << 0;
 /// reconstruct the totals.
 inline constexpr uint8_t IS_LOG_IDX_HDR_FLAG_FINALIZED = 1u << 0;
 
+/// Bit 1 (SN-8383, v2.1): per-record entries carry the trailing
+/// `local_uptime_ms` field (record_size == 32). Absent ⇒ plain v2.0 (24-byte
+/// records, no local delta).
+inline constexpr uint8_t IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA = 1u << 1;
+
+/// Bit 2 (SN-8340, v2.1): `capture_epoch_ms` in the header is set — a durable
+/// absolute host wall-clock (ms since Unix epoch) captured at log-open, so a
+/// log that never acquires GPS still has a real wall-clock anchor.
+inline constexpr uint8_t IS_LOG_IDX_HDR_FLAG_HAS_CAPTURE_EPOCH = 1u << 2;
+
 // ----- Structs (logical, not on-disk) --------------------------------------
 //
 // These mirror the on-disk layout 1:1, but we never serialize them via
@@ -113,7 +130,10 @@ struct is_log_idx_header_t {
     uint8_t  ts_source;             ///< 41    : `HeaderTimeSource`
     uint8_t  flags;                 ///< 42    : `IS_LOG_IDX_HDR_FLAG_*`
     uint8_t  reserved8;             ///< 43    : pad
-    uint8_t  reserved[20];          ///< 44..63: explicit pad to 64 bytes
+    uint16_t record_size;           ///< 44..45: on-disk per-record size in bytes (24=v2.0, 32=v2.1). 0 (pre-v2.1 header) ⇒ reader treats as 24. SN-8383.
+    uint16_t reserved16;            ///< 46..47: pad
+    uint64_t capture_epoch_ms;      ///< 48..55: absolute host wall-clock ms at log-open (0 = unset; valid only when HAS_CAPTURE_EPOCH). SN-8340.
+    uint8_t  reserved[8];           ///< 56..63: explicit pad to 64 bytes
 };
 
 /**
@@ -128,15 +148,20 @@ struct is_log_idx_record_v2_t {
     uint64_t offset;                ///<  8..15: byte offset into the `.raw` segment
     uint32_t did;                   ///< 16..19: data ID; 0 = no associated DID (raw stream)
     uint16_t flags;                 ///< 20..21: `IS_LOG_IDX_REC_FLAG_*`
-    uint16_t reserved;              ///< 22..23: pad
+    uint16_t reserved;              ///< 22..23: pad  — end of the v2.0 (24-byte) prefix
+    // ----- v2.1 trailing fields (present when header record_size == 32) -----
+    uint32_t local_uptime_ms;       ///< 24..27: host-uptime-since-log-start ms for THIS record, stamped by the writer for EVERY record (SN-8383). 0 on v2.0 records.
+    uint32_t reserved2;             ///< 28..31: pad to an 8-byte multiple
 };
 
 #pragma pack(pop)
 
 static_assert(sizeof(is_log_idx_header_t) == IS_LOG_IDX_HEADER_SIZE,
               "is_log_idx_header_t must be exactly 64 bytes — pack discipline.");
-static_assert(sizeof(is_log_idx_record_v2_t) == IS_LOG_IDX_RECORD_V2_SIZE,
-              "is_log_idx_record_v2_t must be exactly 24 bytes — pack discipline.");
+static_assert(sizeof(is_log_idx_record_v2_t) == IS_LOG_IDX_RECORD_V2_1_SIZE,
+              "is_log_idx_record_v2_t must be exactly 32 bytes (v2.1) — pack discipline.");
+static_assert(IS_LOG_IDX_RECORD_V2_SIZE == 24,
+              "v2.0 on-disk record prefix stays 24 bytes.");
 
 // ----- Pure serialize / parse helpers --------------------------------------
 //
@@ -167,21 +192,27 @@ ISExpected<is_log_idx_header_t> parseHeader(
     const uint8_t in[IS_LOG_IDX_HEADER_SIZE]) noexcept;
 
 /**
- * @brief Serialize a v2 record to a 24-byte little-endian buffer.
+ * @brief Serialize a record to a 32-byte v2.1 little-endian buffer.
  *
- * Always writes exactly `IS_LOG_IDX_RECORD_V2_SIZE` bytes.
+ * Always writes exactly `IS_LOG_IDX_RECORD_V2_1_SIZE` bytes (the full v2.1
+ * layout, including the trailing `local_uptime_ms`). All newly-written `.idx`
+ * files are v2.1-format; `record_size` in the header tells readers the stride.
  */
-void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_SIZE],
+void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_1_SIZE],
                      const is_log_idx_record_v2_t& rec) noexcept;
 
 /**
- * @brief Parse a 24-byte buffer into a v2 record.
+ * @brief Parse a little-endian buffer into a record.
  *
- * Pure layout decode — never fails. Caller is responsible for ensuring
- * the buffer was produced by `serializeRecord` (or matches v2 layout).
+ * Reads the 24-byte v2.0 prefix always; reads the trailing `local_uptime_ms`
+ * (SN-8383) only when `record_size >= IS_LOG_IDX_RECORD_V2_1_SIZE` (else it's
+ * left 0). `record_size` comes from the header (`hdr.record_size`, 0 ⇒ legacy
+ * 24). Pure layout decode — never fails; caller ensures `in` holds at least
+ * `record_size` bytes.
  */
 is_log_idx_record_v2_t parseRecord(
-    const uint8_t in[IS_LOG_IDX_RECORD_V2_SIZE]) noexcept;
+    const uint8_t* in,
+    std::size_t record_size = IS_LOG_IDX_RECORD_V2_1_SIZE) noexcept;
 
 // ----- File-level wrappers (cISLogFileBase) --------------------------------
 
@@ -213,11 +244,15 @@ ISExpected<void> writeRecord(cISLogFileBase& file, const is_log_idx_record_v2_t&
 ISExpected<is_log_idx_header_t> readHeader(cISLogFileBase& file);
 
 /**
- * @brief Read a single v2 record from the current file position.
- * @return `Truncated` if fewer than 24 bytes remained; `Io` on
+ * @brief Read a single record (`record_size` bytes) from the current file
+ *        position. Pass `hdr.record_size` (0 ⇒ legacy 24) so v2.0 and v2.1
+ *        files both stride correctly.
+ * @return `Truncated` if fewer than `record_size` bytes remained; `Io` on
  *         underlying read error.
  */
-ISExpected<is_log_idx_record_v2_t> readRecord(cISLogFileBase& file);
+ISExpected<is_log_idx_record_v2_t> readRecord(
+    cISLogFileBase& file,
+    std::size_t record_size = IS_LOG_IDX_RECORD_V2_1_SIZE);
 
 // ----- Convenience constructors --------------------------------------------
 
@@ -231,7 +266,8 @@ ISExpected<is_log_idx_record_v2_t> readRecord(cISLogFileBase& file);
  */
 is_log_idx_header_t makeDefaultHeader(uint32_t producer_version,
                                       TimestampUnits units,
-                                      HeaderTimeSource source) noexcept;
+                                      HeaderTimeSource source,
+                                      uint64_t capture_epoch_ms = 0) noexcept;
 
 } // namespace idx
 } // namespace inertial_sense

--- a/src/ISLogIndex.h
+++ b/src/ISLogIndex.h
@@ -209,10 +209,14 @@ void serializeRecord(uint8_t out[IS_LOG_IDX_RECORD_V2_1_SIZE],
  * left 0). `record_size` comes from the header (`hdr.record_size`, 0 ⇒ legacy
  * 24). Pure layout decode — never fails; caller ensures `in` holds at least
  * `record_size` bytes.
+ *
+ * @note No default `record_size`: the header's stride is authoritative for both
+ *       v2.0 (0 ⇒ 24) and v2.1 (32), and a wrong assumption silently mis-parses
+ *       (SN-8383). Callers pass `hdr.record_size` explicitly.
  */
 is_log_idx_record_v2_t parseRecord(
     const uint8_t* in,
-    std::size_t record_size = IS_LOG_IDX_RECORD_V2_1_SIZE) noexcept;
+    std::size_t record_size) noexcept;
 
 // ----- File-level wrappers (cISLogFileBase) --------------------------------
 
@@ -244,15 +248,17 @@ ISExpected<void> writeRecord(cISLogFileBase& file, const is_log_idx_record_v2_t&
 ISExpected<is_log_idx_header_t> readHeader(cISLogFileBase& file);
 
 /**
- * @brief Read a single record (`record_size` bytes) from the current file
- *        position. Pass `hdr.record_size` (0 ⇒ legacy 24) so v2.0 and v2.1
- *        files both stride correctly.
+ * @brief Read a single record from the current file position, striding by
+ *        `record_size` bytes. Pass `hdr.record_size` (0 ⇒ legacy 24) so v2.0
+ *        and v2.1 files both stride correctly; a future stride > 32 is consumed
+ *        whole (only the known prefix is parsed) so the stream stays aligned.
  * @return `Truncated` if fewer than `record_size` bytes remained; `Io` on
  *         underlying read error.
+ * @note No default `record_size` — see @ref parseRecord (SN-8383).
  */
 ISExpected<is_log_idx_record_v2_t> readRecord(
     cISLogFileBase& file,
-    std::size_t record_size = IS_LOG_IDX_RECORD_V2_1_SIZE);
+    std::size_t record_size);
 
 // ----- Convenience constructors --------------------------------------------
 

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -907,14 +907,20 @@ ISLogReader::detectGaps(const ISDeviceLog& log, const ISTimeResolver& resolver,
     std::vector<SegmentSpan> spans;
     spans.reserve(log.segmentCount());
 
+    // SN-8339: the resolver's arrival index is global across segments (in
+    // composition order), so accumulate each segment's base from the prior
+    // segments' record counts to key the multi-boot resolver per record.
+    uint64_t segArrivalBase = 0;
     for (std::size_t s = 0; s < log.segmentCount(); ++s) {
         bool      any = false;
         TimeStamp lo{};
         TimeStamp hi{};
+        uint64_t  recIdx = 0;
         for (auto v : log.segment(s).allRecords()) {
+            const uint64_t arrivalIndex = segArrivalBase + recIdx++;
             const uint64_t raw = v.timestamp().value;
             if (raw == 0) continue;                       // metadata / sentinel
-            const TimeStamp r = resolver.resolve(raw, devId);
+            const TimeStamp r = resolver.resolve(raw, devId, arrivalIndex);
             if (r.source == TimeSource::SessionOnly) continue;  // no wall-clock anchor
             if (r.value == 0) continue;
             if (!any || r.value < lo.value) lo = r;
@@ -928,6 +934,7 @@ ISLogReader::detectGaps(const ISDeviceLog& log, const ISTimeResolver& resolver,
             sp.end       = hi;
             spans.push_back(sp);
         }
+        segArrivalBase += recIdx;   // advance the global arrival base past this segment
     }
 
     auto gaps = findGaps(std::move(spans), thresholdMs);

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -353,7 +353,16 @@ ISExpected<ISLogReader> ISLogReader::construct(std::unique_ptr<ISLogSource> rawS
                         rebuildReason = RebuildReason::Corrupted;
                     } else {
                         const std::size_t bodyBytes = s.size() - bodyStart;
-                        const std::size_t nRecords  = bodyBytes / idx::IS_LOG_IDX_RECORD_V2_SIZE;
+                        // SN-8383: stride by the header's record_size (legacy v2.0 / pre-v2.1
+                        // headers carry 0 => 24). A future >32 record still strides correctly;
+                        // we parse only the v2.1 prefix we understand.
+                        const std::size_t recSize   = (hdr->record_size >= idx::IS_LOG_IDX_RECORD_V2_SIZE)
+                                                          ? hdr->record_size
+                                                          : idx::IS_LOG_IDX_RECORD_V2_SIZE;
+                        const std::size_t parseLen  = (recSize > idx::IS_LOG_IDX_RECORD_V2_1_SIZE)
+                                                          ? idx::IS_LOG_IDX_RECORD_V2_1_SIZE
+                                                          : recSize;
+                        const std::size_t nRecords  = bodyBytes / recSize;
 
                         // Stale-detection: if the header advertises a total_records that disagrees with what's
                         // physically present in the file body, the sidecar was truncated, partially overwritten, or
@@ -372,9 +381,9 @@ ISExpected<ISLogReader> ISLogReader::construct(std::unique_ptr<ISLogSource> rawS
                             std::vector<idx::is_log_idx_record_v2_t> recs;
                             recs.reserve(nRecords);
                             for (std::size_t i = 0; i < nRecords; ++i) {
-                                uint8_t recBuf[idx::IS_LOG_IDX_RECORD_V2_SIZE];
-                                std::memcpy(recBuf, s.data() + bodyStart + i * idx::IS_LOG_IDX_RECORD_V2_SIZE, idx::IS_LOG_IDX_RECORD_V2_SIZE);
-                                recs.push_back(idx::parseRecord(recBuf));
+                                uint8_t recBuf[idx::IS_LOG_IDX_RECORD_V2_1_SIZE];
+                                std::memcpy(recBuf, s.data() + bodyStart + i * recSize, parseLen);
+                                recs.push_back(idx::parseRecord(recBuf, parseLen));
                             }
 
                             // Poison sweep: pre-fix v2 .idx files baked the host's wall-clock value (~1.7e12 ms in 2026)
@@ -625,9 +634,9 @@ bool ISLogReader::persistIndex() const {
     if (!out) { std::error_code ec; fs::remove(tmpPath, ec); return false; }
 
     for (const auto& rec : records_) {
-        uint8_t recBuf[idx::IS_LOG_IDX_RECORD_V2_SIZE];
+        uint8_t recBuf[idx::IS_LOG_IDX_RECORD_V2_1_SIZE];
         idx::serializeRecord(recBuf, rec);
-        out.write(reinterpret_cast<const char*>(recBuf), idx::IS_LOG_IDX_RECORD_V2_SIZE);
+        out.write(reinterpret_cast<const char*>(recBuf), idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
         if (!out) { std::error_code ec; fs::remove(tmpPath, ec); return false; }
     }
     out.close();

--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -782,7 +782,7 @@ ISRecordView ISLogReader::viewAt(std::size_t recordIdx) const noexcept {
         dataLen = (endOff > off && endOff <= total) ? (endOff - off) : 0;
     }
 
-    return ISRecordView{
+    ISRecordView v{
         rec.did,
         rec.timestamp,
         deviceId_,
@@ -791,6 +791,8 @@ ISRecordView ISLogReader::viewAt(std::size_t recordIdx) const noexcept {
         dataLen,
         rec.flags,
     };
+    v.setLocalUptimeMs(rec.local_uptime_ms);   // SN-8383: carry the per-record delta onto the view
+    return v;
 }
 
 ISRecordView ISLogReader::RangeIterator::operator*() const noexcept {

--- a/src/ISLogWriter.cpp
+++ b/src/ISLogWriter.cpp
@@ -91,14 +91,12 @@ ISExpected<ISLogWriter> ISLogWriter::create(Options opts) {
     w.header_         = idx::makeDefaultHeader(kProducerVersion,
                                                opts.tsUnits,
                                                opts.tsSource);
-    // SN-8383: ISLogWriter is a derivative re-writer driven by ISRecordView,
-    // which does not carry the per-record host-uptime delta. It therefore cannot
-    // produce a meaningful `local_uptime_ms`, so it emits honest v2.0 (24-byte)
-    // records rather than 32-byte records with a permanently-zero delta and a
-    // clear HAS_LOCAL_DELTA flag. The live capture path (DeviceLog) is the v2.1
-    // delta producer. (If ISRecordView ever exposes the source delta, this can
-    // switch back to v2.1 and copy it through.)
-    w.header_.record_size = static_cast<uint16_t>(idx::IS_LOG_IDX_RECORD_V2_SIZE);
+    // SN-8383: the SDK always writes the current .idx version (v2.1); it never
+    // emits an older format. ISLogWriter carries each source record's
+    // per-record host-uptime delta through via ISRecordView::localUptimeMs()
+    // (see append()), so it declares HAS_LOCAL_DELTA. `record_size` stays at
+    // makeDefaultHeader's 32.
+    w.header_.flags |= idx::IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA;
 
     w.rawStream_.open(rawTmp,
                       std::ios::binary | std::ios::out | std::ios::trunc);
@@ -245,19 +243,20 @@ ISExpected<void> ISLogWriter::append(const ISRecordView& view) {
     rawOffset_ += bytes.second;
 
     idx::is_log_idx_record_v2_t rec{};
-    rec.timestamp = view.timestamp().value;
-    rec.offset    = recordOffset;
-    rec.did       = view.did();
-    rec.flags     = view.flags();
-    rec.reserved  = 0;
+    rec.timestamp       = view.timestamp().value;
+    rec.offset          = recordOffset;
+    rec.did             = view.did();
+    rec.flags           = view.flags();
+    rec.reserved        = 0;
+    rec.local_uptime_ms = view.localUptimeMs();   // SN-8383: carry the source's per-record delta through
 
-    // serializeRecord fills the full 32-byte v2.1 layout; ISLogWriter writes
-    // only the 24-byte v2.0 prefix (see header.record_size above). The trailing
-    // local_uptime_ms / reserved2 (both 0 here) are intentionally not emitted.
+    // Always write the full v2.1 (32-byte) record — the SDK never emits an
+    // older .idx version. The per-record delta is preserved from the source
+    // (0 only if the source itself was a v2.0 log with no delta).
     uint8_t buf[idx::IS_LOG_IDX_RECORD_V2_1_SIZE];
     idx::serializeRecord(buf, rec);
     idxStream_.write(reinterpret_cast<const char*>(buf),
-                     idx::IS_LOG_IDX_RECORD_V2_SIZE);
+                     idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
     if (!idxStream_.good()) {
         return fail(ISErrorCode::Io,
                     "ISLogWriter::append: short write on .idx");

--- a/src/ISLogWriter.cpp
+++ b/src/ISLogWriter.cpp
@@ -243,10 +243,10 @@ ISExpected<void> ISLogWriter::append(const ISRecordView& view) {
     rec.flags     = view.flags();
     rec.reserved  = 0;
 
-    uint8_t buf[idx::IS_LOG_IDX_RECORD_V2_SIZE];
+    uint8_t buf[idx::IS_LOG_IDX_RECORD_V2_1_SIZE];
     idx::serializeRecord(buf, rec);
     idxStream_.write(reinterpret_cast<const char*>(buf),
-                     idx::IS_LOG_IDX_RECORD_V2_SIZE);
+                     idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
     if (!idxStream_.good()) {
         return fail(ISErrorCode::Io,
                     "ISLogWriter::append: short write on .idx");

--- a/src/ISLogWriter.cpp
+++ b/src/ISLogWriter.cpp
@@ -91,6 +91,14 @@ ISExpected<ISLogWriter> ISLogWriter::create(Options opts) {
     w.header_         = idx::makeDefaultHeader(kProducerVersion,
                                                opts.tsUnits,
                                                opts.tsSource);
+    // SN-8383: ISLogWriter is a derivative re-writer driven by ISRecordView,
+    // which does not carry the per-record host-uptime delta. It therefore cannot
+    // produce a meaningful `local_uptime_ms`, so it emits honest v2.0 (24-byte)
+    // records rather than 32-byte records with a permanently-zero delta and a
+    // clear HAS_LOCAL_DELTA flag. The live capture path (DeviceLog) is the v2.1
+    // delta producer. (If ISRecordView ever exposes the source delta, this can
+    // switch back to v2.1 and copy it through.)
+    w.header_.record_size = static_cast<uint16_t>(idx::IS_LOG_IDX_RECORD_V2_SIZE);
 
     w.rawStream_.open(rawTmp,
                       std::ios::binary | std::ios::out | std::ios::trunc);
@@ -243,10 +251,13 @@ ISExpected<void> ISLogWriter::append(const ISRecordView& view) {
     rec.flags     = view.flags();
     rec.reserved  = 0;
 
+    // serializeRecord fills the full 32-byte v2.1 layout; ISLogWriter writes
+    // only the 24-byte v2.0 prefix (see header.record_size above). The trailing
+    // local_uptime_ms / reserved2 (both 0 here) are intentionally not emitted.
     uint8_t buf[idx::IS_LOG_IDX_RECORD_V2_1_SIZE];
     idx::serializeRecord(buf, rec);
     idxStream_.write(reinterpret_cast<const char*>(buf),
-                     idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
+                     idx::IS_LOG_IDX_RECORD_V2_SIZE);
     if (!idxStream_.good()) {
         return fail(ISErrorCode::Io,
                     "ISLogWriter::append: short write on .idx");

--- a/src/ISLogger.h
+++ b/src/ISLogger.h
@@ -123,7 +123,10 @@ public:
      * @param serials if non-empty, only devices whose serial number (as a string) appears in this
      *        list are loaded; the literal value "ALL" also matches every serial number found.
      * @return true if at least one device log was found and set up for reading, false otherwise.
+     * @note SN-7901: legacy read path. Prefer the D0021 reader stack —
+     *       `ISDeviceLog::fromSegments()` + `ISLogReader` / `ISRecordView`.
      */
+    [[deprecated("Legacy log-reader API (SN-7901). Use ISDeviceLog::fromSegments() with the ISLogReader / ISRecordView reader stack instead.")]]
     bool LoadFromDirectory(const std::string& directory, eLogType logType = LOGTYPE_RAW, std::vector<std::string> serials = {});
 
     /**
@@ -221,10 +224,15 @@ public:
      * @brief Read the next data set from @p devLogger, skipping over (and logging as errors) any corrupt records.
      * @param devLogger device log to read from; defaults to null, which returns null.
      * @return the next data set, or null if @p devLogger is null or no more data is available.
+     * @note SN-7901: legacy read path. Prefer the D0021 reader stack —
+     *       `ISDeviceLog::fromSegments()` + `ISLogReader` / `ISRecordView`.
      */
+    [[deprecated("Legacy log-reader API (SN-7901). Use ISDeviceLog::fromSegments() with the ISLogReader / ISRecordView reader stack instead.")]]
     p_data_buf_t* ReadData(std::shared_ptr<cDeviceLog> devLogger = nullptr);
 
-    /** @brief ReadData() overload that looks up the device by its index in DeviceLogs(). @return the next data set, or null if @p devIndex is out of range or no more data is available. */
+    /** @brief ReadData() overload that looks up the device by its index in DeviceLogs(). @return the next data set, or null if @p devIndex is out of range or no more data is available.
+     *  @note SN-7901: legacy read path — see the ReadData() overload above. */
+    [[deprecated("Legacy log-reader API (SN-7901). Use ISDeviceLog::fromSegments() with the ISLogReader / ISRecordView reader stack instead.")]]
     p_data_buf_t* ReadData(size_t devIndex);
 
     /**

--- a/src/ISRecordView.h
+++ b/src/ISRecordView.h
@@ -129,6 +129,28 @@ public:
      */
     constexpr uint16_t flags() const noexcept { return flags_; }
 
+    //! SN-8339: sentinel for "arrival index not assigned" (a bare reader view
+    //! that never passed through `ISDeviceLog`'s cross-segment iterator).
+    static constexpr uint64_t kNoArrivalIndex = UINT64_MAX;
+
+    /**
+     * Returns this record's global arrival index — its 0-based position in the
+     * device log's cross-segment arrival order (`ISDeviceLog::allRecords()`).
+     * Set by `ISDeviceLog`'s iterator; `kNoArrivalIndex` on a view obtained
+     * directly from a single-segment reader (no cross-segment context).
+     *
+     * SN-8339: this is the key the multi-boot resolver uses to select which
+     * power-on session's uptime->ToW offset bridges a session-uptime record —
+     * it matches `ISTimeResolver`'s own arrival numbering during its byte scan.
+     *
+     * @return  Global arrival index, or `kNoArrivalIndex` if unassigned.
+     */
+    constexpr uint64_t arrivalIndex() const noexcept { return arrivalIndex_; }
+
+    //! Stamp the global arrival index onto this view. Called by
+    //! `ISDeviceLog`'s cross-segment iterator; not normally used directly.
+    constexpr void setArrivalIndex(uint64_t idx) noexcept { arrivalIndex_ = idx; }
+
     /**
      * Returns the record's bytes as a (pointer, size) pair. The
      * pointer aliases the parent reader's mmap'd region; do not
@@ -174,9 +196,10 @@ private:
     uint64_t       timestampMs_ = 0;
     uint64_t       deviceId_    = 0;
     uint64_t       offset_      = 0;
-    const uint8_t* data_        = nullptr;
-    std::size_t    size_        = 0;
-    uint16_t       flags_       = 0;
+    const uint8_t* data_         = nullptr;
+    std::size_t    size_         = 0;
+    uint16_t       flags_        = 0;
+    uint64_t       arrivalIndex_ = kNoArrivalIndex;
 };
 
 /**
@@ -215,13 +238,15 @@ public:
                 uint64_t deviceId,
                 uint64_t offsetInFile,
                 std::vector<uint8_t> bytes,
-                uint16_t flags = 0)
+                uint16_t flags = 0,
+                uint64_t arrivalIndex = ISRecordView::kNoArrivalIndex)
         : did_(did),
           timestampMs_(timestampMs),
           deviceId_(deviceId),
           offset_(offsetInFile),
           bytes_(std::move(bytes)),
-          flags_(flags) {}
+          flags_(flags),
+          arrivalIndex_(arrivalIndex) {}
 
     /** @return  The record's DID, or 0 if untagged. */
     uint32_t did() const noexcept { return did_; }
@@ -245,6 +270,10 @@ public:
      *          source view at construction.
      */
     uint16_t flags() const noexcept { return flags_; }
+
+    /** @return  Global arrival index preserved from the source view, or
+     *           `ISRecordView::kNoArrivalIndex` if it was unassigned. */
+    uint64_t arrivalIndex() const noexcept { return arrivalIndex_; }
 
     /**
      * @return  `{ data, size }` over the owning buffer; `data` may
@@ -274,12 +303,14 @@ private:
     uint64_t             deviceId_    = 0;
     uint64_t             offset_      = 0;
     std::vector<uint8_t> bytes_;
-    uint16_t             flags_       = 0;
+    uint16_t             flags_        = 0;
+    uint64_t             arrivalIndex_ = ISRecordView::kNoArrivalIndex;
 };
 
 inline OwnedRecord ISRecordView::owned() const {
     std::vector<uint8_t> copy(data_, data_ + size_);
-    return OwnedRecord{ did_, timestampMs_, deviceId_, offset_, std::move(copy), flags_ };
+    return OwnedRecord{ did_, timestampMs_, deviceId_, offset_,
+                        std::move(copy), flags_, arrivalIndex_ };
 }
 
 } // namespace inertial_sense

--- a/src/ISRecordView.h
+++ b/src/ISRecordView.h
@@ -152,6 +152,20 @@ public:
     constexpr void setArrivalIndex(uint64_t idx) noexcept { arrivalIndex_ = idx; }
 
     /**
+     * SN-8383: host-uptime-since-log-start (ms) for THIS record, copied verbatim
+     * from the source `.idx` v2.1 record's `local_uptime_ms`. 0 when the source
+     * was v2.0 (which had no per-record delta). Surfacing it here lets a
+     * re-writer (`ISLogWriter`) carry the delta through bake/trim into its
+     * (always v2.1) output instead of emitting a zeroed field.
+     *
+     * @return  Per-record host-uptime delta in ms (0 if the source lacked it).
+     */
+    constexpr uint32_t localUptimeMs() const noexcept { return localUptimeMs_; }
+
+    //! Stamp the per-record host-uptime delta onto this view. Called by `ISLogReader`.
+    constexpr void setLocalUptimeMs(uint32_t ms) noexcept { localUptimeMs_ = ms; }
+
+    /**
      * Returns the record's bytes as a (pointer, size) pair. The
      * pointer aliases the parent reader's mmap'd region; do not
      * dereference after the reader is destroyed or moved-from.
@@ -200,6 +214,7 @@ private:
     std::size_t    size_         = 0;
     uint16_t       flags_        = 0;
     uint64_t       arrivalIndex_ = kNoArrivalIndex;
+    uint32_t       localUptimeMs_ = 0;   //!< SN-8383: per-record host-uptime delta from the source v2.1 .idx.
 };
 
 /**
@@ -239,14 +254,16 @@ public:
                 uint64_t offsetInFile,
                 std::vector<uint8_t> bytes,
                 uint16_t flags = 0,
-                uint64_t arrivalIndex = ISRecordView::kNoArrivalIndex)
+                uint64_t arrivalIndex = ISRecordView::kNoArrivalIndex,
+                uint32_t localUptimeMs = 0)
         : did_(did),
           timestampMs_(timestampMs),
           deviceId_(deviceId),
           offset_(offsetInFile),
           bytes_(std::move(bytes)),
           flags_(flags),
-          arrivalIndex_(arrivalIndex) {}
+          arrivalIndex_(arrivalIndex),
+          localUptimeMs_(localUptimeMs) {}
 
     /** @return  The record's DID, or 0 if untagged. */
     uint32_t did() const noexcept { return did_; }
@@ -274,6 +291,10 @@ public:
     /** @return  Global arrival index preserved from the source view, or
      *           `ISRecordView::kNoArrivalIndex` if it was unassigned. */
     uint64_t arrivalIndex() const noexcept { return arrivalIndex_; }
+
+    /** @return  SN-8383 per-record host-uptime delta (ms) preserved from the
+     *           source view; 0 if the source `.idx` was v2.0. */
+    uint32_t localUptimeMs() const noexcept { return localUptimeMs_; }
 
     /**
      * @return  `{ data, size }` over the owning buffer; `data` may
@@ -305,12 +326,13 @@ private:
     std::vector<uint8_t> bytes_;
     uint16_t             flags_        = 0;
     uint64_t             arrivalIndex_ = ISRecordView::kNoArrivalIndex;
+    uint32_t             localUptimeMs_ = 0;   //!< SN-8383: per-record host-uptime delta.
 };
 
 inline OwnedRecord ISRecordView::owned() const {
     std::vector<uint8_t> copy(data_, data_ + size_);
     return OwnedRecord{ did_, timestampMs_, deviceId_, offset_,
-                        std::move(copy), flags_, arrivalIndex_ };
+                        std::move(copy), flags_, arrivalIndex_, localUptimeMs_ };
 }
 
 } // namespace inertial_sense

--- a/src/ISTimeResolver.cpp
+++ b/src/ISTimeResolver.cpp
@@ -121,10 +121,26 @@ double slopeBetween(const ISSyncPoint& a, const ISSyncPoint& b) noexcept {
  *
  * @note SN-8107 / D0066.
  */
+//! SN-8339: accumulates one power-on session during the arrival-order scan.
+struct SessionAccum {
+    uint64_t             arrivalStart = 0;   //!< global arrival index of the session's first record
+    std::vector<int64_t> upOffsets;          //!< synced SYS_PARAMS (ToW - upTime) samples in this session
+};
+
+//! Median of a copy (sorts in place); 0 for empty.
+int64_t medianOf(std::vector<int64_t> v) {
+    if (v.empty()) return 0;
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+
 void scanSegmentForSyncs(const ISLogReader& reader,
                          uint64_t deviceId,
                          std::vector<ISSyncPoint>& out,
-                         std::vector<int64_t>& upOffsetsOut) {
+                         std::vector<int64_t>& upOffsetsOut,
+                         uint64_t& arrivalIndex,
+                         double& prevUpTimeSec,
+                         std::vector<SessionAccum>& sessAccum) {
     auto bytes = reader.rawBytes();
     if (!bytes.first || bytes.second == 0) return;
 
@@ -145,6 +161,9 @@ void scanSegmentForSyncs(const ISLogReader& reader,
             continue;
         }
         const auto& hdr = comm.rxPkt.dataHdr;
+        // SN-8339: global record-arrival index (matches ISDeviceLog's ISB-only,
+        // arrival-ordered record stream — both parse the same .raw for ISB).
+        const uint64_t thisArrival = arrivalIndex++;
 
         // SN-8323 (uptime unification): DID_SYS_PARAMS carries BOTH the GPS
         // time-of-week (timeOfWeekMs) and the definitive system uptime (upTime,
@@ -159,6 +178,17 @@ void scanSegmentForSyncs(const ISLogReader& reader,
             hdr.offset == 0 && hdr.size >= sizeof(sys_params_t)) {
             sys_params_t sp2{};
             std::memcpy(&sp2, comm.rxPkt.data.ptr, sizeof(sp2));
+            // SN-8339: a SYS_PARAMS.upTime that DROPS relative to the previous
+            // SYS_PARAMS (in arrival order) means the device rebooted — open a
+            // new power-on session starting at this record. (Checked on every
+            // SYS_PARAMS, regardless of GPS-time validity, since a fresh boot is
+            // typically pre-fix.)
+            if (sp2.upTime > 0.0) {
+                if (prevUpTimeSec >= 0.0 && sp2.upTime < prevUpTimeSec - 0.5) {
+                    sessAccum.push_back(SessionAccum{ thisArrival, {} });
+                }
+                prevUpTimeSec = sp2.upTime;
+            }
             // Only trust timeOfWeekMs as GPS ToW when the device says so:
             // HDW_STATUS_GNSS_TIME_OF_WEEK_VALID. Otherwise timeOfWeekMs is
             // LOCAL system time (uptime-like), and differencing it against
@@ -167,8 +197,9 @@ void scanSegmentForSyncs(const ISLogReader& reader,
                 (sp2.hdwStatus & HDW_STATUS_GNSS_TIME_OF_WEEK_VALID) != 0;
             if (towValid && sp2.timeOfWeekMs > 0 && sp2.upTime > 0.0) {
                 const int64_t upMs = static_cast<int64_t>(sp2.upTime * 1000.0);
-                upOffsetsOut.push_back(
-                    static_cast<int64_t>(sp2.timeOfWeekMs) - upMs);
+                const int64_t off  = static_cast<int64_t>(sp2.timeOfWeekMs) - upMs;
+                upOffsetsOut.push_back(off);                       // global (SN-8323) offset samples
+                if (!sessAccum.empty()) sessAccum.back().upOffsets.push_back(off);  // per-session (SN-8339)
             }
         }
 
@@ -273,17 +304,44 @@ uint32_t chooseAnchorWeek(const std::vector<ISSyncPoint>& syncs) {
 // ============================================================
 
 std::vector<ISSyncPoint> ISTimeResolver::detectSyncPoints(const ISDeviceLog& log) {
-    std::vector<int64_t> upOffsets;  // discarded here; build() consumes them.
-    return detectSyncPointsImpl(log, upOffsets);
+    std::vector<int64_t> upOffsets;   // discarded here; build() consumes them.
+    std::vector<Session> sessions;    // discarded here.
+    return detectSyncPointsImpl(log, upOffsets, sessions);
 }
 
 std::vector<ISSyncPoint> ISTimeResolver::detectSyncPointsImpl(
-    const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut) {
+    const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut,
+    std::vector<Session>& sessionsOut) {
     std::vector<ISSyncPoint> out;
     const uint64_t deviceId = log.deviceId();
 
+    // SN-8339: partition records into power-on sessions during the scan. The
+    // first session starts at arrival index 0; each SYS_PARAMS.upTime drop opens
+    // another. Arrival index is global across segments (matches allRecords()).
+    uint64_t arrivalIndex  = 0;
+    double   prevUpTimeSec = -1.0;
+    std::vector<SessionAccum> sessAccum;
+    sessAccum.push_back(SessionAccum{ 0, {} });
+
     for (std::size_t s = 0; s < log.segmentCount(); ++s) {
-        scanSegmentForSyncs(log.segment(s), deviceId, out, upOffsetsOut);
+        scanSegmentForSyncs(log.segment(s), deviceId, out, upOffsetsOut,
+                            arrivalIndex, prevUpTimeSec, sessAccum);
+    }
+
+    // Finalize sessions: arrivalEnd = next session's start - 1 (last record for
+    // the final session); per-session offset = median of its own SYS_PARAMS
+    // samples (haveOffset=false when it had none — build() fills the fallback).
+    const uint64_t lastArrival = (arrivalIndex == 0) ? 0 : arrivalIndex - 1;
+    for (std::size_t i = 0; i < sessAccum.size(); ++i) {
+        Session sess{};
+        sess.arrivalStart = sessAccum[i].arrivalStart;
+        sess.arrivalEnd   = (i + 1 < sessAccum.size())
+                                ? (sessAccum[i + 1].arrivalStart - 1)
+                                : lastArrival;
+        sess.haveOffset   = !sessAccum[i].upOffsets.empty();
+        sess.uptimeToTowOffsetMs =
+            sess.haveOffset ? medianOf(sessAccum[i].upOffsets) : 0;
+        sessionsOut.push_back(sess);
     }
 
     // Sort by hostTimeMs (the build's downstream expectation). Records
@@ -319,7 +377,8 @@ ISTimeResolver::build(const ISDeviceLog& log) {
 ISExpected<ISTimeResolver>
 ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
     std::vector<int64_t> upOffsets;
-    auto syncs = detectSyncPointsImpl(log, upOffsets);
+    std::vector<Session> sessions;
+    auto syncs = detectSyncPointsImpl(log, upOffsets, sessions);
 
     std::vector<Discontinuity> discs;
     if (syncs.size() >= 3) {
@@ -371,16 +430,36 @@ ISTimeResolver::build(const ISDeviceLog& log, double threshold) {
         haveUptimeOffset    = true;
     }
 
+    // SN-8339: a session with no synced SYS_PARAMS of its own inherits the
+    // log-global offset (best available) rather than 0, so its uptime records
+    // still bridge; sessions with their own samples keep their per-session median.
+    for (auto& sess : sessions) {
+        if (!sess.haveOffset && haveUptimeOffset) {
+            sess.uptimeToTowOffsetMs = uptimeToTowOffsetMs;
+            sess.haveOffset          = true;
+        }
+    }
+
     return ISTimeResolver{ std::move(syncs), std::move(discs), anchorWeek,
                            anchorTowStart, anchorTowEnd,
-                           uptimeToTowOffsetMs, haveUptimeOffset };
+                           uptimeToTowOffsetMs, haveUptimeOffset,
+                           std::move(sessions) };
 }
 
 // ============================================================
 // Resolve
 // ============================================================
 
-TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const {
+// SN-8339: the two public overloads are thin wrappers; all resolution logic
+// lives here, parameterized by the uptime->ToW bridge offset to use. The no-key
+// overload passes the log-global offset (byte-identical to pre-SN-8339
+// behavior); the arrival-keyed overload passes the per-session offset selected
+// from `sessions_`, so a uptime value from any power-on session bridges against
+// that session's own median rather than a single global offset that can only be
+// right for one boot.
+TimeStamp ISTimeResolver::resolveImpl(uint64_t hostTimeMs, uint64_t deviceId,
+                                      int64_t uptimeOffsetMs,
+                                      bool haveOffset) const {
     // SN-8115: idempotency / already-anchored guard. Legitimate raw inputs are
     // either a GPS time-of-week (always < one week, 604,800,000 ms) or a
     // session-uptime (ms since session start — at most hours). Neither can
@@ -433,14 +512,14 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
     // and stops tiny pre-sync ToW values from poisoning the bridge — the mag
     // records that used to resolve to the GPS-week start (days early) now land
     // correctly in the fix window. (Kyle 2026-07-23.)
-    if (haveUptimeOffset_ && epochAnchor && anchorTowEnd_ >= anchorTowStart_) {
+    if (haveOffset && epochAnchor && anchorTowEnd_ >= anchorTowStart_) {
         const int64_t guard    = static_cast<int64_t>(kPreFixGuardMs);
         const int64_t lo       = static_cast<int64_t>(anchorTowStart_);
         const int64_t hi       = static_cast<int64_t>(anchorTowEnd_);
         const int64_t raw      = static_cast<int64_t>(hostTimeMs);
         const bool    rawIsTow = (raw >= lo - guard && raw <= hi + guard);
         if (!rawIsTow) {
-            const int64_t bridged = raw + uptimeToTowOffsetMs_;
+            const int64_t bridged = raw + uptimeOffsetMs;
             if (bridged >= lo - guard && bridged <= hi + guard) {
                 const uint64_t towMs = (bridged < 0) ? 0u
                                                      : static_cast<uint64_t>(bridged);
@@ -537,6 +616,33 @@ TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const 
     return TimeStamp::fromResolvedViaSync(unixOrToW(static_cast<uint64_t>(tow)),
                                           deviceId,
                                           TimeConfidence::Interpolated);
+}
+
+TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId) const {
+    // No arrival key: bridge with the log-global uptime offset. Byte-identical
+    // to the pre-SN-8339 single-offset behavior — every existing caller keeps
+    // its exact results and multi-boot logs simply use one offset (best effort).
+    return resolveImpl(hostTimeMs, deviceId, uptimeToTowOffsetMs_,
+                       haveUptimeOffset_);
+}
+
+TimeStamp ISTimeResolver::resolve(uint64_t hostTimeMs, uint64_t deviceId,
+                                  uint64_t arrivalIndex) const {
+    // SN-8339: with a known arrival index and more than one power-on session,
+    // pick the session whose arrival range covers this record and bridge with
+    // that session's own offset. A single-session log (the common case) is
+    // identical to the no-key path, so this overload is a strict superset.
+    if (sessions_.size() > 1) {
+        for (const auto& sess : sessions_) {
+            if (arrivalIndex >= sess.arrivalStart &&
+                arrivalIndex <= sess.arrivalEnd) {
+                return resolveImpl(hostTimeMs, deviceId,
+                                   sess.uptimeToTowOffsetMs, sess.haveOffset);
+            }
+        }
+    }
+    return resolveImpl(hostTimeMs, deviceId, uptimeToTowOffsetMs_,
+                       haveUptimeOffset_);
 }
 
 ISTimeResolver::Stats ISTimeResolver::computeStats(const ISDeviceLog& log) const {

--- a/src/ISTimeResolver.h
+++ b/src/ISTimeResolver.h
@@ -74,6 +74,25 @@ public:
     };
 
     /**
+     * @brief SN-8339: one power-on session, delimited by a `SYS_PARAMS.upTime`
+     *        drop (device reboot) in arrival order.
+     *
+     * Each session owns its own uptime->ToW offset because uptime resets to ~0
+     * on every boot while GPS ToW continues — so a single global offset (the
+     * pre-SN-8339 model) mis-resolves every session after the first, and a small
+     * session-uptime value can't pick its session by value alone. The
+     * arrival-keyed `resolve()` overload selects the session whose
+     * `[arrivalStart, arrivalEnd]` window (in the device's global record-arrival
+     * order) contains the record's arrival index.
+     */
+    struct Session {
+        uint64_t arrivalStart        = 0;      //!< first record's global arrival index (inclusive)
+        uint64_t arrivalEnd          = 0;      //!< last record's global arrival index (inclusive)
+        int64_t  uptimeToTowOffsetMs = 0;      //!< this session's median uptime->ToW offset
+        bool     haveOffset          = false;  //!< a synced SYS_PARAMS gave this session an offset
+    };
+
+    /**
      * @brief Diagnostic counters from `computeStats(deviceLog)`.
      *
      * Counts of the per-record confidence outcomes when resolving
@@ -172,6 +191,30 @@ public:
     TimeStamp resolve(uint64_t hostTimeMs, uint64_t deviceId) const;
 
     /**
+     * @brief SN-8339: arrival-keyed resolve for multi-boot logs.
+     *
+     * Identical to `resolve(hostTimeMs, deviceId)` EXCEPT that, when the log has
+     * more than one power-on session, `arrivalIndex` (the record's position in
+     * the device's global record-arrival order) selects which session's
+     * uptime->ToW offset bridges a session-uptime input — resolving the
+     * ambiguity where the same small uptime value occurs in two sessions. With a
+     * single session (or an out-of-range key), this is byte-identical to the
+     * no-key overload, so existing callers that don't pass a key are unaffected.
+     *
+     * @param hostTimeMs   Record's `.idx` timestamp field.
+     * @param deviceId     Source device id.
+     * @param arrivalIndex Record's global arrival index (see `ISRecordView`).
+     */
+    TimeStamp resolve(uint64_t hostTimeMs, uint64_t deviceId,
+                      uint64_t arrivalIndex) const;
+
+    /**
+     * @return  Per-power-on sessions detected during build (SN-8339), in
+     *          arrival order. Size 1 for a single-boot log.
+     */
+    const std::vector<Session>& sessions() const noexcept { return sessions_; }
+
+    /**
      * @return  Sync points used to build this resolver, sorted by
      *          `hostTimeMs`. Lifetime tied to the resolver.
      */
@@ -201,20 +244,30 @@ private:
                             uint64_t anchorTowStart,
                             uint64_t anchorTowEnd,
                             int64_t  uptimeToTowOffsetMs,
-                            bool     haveUptimeOffset) noexcept
+                            bool     haveUptimeOffset,
+                            std::vector<Session> sessions = {}) noexcept
         : syncPoints_(std::move(syncs)),
           discontinuities_(std::move(discs)),
           anchorWeek_(anchorWeek),
           anchorTowStart_(anchorTowStart),
           anchorTowEnd_(anchorTowEnd),
           uptimeToTowOffsetMs_(uptimeToTowOffsetMs),
-          haveUptimeOffset_(haveUptimeOffset) {}
+          haveUptimeOffset_(haveUptimeOffset),
+          sessions_(std::move(sessions)) {}
 
     //! Core detection: scans all segments for sync points AND (SN-8323 uptime
     //! unification) authoritative uptime->ToW offset samples from DID_SYS_PARAMS.
     //! `detectSyncPoints` and `build` both delegate here.
     static std::vector<ISSyncPoint> detectSyncPointsImpl(
-        const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut);
+        const ISDeviceLog& log, std::vector<int64_t>& upOffsetsOut,
+        std::vector<Session>& sessionsOut);
+
+    //! SN-8339: shared resolve body, parameterized on the uptime->ToW offset so
+    //! both the global (no-key) path and the per-session (arrival-keyed) path
+    //! reuse identical logic. `resolve(h,d)` passes the global offset; the
+    //! arrival-keyed overload passes the selected session's offset.
+    TimeStamp resolveImpl(uint64_t hostTimeMs, uint64_t deviceId,
+                          int64_t uptimeOffsetMs, bool haveOffset) const;
 
     std::vector<ISSyncPoint>    syncPoints_;
     std::vector<Discontinuity>  discontinuities_;
@@ -241,6 +294,10 @@ private:
     int64_t                     uptimeToTowOffsetMs_ = 0;
     //! True when a synced DID_SYS_PARAMS gave a usable uptime->ToW offset.
     bool                        haveUptimeOffset_ = false;
+    //! SN-8339: per-power-on sessions (reboot = SYS_PARAMS.upTime drop in
+    //! arrival order). Size 1 for a single-boot log; the arrival-keyed resolve()
+    //! overload uses per-session offsets when size > 1.
+    std::vector<Session>        sessions_;
 };
 
 } // namespace inertial_sense

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,14 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 17)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# SN-7901: some tests deliberately exercise the now-[[deprecated]] legacy
+# log-reader API (cISLogger::LoadFromDirectory / ReadData). Suppress the
+# deprecation warnings here to match the SDK core's -Wno-deprecated-declarations
+# convention (CMakeLists.txt); the attribute still signals downstream consumers.
+if(NOT WIN32)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-declarations)
+endif()
+
 # Link IS-SDK libraries to the executable
 include(${IS_SDK_DIR}/include_is_sdk_target_link_libraries.cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ if(WIN32)   # These do not run in Windows
     list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_ISHttpRequest.cpp")
     list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_md5.cpp")
     list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_time_resolver.cpp")
+    list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_v21_e2e.cpp")
     list(FILTER TESTS_SOURCES EXCLUDE REGEX "test_truncated_log.cpp")
     # NOTE (SN-8328): only *some* of this PR's tests are POSIX-only and excluded
     # above (test_log_reader/test_log_writer/test_truncated_log — they use

--- a/tests/test_device_log.cpp
+++ b/tests/test_device_log.cpp
@@ -212,6 +212,44 @@ TEST(ISDeviceLog, SegmentBoundaryCallbackFires) {
     teardown(f);
 }
 
+// SN-8339 — the cross-segment iterator stamps a dense global arrival index
+// (0..N-1 in composition order), and a per-DID filtered range carries the SAME
+// global index (not a per-DID local counter) so the multi-boot resolver keys
+// correctly regardless of which range produced the view.
+TEST(ISDeviceLog, StampsGlobalArrivalIndexAcrossSegments) {
+    auto f = buildSingleDeviceFixture("arrival", kSerialA, 1.0f, 256 * 1024);
+    ASSERT_GE(f.segmentsA.size(), 2u) << "need >=2 segments to prove global (not per-segment) index";
+
+    auto dl = ISDeviceLog::fromSegments(f.segmentsA);
+    ASSERT_TRUE(dl.has_value()) << dl.error().message;
+
+    // allRecords() yields a dense 0..N-1 arrival index, strictly in order.
+    std::vector<uint32_t> didByArrival(dl->recordCount(), 0u);
+    uint64_t expected = 0;
+    for (ISRecordView v : dl->allRecords()) {
+        ASSERT_LT(expected, dl->recordCount());
+        EXPECT_EQ(v.arrivalIndex(), expected);
+        didByArrival[expected] = v.did();
+        ++expected;
+    }
+    EXPECT_EQ(expected, dl->recordCount());
+
+    // A per-DID filtered range carries the GLOBAL arrival index — each view's
+    // index maps back to its own DID in the allRecords() ordering.
+    auto dids = dl->presentDids();
+    ASSERT_FALSE(dids.empty());
+    uint64_t checked = 0;
+    for (ISRecordView v : dl->records(dids.front())) {
+        ASSERT_NE(v.arrivalIndex(), ISRecordView::kNoArrivalIndex);
+        ASSERT_LT(v.arrivalIndex(), dl->recordCount());
+        EXPECT_EQ(didByArrival[v.arrivalIndex()], v.did());
+        ++checked;
+    }
+    EXPECT_EQ(checked, dl->records(dids.front()).size());
+
+    teardown(f);
+}
+
 // SN-8383 / SN-8340 — the live logger writes a v2.1 .idx: 32-byte records with
 // a per-record host-uptime delta (arrival-monotonic), and a durable capture
 // epoch + the two feature flags in the header.

--- a/tests/test_device_log.cpp
+++ b/tests/test_device_log.cpp
@@ -10,6 +10,8 @@
 #include "DeviceLog.h"
 #include "ISDeviceLog.h"
 #include "ISFileManager.h"
+#include "ISLogFile.h"      // cISLogFile (SN-8383/8340 .idx inspection)
+#include "ISLogIndex.h"     // idx::readHeader / readRecord / v2.1 flags
 #include "ISLogger.h"
 #include "test_data_utils.h"
 
@@ -206,6 +208,46 @@ TEST(ISDeviceLog, SegmentBoundaryCallbackFires) {
     for ([[maybe_unused]] ISRecordView v : dl->allRecords()) { /* drain */ }
     // For N segments we expect (N-1) boundary crossings.
     EXPECT_EQ(boundaryHits.load(), dl->segmentCount() - 1);
+
+    teardown(f);
+}
+
+// SN-8383 / SN-8340 — the live logger writes a v2.1 .idx: 32-byte records with
+// a per-record host-uptime delta (arrival-monotonic), and a durable capture
+// epoch + the two feature flags in the header.
+TEST(ISDeviceLog, WriterStampsV21LocalDeltaAndCaptureEpoch) {
+    using namespace inertial_sense::idx;
+    auto f = buildSingleDeviceFixture("v21", kSerialA, 0.3f, 1u << 30);  // one segment
+    ASSERT_FALSE(f.segmentsA.empty());
+
+    fs::path idxPath = f.segmentsA.front();
+    idxPath.replace_extension(".idx");
+    ASSERT_TRUE(fs::exists(idxPath)) << idxPath;
+
+    cISLogFile in(idxPath.string(), "rb");
+    ASSERT_TRUE(in.isOpened());
+    auto hdrR = readHeader(in);
+    ASSERT_TRUE(hdrR.has_value()) << hdrR.error().message;
+
+    // v2.1 header: 32-byte records, both feature flags, a real host wall-clock.
+    EXPECT_EQ(hdrR->record_size, IS_LOG_IDX_RECORD_V2_1_SIZE);
+    EXPECT_NE(hdrR->flags & IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA, 0u);
+    EXPECT_NE(hdrR->flags & IS_LOG_IDX_HDR_FLAG_HAS_CAPTURE_EPOCH, 0u);
+    EXPECT_GT(hdrR->capture_epoch_ms, 1'400'000'000'000ULL)   // > ~2014 => a real epoch, not uptime
+        << "capture_epoch_ms should be a recent host wall-clock (SN-8340)";
+    ASSERT_GT(hdrR->total_records, 0u);
+
+    // Per-record local_uptime_ms is present and arrival-monotonic (the host
+    // clock only advances). Not asserting non-zero: a very fast write could keep
+    // every delta within the same millisecond; monotonicity is the invariant.
+    uint64_t prev = 0;
+    for (uint64_t i = 0; i < hdrR->total_records; ++i) {
+        auto recR = readRecord(in, hdrR->record_size);
+        ASSERT_TRUE(recR.has_value()) << "record " << i << ": " << recR.error().message;
+        EXPECT_GE(recR->local_uptime_ms, prev)
+            << "local_uptime_ms must be arrival-monotonic (record " << i << ")";
+        prev = recR->local_uptime_ms;
+    }
 
     teardown(f);
 }

--- a/tests/test_log_bounds.cpp
+++ b/tests/test_log_bounds.cpp
@@ -365,15 +365,11 @@ TEST_F(LogBoundsTest, W1_SmallLogReadsBackAllRecordsViaFromSegments) {
 // boundaries, no duplication — and the resolved whole-log span must bridge all
 // segments.
 TEST_F(LogBoundsTest, W2_MultiSegmentRoundTripViaFromSegments) {
-    // TEMPORARILY SKIPPED (SN-8328 rotation follow-up): the physical-offset writer
-    // fix makes the reader TRUST each segment's sidecar, which exposes a
-    // pre-existing rotation-boundary bug — at a segment rotation the last-indexed
-    // record's .idx entry is flushed to the CLOSING segment while its data is
-    // written to the NEXT segment, so a trusted sidecar double-counts it (n=kN+1).
-    // Re-enabled by the rotation fix (flush-before-index + reset the file offset
-    // base in cDeviceLogRaw::CloseAllFiles). Single-segment logs are unaffected.
-    GTEST_SKIP() << "re-enable with the SN-8328 rotation-ordering fix";
-
+    // SN-8328: rotation-boundary integrity. The writer flushes/rotates BEFORE
+    // indexing each input buffer, so every record's .idx entry lands in the same
+    // segment as its data (no double-count across a rotation), and the offset
+    // base resets per segment. Each segment's sidecar is trusted; every record
+    // survives rotation exactly once.
     constexpr std::size_t kN = 4000;
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
     recs.reserve(kN);

--- a/tests/test_log_bounds.cpp
+++ b/tests/test_log_bounds.cpp
@@ -365,6 +365,15 @@ TEST_F(LogBoundsTest, W1_SmallLogReadsBackAllRecordsViaFromSegments) {
 // boundaries, no duplication — and the resolved whole-log span must bridge all
 // segments.
 TEST_F(LogBoundsTest, W2_MultiSegmentRoundTripViaFromSegments) {
+    // TEMPORARILY SKIPPED (SN-8328 rotation follow-up): the physical-offset writer
+    // fix makes the reader TRUST each segment's sidecar, which exposes a
+    // pre-existing rotation-boundary bug — at a segment rotation the last-indexed
+    // record's .idx entry is flushed to the CLOSING segment while its data is
+    // written to the NEXT segment, so a trusted sidecar double-counts it (n=kN+1).
+    // Re-enabled by the rotation fix (flush-before-index + reset the file offset
+    // base in cDeviceLogRaw::CloseAllFiles). Single-segment logs are unaffected.
+    GTEST_SKIP() << "re-enable with the SN-8328 rotation-ordering fix";
+
     constexpr std::size_t kN = 4000;
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
     recs.reserve(kN);

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -279,6 +279,92 @@ TEST(IdxFileIO, HeaderAndRecordRoundTripViaCISLogFile) {
     std::remove(path.c_str());
 }
 
+// SN-8383 back-compat: a genuine v2.0 .idx file (legacy header record_size==0,
+// 24-byte on-disk records) must read cleanly under the v2.1 reader — the reader
+// strides by the header's record_size (0 => 24), reads only the 24-byte prefix,
+// and leaves the v2.1 trailing local_uptime_ms zeroed. A v2.1 file (record_size
+// 32) reads its trailing field. Both directions in one test, side by side.
+TEST(IdxFileIO, V20AndV21FilesBothReadCleanly) {
+    // ---- v2.0 file: legacy header (record_size 0) + 24-byte records ----
+    const auto v20 = makeTmpPath("v20file");
+    {
+        cISLogFile out(v20, "wb");
+        ASSERT_TRUE(out.isOpened());
+        auto hdr = makeRoundTripHeader();
+        hdr.record_size   = 0;   // legacy: pre-v2.1 headers carry 0 here
+        hdr.total_records = 3;
+        hdr.flags         = IS_LOG_IDX_HDR_FLAG_FINALIZED;  // no v2.1 feature flags
+        ASSERT_TRUE(writeHeader(out, hdr).has_value());
+
+        // Write each record as its 24-byte v2.0 prefix ONLY (serialize the full
+        // 32-byte layout, persist just the prefix) — a true on-disk v2.0 record.
+        const is_log_idx_record_v2_t recs[3] = {
+            { 1000, 0,    0xAAAu, IS_LOG_IDX_REC_FLAG_HAS_TOW, 0, /*local_uptime*/ 111u },
+            { 2000, 4096, 0xBBBu, 0,                            0,                  222u },
+            { 3000, 8192, 0xCCCu, IS_LOG_IDX_REC_FLAG_HAS_TOW, 0,                  333u },
+        };
+        for (const auto& r : recs) {
+            uint8_t rbuf[IS_LOG_IDX_RECORD_V2_1_SIZE];
+            serializeRecord(rbuf, r);
+            ASSERT_EQ(out.write(rbuf, IS_LOG_IDX_RECORD_V2_SIZE),  // 24 bytes only
+                      IS_LOG_IDX_RECORD_V2_SIZE);
+        }
+    }
+    {
+        cISLogFile in(v20, "rb");
+        ASSERT_TRUE(in.isOpened());
+        auto hdrR = readHeader(in);
+        ASSERT_TRUE(hdrR.has_value()) << hdrR.error().message;
+        EXPECT_EQ(hdrR->record_size, 0u) << "legacy v2.0 header carries record_size 0";
+
+        const uint32_t stride = hdrR->record_size;  // 0 -> readRecord clamps to 24
+        const uint32_t wantDid[3] = { 0xAAAu, 0xBBBu, 0xCCCu };
+        const uint64_t wantOff[3] = { 0u, 4096u, 8192u };
+        for (int i = 0; i < 3; ++i) {
+            auto r = readRecord(in, stride);
+            ASSERT_TRUE(r.has_value()) << "record " << i << ": " << r.error().message;
+            EXPECT_EQ(r->did, wantDid[i]) << "record " << i;
+            EXPECT_EQ(r->offset, wantOff[i]) << "record " << i;
+            EXPECT_EQ(r->local_uptime_ms, 0u)
+                << "v2.0 record must have NO trailing delta (record " << i << ")";
+        }
+        // Reader consumed exactly header + 3*24 bytes; a 4th read hits EOF.
+        auto past = readRecord(in, stride);
+        EXPECT_FALSE(past.has_value());
+    }
+    std::remove(v20.c_str());
+
+    // ---- v2.1 file: header record_size 32 + 32-byte records w/ delta ----
+    const auto v21 = makeTmpPath("v21file");
+    {
+        cISLogFile out(v21, "wb");
+        ASSERT_TRUE(out.isOpened());
+        auto hdr = makeRoundTripHeader();
+        hdr.record_size   = IS_LOG_IDX_RECORD_V2_1_SIZE;  // 32
+        hdr.total_records = 2;
+        ASSERT_TRUE(writeHeader(out, hdr).has_value());
+        is_log_idx_record_v2_t r1{ 5000, 0,   0xD1u, IS_LOG_IDX_REC_FLAG_HAS_TOW, 0, 4444u };
+        is_log_idx_record_v2_t r2{ 6000, 512, 0xD2u, 0,                            0, 5555u };
+        ASSERT_TRUE(writeRecord(out, r1).has_value());  // writes full 32 bytes
+        ASSERT_TRUE(writeRecord(out, r2).has_value());
+    }
+    {
+        cISLogFile in(v21, "rb");
+        ASSERT_TRUE(in.isOpened());
+        auto hdrR = readHeader(in);
+        ASSERT_TRUE(hdrR.has_value());
+        EXPECT_EQ(hdrR->record_size, IS_LOG_IDX_RECORD_V2_1_SIZE);
+        auto a = readRecord(in, hdrR->record_size);
+        ASSERT_TRUE(a.has_value());
+        EXPECT_EQ(a->did, 0xD1u);
+        EXPECT_EQ(a->local_uptime_ms, 4444u) << "v2.1 record carries the trailing delta";
+        auto b = readRecord(in, hdrR->record_size);
+        ASSERT_TRUE(b.has_value());
+        EXPECT_EQ(b->local_uptime_ms, 5555u);
+    }
+    std::remove(v21.c_str());
+}
+
 TEST(IdxFileIO, TruncatedHeaderReturnsTruncated) {
     const auto path = makeTmpPath("trunc");
     // Write a file with only 32 bytes — half a header.

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -62,9 +62,10 @@ TEST(IdxLayout, StaticSizes) {
     // in the header but exercises it through gtest so we get a named
     // failure if some future struct edit breaks the discipline.
     EXPECT_EQ(sizeof(is_log_idx_header_t),    IS_LOG_IDX_HEADER_SIZE);
-    EXPECT_EQ(sizeof(is_log_idx_record_v2_t), IS_LOG_IDX_RECORD_V2_SIZE);
-    EXPECT_EQ(IS_LOG_IDX_HEADER_SIZE,    64u);
-    EXPECT_EQ(IS_LOG_IDX_RECORD_V2_SIZE, 24u);
+    EXPECT_EQ(sizeof(is_log_idx_record_v2_t), IS_LOG_IDX_RECORD_V2_1_SIZE);   // v2.1 struct = 32
+    EXPECT_EQ(IS_LOG_IDX_HEADER_SIZE,      64u);
+    EXPECT_EQ(IS_LOG_IDX_RECORD_V2_SIZE,   24u);   // v2.0 on-disk prefix (unchanged)
+    EXPECT_EQ(IS_LOG_IDX_RECORD_V2_1_SIZE, 32u);   // SN-8383 trailing local_uptime_ms + pad
 }
 
 TEST(IdxRoundTrip, HeaderSerializeAndParse) {
@@ -101,15 +102,23 @@ TEST(IdxRoundTrip, RecordSerializeAndParse) {
         /* did       */ 0x1234,
         /* flags     */ IS_LOG_IDX_REC_FLAG_HAS_TOW,
         /* reserved  */ 0,
+        /* local_uptime_ms */ 777u,
+        /* reserved2 */ 0,
     };
-    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
     serializeRecord(buf, src);
 
-    const auto parsed = parseRecord(buf);
-    EXPECT_EQ(parsed.timestamp, src.timestamp);
-    EXPECT_EQ(parsed.offset,    src.offset);
-    EXPECT_EQ(parsed.did,       src.did);
-    EXPECT_EQ(parsed.flags,     src.flags);
+    const auto parsed = parseRecord(buf);   // default record_size = v2.1 (32)
+    EXPECT_EQ(parsed.timestamp,       src.timestamp);
+    EXPECT_EQ(parsed.offset,          src.offset);
+    EXPECT_EQ(parsed.did,             src.did);
+    EXPECT_EQ(parsed.flags,           src.flags);
+    EXPECT_EQ(parsed.local_uptime_ms, src.local_uptime_ms);   // SN-8383 trailing field round-trips
+
+    // v2.0 back-compat: parsing only the 24-byte prefix leaves local_uptime_ms 0.
+    const auto parsed20 = parseRecord(buf, IS_LOG_IDX_RECORD_V2_SIZE);
+    EXPECT_EQ(parsed20.timestamp,       src.timestamp);
+    EXPECT_EQ(parsed20.local_uptime_ms, 0u);
 }
 
 TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
@@ -117,7 +126,8 @@ TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
     // single contiguous buffer. The reader walks: parseHeader at
     // offset 0, then parseRecord at offset 64, 64+24, 64+48, ....
     constexpr std::size_t N = 10;
-    std::vector<uint8_t> buf(IS_LOG_IDX_HEADER_SIZE + N * IS_LOG_IDX_RECORD_V2_SIZE, 0);
+    constexpr std::size_t REC = IS_LOG_IDX_RECORD_V2_1_SIZE;   // writer emits v2.1 (32-byte) records
+    std::vector<uint8_t> buf(IS_LOG_IDX_HEADER_SIZE + N * REC, 0);
 
     auto hdr = makeRoundTripHeader();
     hdr.total_records = N;
@@ -133,7 +143,7 @@ TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
         r.flags     = (i % 2 == 0) ? IS_LOG_IDX_REC_FLAG_HAS_TOW : 0;
         r.reserved  = 0;
         sources.push_back(r);
-        serializeRecord(buf.data() + IS_LOG_IDX_HEADER_SIZE + i * IS_LOG_IDX_RECORD_V2_SIZE, r);
+        serializeRecord(buf.data() + IS_LOG_IDX_HEADER_SIZE + i * REC, r);
     }
 
     auto parsedHdr = parseHeader(buf.data());
@@ -142,7 +152,7 @@ TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
 
     for (std::size_t i = 0; i < N; ++i) {
         const auto p = parseRecord(
-            buf.data() + IS_LOG_IDX_HEADER_SIZE + i * IS_LOG_IDX_RECORD_V2_SIZE);
+            buf.data() + IS_LOG_IDX_HEADER_SIZE + i * REC);
         EXPECT_EQ(p.timestamp, sources[i].timestamp);
         EXPECT_EQ(p.offset,    sources[i].offset);
         EXPECT_EQ(p.did,       sources[i].did);
@@ -316,7 +326,7 @@ TEST(IdxRecordRange, LargeOffsetRoundTrip) {
     // >4GB (i.e. wouldn't fit in v1's u32) round-trips cleanly.
     constexpr uint64_t big_offset = 0x0000'0001'0000'0000ULL;  // 4 GiB exactly
     is_log_idx_record_v2_t src{ 1234, big_offset, 100, 0, 0 };
-    uint8_t buf[IS_LOG_IDX_RECORD_V2_SIZE];
+    uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
     serializeRecord(buf, src);
     auto p = parseRecord(buf);
     EXPECT_EQ(p.offset, big_offset);
@@ -682,8 +692,11 @@ TEST(IdxIntegration, ISLoggerMultiSegmentRotationProducesValidIdxPerSegment) {
         EXPECT_NE(hdrR->flags & IS_LOG_IDX_HDR_FLAG_FINALIZED, 0u)
             << f.name << ": each segment must be finalized";
 
+        // SN-8383: the writer now emits v2.1 (32-byte) records; use the header's
+        // record_size (authoritative) rather than a hard-coded stride.
+        EXPECT_EQ(hdrR->record_size, IS_LOG_IDX_RECORD_V2_1_SIZE) << f.name;
         const size_t expectedFromSize =
-            (f.size - IS_LOG_IDX_HEADER_SIZE) / IS_LOG_IDX_RECORD_V2_SIZE;
+            (f.size - IS_LOG_IDX_HEADER_SIZE) / hdrR->record_size;
         EXPECT_EQ(hdrR->total_records, expectedFromSize)
             << f.name << ": header total_records must match on-disk record count "
                          "(= file_size - header) / record_size";

--- a/tests/test_log_index.cpp
+++ b/tests/test_log_index.cpp
@@ -108,7 +108,7 @@ TEST(IdxRoundTrip, RecordSerializeAndParse) {
     uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
     serializeRecord(buf, src);
 
-    const auto parsed = parseRecord(buf);   // default record_size = v2.1 (32)
+    const auto parsed = parseRecord(buf, IS_LOG_IDX_RECORD_V2_1_SIZE);   // full v2.1 stride (32)
     EXPECT_EQ(parsed.timestamp,       src.timestamp);
     EXPECT_EQ(parsed.offset,          src.offset);
     EXPECT_EQ(parsed.did,             src.did);
@@ -152,7 +152,7 @@ TEST(IdxRoundTrip, ManyRecordsViaContiguousBuffer) {
 
     for (std::size_t i = 0; i < N; ++i) {
         const auto p = parseRecord(
-            buf.data() + IS_LOG_IDX_HEADER_SIZE + i * REC);
+            buf.data() + IS_LOG_IDX_HEADER_SIZE + i * REC, REC);
         EXPECT_EQ(p.timestamp, sources[i].timestamp);
         EXPECT_EQ(p.offset,    sources[i].offset);
         EXPECT_EQ(p.did,       sources[i].did);
@@ -261,17 +261,17 @@ TEST(IdxFileIO, HeaderAndRecordRoundTripViaCISLogFile) {
         EXPECT_EQ(hdrR->version, IS_LOG_IDX_VERSION_V2);
         EXPECT_EQ(hdrR->total_records, 3u);
 
-        auto a = readRecord(in);
+        auto a = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
         ASSERT_TRUE(a.has_value());
         EXPECT_EQ(a->did, 0xAAAu);
         EXPECT_EQ(a->flags, IS_LOG_IDX_REC_FLAG_HAS_TOW);
 
-        auto b = readRecord(in);
+        auto b = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
         ASSERT_TRUE(b.has_value());
         EXPECT_EQ(b->did, 0xBBBu);
         EXPECT_EQ(b->flags, 0u);
 
-        auto c = readRecord(in);
+        auto c = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
         ASSERT_TRUE(c.has_value());
         EXPECT_EQ(c->did, 0xCCCu);
         EXPECT_EQ(c->offset, 4096u);
@@ -400,7 +400,7 @@ TEST(IdxFileIO, TruncatedRecordReturnsTruncated) {
     cISLogFile in(path, "rb");
     ASSERT_TRUE(in.isOpened());
     ASSERT_TRUE(readHeader(in).has_value());
-    auto rec = readRecord(in);
+    auto rec = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
     ASSERT_FALSE(rec.has_value());
     EXPECT_EQ(rec.error().code, ISErrorCode::Truncated);
 
@@ -414,13 +414,13 @@ TEST(IdxRecordRange, LargeOffsetRoundTrip) {
     is_log_idx_record_v2_t src{ 1234, big_offset, 100, 0, 0 };
     uint8_t buf[IS_LOG_IDX_RECORD_V2_1_SIZE];
     serializeRecord(buf, src);
-    auto p = parseRecord(buf);
+    auto p = parseRecord(buf, IS_LOG_IDX_RECORD_V2_1_SIZE);
     EXPECT_EQ(p.offset, big_offset);
 
     constexpr uint64_t huge_offset = 0xFFFF'FFFF'FFFF'0000ULL;
     src.offset = huge_offset;
     serializeRecord(buf, src);
-    p = parseRecord(buf);
+    p = parseRecord(buf, IS_LOG_IDX_RECORD_V2_1_SIZE);
     EXPECT_EQ(p.offset, huge_offset);
 }
 
@@ -519,15 +519,15 @@ TEST(IdxIntegration, EndToEndViaDeviceLogApi) {
     EXPECT_NE(hdrR->producer_version, 0u)
         << "producer_version must be filled from PROTOCOL_VERSION_CHAR0..3";
 
-    auto rec1 = readRecord(in);
+    auto rec1 = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
     ASSERT_TRUE(rec1.has_value());
     EXPECT_EQ(rec1->did, static_cast<uint32_t>(DID_DEV_INFO));
 
-    auto rec2 = readRecord(in);
+    auto rec2 = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
     ASSERT_TRUE(rec2.has_value());
     EXPECT_EQ(rec2->did, static_cast<uint32_t>(DID_INS_1));
 
-    auto rec3 = readRecord(in);
+    auto rec3 = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
     ASSERT_TRUE(rec3.has_value());
     EXPECT_EQ(rec3->did, static_cast<uint32_t>(DID_GNSS1_POS));
 
@@ -631,7 +631,7 @@ TEST(IdxIntegration, ISLoggerEndToEndProducesViableIdx) {
             << idxInfo.name << ": some ISB packets should have been indexed";
 
         for (uint32_t i = 0; i < hdrR->total_records; ++i) {
-            auto recR = readRecord(in);
+            auto recR = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
             ASSERT_TRUE(recR.has_value())
                 << idxInfo.name << " record " << i << ": "
                 << recR.error().message;
@@ -788,7 +788,7 @@ TEST(IdxIntegration, ISLoggerMultiSegmentRotationProducesValidIdxPerSegment) {
                          "(= file_size - header) / record_size";
 
         for (uint32_t i = 0; i < hdrR->total_records; ++i) {
-            auto rec = readRecord(in);
+            auto rec = readRecord(in, IS_LOG_IDX_RECORD_V2_1_SIZE);
             ASSERT_TRUE(rec.has_value())
                 << f.name << " record " << i << "/" << hdrR->total_records
                 << ": " << rec.error().message;

--- a/tests/test_log_reader.cpp
+++ b/tests/test_log_reader.cpp
@@ -439,7 +439,7 @@ TEST_F(LogReaderTest, GpsRawObsTimeTriggersRebuild) {
     ASSERT_GT(bytes.size(), IS_LOG_IDX_HEADER_SIZE + IS_LOG_IDX_RECORD_V2_SIZE);
 
     auto* recPtr = reinterpret_cast<uint8_t*>(bytes.data() + IS_LOG_IDX_HEADER_SIZE);
-    is_log_idx_record_v2_t r = parseRecord(recPtr);
+    is_log_idx_record_v2_t r = parseRecord(recPtr, IS_LOG_IDX_RECORD_V2_1_SIZE);
     r.did       = DID_GNSS1_RAW;
     r.timestamp = 1'700'000'000'000ULL;   // baked absolute obs-time — not a valid device-timeline value
     serializeRecord(recPtr, r);

--- a/tests/test_log_reader.cpp
+++ b/tests/test_log_reader.cpp
@@ -141,15 +141,13 @@ protected:
 TEST_F(LogReaderTest, OpenSegmentSucceeds) {
     auto r = ISLogReader::openSegment(f_.rawFile);
     ASSERT_TRUE(r.has_value()) << "openSegment failed: " << r.error().message;
-    // SN-8328 (B): this fixture is a ~1 MB cISLogger raw log, i.e. larger than
-    // one 128 KB chunk. The SDK writer stores chunk-relative .idx offsets that
-    // desync from the physical .raw offset past the first chunk flush (tracked
-    // as an SDK writer-offset follow-up). The reader's offset-sanity probe
-    // detects this and rebuilds the index from a full .raw scan, so
-    // hadOnDiskIndex() is false here — and the rebuilt index is correct, which
-    // the rest of this assertion set verifies. (A <128 KB log's writer index is
-    // trusted; RoundTripBitIdentical covers that path via ISLogWriter output.)
-    EXPECT_FALSE(r->hadOnDiskIndex());
+    // SN-8328: this fixture is a ~1 MB cISLogger raw log spanning several 128 KB
+    // chunks. The RAW writer now stamps each record's true physical .raw offset
+    // (m_fileSize + chunk fill + within-buffer position), so the offsets are
+    // monotonic and correct across chunk boundaries and the reader TRUSTS the
+    // on-disk sidecar — no rebuild. (Previously the writer stamped chunk-relative
+    // offsets that reset at each flush, forcing a scan-rebuild here.)
+    EXPECT_TRUE(r->hadOnDiskIndex());
     EXPECT_GT(r->recordCount(), 0u);
     EXPECT_EQ(r->header().magic[0], 'I');
     EXPECT_EQ(r->header().magic[3], 'X');

--- a/tests/test_log_writer.cpp
+++ b/tests/test_log_writer.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <list>
 #include <string>
 #include <vector>
@@ -170,6 +171,72 @@ TEST_F(LogWriterTest, RoundTripBitIdentical) {
             << "byte mismatch at record " << (i - 1);
     }
     EXPECT_EQ(i, inCount);
+}
+
+// ---------------------------------------------------------------------------
+// SN-8383: the writer always emits the current .idx version (v2.1) and carries
+// the source's per-record host-uptime delta through, declaring HAS_LOCAL_DELTA.
+// Guards against the writer emitting an older format or zeroing the delta.
+// ---------------------------------------------------------------------------
+TEST_F(LogWriterTest, PreservesLocalUptimeDeltaAndAlwaysWritesV21) {
+    fixture = buildFixture("delta");   // only needed for a scratch directory
+    ASSERT_FALSE(fixture.directory.empty());
+
+    // Drive the writer with synthetic views carrying known, non-zero per-record
+    // deltas. Benign (non-GNSS-raw) DIDs + small host-uptime timestamps keep the
+    // reader on its trust-the-sidecar path (no poison/obs-time rebuild), so we
+    // observe exactly what the writer emitted.
+    struct SrcRec { uint32_t did; uint64_t ts; uint16_t flags; uint32_t delta; std::vector<uint8_t> payload; };
+    const std::vector<SrcRec> src = {
+        { 4u, 1000u, idx::IS_LOG_IDX_REC_FLAG_HAS_TOW, 5u,    {1, 2, 3, 4} },
+        { 5u, 2000u, 0u,                                123u,  {9, 9}       },
+        { 4u, 3000u, 0u,                                4567u, {7, 7, 7}    },
+    };
+    const uint64_t devId = 0x42u;
+
+    const fs::path outRaw = fixture.directory / "delta_synth.raw";
+    {
+        auto writerR = ISLogWriter::create(outRaw, devId);
+        ASSERT_TRUE(writerR.has_value()) << writerR.error().message;
+        ISLogWriter writer = std::move(writerR.value());
+        for (const auto& r : src) {
+            ISRecordView v{ r.did, r.ts, devId, /*offset*/ 0u,
+                            r.payload.data(), r.payload.size(), r.flags };
+            v.setLocalUptimeMs(r.delta);
+            ASSERT_TRUE(writer.append(v).has_value());
+        }
+        ASSERT_TRUE(writer.finalize().has_value());
+    }
+
+    // Inspect the writer's on-disk .idx bytes directly — this is the writer's
+    // output contract. (Round-tripping through ISLogReader::openSegment would
+    // conflate the writer with the reader's .raw-validation / rebuild logic,
+    // which a synthetic garbage .raw would trip.)
+    fs::path outIdx = outRaw;
+    outIdx.replace_extension(".idx");
+    std::ifstream in(outIdx, std::ios::binary);
+    ASSERT_TRUE(in.good());
+    const std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+                                     std::istreambuf_iterator<char>());
+    ASSERT_GE(bytes.size(),
+              idx::IS_LOG_IDX_HEADER_SIZE + src.size() * idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
+
+    auto hdr = idx::parseHeader(bytes.data());
+    ASSERT_TRUE(hdr.has_value()) << hdr.error().message;
+
+    // Always v2.1: 32-byte stride + HAS_LOCAL_DELTA declared (never a downgrade).
+    EXPECT_EQ(hdr->record_size, idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
+    EXPECT_NE(0, hdr->flags & idx::IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA);
+    EXPECT_EQ(hdr->total_records, src.size());
+
+    // Each record, in write order, carries its source delta verbatim.
+    for (std::size_t i = 0; i < src.size(); ++i) {
+        const auto rec = idx::parseRecord(
+            bytes.data() + idx::IS_LOG_IDX_HEADER_SIZE + i * idx::IS_LOG_IDX_RECORD_V2_1_SIZE,
+            idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
+        EXPECT_EQ(rec.timestamp,       src[i].ts)    << "ts mismatch at record " << i;
+        EXPECT_EQ(rec.local_uptime_ms, src[i].delta) << "delta mismatch at record " << i;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -320,6 +320,70 @@ TEST_F(TimeResolverTest, UnsyncedSysParamsDoesNotEstablishOffset) {
 }
 
 // ---------------------------------------------------------------------------
+// SN-8339 — multi-boot: a mid-log power cycle resets the device's uptime while
+// GPS ToW keeps advancing, so a single global uptime->ToW offset can only be
+// right for one boot. The resolver must detect the reboot (SYS_PARAMS.upTime
+// drop in arrival order) into two sessions, each with its own offset, and the
+// arrival-keyed resolve() overload must bridge a uptime value against the offset
+// of the session that record belongs to.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, MultiBootSessionsBridgeUptimePerSession) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+
+    // --- Session 1: upTime ~100 s, ToW ~250,000 s (week 2300). ---
+    // Pre-sync record (week 1) must not anchor the log.
+    { ins_2_t p = makeIns2(0.9); p.week = 1; recs.emplace_back(DID_INS_2, bytesOf(p)); }
+    // Synced SYS_PARAMS: offset1 = 250,000,000 - 100,000 = 249,900,000 ms.
+    recs.emplace_back(DID_SYS_PARAMS, bytesOf(makeSysParams(100.0, 250'000'000u)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(250000.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(250100.0)));
+    // Session-1 magnetometer at uptime 100 s (bridges to 250,000,000 ms ToW).
+    recs.emplace_back(DID_MAGNETOMETER, bytesOf(makeMag(100.0)));
+
+    // --- Reboot: upTime drops 100 s -> 5 s. Session 2: ToW ~350,000 s. ---
+    // Synced SYS_PARAMS: offset2 = 350,000,000 - 5,000 = 349,995,000 ms.
+    recs.emplace_back(DID_SYS_PARAMS, bytesOf(makeSysParams(5.0, 350'000'000u)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(350000.0)));
+    recs.emplace_back(DID_INS_2, bytesOf(makeIns2(350100.0)));
+    // Session-2 magnetometer at uptime 5 s (bridges to 350,000,000 ms ToW).
+    recs.emplace_back(DID_MAGNETOMETER, bytesOf(makeMag(5.0)));
+
+    f = buildFixture("multiboot", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+
+    // Two power-on sessions detected, in arrival order, each with its own offset.
+    const auto& S = resolver->sessions();
+    ASSERT_EQ(S.size(), 2u) << "reboot (upTime drop) should split into 2 sessions";
+    EXPECT_LT(S[0].arrivalEnd, S[1].arrivalStart);
+    EXPECT_TRUE(S[0].haveOffset);
+    EXPECT_TRUE(S[1].haveOffset);
+    EXPECT_EQ(S[0].uptimeToTowOffsetMs, 249'900'000);
+    EXPECT_EQ(S[1].uptimeToTowOffsetMs, 349'995'000);
+
+    // Arrival-keyed resolve picks the covering session's offset.
+    // Session-1 uptime 100 s -> ToW 250,000,000 ms (via offset1).
+    auto t1 = resolver->resolve(100'000, kFixtureSerial, S[0].arrivalStart);
+    EXPECT_EQ(t1.value, expectedUnixMsForFixtureWeek(250'000'000ull, 2300));
+    EXPECT_NE(t1.source, TimeSource::SessionOnly);
+    // Session-2 uptime 5 s -> ToW 350,000,000 ms (via offset2).
+    auto t2 = resolver->resolve(5'000, kFixtureSerial, S[1].arrivalStart);
+    EXPECT_EQ(t2.value, expectedUnixMsForFixtureWeek(350'000'000ull, 2300));
+    EXPECT_NE(t2.source, TimeSource::SessionOnly);
+
+    // The arrival key matters: without it, the session-1 uptime bridges against
+    // the log-global offset (which the reboot makes wrong for session 1) and
+    // lands somewhere other than its true 250,000,000 ms — the exact multi-boot
+    // mis-resolution this overload fixes.
+    auto t1NoKey = resolver->resolve(100'000, kFixtureSerial);
+    EXPECT_NE(t1NoKey.value, t1.value);
+}
+
+// ---------------------------------------------------------------------------
 // Resolve between two sync points → Interpolated.
 // ---------------------------------------------------------------------------
 TEST_F(TimeResolverTest, ResolveInterpolated) {

--- a/tests/test_time_resolver.cpp
+++ b/tests/test_time_resolver.cpp
@@ -384,6 +384,39 @@ TEST_F(TimeResolverTest, MultiBootSessionsBridgeUptimePerSession) {
 }
 
 // ---------------------------------------------------------------------------
+// SN-8105 — ISDeviceLog::anchoredSpanStart/End route the raw first/last
+// timestamps through the resolver, so a GPS-anchored log reports absolute
+// wall-clock ms rather than the raw ToW/uptime value `spanStart/End` return.
+// ---------------------------------------------------------------------------
+TEST_F(TimeResolverTest, AnchoredSpanIsGpsAnchoredNotRaw) {
+    std::vector<std::pair<uint32_t, std::vector<uint8_t>>> recs;
+    for (double tow : { 100.0, 110.0, 120.0, 130.0 }) {
+        recs.emplace_back(DID_INS_2, bytesOf(makeIns2(tow)));
+    }
+    f = buildFixture("anchored_span", recs);
+    ASSERT_FALSE(f.rawFile.empty());
+
+    auto log = ISDeviceLog::fromSegments({ f.rawFile });
+    ASSERT_TRUE(log.has_value());
+    auto resolver = ISTimeResolver::build(log.value());
+    ASSERT_TRUE(resolver.has_value());
+    ASSERT_FALSE(resolver->syncPoints().empty());
+
+    constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
+
+    // Raw span is the ToW ms of the first/last record — a pre-1980 value.
+    EXPECT_LT(log->spanStart().value, kGpsEpochUnixMs);
+
+    // Anchored span epoch-anchors to week 2300: real 2026-era absolute ms.
+    const auto aStart = log->anchoredSpanStart(resolver.value());
+    const auto aEnd   = log->anchoredSpanEnd(resolver.value());
+    EXPECT_EQ(aStart.value, expectedUnixMsForFixtureWeek(100'000));
+    EXPECT_EQ(aEnd.value,   expectedUnixMsForFixtureWeek(130'000));
+    EXPECT_GT(aStart.value, kGpsEpochUnixMs);
+    EXPECT_LT(aStart.value, aEnd.value);
+}
+
+// ---------------------------------------------------------------------------
 // Resolve between two sync points → Interpolated.
 // ---------------------------------------------------------------------------
 TEST_F(TimeResolverTest, ResolveInterpolated) {

--- a/tests/test_truncated_log.cpp
+++ b/tests/test_truncated_log.cpp
@@ -243,14 +243,12 @@ TEST_F(TruncatedLogTest, CleanFixture_NoTruncationNoWarnings) {
 
     auto r = ISLogReader::openSegment(f_.rawFile);
     ASSERT_TRUE(r.has_value());
-    // SN-8328 (B): a clean (non-truncated) log must never be flagged as
-    // truncated. This ~1 MB cISLogger fixture spans several 128 KB chunks, so
-    // its writer .idx carries chunk-relative offsets (SDK writer-offset
-    // follow-up); the reader detects that and rebuilds from scan
-    // (hadOnDiskIndex() false, one benign "sidecar rebuilt" warning). The
-    // property under test is that this emits NO *truncation* warning and the
-    // segment reads to its end.
-    EXPECT_FALSE(r->hadOnDiskIndex());
+    // SN-8328: a clean (non-truncated) log must never be flagged as truncated.
+    // This ~1 MB cISLogger fixture spans several 128 KB chunks; the RAW writer
+    // now stamps true physical .raw offsets, so the reader TRUSTS the sidecar
+    // (no rebuild). The property under test is that this emits NO *truncation*
+    // warning and the segment reads to its end.
+    EXPECT_TRUE(r->hadOnDiskIndex());
     EXPECT_FALSE(r->isTruncated());
     EXPECT_EQ(r->truncationOffset(), r->fileSize());
     for (const auto& w : r->warnings()) {

--- a/tests/test_v21_e2e.cpp
+++ b/tests/test_v21_e2e.cpp
@@ -1,0 +1,254 @@
+// End-to-end (SN-8383 / SN-8339 / D0066): drive the COMPLETE writer path
+// (cISLogger -> DeviceLog -> v2.1 .idx) with ~30-45 s of pseudo-random,
+// multi-rate DID traffic that INCLUDES a timeless DID (DID_PORT_MONITOR), then
+// verify:
+//   1. the .idx is v2.1 (32-byte records + HAS_LOCAL_DELTA) and carries
+//      per-record host-uptime deltas that grow with the log's real elapsed time
+//      (i.e. reflect each DID's logging periodicity),
+//   2. ISLogReader parses the resulting pair, and
+//   3. ISTimeResolver, built from the log, resolves the timeless PORT_MONITOR
+//      records (which have NO payload timestamp) to the correct wall-clock times
+//      by bridging their per-record uptime delta through the SYS_PARAMS
+//      uptime->ToW offset.
+//
+// This runs in REAL TIME on purpose: the per-record delta is stamped from the
+// host monotonic clock (current_uptimeMs), which is not injectable, so the only
+// way the delta and the SYS_PARAMS.upTime land on the same scale — the property
+// that lets a timeless record resolve correctly — is to let real time pass. Set
+// IS_E2E_DURATION_MS to shorten the run for local iteration / CI smoke.
+//
+// Copyright (c) 2026 Inertial Sense, Inc. All rights reserved.
+
+#include <gtest/gtest.h>
+
+// com_manager.h first — short-circuits the broken extern-C wrap in
+// ISFirmwareUpdater.h (same trick as test_log_index.cpp / test_log_reader.cpp).
+#include "com_manager.h"
+
+#include "ISComm.h"
+#include "ISDeviceLog.h"
+#include "ISFileManager.h"
+#include "ISLogIndex.h"
+#include "ISLogReader.h"
+#include "ISLogger.h"
+#include "ISTimeResolver.h"
+#include "ISUtilities.h"       // current_uptimeMs
+#include "data_sets.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <filesystem>
+#include <random>
+#include <thread>
+#include <vector>
+
+using namespace inertial_sense;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint16_t kHwId       = ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0);
+constexpr uint32_t kSerial     = 990321u;
+constexpr uint32_t kGpsWeek    = 2300u;
+constexpr uint32_t kStartTowMs = 200'000'000u;   // GPS ToW ms at log start (well inside a 604,800,000 ms week)
+
+// Unix-epoch ms for (kGpsWeek, towMs) — the resolver epoch-anchors output once
+// any sync point carries a non-zero gpsWeek (SN-8107 / D0066).
+uint64_t expectedUnixMs(uint64_t towMs) {
+    constexpr uint64_t kGpsEpochUnixMs = 315'964'800'000ULL;
+    constexpr uint64_t kWeekMs         = 604'800'000ULL;
+    return static_cast<uint64_t>(kGpsWeek) * kWeekMs + kGpsEpochUnixMs + towMs;
+}
+
+void writeRecord(cISLogger& logger, std::shared_ptr<cDeviceLog> dev,
+                 uint32_t did, const void* payload, std::size_t size) {
+    is_comm_instance_t comm{};
+    uint8_t buf[1024];
+    is_comm_init(&comm, buf, sizeof(buf), nullptr);
+    uint8_t pkt[2048];
+    const int n = is_comm_data_to_buf(pkt, sizeof(pkt), &comm,
+                                      static_cast<uint16_t>(did),
+                                      static_cast<uint16_t>(size), 0,
+                                      const_cast<void*>(payload));
+    if (n > 0) logger.LogData(dev, n, pkt);
+}
+
+// A timed source (ToW-bearing). timeOfWeek is seconds.
+ins_2_t makeIns2(uint32_t elapsedMs) {
+    ins_2_t s{};
+    s.week       = kGpsWeek;
+    s.timeOfWeek = (kStartTowMs + elapsedMs) / 1000.0;
+    s.qn2b[0]    = 1.0f;
+    s.lla[0] = 40.0; s.lla[1] = -111.0; s.lla[2] = 1400.0;
+    return s;
+}
+
+// The uptime<->ToW anchor. upTime is fractional seconds so the offset is exact.
+sys_params_t makeSysParams(uint32_t elapsedMs) {
+    sys_params_t s{};
+    s.timeOfWeekMs = kStartTowMs + elapsedMs;
+    s.upTime       = elapsedMs / 1000.0;
+    s.hdwStatus   |= HDW_STATUS_GNSS_TIME_OF_WEEK_VALID;
+    return s;
+}
+
+// A non-ToW uptime source (payload `time` is seconds-since-boot).
+imu_t makeImu(uint32_t elapsedMs) {
+    imu_t s{};
+    s.time = elapsedMs / 1000.0;
+    s.I.acc[0] = 0.1f; s.I.acc[1] = 0.2f; s.I.acc[2] = 9.8f;
+    return s;
+}
+
+// The timeless subject: DID_PORT_MONITOR has no payload timestamp field, so its
+// .idx timestamp is the host-uptime delta and HAS_TOW is clear.
+port_monitor_t makePortMon() {
+    port_monitor_t s{};
+    s.activePorts = 2;
+    return s;
+}
+
+uint32_t durationMs() {
+    if (const char* e = std::getenv("IS_E2E_DURATION_MS")) {
+        const long v = std::strtol(e, nullptr, 10);
+        if (v > 0) return static_cast<uint32_t>(v);
+    }
+    return 15'000u;   // >128KB (multi-chunk) at the rates below; overridable
+}
+
+}  // namespace
+
+// Guarded end-to-end soak: OFF by default (runs in real time and sleeps), so it
+// does not slow routine CI. Run it explicitly to revalidate the writer/reader/
+// resolver chain end-to-end: `IS_RUN_E2E_TESTS=1 ./IS-SDK_unit-tests
+// --gtest_filter=V21EndToEnd*` (optionally IS_E2E_DURATION_MS=<ms>). It still
+// compiles every build, so it can't bit-rot.
+TEST(V21EndToEnd, PseudoRandomMultiDidWithTimelessPortMonitor) {
+    if (std::getenv("IS_RUN_E2E_TESTS") == nullptr) {
+        GTEST_SKIP() << "end-to-end soak disabled by default; set IS_RUN_E2E_TESTS=1 to run";
+    }
+    const uint32_t durMs = durationMs();
+
+    char dirBuf[256];
+    std::snprintf(dirBuf, sizeof(dirBuf), "/tmp/test_v21_e2e_%d_%ld",
+                  ::getpid(), static_cast<long>(::time(nullptr)));
+    const fs::path dir = dirBuf;
+    ISFileManager::DeleteDirectory(dir.string());
+
+    cISLogger logger;
+    cISLogger::sSaveOptions opts;
+    opts.logType               = cISLogger::LOGTYPE_RAW;
+    opts.useSubFolderTimestamp = false;
+    ASSERT_TRUE(logger.InitSave(dir.string(), opts));
+    auto dev = logger.registerDevice(kHwId, kSerial);
+    ASSERT_TRUE(dev != nullptr);
+    logger.EnableLogging(true);
+
+    // Per-DID nominal periods (ms). Pseudo-random jitter is applied per tick.
+    struct Stream { uint32_t did; uint32_t period; uint32_t nextDue; };
+    std::vector<Stream> streams = {
+        { DID_INS_2,        20,  0 },   // 50 Hz timed
+        { DID_IMU,          5,   0 },   // 200 Hz uptime-only (fastest — Kyle: ~5 ms periodicity)
+        { DID_SYS_PARAMS,   500, 0 },   // 2 Hz uptime<->ToW anchor
+        { DID_PORT_MONITOR, 100, 0 },   // 10 Hz timeless subject
+    };
+
+    std::mt19937 rng(0xC0FFEEu);
+    std::uniform_int_distribution<int> jitter(-8, 8);   // ms of pseudo-random jitter
+
+    std::size_t portMonEmitted = 0;
+    const uint32_t t0 = current_uptimeMs();
+    for (;;) {
+        const uint32_t elapsed = current_uptimeMs() - t0;
+        if (elapsed >= durMs) break;
+
+        // Pseudo-randomize emission order within this tick.
+        std::shuffle(streams.begin(), streams.end(), rng);
+        for (auto& s : streams) {
+            if (elapsed < s.nextDue) continue;
+            switch (s.did) {
+                case DID_INS_2:      { auto p = makeIns2(elapsed);     writeRecord(logger, dev, s.did, &p, sizeof(p)); } break;
+                case DID_IMU:        { auto p = makeImu(elapsed);      writeRecord(logger, dev, s.did, &p, sizeof(p)); } break;
+                case DID_SYS_PARAMS: { auto p = makeSysParams(elapsed);writeRecord(logger, dev, s.did, &p, sizeof(p)); } break;
+                case DID_PORT_MONITOR:{ auto p = makePortMon();        writeRecord(logger, dev, s.did, &p, sizeof(p)); ++portMonEmitted; } break;
+                default: break;
+            }
+            const int j = jitter(rng);
+            s.nextDue = elapsed + static_cast<uint32_t>(std::max<int>(1, static_cast<int>(s.period) + j));
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));   // fine granularity for the ~5 ms streams
+    }
+    logger.CloseAllFiles();
+    // Nominal 4 Hz => ~durMs/250 records; require at least half (jitter/scheduling slack).
+    const std::size_t minPortMon = durMs / 500u;
+    ASSERT_GT(portMonEmitted, minPortMon) << "expected many PORT_MONITOR records over the run";
+
+    // Locate the single .raw segment cISLogger produced.
+    std::vector<ISFileManager::file_info_t> rawFiles;
+    ISFileManager::GetAllFilesInDirectory(dir.string(), true, "\\.raw$", rawFiles);
+    ASSERT_FALSE(rawFiles.empty());
+    const fs::path rawFile = rawFiles.front().name;
+
+    // ---- (1) v2.1 .idx with periodicity-based deltas -----------------------
+    auto readerR = ISLogReader::openSegment(rawFile);
+    ASSERT_TRUE(readerR.has_value()) << readerR.error().message;
+    const ISLogReader& reader = readerR.value();
+    ASSERT_TRUE(reader.hadOnDiskIndex()) << "cISLogger's v2.1 sidecar should be trusted, not rebuilt";
+
+    EXPECT_EQ(reader.header().record_size, idx::IS_LOG_IDX_RECORD_V2_1_SIZE);
+    EXPECT_NE(0, reader.header().flags & idx::IS_LOG_IDX_HDR_FLAG_HAS_LOCAL_DELTA);
+
+    // PORT_MONITOR records: timeless (HAS_TOW clear); .idx timestamp == the
+    // host-uptime delta, which must climb across the run reflecting the 4 Hz
+    // periodicity — not collapse to ~0.
+    std::vector<uint64_t> pmDeltas;
+    std::vector<std::size_t> pmSpans;   // physical byte span of each record via the trusted offsets
+    for (auto v : reader.records(DID_PORT_MONITOR)) {
+        EXPECT_EQ(0, v.flags() & idx::IS_LOG_IDX_REC_FLAG_HAS_TOW) << "PORT_MONITOR must be timeless";
+        pmDeltas.push_back(v.timestamp().value);      // .idx timestamp == local delta for a timeless record
+        pmSpans.push_back(v.bytes().second);          // bytes sliced from the .raw at rec.offset
+    }
+    ASSERT_GT(pmDeltas.size(), minPortMon);
+    EXPECT_TRUE(std::is_sorted(pmDeltas.begin(), pmDeltas.end())) << "deltas must be arrival-monotonic";
+    EXPECT_LT(pmDeltas.front(), 2'000u)          << "first PORT_MONITOR near log start";
+    EXPECT_GT(pmDeltas.back(),  durMs - 3'000u)  << "last PORT_MONITOR near log end (deltas track real elapsed)";
+
+    // Byte-level offset proof: PORT_MONITOR packets are a fixed size, so the
+    // physical byte span the reader slices at each rec.offset must be identical
+    // and non-empty across all records except possibly the last (which runs to
+    // EOF). If the writer stamped chunk-relative/garbage offsets, these spans
+    // would be wrong or zero. (The whole read path also asserts hadOnDiskIndex
+    // above, i.e. the sidecar was TRUSTED, not rebuilt.)
+    ASSERT_GE(pmSpans.size(), 2u);
+    const std::size_t firstSpan = pmSpans.front();
+    EXPECT_GT(firstSpan, 0u) << "PORT_MONITOR payload span must be non-empty";
+    for (std::size_t i = 0; i + 1 < pmSpans.size(); ++i) {
+        EXPECT_EQ(pmSpans[i], firstSpan) << "PORT_MONITOR physical byte span differs at record " << i
+                                         << " -> offsets are not correct physical positions";
+    }
+
+    // ---- (2)+(3) resolver places the timeless records at correct times -----
+    auto logR = ISDeviceLog::fromSegments({ rawFile });
+    ASSERT_TRUE(logR.has_value()) << logR.error().message;
+    auto resolverR = ISTimeResolver::build(logR.value());
+    ASSERT_TRUE(resolverR.has_value());
+    EXPECT_FALSE(resolverR->syncPoints().empty()) << "SYS_PARAMS/INS should yield sync points";
+
+    // Each PORT_MONITOR delta, bridged through the SYS_PARAMS uptime->ToW offset
+    // (which is exactly kStartTowMs here), must resolve to the wall-clock time of
+    // (kStartTowMs + delta) — i.e. the moment it was actually logged.
+    uint64_t prevResolved = 0;
+    for (const uint64_t d : pmDeltas) {
+        const TimeStamp r = resolverR->resolve(d, kSerial);
+        EXPECT_EQ(r.source, TimeSource::ResolvedViaSync) << "timeless record must bridge via sync, at delta " << d;
+        const uint64_t want = expectedUnixMs(kStartTowMs + d);
+        EXPECT_NEAR(static_cast<double>(r.value), static_cast<double>(want), 100.0)
+            << "PORT_MONITOR at delta " << d << " resolved to the wrong wall-clock time";
+        EXPECT_GE(r.value, prevResolved) << "resolved PORT_MONITOR times must be monotonic";
+        prevResolved = r.value;
+    }
+
+    ISFileManager::DeleteDirectory(dir.string());
+}


### PR DESCRIPTION
## Summary

Consolidated SDK time-resolution + `.idx`-schema work, targeting **`3.1.0-rc`** (not `develop`). Five related cards land together because they all touch the same reader/resolver/`.idx` surface:

- **SN-8339** — multi-boot (mid-log reboot) time resolver
- **SN-8383 + SN-8340** — v2.1 `.idx`: per-record host-uptime delta + durable capture epoch
- **SN-8105** — resolver-anchored `ISDeviceLog` span accessors
- **SN-7901** — deprecate the legacy `cISLogger` read entry points

Full SDK unit suite: **453 passed / 0 failed / 3 skipped** (skips are live-fixture-gated only). New tests added for every card.

---

## SN-8339 — multi-boot uptime→ToW resolver

A mid-log power cycle resets the device's uptime while GPS time-of-week keeps advancing, so a single global uptime→ToW offset can only be correct for one boot. Session-uptime records (mag/imu, and each boot's pre-re-fix head) from the second boot mis-resolve against the first boot's offset.

Fix (reader-side, **non-breaking**):
- Reboot detection at build: a `SYS_PARAMS.upTime` **drop in arrival order** opens a new power-on session.
- Per-session model: each session carries its own median uptime→ToW offset + arrival range; a session with no synced `SYS_PARAMS` of its own inherits the log-global offset.
- New overload `resolve(hostTimeMs, deviceId, arrivalIndex)` selects the covering session's offset. **The existing `resolve(hostTimeMs, deviceId)` path is byte-identical to before** — single-boot logs and every current caller are unchanged.
- `ISRecordView` now surfaces a dense global `arrivalIndex()` (stamped by `ISDeviceLog`'s cross-segment iterator), matching the resolver's own byte-scan numbering. `ISLogReader::detectGaps` is keyed on it.

**Set B (real fixture)** — validated on a real IMX (SN520487) reset log, 172,698 records / 3566 sync points:
- Exactly **2 sessions** detected (the reboot), arrival `[0..34468]` and `[34469..172697]`, offsets `282,991,093 ms` and `283,191,546 ms` — differing by ~200 s, consistent with uptime resetting while ToW advanced.

## SN-8383 + SN-8340 — v2.1 `.idx`

File layout is unchanged in shape: `[ header : 64 B ][ record 0 ][ record 1 ] … [ record N-1 ]`. **Exactly one on-disk size changed — the per-record entry (24 → 32 bytes). The header did *not* change size.**

**Header** (`is_log_idx_header_t`, one per file, at offset 0) — **stays 64 bytes**, same as v2.0. v2.1 only assigns meaning to bytes that were `reserved` padding inside that fixed block, so a v2.0 reader reads the same 64 bytes and ignores them (forward-compatible):
- `record_size` (u16 @ 44–45): on-disk per-record stride — 24 for v2.0, 32 for v2.1; a pre-v2.1 header has 0 here, which readers treat as 24.
- `capture_epoch_ms` (u64 @ 48–55, **SN-8340**): durable absolute host wall-clock at log-open.

**Record** (`is_log_idx_record_v2_t`, N of them, packed after the header) — **grows 24 → 32 bytes**. The 24-byte v2.0 prefix (`timestamp`/`offset`/`did`/`flags`/`reserved`) is untouched; the new fields are **appended at the end** (not inserted):
- `local_uptime_ms` (u32 @ 24–27, **SN-8383**): per-record host-uptime-since-log-start, stamped for every record (arrival-monotonic).
- `reserved2` (u32 @ 28–31): pad to an 8-byte multiple.

Feature flags `HAS_LOCAL_DELTA` / `HAS_CAPTURE_EPOCH` in the header signal presence. Rebuild-from-scan leaves the per-record delta zeroed (unrecoverable from the `.raw` alone).

**Compatibility.** The header's `record_size` is the single source of truth for stride: the reader strides by it (24 for a v2.0 file — a legacy header carries 0, treated as 24 — and 32 for v2.1), and reads the trailing `local_uptime_ms` only when it's ≥ 32. Because the prefix stays at fixed offsets, one reader parses **both** formats identically for the common fields. This is clean **backward** compat (a v2.1-aware reader reading any older file). It is *not* forward compat: a pre-v2.1 binary that hardcodes a 24-byte stride and never consults `record_size` would misalign on a v2.1 file — consulting `record_size` is what makes the stride correct. Covered by `IdxFileIO.V20AndV21FilesBothReadCleanly` (a genuine v2.0 file and a v2.1 file, read side by side) plus the record-level and end-to-end idx tests.

## SN-8105 — resolver-anchored span

`ISDeviceLog::anchoredSpanStart/End(const ISTimeResolver&)` fold the min/max of every record's resolver-bridged timestamp (arrival-keyed, so multi-boot-correct), so a GPS-anchored log reports absolute wall-clock ms instead of the raw ToW/uptime value `spanStart/End` return (the 1970-epoch bug). Falls back to the raw span when nothing anchors. On the Set B log the anchored span reads as a real 2026-07-29 ~5.7-minute window.

## SN-7901 — deprecate legacy read entry points

`cISLogger::LoadFromDirectory` and both `ReadData` overloads are marked `[[deprecated]]`, pointing at the D0021 reader stack (`ISDeviceLog::fromSegments` / `ISLogReader` / `ISRecordView`). Labeling, **not removing** — the legacy path stays functional. Follows the existing per-method-deprecation precedent (`cISLogger::InitSave`). The write path (`InitSave`/`LogData`/`OpenNewSaveFile`) and `CopyLog` are untouched.

**Blast-radius audit:** in-repo, only 9 production read call sites across 3 files (cltool, idx_benchmark, python binding), all funneling through those two methods. The SDK core already builds with `-Wno-deprecated-declarations`; the unit-test target now does too (it deliberately exercises the legacy API).

> :warning: **EvalTool** lives in the `imx` repo and was not auditable from this tree. It very likely calls the legacy read API, so its build will start emitting deprecation warnings after this merges. If EvalTool builds `-Werror`, those callers need updating (or a local suppression) — flagging for the EvalTool owners.

---

## Follow-up (separate PR)

Logalyzer's app-side consumption of the keyed `resolve()` + `anchoredSpan` (in `RawSeriesBuilder` / `device_span`) is held until `inertialsense/logalyzer#76` merges, then lands as a single Logalyzer submodule-pin PR off `develop`.

## Not merging / closing

Per team convention I will not merge this PR or resolve the ticket — reviewers own that.
