### PR TITLE
SN-8269 Example Project fix for Minimal_ISDevice weak pointer run problem

### DIFF
--- a/ExampleProjects/Minimal_ISDevice/ISDeviceExample1.cpp
+++ b/ExampleProjects/Minimal_ISDevice/ISDeviceExample1.cpp
@@ -65,8 +65,11 @@ int main_explained(const char* portStr) {
     }
 
     // With a valid, opened port, we can instance an ISDevice - in this case, an IMX-5.0 and associate the port to it.
-    ISDevice* device = new ISDevice(IS_HARDWARE_IMX_5_0, port);
-
+    // NOTE: ISDevice derives from std::enable_shared_from_this, and several of its methods (connect/validate/step)
+    // call shared_from_this() internally. It MUST therefore be owned by a std::shared_ptr - allocating it with a raw
+    // 'new' would leave it without a control block and throw std::bad_weak_ptr at the first such call.
+    std::shared_ptr<ISDevice> device = std::make_shared<ISDevice>(IS_HARDWARE_IMX_5_0, port);
+    
     if (!device->isConnected())
         exit(3); // this is another way we can confirm the connected status of the device
 
@@ -128,7 +131,9 @@ int main_minimal(const char* portStr) {
     port_handle_t port = SerialPortFactory::getInstance().bindPort(portStr);
 
     // create a new IMX-5.0 device and bind the associated port
-    ISDevice* device = new ISDevice(IS_HARDWARE_IMX_5_0, port);
+    // NOTE: ISDevice uses shared_from_this() internally, so it must be owned by a std::shared_ptr (make_shared),
+    // not a raw 'new' - otherwise connect()/validate()/step() throw std::bad_weak_ptr.
+    std::shared_ptr<ISDevice> device = std::make_shared<ISDevice>(IS_HARDWARE_IMX_5_0, port);
 
     // connect to the device
     if (!device->connect()) {


### PR DESCRIPTION
The develop branch Minimal_ISDevice project did not run (whether given a command line argument with a port name of an IS device channel or not), with error
```
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  bad_weak_ptr
Aborted (core dumped)

``` 

Was found to come from using a raw ISDevice pointer instead of shared, the latter necessitated by updates to SDK ISDevice class, and some Example Projects needed to pick up the appropriate new usage.

This change was tested, and the project now runs rather than throwing the bad_weak_ptr exception.  This is the exact change to the two lines, taken from the `Airgap` branch commit: https://github.com/inertialsense/inertial-sense-sdk/commit/e88743903e944e4ff4b33edcb4bd343f33f80246, just the changes associated with this ISDevice* only.  Kyle and I determined to go ahead and get this small particular change done quicker independently.