### PR TITLE
Open up MAX_DATASET_SIZE

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -516,10 +516,7 @@ static protocol_type_t processIsbPkt(void* v)
     case PKT_TYPE_SET_DATA:
     case PKT_TYPE_DATA:
         // Validate data size
-        if (pkt->data.size <= MAX_DATASET_SIZE ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_GYR ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_ACC ||
-            pkt->hdr.id == DID_CAL_TEMP_COMP_MAG)
+        if (pkt->data.size <= MAX_DATASET_SIZE)
         {
             if (ptype==PKT_TYPE_SET_DATA)
             {   // acknowledge valid data received
@@ -538,10 +535,7 @@ static protocol_type_t processIsbPkt(void* v)
         {
             p_data_get_t *get = (p_data_get_t*)&(isbPkt->payload.data);
             // Validate data size
-            if (get->size <= MAX_DATASET_SIZE ||
-                get->id == DID_CAL_TEMP_COMP_GYR ||
-                get->id == DID_CAL_TEMP_COMP_ACC ||
-                get->id == DID_CAL_TEMP_COMP_MAG)
+            if (get->size <= MAX_DATASET_SIZE)
             {   // Update data pointer
                 return _PTYPE_INERTIAL_SENSE_CMD;
             }

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -131,15 +131,6 @@ typedef enum
 /** Default protocol enable mask used by is_comm_init() when no explicit mask is set. */
 #define DEFAULT_PROTO_MASK (ENABLE_PROTOCOL_ISB | ENABLE_PROTOCOL_NMEA | ENABLE_PROTOCOL_UBLOX | ENABLE_PROTOCOL_RTCM3)
 
-/** The maximum allowable dataset size. SN-8405: raised from 1024 to cover gnss_sig_t's new
- *  max size (1128 bytes at MAX_NUM_SAT_SIGNALS=160) with headroom; a single ISB packet can
- *  carry far more than this (see is_comm_write_isb_precomp_to_port's PKT_BUF_SIZE check), so
- *  this does not require any change to PKT_BUF_SIZE. */
-#define MAX_DATASET_SIZE        1280
-
-/** The decoded overhead involved in sending a packet - 4 bytes for header, 4 bytes for footer */
-#define PKT_OVERHEAD_SIZE       8       // = START_BYTE + INFO_BYTE + COUNTER_BYTE + FLAGS_BYTE + CHECKSUM_BYTE_1 + CHECKSUM_BYTE_2 + CHECKSUM_BYTE_3 + END_BYTE
-
 /** The maximum buffer space that is used for sending and receiving packets */
 #ifndef PKT_BUF_SIZE
 #define PKT_BUF_SIZE            2048
@@ -148,17 +139,9 @@ typedef enum
 /** The maximum time between received data that will reset in the parser */
 #define MAX_PARSER_GAP_TIME_MS  100
 
-/** The maximum encoded overhead size in sending a packet (7 bytes for header, 7 bytes for footer). The packet start and end bytes are never encoded. */
-#define MAX_PKT_OVERHEAD_SIZE   (PKT_OVERHEAD_SIZE + PKT_OVERHEAD_SIZE - 2)  // worst case for packet encoding header / footer
-
-/** The maximum size of an decoded packet body */
-#define MAX_PKT_BODY_SIZE       (((PKT_BUF_SIZE - MAX_PKT_OVERHEAD_SIZE) / 2) & 0xFFFFFFFE) // worst case for packet encoding body, rounded down to even number
-
-/** The maximum size of decoded data in a packet body */
-#define MAX_P_DATA_BODY_SIZE    (MAX_PKT_BODY_SIZE-sizeof(p_data_hdr_t))    // Data size limit
-
-/** The maximum size of a decoded ACK message */
-#define MAX_P_ACK_BODY_SIZE     (MAX_PKT_BODY_SIZE-sizeof(p_ack_hdr_t))     // Ack data size
+// MAX_DATASET_SIZE, PKT_OVERHEAD_SIZE, MAX_PKT_OVERHEAD_SIZE, MAX_PKT_BODY_SIZE, and
+// MAX_P_DATA_BODY_SIZE are defined below, once packet_hdr_t and p_data_hdr_t exist, since they're
+// computed from sizeof() those structs. MAX_P_ACK_BODY_SIZE is defined further below, after p_ack_hdr_t.
 
 /** Binary checksum start value */
 #define CHECKSUM_SEED 0x00AAAAAA
@@ -418,6 +401,30 @@ typedef struct
 #define ISB_MIN_PACKET_SIZE             (sizeof(packet_hdr_t) + 2)                                      //!< Minimum ISB packet size: header + 2-byte checksum, no payload
 #define ISB_HDR_TO_PACKET_SIZE(hdr)     ((hdr).size + ISB_MIN_PACKET_SIZE + ((hdr).offset ? 2 : 0))     //!< Compute total ISB packet byte size from a packet_hdr_t
 
+/** The overhead involved in sending a packet: @ref packet_hdr_t header + 2-byte checksum footer.
+ *  Same computation as @ref ISB_MIN_PACKET_SIZE (a packet with zero-length payload is pure overhead). */
+#define PKT_OVERHEAD_SIZE       ISB_MIN_PACKET_SIZE
+
+/** The maximum overhead size in sending a packet. Equal to @ref PKT_OVERHEAD_SIZE: protocol 2.x
+ *  (see PROTOCOL_VERSION_CHAR0) is a length-prefixed binary format with no byte-stuffing/escaping,
+ *  so unlike the old v1 protocol's PSC_RESERVED_KEY escaping, there is no worst-case encoding growth
+ *  to account for here. */
+#define MAX_PKT_OVERHEAD_SIZE   PKT_OVERHEAD_SIZE
+
+/** The maximum size of a decoded packet body: full buffer minus header/footer overhead, rounded down to an even number. */
+#define MAX_PKT_BODY_SIZE       ((PKT_BUF_SIZE - MAX_PKT_OVERHEAD_SIZE) & 0xFFFFFFFE)
+
+/** The maximum size of decoded data in a packet body */
+#define MAX_P_DATA_BODY_SIZE    (MAX_PKT_BODY_SIZE-sizeof(p_data_hdr_t))    // Data size limit
+
+/** The maximum allowable dataset size: tied directly to @ref MAX_P_DATA_BODY_SIZE, the actual
+ *  per-packet data capacity, since a dataset must fit in a single (non-fragmented) ISB packet --
+ *  ISB_FLAGS_EXTENDED_PAYLOAD exists as a flag bit but has no reassembly implementation anywhere
+ *  in this parser. SN-8405 raised this from a hardcoded 1024 to cover gnss_sig_t's new max size
+ *  (1128 bytes at MAX_NUM_SAT_SIGNALS=160); deriving it from MAX_P_DATA_BODY_SIZE instead means
+ *  it no longer needs manual bumping as datasets grow, as long as they still fit in one packet. */
+#define MAX_DATASET_SIZE        MAX_P_DATA_BODY_SIZE
+
 /** Represents a packet header and body */
 typedef struct
 {
@@ -524,6 +531,9 @@ typedef struct
     /** Packet counter of the received packet */
     uint16_t            pktCounter;
 } p_ack_hdr_t;
+
+/** The maximum size of a decoded ACK message */
+#define MAX_P_ACK_BODY_SIZE     (MAX_PKT_BODY_SIZE-sizeof(p_ack_hdr_t))     // Ack data size
 
 /** Represents the entire body of an ACK or NACK packet */
 typedef struct

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -417,13 +417,10 @@ typedef struct
 /** The maximum size of decoded data in a packet body */
 #define MAX_P_DATA_BODY_SIZE    (MAX_PKT_BODY_SIZE-sizeof(p_data_hdr_t))    // Data size limit
 
-/** The maximum allowable dataset size: tied directly to @ref MAX_P_DATA_BODY_SIZE, the actual
- *  per-packet data capacity, since a dataset must fit in a single (non-fragmented) ISB packet --
- *  ISB_FLAGS_EXTENDED_PAYLOAD exists as a flag bit but has no reassembly implementation anywhere
- *  in this parser. SN-8405 raised this from a hardcoded 1024 to cover gnss_sig_t's new max size
- *  (1128 bytes at MAX_NUM_SAT_SIGNALS=160); deriving it from MAX_P_DATA_BODY_SIZE instead means
- *  it no longer needs manual bumping as datasets grow, as long as they still fit in one packet. */
-#define MAX_DATASET_SIZE        MAX_P_DATA_BODY_SIZE
+/** The maximum allowable dataset size: tied directly to the maximum packet payload capacity.
+ *  Note: for packets with ISB_FLAGS_PAYLOAD_W_OFFSET set, pkt->data.size already excludes the 2-byte offset.
+ *  This limit intentionally bounds pkt->data.size (dataset bytes), not on-wire payloadSize. */
+#define MAX_DATASET_SIZE        MAX_PKT_BODY_SIZE
 
 /** Represents a packet header and body */
 typedef struct


### PR DESCRIPTION
## Fix stale byte-stuffing assumptions in ISComm packet-size macros

### Context

Copilot flagged on the SN-8405 PR that `MAX_PKT_BODY_SIZE` (and its derived macros) compute packet capacity by halving `PKT_BUF_SIZE`, based on a comment assuming "packet encoding doubles size." That assumption dates to the pre-2023 v1 ISB protocol, which escaped reserved bytes via `PSC_RESERVED_KEY` (see the old `encodeByteAddToBuffer()`). The v2 packet format rewrite (SN-3585, #456) removed all byte-stuffing — the wire format is now purely length-prefixed binary — but never updated this math, so the macros understated real packet capacity by ~2x ever since (even before SN-8405 raised `MAX_DATASET_SIZE`, `MAX_PKT_BODY_SIZE` was already inconsistent with it).

### Changes

- **`PKT_OVERHEAD_SIZE`**: now `ISB_MIN_PACKET_SIZE` (`sizeof(packet_hdr_t) + 2`) instead of a hardcoded `8` with a comment describing v1-era fields (`START_BYTE`, `COUNTER_BYTE`, three checksum bytes) that no longer exist.
- **`MAX_PKT_OVERHEAD_SIZE`**: dropped the `PKT_OVERHEAD_SIZE * 2 - 2` doubling; now equals `PKT_OVERHEAD_SIZE` directly.
- **`MAX_PKT_BODY_SIZE`**: dropped the erroneous `/ 2`. Now `2040` bytes (`PKT_BUF_SIZE - PKT_OVERHEAD_SIZE`, rounded down to even).
- **`MAX_DATASET_SIZE`**: now `MAX_PKT_BODY_SIZE` directly — **2040 bytes** (was a hardcoded `1280`, and briefly `MAX_P_DATA_BODY_SIZE` / 2035 in an earlier revision of this PR — see "Follow-up" below). Since a dataset must fit in a single ISB packet — `ISB_FLAGS_EXTENDED_PAYLOAD` is defined but has no reassembly implementation anywhere in the parser — tying it to actual packet capacity means it no longer needs manual bumping every time a DID grows.
- Reordered these macros to sit after `packet_hdr_t`/`p_data_hdr_t`/`p_ack_hdr_t` are declared, since they're now computed from `sizeof()` those structs.
- **`ISComm.c`**: removed the `DID_CAL_TEMP_COMP_GYR/ACC/MAG` bypasses in the `PKT_TYPE_SET_DATA`/`PKT_TYPE_DATA`/`PKT_TYPE_GET_DATA` size validation. Those three DIDs carry `sensor_tcal_{gyr,acc,mag}_group_t` (1620 bytes for gyr/acc, 324 for mag — the per-sensor-type subset, not the combined 3564-byte `sensor_tcal_group_t` the DID comment names) and were hardcoded exceptions because they exceeded the old 1280-byte ceiling. They fit comfortably under the new 2040-byte ceiling, so the exemption — which let those IDs bypass the size check for *any* size — is no longer needed.

### Follow-up: why `MAX_PKT_BODY_SIZE` and not `MAX_P_DATA_BODY_SIZE`

An earlier revision of this PR defined `MAX_DATASET_SIZE` as `MAX_P_DATA_BODY_SIZE` (`MAX_PKT_BODY_SIZE - sizeof(p_data_hdr_t)`, 2035 bytes), reasoning that a `p_data_hdr_t` (id + size + offset) rides in the payload alongside the data. It doesn't. `packet_t`'s union aliases `dataHdr.id`/`dataHdr.size` directly onto `packet_hdr_t.id`/`packet_hdr_t.payloadSize` — fields already inside the 6-byte header that `PKT_OVERHEAD_SIZE` accounts for; they're never serialized a second time. Only `dataHdr.offset` (2 bytes) is a real extra wire byte, and it's optional (`ISB_FLAGS_PAYLOAD_W_OFFSET`) — and `processIsbPkt` already computes `pkt->data.size = payloadSize - 2` when it's present, netting it out before anything compares against `MAX_DATASET_SIZE`. So no further subtraction is needed: `MAX_DATASET_SIZE = MAX_PKT_BODY_SIZE` is the correct, non-double-counted ceiling.

### Why it's safe

In `is-imx`, `CMakeLists.txt` builds the firmware from an explicit source list (`ISComm.c`, `com_manager.cpp`, `data_sets.c`, etc.) that excludes `DataJSON.cpp`, `DataCSV.cpp`, `ISDisplay.cpp`, and `ISLogger.cpp` — the only files where `MAX_DATASET_SIZE`/`MAX_P_DATA_BODY_SIZE` size a buffer rather than a scalar comparison. Those files are host-only (SDK/EvalTool/NavPostProcess), so growing the constant costs no embedded RAM there. Other consumers of this shared SDK header (`is-gpx`, host tool builds) may compile more broadly; this hasn't been independently re-verified for every consumer, but wherever the constant only backs a scalar bound check (as it does in `ISComm.c` itself) the change is free regardless of what else gets compiled alongside it.

### Testing

- `gcc -fsyntax-only` on `ISComm.c` — clean.
- Built the full SDK from source and ran the complete unit test suite: **459 tests, 455 passed, 4 skipped** (pre-existing skips: missing live-fixture log files and an opt-in E2E soak test — unrelated to this change).
- Targeted filter (`*ISComm*:*ComManager*:*com_manager*:*Protocol*:*Logger*:*DeviceCal*`): 42/42 passed, including `test_ISDeviceCal.cpp`, which directly exercises `sensor_tcal_group_t` — confirms the calibration-DID bypass removal doesn't break calibration upload/download.
