### PR TITLE
SN-8402: Redefine GPX RX-traffic status bits as detected (breaking)

### DIFF
--- a/python/inertialsense/logInspector/logPlotter.py
+++ b/python/inertialsense/logInspector/logPlotter.py
@@ -2023,24 +2023,26 @@ class logPlot:
                     if r: ax.text(labelX, -cnt * 1.5, 'Com parse err count', transform=ax.get_yaxis_transform())
                     cnt += 1
 
-                    ### No Comms flags
-                    # Shift amounts must match each mask's own bit position (GPX_STATUS_COM0/1/2_RX_TRAFFIC_NOT_DETECTED
-                    # and GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED are bits 4-7 -- these were previously shifted by
+                    ### Comms Detected flags
+                    # Shift amounts must match each mask's own bit position (GPX_STATUS_COM0/1/2_RX_TRAFFIC_DETECTED
+                    # and GPX_STATUS_USB_RX_TRAFFIC_DETECTED are bits 4-7 -- these were previously shifted by
                     # 8-11, which always evaluates to 0 regardless of the actual bit's state).
+                    # SN-8402: bit meaning was inverted (formerly ..._NOT_DETECTED, set = no comms);
+                    # 1 now means comms WERE detected in the last 30s, matching the label.
                     ax.plot(time[ind], -cnt * 1.5 + ((status[ind] & 0x00000010) >> 4))
-                    if r: ax.text(labelX, -cnt * 1.5, 'No Ser0 Comms', transform=ax.get_yaxis_transform())
+                    if r: ax.text(labelX, -cnt * 1.5, 'Ser0 Comms Detected', transform=ax.get_yaxis_transform())
                     cnt += 1
 
                     ax.plot(time[ind], -cnt * 1.5 + ((status[ind] & 0x00000020) >> 5))
-                    if r: ax.text(labelX, -cnt * 1.5, 'No Ser1 Comms', transform=ax.get_yaxis_transform())
+                    if r: ax.text(labelX, -cnt * 1.5, 'Ser1 Comms Detected', transform=ax.get_yaxis_transform())
                     cnt += 1
 
                     ax.plot(time[ind], -cnt * 1.5 + ((status[ind] & 0x00000040) >> 6))
-                    if r: ax.text(labelX, -cnt * 1.5, 'No Ser2 Comms', transform=ax.get_yaxis_transform())
+                    if r: ax.text(labelX, -cnt * 1.5, 'Ser2 Comms Detected', transform=ax.get_yaxis_transform())
                     cnt += 1
 
                     ax.plot(time[ind], -cnt * 1.5 + ((status[ind] & 0x00000080) >> 7))
-                    if r: ax.text(labelX, -cnt * 1.5, 'No USB Comms', transform=ax.get_yaxis_transform())
+                    if r: ax.text(labelX, -cnt * 1.5, 'USB Comms Detected', transform=ax.get_yaxis_transform())
                     cnt += 1
 
                     ### General Faults

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -27,7 +27,7 @@ uint32_t maskShift(uint32_t mask)
 }
 
 /** @brief Build a single on/off-bit sub-field descriptor. */
-status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const char* legacy)
+status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const char* legacy, bool boolInvert = false)
 {
     status_subfield_t s;
     s.name       = name;
@@ -35,6 +35,7 @@ status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const 
     s.mask       = mask;
     s.shift      = 0;
     s.isError    = isError;
+    s.boolInvert = boolInvert;
     s.gateMask   = 0;
     s.legacyText = legacy;
     return s;
@@ -488,21 +489,21 @@ status_field_decode_t buildGpxStatusDecode()
     d.fieldName = "status";   // registry key is "gpxStatus"
     d.errorMask = (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK;
 
-    auto gerr = [](const char* name, uint32_t mask, const char* legacy) {
-        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy);
-    };
-    // Inverted variant: bit set means "OK" (e.g. traffic detected), not fault.
-    auto gerrInv = [](const char* name, uint32_t mask, const char* legacy) {
-        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) == 0, legacy);
+    auto gerr = [](const char* name, uint32_t mask, const char* legacy, bool boolInvert = false) {
+        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy, boolInvert);
     };
 
     // Parse-error count is rendered by the legacy code as a presence flag (any of the low nibble),
     // not a number — model it as a Bit on the count mask.
     d.subfields.push_back(gerr("COM parse errors", GPX_STATUS_COM_PARSE_ERR_COUNT_MASK, "0x0000000F - Communications parse error count"));
-    d.subfields.push_back(gerrInv("COM0 RX traffic detected", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED, "0x00000010 - COM0 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerrInv("COM1 RX traffic detected", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED, "0x00000020 - COM1 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerrInv("COM2 RX traffic detected", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED, "0x00000040 - COM2 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerrInv("USB RX traffic detected", GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED, "0x00000080 - USB RX traffic not detected in last 30 seconds."));
+    // These four are a status, not a fault (deliberately outside GPX_STATUS_GENERAL_FAULT_MASK, so
+    // isError stays false via gerr()) -- positively-worded name + boolInvert=true so a boolean-style
+    // consumer (the status-ribbon chart) shows "RX traffic detected" = true when the underlying
+    // NOT_DETECTED bit is clear. legacyText (and RenderStatusFromDecode's line output) is untouched.
+    d.subfields.push_back(gerr("COM0 RX traffic detected", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED, "0x00000010 - COM0 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
+    d.subfields.push_back(gerr("COM1 RX traffic detected", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED, "0x00000020 - COM1 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
+    d.subfields.push_back(gerr("COM2 RX traffic detected", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED, "0x00000040 - COM2 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
+    d.subfields.push_back(gerr("USB RX traffic detected", GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED, "0x00000080 - USB RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
     d.subfields.push_back(gerr("Firmware image confirmed", GPX_STATUS_UPDATE_CONFIRMED, "0x00000100 - Update confirmed."));
     d.subfields.push_back(gerr("RTK buffer overflow", GPX_STATUS_FAULT_RTK_QUEUE_LIMITED, "0x00010000 - RTK buffer overflow."));
     d.subfields.push_back(gerr("GNSS receiver time fault", GPX_STATUS_FAULT_GNSS_RCVR_TIME, "0x00100000 - GNSS receiver time fault"));

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -27,7 +27,7 @@ uint32_t maskShift(uint32_t mask)
 }
 
 /** @brief Build a single on/off-bit sub-field descriptor. */
-status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const char* legacy, bool boolInvert = false)
+status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const char* legacy)
 {
     status_subfield_t s;
     s.name       = name;
@@ -35,7 +35,6 @@ status_subfield_t bitField(const char* name, uint32_t mask, bool isError, const 
     s.mask       = mask;
     s.shift      = 0;
     s.isError    = isError;
-    s.boolInvert = boolInvert;
     s.gateMask   = 0;
     s.legacyText = legacy;
     return s;
@@ -489,21 +488,22 @@ status_field_decode_t buildGpxStatusDecode()
     d.fieldName = "status";   // registry key is "gpxStatus"
     d.errorMask = (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK;
 
-    auto gerr = [](const char* name, uint32_t mask, const char* legacy, bool boolInvert = false) {
-        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy, boolInvert);
+    auto gerr = [](const char* name, uint32_t mask, const char* legacy) {
+        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy);
     };
 
     // Parse-error count is rendered by the legacy code as a presence flag (any of the low nibble),
     // not a number — model it as a Bit on the count mask.
     d.subfields.push_back(gerr("COM parse errors", GPX_STATUS_COM_PARSE_ERR_COUNT_MASK, "0x0000000F - Communications parse error count"));
-    // These four are a status, not a fault (deliberately outside GPX_STATUS_GENERAL_FAULT_MASK, so
-    // isError stays false via gerr()) -- positively-worded name + boolInvert=true so a boolean-style
-    // consumer (the status-ribbon chart) shows "RX traffic detected" = true when the underlying
-    // NOT_DETECTED bit is clear. legacyText (and RenderStatusFromDecode's line output) is untouched.
-    d.subfields.push_back(gerr("COM0 RX traffic detected", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED, "0x00000010 - COM0 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
-    d.subfields.push_back(gerr("COM1 RX traffic detected", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED, "0x00000020 - COM1 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
-    d.subfields.push_back(gerr("COM2 RX traffic detected", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED, "0x00000040 - COM2 RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
-    d.subfields.push_back(gerr("USB RX traffic detected", GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED, "0x00000080 - USB RX traffic not detected in last 30 seconds.", /*boolInvert=*/true));
+    // SN-8402: these four are a status, not a fault (deliberately outside GPX_STATUS_GENERAL_FAULT_MASK,
+    // isError stays false). The bit itself was redefined (GPX_STATUS_COM*_RX_TRAFFIC_NOT_DETECTED ->
+    // GPX_STATUS_COM*_RX_TRAFFIC_DETECTED, same mask, inverted meaning) so the wire value now directly
+    // matches its positive name -- no display-side inversion needed. Firmware that sets this bit
+    // (communications.cpp) was updated to match.
+    d.subfields.push_back(gerr("COM0 RX traffic detected", GPX_STATUS_COM0_RX_TRAFFIC_DETECTED, "0x00000010 - COM0 RX traffic detected in last 30 seconds."));
+    d.subfields.push_back(gerr("COM1 RX traffic detected", GPX_STATUS_COM1_RX_TRAFFIC_DETECTED, "0x00000020 - COM1 RX traffic detected in last 30 seconds."));
+    d.subfields.push_back(gerr("COM2 RX traffic detected", GPX_STATUS_COM2_RX_TRAFFIC_DETECTED, "0x00000040 - COM2 RX traffic detected in last 30 seconds."));
+    d.subfields.push_back(gerr("USB RX traffic detected", GPX_STATUS_USB_RX_TRAFFIC_DETECTED, "0x00000080 - USB RX traffic detected in last 30 seconds."));
     d.subfields.push_back(gerr("Firmware image confirmed", GPX_STATUS_UPDATE_CONFIRMED, "0x00000100 - Update confirmed."));
     d.subfields.push_back(gerr("RTK buffer overflow", GPX_STATUS_FAULT_RTK_QUEUE_LIMITED, "0x00010000 - RTK buffer overflow."));
     d.subfields.push_back(gerr("GNSS receiver time fault", GPX_STATUS_FAULT_GNSS_RCVR_TIME, "0x00100000 - GNSS receiver time fault"));

--- a/src/ISStatusDecode.cpp
+++ b/src/ISStatusDecode.cpp
@@ -491,14 +491,18 @@ status_field_decode_t buildGpxStatusDecode()
     auto gerr = [](const char* name, uint32_t mask, const char* legacy) {
         return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) != 0, legacy);
     };
+    // Inverted variant: bit set means "OK" (e.g. traffic detected), not fault.
+    auto gerrInv = [](const char* name, uint32_t mask, const char* legacy) {
+        return bitField(name, mask, (mask & (uint32_t)GPX_STATUS_GENERAL_FAULT_MASK) == 0, legacy);
+    };
 
     // Parse-error count is rendered by the legacy code as a presence flag (any of the low nibble),
     // not a number — model it as a Bit on the count mask.
     d.subfields.push_back(gerr("COM parse errors", GPX_STATUS_COM_PARSE_ERR_COUNT_MASK, "0x0000000F - Communications parse error count"));
-    d.subfields.push_back(gerr("COM0 RX traffic lost", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED, "0x00000010 - COM0 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerr("COM1 RX traffic lost", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED, "0x00000020 - COM1 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerr("COM2 RX traffic lost", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED, "0x00000040 - COM2 RX traffic not detected in last 30 seconds."));
-    d.subfields.push_back(gerr("USB RX traffic lost", GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED, "0x00000080 - USB RX traffic not detected in last 30 seconds."));
+    d.subfields.push_back(gerrInv("COM0 RX traffic detected", GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED, "0x00000010 - COM0 RX traffic not detected in last 30 seconds."));
+    d.subfields.push_back(gerrInv("COM1 RX traffic detected", GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED, "0x00000020 - COM1 RX traffic not detected in last 30 seconds."));
+    d.subfields.push_back(gerrInv("COM2 RX traffic detected", GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED, "0x00000040 - COM2 RX traffic not detected in last 30 seconds."));
+    d.subfields.push_back(gerrInv("USB RX traffic detected", GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED, "0x00000080 - USB RX traffic not detected in last 30 seconds."));
     d.subfields.push_back(gerr("Firmware image confirmed", GPX_STATUS_UPDATE_CONFIRMED, "0x00000100 - Update confirmed."));
     d.subfields.push_back(gerr("RTK buffer overflow", GPX_STATUS_FAULT_RTK_QUEUE_LIMITED, "0x00010000 - RTK buffer overflow."));
     d.subfields.push_back(gerr("GNSS receiver time fault", GPX_STATUS_FAULT_GNSS_RCVR_TIME, "0x00100000 - GNSS receiver time fault"));

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -55,6 +55,7 @@ struct status_subfield_t
     uint32_t                          mask     = 0;                            //!< Bit(s) this sub-field occupies in the raw value.
     uint32_t                          shift    = 0;                            //!< Right-shift for Enum/Count extraction; 0 for Bit.
     bool                              isError  = false;                        //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
+    bool                              boolInvert = false;                     //!< Bit only: for boolean-style consumers (e.g. the status-ribbon chart), invert the raw `(value & mask) != 0` truthiness before display. Lets a negatively-worded status bit (e.g. "...NOT_DETECTED") carry a positively-worded `name` ("...detected") without changing the underlying bit or `legacyText`/`RenderStatusFromDecode` line output, which is governed by the raw bit and unaffected by this flag.
     uint32_t                          gateMask = 0;                            //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
     bool                              emitZero = false;                        //!< Count: emit a line even when the extracted value is 0 (e.g. GNSS satellite count). Default: skip zero.
     bool                              modeHexDec = false;                      //!< Count: format args are `(masked, shifted)` instead of `(value, value)` — for "hex(masked) ... dec(shifted)" lines (the BIT-mode pattern).

--- a/src/ISStatusDecode.h
+++ b/src/ISStatusDecode.h
@@ -55,7 +55,6 @@ struct status_subfield_t
     uint32_t                          mask     = 0;                            //!< Bit(s) this sub-field occupies in the raw value.
     uint32_t                          shift    = 0;                            //!< Right-shift for Enum/Count extraction; 0 for Bit.
     bool                              isError  = false;                        //!< Bit: this flag is an error. Enum/Count: sub-field is error-bearing (per-value override via `values`).
-    bool                              boolInvert = false;                     //!< Bit only: for boolean-style consumers (e.g. the status-ribbon chart), invert the raw `(value & mask) != 0` truthiness before display. Lets a negatively-worded status bit (e.g. "...NOT_DETECTED") carry a positively-worded `name` ("...detected") without changing the underlying bit or `legacyText`/`RenderStatusFromDecode` line output, which is governed by the raw bit and unaffected by this flag.
     uint32_t                          gateMask = 0;                            //!< If non-zero, only decode/emit when `(raw & gateMask) != 0` (hybrid pattern). 0 = always.
     bool                              emitZero = false;                        //!< Count: emit a line even when the extracted value is 0 (e.g. GNSS satellite count). Default: skip zero.
     bool                              modeHexDec = false;                      //!< Count: format args are `(masked, shifted)` instead of `(value, value)` — for "hex(masked) ... dec(shifted)" lines (the BIT-mode pattern).

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4290,7 +4290,7 @@ typedef struct
 
 } gpx_flash_cfg_t;
 
-/** @brief (DID_GPX_STATUS) GPX status flags, reported in gpx_status_t.status. Packs a communications parse-error counter, per-port Rx-traffic-not-detected flags, an update-confirmed flag, and a general fault region (bits 16-31) covering RTK/GNSS/RTOS/DMA fault flags plus a fatal-fault sub-field (GPX_STATUS_FATAL_MASK) that reports the specific cause the last time a critical CPU reset occurred. GPX_STATUS_FATAL_RESET_LOW_POW..GPX_STATUS_FATAL_UNKNOWN are raw cause codes, not individual bit flags -- shift the code left by GPX_STATUS_FATAL_OFFSET and mask with GPX_STATUS_FATAL_MASK to read/write the sub-field. */
+/** @brief (DID_GPX_STATUS) GPX status flags, reported in gpx_status_t.status. Packs a communications parse-error counter, per-port Rx-traffic-detected flags, an update-confirmed flag, and a general fault region (bits 16-31) covering RTK/GNSS/RTOS/DMA fault flags plus a fatal-fault sub-field (GPX_STATUS_FATAL_MASK) that reports the specific cause the last time a critical CPU reset occurred. GPX_STATUS_FATAL_RESET_LOW_POW..GPX_STATUS_FATAL_UNKNOWN are raw cause codes, not individual bit flags -- shift the code left by GPX_STATUS_FATAL_OFFSET and mask with GPX_STATUS_FATAL_MASK to read/write the sub-field. */
 enum eGpxStatus
 {
     GPX_STATUS_COM_PARSE_ERR_COUNT_MASK         = (int)0x0000000F,  //!< Mask for the communications parse error count field

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -4293,10 +4293,10 @@ enum eGpxStatus
     GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET       = 0,                //!< Bit offset of GPX_STATUS_COM_PARSE_ERR_COUNT_MASK within status
 #define GPX_STATUS_COM_PARSE_ERROR_COUNT(gpxStatus) ((gpxStatus&GPX_STATUS_COM_PARSE_ERR_COUNT_MASK)>>GPX_STATUS_COM_PARSE_ERR_COUNT_OFFSET)  //!< Extract the communications parse error count from a status value
 
-    GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED     = (int)0x00000010,  //!< Rx communications not detected on serial port 0 in the last 30 seconds
-    GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED     = (int)0x00000020,  //!< Rx communications not detected on serial port 1 in the last 30 seconds
-    GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED     = (int)0x00000040,  //!< Rx communications not detected on serial port 2 in the last 30 seconds
-    GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED      = (int)0x00000080,  //!< Rx communications not detected on USB in the last 30 seconds
+    GPX_STATUS_COM0_RX_TRAFFIC_DETECTED         = (int)0x00000010,  //!< Rx communications detected on serial port 0 in the last 30 seconds
+    GPX_STATUS_COM1_RX_TRAFFIC_DETECTED         = (int)0x00000020,  //!< Rx communications detected on serial port 1 in the last 30 seconds
+    GPX_STATUS_COM2_RX_TRAFFIC_DETECTED         = (int)0x00000040,  //!< Rx communications detected on serial port 2 in the last 30 seconds
+    GPX_STATUS_USB_RX_TRAFFIC_DETECTED          = (int)0x00000080,  //!< Rx communications detected on USB in the last 30 seconds
 
     GPX_STATUS_UPDATE_CONFIRMED                 = (int)0x00000100,  //!< Update confirmed
 

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -259,10 +259,10 @@ std::string legacyRenderGpxStatusReference(uint32_t status)
     std::stringstream buff;
 #define BIT_MSG(_F_, _B_, _M_)    if (_F_ & _B_) { buff << _M_ << std::endl; }
     BIT_MSG(status, GPX_STATUS_COM_PARSE_ERR_COUNT_MASK     , "0x0000000F - Communications parse error count");
-    BIT_MSG(status, GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED , "0x00000010 - COM0 RX traffic not detected in last 30 seconds.");
-    BIT_MSG(status, GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED , "0x00000020 - COM1 RX traffic not detected in last 30 seconds.");
-    BIT_MSG(status, GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED , "0x00000040 - COM2 RX traffic not detected in last 30 seconds.");
-    BIT_MSG(status, GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED  , "0x00000080 - USB RX traffic not detected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_COM0_RX_TRAFFIC_DETECTED     , "0x00000010 - COM0 RX traffic detected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_COM1_RX_TRAFFIC_DETECTED     , "0x00000020 - COM1 RX traffic detected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_COM2_RX_TRAFFIC_DETECTED     , "0x00000040 - COM2 RX traffic detected in last 30 seconds.");
+    BIT_MSG(status, GPX_STATUS_USB_RX_TRAFFIC_DETECTED      , "0x00000080 - USB RX traffic detected in last 30 seconds.");
     BIT_MSG(status, GPX_STATUS_UPDATE_CONFIRMED             , "0x00000100 - Update confirmed.");
     BIT_MSG(status, GPX_STATUS_FAULT_RTK_QUEUE_LIMITED      , "0x00010000 - RTK buffer overflow.");
     BIT_MSG(status, GPX_STATUS_FAULT_GNSS_RCVR_TIME         , "0x00100000 - GNSS receiver time fault");
@@ -901,22 +901,21 @@ TEST(ISStatusDecode, GpxStatus_RoundTrip_RandomSweep)
     }
 }
 
-// SN-8402: the four RX-traffic subfields are a status, not a fault (isError stays false,
-// consistent with them being excluded from GPX_STATUS_GENERAL_FAULT_MASK) -- but a boolean-style
-// consumer (the status-ribbon chart) needs boolInvert=true so the positively-worded "detected" name
-// shows true when the underlying NOT_DETECTED bit is clear. Confirms the schema data, not any
-// particular consumer's rendering (that's covered on the Logalyzer side).
-TEST(ISStatusDecode, GpxStatus_RxTrafficSubfields_PositiveNameNotFaultButInverted)
+// SN-8402: GPX_STATUS_COM*_RX_TRAFFIC_DETECTED (bits 4-7) were redefined from the prior
+// ..._NOT_DETECTED (same mask, inverted meaning) so the wire bit itself carries positive
+// polarity -- these are a status, not a fault, so isError stays false. No display-side
+// inversion needed: the raw bit now directly matches the positive name.
+TEST(ISStatusDecode, GpxStatus_RxTrafficSubfields_PositivePolarityNotFault)
 {
     const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
     ASSERT_NE(dec, nullptr);
 
     struct Want { const char* name; uint32_t mask; };
     const Want wants[] = {
-        { "COM0 RX traffic detected", (uint32_t)GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED },
-        { "COM1 RX traffic detected", (uint32_t)GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED },
-        { "COM2 RX traffic detected", (uint32_t)GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED },
-        { "USB RX traffic detected",  (uint32_t)GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED },
+        { "COM0 RX traffic detected", (uint32_t)GPX_STATUS_COM0_RX_TRAFFIC_DETECTED },
+        { "COM1 RX traffic detected", (uint32_t)GPX_STATUS_COM1_RX_TRAFFIC_DETECTED },
+        { "COM2 RX traffic detected", (uint32_t)GPX_STATUS_COM2_RX_TRAFFIC_DETECTED },
+        { "USB RX traffic detected",  (uint32_t)GPX_STATUS_USB_RX_TRAFFIC_DETECTED },
     };
 
     for (const auto& w : wants) {
@@ -927,10 +926,10 @@ TEST(ISStatusDecode, GpxStatus_RxTrafficSubfields_PositiveNameNotFaultButInverte
         EXPECT_EQ(sf->name, w.name);
         EXPECT_EQ(sf->kind, eStatusSubfieldKind::Bit);
         EXPECT_FALSE(sf->isError) << w.name << " is a status, not a fault";
-        EXPECT_TRUE(sf->boolInvert) << w.name;
-        // legacyText / RenderStatusFromDecode's line output is unaffected by the rename or the
-        // invert flag -- still only emitted when the raw NOT_DETECTED bit is actually set.
-        EXPECT_NE(sf->legacyText.find("not detected"), std::string::npos) << w.name;
+        // legacyText / RenderStatusFromDecode's line output: emitted (positive-worded) only when
+        // the bit is actually set -- i.e. only when traffic IS detected.
+        EXPECT_NE(sf->legacyText.find("detected"), std::string::npos) << w.name;
+        EXPECT_EQ(sf->legacyText.find("not detected"), std::string::npos) << w.name;
         EXPECT_EQ(RenderStatusFromDecode(*dec, w.mask), legacyRenderGpxStatusReference(w.mask));
     }
 }

--- a/tests/test_ISStatusDecode.cpp
+++ b/tests/test_ISStatusDecode.cpp
@@ -901,6 +901,40 @@ TEST(ISStatusDecode, GpxStatus_RoundTrip_RandomSweep)
     }
 }
 
+// SN-8402: the four RX-traffic subfields are a status, not a fault (isError stays false,
+// consistent with them being excluded from GPX_STATUS_GENERAL_FAULT_MASK) -- but a boolean-style
+// consumer (the status-ribbon chart) needs boolInvert=true so the positively-worded "detected" name
+// shows true when the underlying NOT_DETECTED bit is clear. Confirms the schema data, not any
+// particular consumer's rendering (that's covered on the Logalyzer side).
+TEST(ISStatusDecode, GpxStatus_RxTrafficSubfields_PositiveNameNotFaultButInverted)
+{
+    const status_field_decode_t* dec = GetStatusDecodeByField("gpxStatus");
+    ASSERT_NE(dec, nullptr);
+
+    struct Want { const char* name; uint32_t mask; };
+    const Want wants[] = {
+        { "COM0 RX traffic detected", (uint32_t)GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED },
+        { "COM1 RX traffic detected", (uint32_t)GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED },
+        { "COM2 RX traffic detected", (uint32_t)GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED },
+        { "USB RX traffic detected",  (uint32_t)GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED },
+    };
+
+    for (const auto& w : wants) {
+        const status_subfield_t* sf = nullptr;
+        for (const auto& cand : dec->subfields)
+            if (cand.mask == w.mask) { sf = &cand; break; }
+        ASSERT_NE(sf, nullptr) << w.name;
+        EXPECT_EQ(sf->name, w.name);
+        EXPECT_EQ(sf->kind, eStatusSubfieldKind::Bit);
+        EXPECT_FALSE(sf->isError) << w.name << " is a status, not a fault";
+        EXPECT_TRUE(sf->boolInvert) << w.name;
+        // legacyText / RenderStatusFromDecode's line output is unaffected by the rename or the
+        // invert flag -- still only emitted when the raw NOT_DETECTED bit is actually set.
+        EXPECT_NE(sf->legacyText.find("not detected"), std::string::npos) << w.name;
+        EXPECT_EQ(RenderStatusFromDecode(*dec, w.mask), legacyRenderGpxStatusReference(w.mask));
+    }
+}
+
 TEST(ISStatusDecode, GpxHdwStatus_RoundTrip_EverySingleBit)
 {
     const status_field_decode_t* dec = GetStatusDecodeByField("gpxHdwStatus");


### PR DESCRIPTION
## Summary — REVISED per Kyle's correction

Earlier revisions of this PR used a display-layer `boolInvert` flag to translate the negatively-worded bits for the ribbon chart, while leaving the underlying `GPX_STATUS_COM0/1/2/USB_RX_TRAFFIC_NOT_DETECTED` bit definition untouched. Kyle's correction: that's the wrong shape of fix — the underlying bit definition should carry the correct meaning; the rendering should just reflect it, not translate it.

## This version

**BREAKING:** renamed the four enum constants in `data_sets.h` (same mask, bits 4-7 of `DID_GPX_STATUS.status`, **inverted meaning**):
```
GPX_STATUS_COM0_RX_TRAFFIC_NOT_DETECTED -> GPX_STATUS_COM0_RX_TRAFFIC_DETECTED
GPX_STATUS_COM1_RX_TRAFFIC_NOT_DETECTED -> GPX_STATUS_COM1_RX_TRAFFIC_DETECTED
GPX_STATUS_COM2_RX_TRAFFIC_NOT_DETECTED -> GPX_STATUS_COM2_RX_TRAFFIC_DETECTED
GPX_STATUS_USB_RX_TRAFFIC_NOT_DETECTED  -> GPX_STATUS_USB_RX_TRAFFIC_DETECTED
```
The bit is now **1 when traffic HAS been heard in the last 30s**, previously 1 when it had NOT.

- `ISStatusDecode.{h,cpp}`: removed the `boolInvert` schema field (dead once the bit itself is correct); `buildGpxStatusDecode()` uses the new names via the existing `gerr()` helper — no special-casing needed. `isError` stays `false` (status, not fault). `legacyText` flipped to positive phrasing ("...RX traffic detected...").
- `data_sets.h`: also fixed the `eGpxStatus` block doc comment, which still said "per-port Rx-traffic-not-detected flags" (caught by Copilot review).
- `python/inertialsense/logInspector/logPlotter.py`: relabeled the four GPX-status plot rows to match (same raw bit; meaning flips).
- `tests/test_ISStatusDecode.cpp`: updated the legacy-oracle text to the new polarity; replaced the `boolInvert`-specific test with one asserting the new positive-polarity, non-fault subfields directly.

**Compatibility note (raised in review):** this is an intentional, documented breaking change to the wire meaning of bits 4-7 of `DID_GPX_STATUS.status`. Two concrete consequences:
1. Any external tooling reading these raw bits directly (not through `ISDataMappings`/`ISStatusDecode`) will misinterpret them against firmware built from this change vs. any prior release.
2. **Historical logs recorded with pre-fix firmware, replayed through a post-fix build of this SDK** (cltool/EvalTool/Logalyzer), will show the new positive-polarity label/legend applied to the old bit semantics — i.e. an old log where the bit meant "not detected" will now display as if it meant "detected". There's no data-format flag distinguishing pre- and post-fix firmware for this field, so this is a real, accepted limitation, not an oversight — flagging it explicitly rather than leaving it implicit.

## Companion PRs

- `inertialsense/imx#1643` — the actual firmware fix (where the bit is set).
- `inertialsense/is-gpx#178` — submodule bump so shipped GPX-1 3.1.0 firmware picks it up.
- `inertialsense/logalyzer#84` — where the bug was first observed; now needs no special handling at all since the bit itself is correct.

## Test plan

- [x] Full SDK suite: 460 tests, 456 pass / 4 pre-existing skips, 0 failures.
- [x] `GpxStatus_RxTrafficSubfields_PositivePolarityNotFault` (new) — asserts name/kind/isError/legacyText for all four subfields.
- [x] Existing `GpxStatus_RoundTrip_*` (every-bit, fatal-resets, random-sweep) all still pass against the updated legacy oracle.