### PR TITLE
SN-8390 Fix NTRIP connect + reconnect with non-blocking TCP

### DIFF
--- a/src/CorrectionService.h
+++ b/src/CorrectionService.h
@@ -179,10 +179,13 @@ public:
     void removeRTCM3PacketListeners(uint32_t id);
 
     /**
-     * Checks the source port for data and forwards it to all devices
+     * Checks the source port for data and forwards it to all devices.
+     * Also (re)opens the source port if it is not currently open. Virtual so that protocol-specific
+     * subclasses (e.g. NtripCorrectionService) can extend the (re)connection handling -- NTRIP, for
+     * example, must re-negotiate its mount-point request after every (re)connect, not just reopen the socket.
      * @return 0 if no packets processed, positive number representing number of packets processed, negative number representing errno
      */
-    int step();
+    virtual int step();
 
     /**
      * @return the age, in milliseconds, of the last received RTCM3 message.
@@ -209,6 +212,7 @@ public:
 protected:
     port_handle_t source {};                  //!< The bound source port from which correction data is read
     std::vector<port_handle_t> ports;          //!< Downstream ports to which correction data is forwarded
+    uint32_t lastConnAttemptTs = 0;            //!< timestamp (ms) after which the next source (re)connection attempt is allowed (reconnect backoff)
 
 private:
     inline static const std::vector<PortFactory*>& nullFactories = {};    //!< Empty factory list, used as the default argument for the portName-based constructor
@@ -217,7 +221,6 @@ private:
     is_comm_instance_t packetParser = {};                                 //!< SDK comm-protocol parser instance bound to the source port
     uint32_t rtcm3PacketsProcessed = 0;                                 //!< total number of RTCM3 packets that have been processed
     uint32_t rtcm3PacketLastMs = 0;                                     //!< timestamp in ms, since the last RTCM3 packet was seen
-    uint32_t lastConnAttemptTs = 0;                                     //!< timestamp (ms) of the last (re)connection attempt to the source
     bool localSrcPort = false;                                          //!< true if the source port was locally instantiated rather than passed in the constructor
     PortFactory* srcPortFactory = nullptr;                               //!< the factory used to create the source port (if localSrcPort is true)
 

--- a/src/NtripCorrectionService.cpp
+++ b/src/NtripCorrectionService.cpp
@@ -12,6 +12,9 @@
 #include "TcpPortFactory.h"
 #include "util/util.h"
 
+// Max time to wait for the (non-blocking) TCP connection to the caster to complete before giving up.
+#define NTRIP_CONNECT_TIMEOUT_MS 5000
+
 bool NtripCorrectionService::connect(const std::string& connectUrl, std::string userAgent) {
     // parse the URL; NTRIP defaults to port 2101 when the caster URL omits one
     const utils::UriParts uri = utils::parseUri(connectUrl, "ntrip://:2101");
@@ -65,8 +68,11 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
     std::string serverUrl = "tcp://" + host + ":" + std::to_string(port);
     source = TcpPortFactory::getInstance().bindPort(serverUrl, PORT_TYPE__TCP | PORT_TYPE__COMM);
 
-    // Remember, binding a port doesn't open it - it just creates the underlying instance that references the underlying hardware
-    if (!source || (portOpen(source) != PORT_ERROR__NONE))
+    // Remember, binding a port doesn't open it - it just creates the underlying instance that references the underlying hardware.
+    // tcpPort uses a non-blocking connect: portOpen() returns PORT_ERROR__NONE while the TCP handshake is still in flight and
+    // only sets PORT_FLAG__OPENED once connected. We must wait for the connection to actually complete (via portOpenRetry, which
+    // polls until portIsOpened()) before writing the NTRIP request below - otherwise the write races the handshake and fails.
+    if (!source || (portOpenRetry(source, NTRIP_CONNECT_TIMEOUT_MS, 2) != PORT_ERROR__NONE))
         return false;
 
     std::string msg = "GET " + uri.path + " HTTP/1.1\r\n";

--- a/src/NtripCorrectionService.cpp
+++ b/src/NtripCorrectionService.cpp
@@ -14,6 +14,8 @@
 
 // Max time to wait for the (non-blocking) TCP connection to the caster to complete before giving up.
 #define NTRIP_CONNECT_TIMEOUT_MS 5000
+// Minimum delay between reconnect attempts after a hard connection failure (avoids hammering the caster).
+#define NTRIP_RECONNECT_BACKOFF_MS 2500
 
 bool NtripCorrectionService::connect(const std::string& connectUrl, std::string userAgent) {
     // parse the URL; NTRIP defaults to port 2101 when the caster URL omits one
@@ -21,48 +23,24 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
     const std::string& host = uri.host;
     const int port = uri.port;
 
-    /***
-     * One issue here is that connect() is not the same as portOpen(), because connect needs to do some talking
-     * to negotiate the connection - we open the port, and then we send the following parameters and wait for a
-     * response. If the parameters aren't right, the remote end will shut down, and we didn't really connect.
-     *
-     * If we try and call portOpen() again to reconnect (which we will in CorrectionService::step()), we'll
-     * reconnect the TCP socket, but won't call connect(), which mean no negotiations.
-     *
-     * One option here is to replace tcp_port_t.base.portOpen function pointer with a Ntrip-specific function,
-     * injecting itself into the middle, so that portOpen() calls the Ntrip's connect() and directly calls
-     * tcpPortOpen().  We could do this because NTRIP should only ever use tcpPort.  Should being the operative
-     * word there.
-     *
-     * However, we also have an issue of context - since NtripCorrectionService is C++ and needs its 'this'
-     * but tcpPort doesn't known anything about that... How do you call portOpen() and will carry over the
-     * object instance that holds the tcp_port_s struct?  These are good questions!
-     *
-     * Solving the instance issue, we could add a "context" or "userdata" parameter to base_port_t. This would
-     * be pretty minimally invasive, and wouldn't change any functions signatures, etc. This would only require
-     * two additional functions, portSetUserContext() and portGetUserContext(), and a corresponding void pointer
-     * in base_port_t. The context pointer is assigned per port though, not per call, etc. I think this can work.
-     *
-     * In addition to the userContext pointer, we'd need to implement an additional callback into base_port_t, a
-     * portNotify callback which would get called (if defined) when port operations (like an Open, Close, etc) are
-     * made with a port. Similar to the portLogger callback, this would include the port_handle_t and a PORT_OP__*
-     * argument indicating the event type that we are being notified of.  This could grow, if we're not careful
-     * since there might be need for things like PORT_OP__OPENING vs PORT_OP__OPENED, etc.  Still, might be worth
-     * exploring.
-     *
-     * In our case here for the Ntrip, we'd do the following:
-     *      portSetUserContext(source, this);
-     *      portSetNotifyCallback(source, NtripCorrectionService::portConnected);
-     *
-     * Where NtripCorrectionService::portConnected() would look like:
-     *      static void NtripCorrectionService::portConnected(port_handle_t port, int port_op) {
-     *          if (port_op == PORT_OP__OPENED) {
-     *              NtripCorrectionService* ntrip = (NtripCorrectionService*)portGetUserContext(port);
-     *              if (ntrip)
-     *                  ntrip->makeConnectionRequest();
-     *          }
-     *      }
-     ****/
+    /*
+     * connect() is more than portOpen(): once the TCP socket is up we must send the mount-point request
+     * and read the caster's response before corrections flow. Because that negotiation has to be repeated
+     * whenever the TCP link is re-established, the request is cached (requestMsg) and the negotiation is
+     * factored into negotiateMountPoint(); step() replays it on reconnect. (A future refactor could instead
+     * hook a port "opened" notification callback so the negotiation is driven by the port layer itself.)
+     */
+
+    // Build and cache the mount-point request up front so it can be re-sent verbatim on reconnect
+    // (see step() / negotiateMountPoint()) without having to re-parse the URL.
+    casterUrl = connectUrl;
+    requestMsg = "GET " + uri.path + " HTTP/1.1\r\n";
+    requestMsg += "User-Agent: " + userAgent + "\r\n";
+    if (uri.hasUserinfo()) {
+        std::string auth = uri.user + ":" + uri.password;
+        requestMsg += "Authorization: Basic " + base64Encode((const unsigned char*)auth.data(), (int)auth.length()) + "\r\n";
+    }
+    requestMsg += "Accept: */*\r\nConnection: close\r\n\r\n";
 
     // extract the host & port, and make the socket/port connection
     std::string serverUrl = "tcp://" + host + ":" + std::to_string(port);
@@ -75,17 +53,25 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
     if (!source || (portOpenRetry(source, NTRIP_CONNECT_TIMEOUT_MS, 2) != PORT_ERROR__NONE))
         return false;
 
-    std::string msg = "GET " + uri.path + " HTTP/1.1\r\n";
-    msg += "User-Agent: " + userAgent + "\r\n";
-    if (uri.hasUserinfo()) {
-        std::string auth = uri.user + ":" + uri.password;
-        msg += "Authorization: Basic " + base64Encode((const unsigned char*)auth.data(), (int)auth.length()) + "\r\n";
-    }
-    msg += "Accept: */*\r\nConnection: close\r\n\r\n";
+    if (!negotiateMountPoint())
+        return false;
 
-    int bytesSent = portWrite(source, (uint8_t*)msg.data(), (int)msg.length());
-    if ((size_t)bytesSent != msg.length()) {
-        log_debug(IS_LOG_PORT, "Error submitting NTRIP connection request to %s", connectUrl.c_str());
+    setSourcePort(source);  // set the sourcePort for the underlying CorrectionService to this port
+    return true;
+}
+
+/**
+ * Sends the cached mount-point request and consumes the caster's response headers. The source port
+ * must already be open. Factored out of connect() so the same negotiation can be replayed on reconnect
+ * from step() (an NTRIP caster only starts streaming after it receives the mount-point request).
+ */
+bool NtripCorrectionService::negotiateMountPoint() {
+    if (!portIsOpened(source) || requestMsg.empty())
+        return false;
+
+    int bytesSent = portWrite(source, (uint8_t*)requestMsg.data(), (int)requestMsg.length());
+    if ((size_t)bytesSent != requestMsg.length()) {
+        log_debug(IS_LOG_PORT, "Error submitting NTRIP connection request to %s", casterUrl.c_str());
         return false;
     }
 
@@ -98,7 +84,7 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
         contentLength -= bytesRead;
 
         if (bytesRead < 0) {
-            log_debug(IS_LOG_PORT, "Timeout waiting for response from %s", connectUrl.c_str());
+            log_debug(IS_LOG_PORT, "Timeout waiting for response from %s", casterUrl.c_str());
             return false;
         }
         printf("%s\n", buffer);
@@ -111,8 +97,33 @@ bool NtripCorrectionService::connect(const std::string& connectUrl, std::string 
         }
     } while ((bytesRead != 0) || (contentLength > 0));
 
-    setSourcePort(source);  // set the sourcePort for the underlying CorrectionService to this port
     return true;
+}
+
+int NtripCorrectionService::step() {
+    if (!portIsOpened(source)) {
+        // The NTRIP TCP stream is down (initial connect failed, or the caster dropped us). Reconnecting
+        // means more than reopening the socket: the caster only streams after it receives the mount-point
+        // request, so we must re-negotiate it. CorrectionService::step() would only reopen the socket and
+        // leave us connected-but-silent. The TCP (re)connect is non-blocking (portOpen() is polled across
+        // successive step() calls, just like the base class), so we don't stall the caller here.
+        if (source && !requestMsg.empty() && (lastConnAttemptTs < current_timeMs())) {
+            if (portOpen(source) < PORT_ERROR__NONE) {
+                lastConnAttemptTs = current_timeMs() + NTRIP_RECONNECT_BACKOFF_MS;   // hard failure -> back off
+            } else if (portIsOpened(source)) {
+                // TCP is (re)connected -- re-negotiate the mount point before corrections can resume.
+                if (negotiateMountPoint()) {
+                    setSourcePort(source);
+                } else {
+                    portClose(source);                                              // negotiation failed; drop and retry later
+                    lastConnAttemptTs = current_timeMs() + NTRIP_RECONNECT_BACKOFF_MS;
+                }
+            }
+        }
+        if (!portIsOpened(source))
+            return -1;
+    }
+    return CorrectionService::step();
 }
 
 bool NtripCorrectionService::updatePosition(const gnss_pos_t& gps) {

--- a/src/NtripCorrectionService.h
+++ b/src/NtripCorrectionService.h
@@ -53,6 +53,17 @@ class NtripCorrectionService : public CorrectionService {
         bool connect(const std::string& connectUrl, std::string userAgent = "NTRIP Inertial Sense");
 
         /**
+         * @brief Reads/forwards corrections, and (re)establishes the caster connection when needed.
+         * Overrides CorrectionService::step() because reconnecting an NTRIP source requires re-sending
+         * the mount-point request after the TCP socket reconnects -- the base class only reopens the
+         * socket, which would leave us connected to the caster but never streaming. The TCP (re)connect
+         * itself is non-blocking (polled across successive step() calls); only the bounded mount-point
+         * negotiation blocks briefly, once per (re)connection.
+         * @return 0 if no packets processed, >0 number of packets processed, <0 on error / not connected.
+         */
+        int step() override;
+
+        /**
          * @return true if there is an open connection/socket with the NTRIP server
          */
         bool isConnected() { return portIsOpened(source); }
@@ -89,8 +100,18 @@ class NtripCorrectionService : public CorrectionService {
         void setConnectionRequestHeaders(std::map<std::string, std::string> hdrs);
 
     private:
+        /**
+         * @brief Sends the cached NTRIP mount-point request over the (already-open) source port and waits
+         * for the caster's response. Shared by connect() (initial) and step() (reconnect). Requires the
+         * source port to be open and requestMsg to have been built by a prior connect().
+         * @return true if the request was sent and a response was received, false otherwise.
+         */
+        bool negotiateMountPoint();
+
         MessageStats::mul_stats_t srcStats;         //!< Per-protocol message statistics for the caster connection; CorrectionService only holds a pointer to stats, so this instance owns the storage.
         std::map<std::string, std::string> headers; //!< Custom headers which will be sent to the NTRIP caster when connecting
+        std::string requestMsg;                      //!< Cached mount-point HTTP GET request, built in connect(), re-sent by negotiateMountPoint() on (re)connect
+        std::string casterUrl;                       //!< Cached caster URL, retained for log messages on reconnect
 };
 
 

--- a/src/core/base_port.c
+++ b/src/core/base_port.c
@@ -28,13 +28,19 @@ int portOpenRetry(port_handle_t port, unsigned int timeoutMs, unsigned int retry
     do {
         if (portIsOpened(port)) return PORT_ERROR__NONE;
 
+        // A port is only truly ready once PORT_FLAG__OPENED is set. With a non-blocking connect
+        // (e.g. tcpPort), portOpen() returns PORT_ERROR__NONE while the handshake is still in flight
+        // ("pending") WITHOUT setting that flag, so we must keep polling until portIsOpened() rather
+        // than returning on the first PORT_ERROR__NONE. Only a negative result is a hard failure.
         lastResult = portOpen(port);
-        if (lastResult == PORT_ERROR__NONE) return lastResult;
+        if (portIsOpened(port)) return PORT_ERROR__NONE;    // opened synchronously (blocking connect / serial)
+        if (lastResult < PORT_ERROR__NONE)
+            log_more_debug(IS_LOG_PORT, "portOpenRetry(): portOpen() failed with error: %d (%d)", lastResult, portError(port));
 
-        log_more_debug(IS_LOG_PORT, "portOpenRetry(): portOpen() failed with error: %d (%d)", lastResult, portError(port));
         SLEEP_MS(retryDelayMs);
     } while (current_timeMs() < timeout);
-    return lastResult;
+    // Final check: the last portOpen() above may have completed the handshake just before we timed out.
+    return portIsOpened(port) ? PORT_ERROR__NONE : lastResult;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes NTRIP corrections failing on 3.1.0-rc. The caster is healthy — the failures are SDK regressions/gaps in the NTRIP connect path around the non-blocking-connect change. The non-blocking connect itself is **retained**.

Jira: [SN-8390](https://inertialsense.atlassian.net/browse/SN-8390)

Two related bugs (the second found during discovery of the first):

### Bug 1 — initial connect writes before the socket is connected

`SN-8274` (`72b9c298`) made `tcpPortOpen()` use a **non-blocking** connect (good — avoids stalling the caller for the full kernel SYN timeout). `portOpen()` now returns `PORT_ERROR__NONE` while the handshake is still in flight ("pending"), **without** setting `PORT_FLAG__OPENED`; the caller must poll until `portIsOpened()`.

`NtripCorrectionService::connect()` called `portOpen()` once, saw `NONE`, and immediately `portWrite()` the NTRIP GET → `EAGAIN` → the reported `Error submitting NTRIP connection request`. `portOpenRetry()` had the same latent bug (returned on the pending `0`).

**Fix:**
- `base_port.c portOpenRetry()`: keep polling until `portIsOpened()` instead of returning on the first `PORT_ERROR__NONE`; only a negative result is a hard failure. (No existing callers; synchronous/blocking opens still return immediately via a post-`portOpen()` `portIsOpened()` check.)
- `NtripCorrectionService::connect()`: use `portOpenRetry()` (5 s) so the TCP connection is established before the GET is written.

### Bug 2 — corrections never resume after a reconnect

`CorrectionService::step()` reopens the source TCP socket after a drop but never re-sends the NTRIP mount-point request. Since an NTRIP caster only streams after it receives that request, a reconnected socket sits connected-but-silent.

**Fix:**
- Make `CorrectionService::step()` `virtual` (and `lastConnAttemptTs` protected) so protocol subclasses can extend (re)connect handling.
- Factor the mount-point negotiation out of `connect()` into `negotiateMountPoint()`, and cache the built request (`requestMsg`) for replay.
- Override `NtripCorrectionService::step()`: when the source isn't open, advance the non-blocking TCP connect and, once the socket reopens, re-run `negotiateMountPoint()` before delegating to `CorrectionService::step()`. Reconnect stays non-blocking (portOpen polled across `step()` calls); only the bounded mount-point negotiation blocks briefly, once per reconnect.

`tcpPortOpen()`'s non-blocking connect is intentionally unchanged.

## Validation

Against the **live caster** with SDK harnesses using the real `TcpPortFactory` / `portOpen` / `portWrite` / `NtripCorrectionService`:

- Caster healthy: sourcetable `SOURCETABLE 200 OK`; mountpoint `GET /GNSS-VRS-NAD83-RTCM32` → `ICY 200 OK`.
- **Bug 1 before:** single `portOpen()` → `portIsOpened()`=0, immediate `portWrite()` = `-11` (`-EAGAIN`) → fails. `portOpenRetry()` returns 0 with `portIsOpened()`=0.
- **Bug 1 after:** `portOpenRetry()` returns 0 with `portIsOpened()`=1; the exact new `connect()` sequence writes all bytes and gets `ICY 200 OK`.
- **Bug 2 after:** construct `NtripCorrectionService` (connects, `ICY 200 OK`); force-close the source socket (`isConnected()`→0); pump `step()` → reconnects and re-negotiates within ~3 iterations (`ICY 200 OK` again), `isConnected()`→1.

Builds clean on Linux/GCC (SDK lib + full EvalTool). MSVC via CI (the `WSAEWOULDBLOCK`/`WSAEINPROGRESS` pending branch in `tcpPortOpen()` mirrors the POSIX path, so `portOpenRetry()` polls identically on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SN-8390]: https://inertialsense.atlassian.net/browse/SN-8390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ