### PR TITLE
Exclude GPX_STATUS_FAULT_RTOS_TASK_PERIOD_OVERRUN from GPX_STATUS_GENERAL_FAULT_MASK

### DIFF
--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4300,7 +4300,9 @@ enum eGpxStatus
 
     GPX_STATUS_UPDATE_CONFIRMED                 = (int)0x00000100,  //!< Update confirmed
 
-    GPX_STATUS_GENERAL_FAULT_MASK               = (int)0xFFFF0000,  //!< Mask covering all general fault bits (RTK/GNSS/RTOS/DMA faults and the fatal sub-field)
+    // TODO: Re-enable this after we have addressed the cause of the RTOS task period overruns. For now, we will ignore this fault to avoid false positives. WHJ
+    // GPX_STATUS_GENERAL_FAULT_MASK               = (int)0xFFFF0000,  //!< Mask covering all general fault bits (RTK/GNSS/RTOS/DMA faults and the fatal sub-field)
+    GPX_STATUS_GENERAL_FAULT_MASK               = (int)0xFFDF0000,  //!< Mask covering all general fault bits (RTK/GNSS/RTOS/DMA faults and the fatal sub-field)        // GPX_STATUS_FAULT_RTOS_TASK_PERIOD_OVERRUN excluded to prevent RTOS task period overrun false positives. WHJ
 
     GPX_STATUS_FAULT_RTK_QUEUE_LIMITED          = (int)0x00010000,  //!< RTK buffer filled causing data loss
 


### PR DESCRIPTION
This pull request makes a targeted change to the general fault mask in the `eGpxStatus` enum to temporarily exclude the RTOS task period overrun fault. This is intended to prevent false positives until the underlying issue is addressed.

Fault handling adjustment:

* In `src/data_sets.h`, the value of `GPX_STATUS_GENERAL_FAULT_MASK` was changed to exclude `GPX_STATUS_FAULT_RTOS_TASK_PERIOD_OVERRUN`, with a comment explaining this is a temporary measure to avoid false positives related to RTOS task period overruns.