### PR TITLE
SN-8405: Increase MAX_NUM_SATELLITES to 80, MAX_NUM_SAT_SIGNALS to 160

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -516,10 +516,7 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_GYR ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_ACC ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_MAG)
+        if (pkt->data.size <= MAX_DATASET_SIZE)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -538,10 +535,7 @@ static protocol_type_t processIsbPkt(void* v)
         {
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
-            if (get->size <= MAX_DATASET_SIZE ||
-                get->id == DID_CAL_TEMP_COMP_GYR ||
-                get->id == DID_CAL_TEMP_COMP_ACC ||
-                get->id == DID_CAL_TEMP_COMP_MAG)
+            if (get->size <= MAX_DATASET_SIZE)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -131,15 +131,6 @@ typedef enum
 /** Default protocol enable mask used by is_comm_init() when no explicit mask is set. */
 #define DEFAULT_PROTO_MASK (ENABLE_PROTOCOL_ISB | ENABLE_PROTOCOL_NMEA | ENABLE_PROTOCOL_UBLOX | ENABLE_PROTOCOL_RTCM3)
 
-/** The maximum allowable dataset size. SN-8405: raised from 1024 to cover gnss_sig_t's new
- *  max size (1128 bytes at MAX_NUM_SAT_SIGNALS=160) with headroom; a single ISB packet can
- *  carry far more than this (see is_comm_write_isb_precomp_to_port's PKT_BUF_SIZE check), so
- *  this does not require any change to PKT_BUF_SIZE. */
-#define MAX_DATASET_SIZE        1280
-
-/** The decoded overhead involved in sending a packet - 4 bytes for header, 4 bytes for footer */
-#define PKT_OVERHEAD_SIZE       8       // = START_BYTE + INFO_BYTE + COUNTER_BYTE + FLAGS_BYTE + CHECKSUM_BYTE_1 + CHECKSUM_BYTE_2 + CHECKSUM_BYTE_3 + END_BYTE
-
 /** The maximum buffer space that is used for sending and receiving packets */
 #ifndef PKT_BUF_SIZE
 #define PKT_BUF_SIZE            2048
@@ -148,17 +139,9 @@ typedef enum
 /** The maximum time between received data that will reset in the parser */
 #define MAX_PARSER_GAP_TIME_MS  100
 
-/** The maximum encoded overhead size in sending a packet (7 bytes for header, 7 bytes for footer). The packet start and end bytes are never encoded. */
-#define MAX_PKT_OVERHEAD_SIZE   (PKT_OVERHEAD_SIZE + PKT_OVERHEAD_SIZE - 2)  // worst case for packet encoding header / footer
-
-/** The maximum size of an decoded packet body */
-#define MAX_PKT_BODY_SIZE       (((PKT_BUF_SIZE - MAX_PKT_OVERHEAD_SIZE) / 2) & 0xFFFFFFFE) // worst case for packet encoding body, rounded down to even number
-
-/** The maximum size of decoded data in a packet body */
-#define MAX_P_DATA_BODY_SIZE    (MAX_PKT_BODY_SIZE-sizeof(p_data_hdr_t))    // Data size limit
-
-/** The maximum size of a decoded ACK message */
-#define MAX_P_ACK_BODY_SIZE     (MAX_PKT_BODY_SIZE-sizeof(p_ack_hdr_t))     // Ack data size
+// MAX_DATASET_SIZE, PKT_OVERHEAD_SIZE, MAX_PKT_OVERHEAD_SIZE, MAX_PKT_BODY_SIZE, and
+// MAX_P_DATA_BODY_SIZE are defined below, once packet_hdr_t and p_data_hdr_t exist, since they're
+// computed from sizeof() those structs. MAX_P_ACK_BODY_SIZE is defined further below, after p_ack_hdr_t.
 
 /** Binary checksum start value */
 #define CHECKSUM_SEED 0x00AAAAAA
@@ -418,6 +401,27 @@ typedef struct
 #define ISB_MIN_PACKET_SIZE             (sizeof(packet_hdr_t) + 2)                                      //!< Minimum ISB packet size: header + 2-byte checksum, no payload
 #define ISB_HDR_TO_PACKET_SIZE(hdr)     ((hdr).size + ISB_MIN_PACKET_SIZE + ((hdr).offset ? 2 : 0))     //!< Compute total ISB packet byte size from a packet_hdr_t
 
+/** The overhead involved in sending a packet: @ref packet_hdr_t header + 2-byte checksum footer.
+ *  Same computation as @ref ISB_MIN_PACKET_SIZE (a packet with zero-length payload is pure overhead). */
+#define PKT_OVERHEAD_SIZE       ISB_MIN_PACKET_SIZE
+
+/** The maximum overhead size in sending a packet. Equal to @ref PKT_OVERHEAD_SIZE: protocol 2.x
+ *  (see PROTOCOL_VERSION_CHAR0) is a length-prefixed binary format with no byte-stuffing/escaping,
+ *  so unlike the old v1 protocol's PSC_RESERVED_KEY escaping, there is no worst-case encoding growth
+ *  to account for here. */
+#define MAX_PKT_OVERHEAD_SIZE   PKT_OVERHEAD_SIZE
+
+/** The maximum size of a decoded packet body: full buffer minus header/footer overhead, rounded down to an even number. */
+#define MAX_PKT_BODY_SIZE       ((PKT_BUF_SIZE - MAX_PKT_OVERHEAD_SIZE) & 0xFFFFFFFE)
+
+/** The maximum size of decoded data in a packet body */
+#define MAX_P_DATA_BODY_SIZE    (MAX_PKT_BODY_SIZE-sizeof(p_data_hdr_t))    // Data size limit
+
+/** The maximum allowable dataset size: tied directly to the maximum packet payload capacity.
+ *  Note: for packets with ISB_FLAGS_PAYLOAD_W_OFFSET set, pkt->data.size already excludes the 2-byte offset.
+ *  This limit intentionally bounds pkt->data.size (dataset bytes), not on-wire payloadSize. */
+#define MAX_DATASET_SIZE        MAX_PKT_BODY_SIZE
+
 /** Represents a packet header and body */
 typedef struct
 {
@@ -524,6 +528,9 @@ typedef struct
     /** Packet counter of the received packet */
     uint16_t            pktCounter;
 } p_ack_hdr_t;
+
+/** The maximum size of a decoded ACK message */
+#define MAX_P_ACK_BODY_SIZE     (MAX_PKT_BODY_SIZE-sizeof(p_ack_hdr_t))     // Ack data size
 
 /** Represents the entire body of an ACK or NACK packet */
 typedef struct

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -131,8 +131,11 @@ typedef enum
 /** Default protocol enable mask used by is_comm_init() when no explicit mask is set. */
 #define DEFAULT_PROTO_MASK (ENABLE_PROTOCOL_ISB | ENABLE_PROTOCOL_NMEA | ENABLE_PROTOCOL_UBLOX | ENABLE_PROTOCOL_RTCM3)
 
-/** The maximum allowable dataset size */
-#define MAX_DATASET_SIZE        1024
+/** The maximum allowable dataset size. SN-8405: raised from 1024 to cover gnss_sig_t's new
+ *  max size (1128 bytes at MAX_NUM_SAT_SIGNALS=160) with headroom; a single ISB packet can
+ *  carry far more than this (see is_comm_write_isb_precomp_to_port's PKT_BUF_SIZE check), so
+ *  this does not require any change to PKT_BUF_SIZE. */
+#define MAX_DATASET_SIZE        1280
 
 /** The decoded overhead involved in sending a packet - 4 bytes for header, 4 bytes for footer */
 #define PKT_OVERHEAD_SIZE       8       // = START_BYTE + INFO_BYTE + COUNTER_BYTE + FLAGS_BYTE + CHECKSUM_BYTE_1 + CHECKSUM_BYTE_2 + CHECKSUM_BYTE_3 + END_BYTE

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -204,10 +204,10 @@ typedef uint32_t eDataIDs;
 // END DATA IDENTIFIERS --------------------------------------------------------------------------
 
 /** Maximum number of satellite channels */
-#define MAX_NUM_SATELLITES  50
+#define MAX_NUM_SATELLITES  80
 
 /** Maximum number of satellite signals */
-#define MAX_NUM_SAT_SIGNALS 100
+#define MAX_NUM_SAT_SIGNALS 160
 
 /** Maximum length of device info manufacturer string (must be a multiple of 4) */
 #define DEVINFO_MANUFACTURER_STRLEN 24
@@ -221,7 +221,11 @@ typedef uint32_t eDataIDs;
 
 // Increment w/ non-breaking changes (in data_sets.h) that would still backward compatibility with older protocols
 // #define PROTOCOL_VERSION_CHAR2   .   // Non-breaking changes (Packet):   (defined in ISComm.h)
-#define PROTOCOL_VERSION_CHAR3      0   // Non-breaking changes (Payload):
+// SN-8405: MAX_NUM_SATELLITES/MAX_NUM_SAT_SIGNALS increased (80/160). Wire size is computed
+// dynamically from actual satellite/signal count, so old/new peers interoperate normally in the
+// overwhelming majority of cases; a peer running the prior protocol version only NACKs a
+// gnss_sig_t dataset if the receiver is actually tracking >=146 discrete signals at once.
+#define PROTOCOL_VERSION_CHAR3      1   // Non-breaking changes (Payload):
 
 /** Rtk rover receiver index */
 #define RECEIVER_INDEX_GNSS1            1   // DO NOT CHANGE


### PR DESCRIPTION
## Problem

We want to track more satellites and signals: increase `MAX_NUM_SATELLITES` 50→80 and `MAX_NUM_SAT_SIGNALS` 100→160, covering realistic worst-case multi-constellation deployments (GPS+GLONASS+Galileo+BeiDou plus regional QZSS/NavIC/SBAS augmentation).

## Changes

**Satellite/signal ceilings** (`data_sets.h`):
- `MAX_NUM_SATELLITES` 50→80, `MAX_NUM_SAT_SIGNALS` 100→160.
- `PROTOCOL_VERSION_CHAR3` bumped (non-breaking payload version) — see "Protocol version" below.

**`ISComm.h`/`ISComm.c` packet-capacity macros** (merged in from #1258, credit @waltjohnson):

`gnss_sig_t` grows to 1128 bytes at the new signal ceiling. The original fix for this raised `MAX_DATASET_SIZE` from a hardcoded `1024` to a hardcoded `1280`. Copilot flagged on that PR that the packet-capacity macros this ceiling should really be derived from (`MAX_PKT_BODY_SIZE`, `MAX_P_DATA_BODY_SIZE`) were themselves wrong: they halved `PKT_BUF_SIZE` based on a stale assumption that packet encoding could double payload size via byte-stuffing (`PSC_RESERVED_KEY` escaping, pre-2023 v1 ISB protocol). The v2 packet rewrite (SN-3585) removed all byte-stuffing — the wire format is purely length-prefixed binary — but the `/2` was never removed, so these macros had understated real packet capacity by ~2x for years, independent of this ticket.

Final state:
- `PKT_OVERHEAD_SIZE` is now `ISB_MIN_PACKET_SIZE` (`sizeof(packet_hdr_t) + 2`) instead of a hardcoded `8` with a comment describing v1-era fields that no longer exist. (Same numeric value, 8 — now derived instead of hand-typed.)
- `MAX_PKT_OVERHEAD_SIZE` drops the `* 2 - 2` doubling (protocol 2.x has no byte-stuffing worst case to account for).
- `MAX_PKT_BODY_SIZE` drops the erroneous `/ 2`.
- **`MAX_DATASET_SIZE` is now `MAX_PKT_BODY_SIZE` directly — 2040 bytes.** (An intermediate version derived it as `MAX_P_DATA_BODY_SIZE`, i.e. `MAX_PKT_BODY_SIZE - sizeof(p_data_hdr_t)` = 2035; Copilot correctly caught that `p_data_hdr_t`'s `id`/`size` fields aren't separately transmitted on the wire — `id` comes from `packet_hdr_t.id` and `size` is derived from `payloadSize`, never serialized as its own field — so subtracting `sizeof(p_data_hdr_t)` over-counted overhead by 5 bytes. Verified this independently by reading `is_comm_encode_hdr()` directly.) Since a dataset must fit in a single ISB packet — `ISB_FLAGS_EXTENDED_PAYLOAD` is defined but has no reassembly implementation anywhere in the parser — tying the ceiling to actual packet capacity means it no longer needs manual bumping every time a DID grows, as long as it still fits in one packet.
- `ISComm.c`: removed the `DID_CAL_TEMP_COMP_GYR/ACC/MAG` bypasses in the size-validation gate. Those three DIDs were hardcoded exceptions because their individual transmitted sizes (up to 1620 bytes — `SIZE_OF_SENSOR_TCAL_GYR_V1P4`/`_ACC_V1P4`, 5 IMU devices × 324 bytes each) exceeded the old 1280-byte ceiling; they fit comfortably under 2040, so the exemption is no longer needed.

## Protocol version

Verified `gnss_sat_t` never risks an old peer's validation ceiling even at the new max (648 bytes, well under 2040 either way). `gnss_sig_t` only would if a receiver is *actually* tracking ≥146 discrete signals simultaneously — both IMX and GPX-1 compute wire size dynamically from actual tracked count (`8 + sizeof(entry) * actual_count`), not the full struct size. Old/new peers interoperate normally in the overwhelming majority of cases; the one edge case degrades gracefully (a clean NACK), not a crash or data corruption — hence the non-breaking version bump.

## RAM impact (firmware)

`MAX_DATASET_SIZE` itself costs zero firmware RAM — audited every consumer repo-wide; the only places it sizes an actual buffer (`p_data_buf_t::buf[]`, `ISDisplay.h`, `DataCSV.cpp`/`DataJSON.cpp` scratch buffers) are host-only SDK/EvalTool/NavPostProcess code, never compiled into the device image. The array-size growth itself costs real static RAM on-device:
- **IMX-5** (single `gnss_sat_t`/`gnss_sig_t` instance): pulled real `size` output from `develop` CI (`IMX-5 Hardware Integration` job) — 157,672B used of 163,840B (160KB) total, 6,168B (3.76%) free. This change costs +660B (sat +240B, sig +420B) — 10.7% of current headroom, leaving ~5,508B (3.36% of total) free.
- **GPX-1** (768KB RAM, two GNSS instances): +1,320B, well under 0.2% of total. Ample headroom.

## Testing

Full SDK unit test suite against the final merged state: **459 tests, 455 pass, 4 pre-existing skips (unrelated to this change — missing live-fixture log files and an opt-in E2E soak test), 0 failures.**

Jira: SN-8405

🤖 Generated with [Claude Code](https://claude.com/claude-code)
