### PR TITLE
SN-8317: rename external-aiding DIDs, register in ISDataMappings, add GRMC bits

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1181,6 +1181,26 @@ static void PopulateMapGroundVehicle(data_set_t data_set[DID_COUNT], uint32_t di
     mapper.AddMember2("wheelConfig.radius", offsetof(ground_vehicle_t, wheelConfig.radius), DATA_TYPE_F32, "m", "Wheel radius");
 }
 
+static void PopulateMapExtAidingPos(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_pos_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_pos_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_pos_t::status, DATA_TYPE_UINT32, "", "Frame of measurement: 1=ECEF, 2=NED, 3=Body (see eExtAidingFrame)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddArray("pos", &ext_aiding_pos_t::pos, DATA_TYPE_F64, 3, {"m"}, {"Position {x,y,z}, in the frame given by status (ECEF expected)"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("offset", &ext_aiding_pos_t::offset, DATA_TYPE_F32, 3, {"m"}, {"Point of measurement relative to IMU origin, in IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("var", &ext_aiding_pos_t::var, DATA_TYPE_F32, 3, {"m^2"}, {"Observation variance per axis, in NED.  Must be non-zero or the observation is discarded"}, DATA_FLAGS_FIXED_DECIMAL_4);
+}
+
+static void PopulateMapExtAidingVel(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_vel_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_vel_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_vel_t::status, DATA_TYPE_UINT32, "", "Frame of measurement: 1=ECEF, 2=NED, 3=Body (see eExtAidingFrame)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddArray("vel", &ext_aiding_vel_t::vel, DATA_TYPE_F32, 3, {SYM_M_PER_S}, {"Velocity {vx,vy,vz}, in the frame given by status (ECEF expected)"}, DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddArray("offset", &ext_aiding_vel_t::offset, DATA_TYPE_F32, 3, {"m"}, {"Point of measurement relative to IMU origin, in IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("var", &ext_aiding_vel_t::var, DATA_TYPE_F32, 3, {"m^2/s^2"}, {"Observation variance per axis, in NED.  Must be non-zero or the observation is discarded"}, DATA_FLAGS_FIXED_DECIMAL_4);
+}
+
 static void PopulateMapSystemCommand(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<system_command_t> mapper(data_set, did);
@@ -2258,8 +2278,8 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_CAL_MOTION_GYR",               // 103
     "DID_CAL_MOTION_ACC",               // 104
     "DID_CAL_MOTION_MAG",               // 105
-    "UNUSED_106",                       // 106
-    "UNUSED_107",                       // 107
+    "DID_EXT_AIDING_POS",               // 106
+    "DID_EXT_AIDING_VEL",               // 107
     "UNUSED_108",                       // 108
     "UNUSED_109",                       // 109
     "UNUSED_110",                       // 110
@@ -2333,6 +2353,8 @@ cISDataMappings::cISDataMappings()
     PopulateMapMagnetometer(m_data_set, DID_MAGNETOMETER);
     PopulateMapBarometer(m_data_set, DID_BAROMETER);
     PopulateMapWheelEncoder(m_data_set, DID_WHEEL_ENCODER);
+    PopulateMapExtAidingPos(m_data_set, DID_EXT_AIDING_POS);
+    PopulateMapExtAidingVel(m_data_set, DID_EXT_AIDING_VEL);
 
     PopulateMapGnssPos(m_data_set, DID_GNSS1_RTK_POS);
     PopulateMapGnssRtkRel(m_data_set, DID_GNSS1_RTK_POS_REL);

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -263,6 +263,14 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetof(survey_in_t, lla[2])
     };
 
+    static uint16_t offsetsExtAidingPos[] =
+    {
+        3,
+        offsetof(ext_aiding_pos_t, pos[0]),
+        offsetof(ext_aiding_pos_t, pos[1]),
+        offsetof(ext_aiding_pos_t, pos[2])
+    };
+
     static uint16_t* s_doubleOffsets[] =
     {
         0,                      //  0: DID_NULL
@@ -371,8 +379,8 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 103: DID_CAL_MOTION_GYR
         0,                      // 104: DID_CAL_MOTION_ACC
         0,                      // 105: DID_CAL_MOTION_MAG
-        0,                      // 106:
-        0,                      // 107:
+        offsetsExtAidingPos,    // 106: DID_EXT_AIDING_POS
+        0,                      // 107: DID_EXT_AIDING_VEL
         0,                      // 108:
         0,                      // 109:
         0,                      // 110:
@@ -561,8 +569,8 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 103: DID_CAL_MOTION_GYR
         0,                      // 104: DID_CAL_MOTION_ACC
         0,                      // 105: DID_CAL_MOTION_MAG
-        0,                      // 106:
-        0,                      // 107:
+        0,                      // 106: DID_EXT_AIDING_POS
+        0,                      // 107: DID_EXT_AIDING_VEL
         0,                      // 108:
         0,                      // 109:
         0,                      // 110:

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -772,6 +772,8 @@ const uint64_t g_gpxDidToGrmcBit[DID_COUNT] =
     [DID_GNSS_BASE_RAW]          = GRMC_BITS_GNSS_BASE_RAW,
     [DID_GPX_SYS_FAULT]         = GRMC_BITS_GPX_SYS_FAULT,
     [DID_GNSS1_RCVR_POS]         = GRMC_BITS_GNSS1_RCVR_POS,
+    [DID_EXT_AIDING_POS]         = GRMC_BITS_EXT_AIDING_POS,
+    [DID_EXT_AIDING_VEL]         = GRMC_BITS_EXT_AIDING_VEL,
 };
 
 const uint16_t g_gpxGRMCPresetLookup[GRMC_BIT_POS_COUNT] =
@@ -804,6 +806,8 @@ const uint16_t g_gpxGRMCPresetLookup[GRMC_BIT_POS_COUNT] =
     [GRMC_BIT_POS_DID_GPX_PORT_MON]     = GRMC_PRESET_GPX_PORT_MON_PERIOD_MS,
     [GRMC_BIT_POS_DID_GNSS_BASE_RAW]     = 1,
     [GRMC_BIT_POS_GNSS1_RCVR_POS]        = 1,
+    [GRMC_BIT_POS_EXT_AIDING_POS]        = 1,
+    [GRMC_BIT_POS_EXT_AIDING_VEL]        = 1,
 };
 
 #ifndef GPX_1

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -172,9 +172,11 @@ typedef uint32_t eDataIDs;
 #define DID_CAL_MOTION_GYR              (eDataIDs)103   /**< INTERNAL USE ONLY (sensor_mcal_group_t) */
 #define DID_CAL_MOTION_ACC              (eDataIDs)104   /**< INTERNAL USE ONLY (sensor_mcal_group_t) */
 #define DID_CAL_MOTION_MAG              (eDataIDs)105   /**< INTERNAL USE ONLY (sensor_mcal_group_t) */
-#define DID_EXT_POS                     (eDataIDs)106   /**< (ext_pos_t) External position observation */
-#define DID_EXT_VEL                     (eDataIDs)107   /**< (ext_vel_t) External velocity observation */
-// #define DID_EXTERNAL_AIDING             (eDataIDs)106   /**< (external_aiding_u) External aiding information. */
+#define DID_EXT_AIDING_POS              (eDataIDs)106   /**< (ext_aiding_pos_t) External aiding position observation, input to the INS/EKF */
+#define DID_EXT_AIDING_VEL              (eDataIDs)107   /**< (ext_aiding_vel_t) External aiding velocity observation, input to the INS/EKF */
+// RESERVED: a future consolidated external-aiding message (DID + sub-ID + SID-dependent payload,
+// covering position/velocity/speed/heading/attitude/IMU/config with full covariance) was proposed
+// under SN-7740. The two flat DIDs above are the initial subset; see SN-7740 before adding more.
 
 #define DID_EVENT                       (eDataIDs)119   /**< INTERNAL USE ONLY (did_event_t)*/
 
@@ -3313,34 +3315,34 @@ typedef struct PACKED
 
 } ground_vehicle_t;
 
-/** @brief External aiding status bitflags, used with ext_vel_t.status (DID_EXTERNAL_AIDING). Reports the frame of measurement for the external aiding sensor. */
-enum eExternalAidingStatus
+/** @brief Frame of measurement for an external aiding observation, held in the low nibble of ext_aiding_pos_t.status / ext_aiding_vel_t.status (DID_EXT_AIDING_POS, DID_EXT_AIDING_VEL). Note 0 is not a valid frame. */
+enum eExtAidingFrame
 {
-    EP_STATUS_FRAME_MASK    = 0x0000000F,  //!< Mask for the frame of measurement
-    EP_STATUS_FRAME_ECEF    = 1,           //!< ECEF frame
-    EP_STATUS_FRAME_NED     = 2,           //!< NED frame
-    EP_STATUS_FRAME_BODY    = 3            //!< Body frame
+    EXT_AIDING_FRAME_MASK    = 0x0000000F,  //!< Mask for the frame of measurement
+    EXT_AIDING_FRAME_ECEF    = 1,           //!< ECEF frame
+    EXT_AIDING_FRAME_NED     = 2,           //!< NED frame
+    EXT_AIDING_FRAME_BODY    = 3            //!< Body frame
 };
 
-/** @brief External position sensor sample. */
+/** @brief (DID_EXT_AIDING_POS) External aiding position observation, supplied by a host or external sensor as an input to the INS/EKF. Position is expected in ECEF; var is expected in NED. */
 typedef struct PACKED
 {
     uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
-    uint32_t   status;       //!< frame of measurement: 0=ECEF, 1=NED (see eExternalAidingStatus)
+    uint32_t   status;       //!< Frame of measurement, 1=ECEF, 2=NED, 3=Body (see eExtAidingFrame)
     double     pos[3];       //!< position {x,y,z} (m)
     float      offset[3];    //!< point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
-    float      var[3];       //!< observation variance 
-} ext_pos_t;
+    float      var[3];       //!< observation variance, per axis, in NED (m^2).  Must be non-zero or the observation is discarded.
+} ext_aiding_pos_t;
 
-/** @brief External velocity sensor sample. */
+/** @brief (DID_EXT_AIDING_VEL) External aiding velocity observation, supplied by a host or external sensor as an input to the INS/EKF. Velocity is expected in ECEF; var is expected in NED. */
 typedef struct PACKED
 {
     uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
-    uint32_t   status;       //!< frame of measurement: 0=ECEF, 1=NED, 2=Body (see eExternalAidingStatus)
+    uint32_t   status;       //!< Frame of measurement, 1=ECEF, 2=NED, 3=Body (see eExtAidingFrame)
     float      vel[3];       //!< velocity {vx,vy,vz} (m/s)
     float      offset[3];    //!< point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
-    float      var[3];       //!< observation variance 
-} ext_vel_t;
+    float      var[3];       //!< observation variance, per axis, in NED (m^2/s^2).  Must be non-zero or the observation is discarded.
+} ext_aiding_vel_t;
 
 /** @brief INS dynamic platform model selection, used with nvm_flash_cfg_t.dynamicModel (DID_FLASH_CONFIG). Selects a motion-profile model (expected acceleration/jerk limits) that the EKF and the GNSS receiver's own navigation filter use to balance measurement noise rejection against tracking responsiveness; the model chosen must be at least as dynamic as the actual platform motion or navigation accuracy will suffer. Also passed through to the GNSS receiver's dynamic model setting where supported. */
 enum eDynamicModel

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -2198,6 +2198,8 @@ enum GRMC_BIT_POS{
     GRMC_BIT_POS_DID_GNSS_BASE_RAW  = 25,  //!< DID_GNSS_BASE_RAW - raw observation data forwarded from the RTK base station
     GRMC_BIT_POS_DID_GPX_SYS_FAULT  = 26,  //!< DID_GPX_SYS_FAULT - GPX system fault/exception info
     GRMC_BIT_POS_GNSS1_RCVR_POS     = 27,  //!< DID_GNSS1_RCVR_POS - GNSS 1 receiver-reported position
+    GRMC_BIT_POS_EXT_AIDING_POS     = 28,  //!< DID_EXT_AIDING_POS - GNSS position restated as an external aiding observation, for feeding an INS
+    GRMC_BIT_POS_EXT_AIDING_VEL     = 29,  //!< DID_EXT_AIDING_VEL - GNSS velocity restated as an external aiding observation, for feeding an INS
     GRMC_BIT_POS_COUNT,                    //!< Number of GRMC bit positions; sizes grmci_t.periodMultiple
 };
 
@@ -2229,6 +2231,8 @@ enum GRMC_BIT_POS{
 #define GRMC_BITS_GNSS_BASE_RAW         (0x0000000000000001 << GRMC_BIT_POS_DID_GNSS_BASE_RAW)
 #define GRMC_BITS_GPX_SYS_FAULT         (0x0000000000000001 << GRMC_BIT_POS_DID_GPX_SYS_FAULT)
 #define GRMC_BITS_GNSS1_RCVR_POS        (0x0000000000000001 << GRMC_BIT_POS_GNSS1_RCVR_POS)
+#define GRMC_BITS_EXT_AIDING_POS        (0x0000000000000001 << GRMC_BIT_POS_EXT_AIDING_POS)
+#define GRMC_BITS_EXT_AIDING_VEL        (0x0000000000000001 << GRMC_BIT_POS_EXT_AIDING_VEL)
 #define GRMC_BITS_PRESET                (0x8000000000000000)                                        // Indicate BITS is a preset.  This sets the rmc period multiple and enables broadcasting.
 
 #define GRMC_PRESET_DID_RTK_DEBUG_PERIOD_MS     1000


### PR DESCRIPTION
Part of the SN-8317 / SN-8472 external-aiding work. Targets `SN-8318_external_aiding` so the whole feature integrates once.

## What this does

**Rename (no wire change).** `DID_EXT_POS`/`DID_EXT_VEL` → `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL`, `ext_pos_t`/`ext_vel_t` → `ext_aiding_pos_t`/`ext_aiding_vel_t`, `eExternalAidingStatus` → `eExtAidingFrame`, `EP_STATUS_FRAME_*` → `EXT_AIDING_FRAME_*`. DID numbers (106/107) and struct layout are untouched.

**Register the data sets.** ISDataMappings name-table entries plus `PopulateMapExtAidingPos/Vel`; `offsetsExtAidingPos` in data_sets.c so the three doubles in `pos[]` byte-flip on big-endian hosts.

**GRMC bits** for the GPX producer: positions 28/29, `GRMC_BIT_POS_COUNT` → 30, masks, `g_gpxDidToGrmcBit` and `g_gpxGRMCPresetLookup` entries.

## Decisions worth a look

- **Both DIDs are left writable** (no `DATA_FLAGS_READ_ONLY`) because they are inputs to the EKF. Side benefit: an observation can be injected with `cltool -set "{DID_EXT_AIDING_POS: {...}}"`, which makes the SN-8318 EKF path testable with no GPX and no external hardware.
- **Two GRMC bits, not one shared bit.** `g_gpxDidToGrmcBit` is one-to-one and `getPeriodMultiPos()` derives the period slot from the DID, so a shared bit would collapse both data sets into one period slot with shared auto-disable.
- **Not added to `GRMC_PRESET_GPX_IMX`.** An IMX consuming these from the same GPX it already uses as its GNSS receiver would fuse one solution twice, so this stays opt-in.
- `DefaultPeriodMultiple()` intentionally unchanged — unlisted DIDs default to 1, correct for epoch-rate data.

## Documentation corrections

The `status` comments claimed `0=ECEF, 1=NED` while the enum defines `ECEF=1, NED=2, BODY=3` with 0 invalid, so anyone coding to the comment would have sent an invalid frame. The frame enum also referenced a `DID_EXTERNAL_AIDING` that does not exist; that commented-out define is now an explicit RESERVED note pointing at the consolidated SID-based message proposed in SN-7740. Also recorded two previously-undocumented, load-bearing facts for producers: `var[]` is consumed as NED covariance even though `pos[]`/`vel[]` are ECEF, and a zero `var` silently discards the observation.

## Heads-up on flash layout

`GRMC_BIT_POS_COUNT` 28 → 30 grows `grmci_t` by 4 bytes and `grmci_sysCfg_t` from 376 to 392. `GPXFlashCfg_readConfig()` gates on `size == sizeof(grmci_sysCfg_t)`, so **any persisted GRMC config self-invalidates to defaults on upgrade** — needs a release note. Verified on hardware that persistence round-trips correctly at the new size.

## Verification

cltool builds; IMX-5 firmware builds. Both DIDs appear in `cltool -dids`. Mapper field resolution tested with positive and negative controls: all five field names resolve on each DID, an unknown name is rejected, and `pos` is correctly rejected on the VEL DID, confirming the two mappings are distinct. Full hardware results on SN-8472.

## Merge order

This first, then `inertialsense/imx` (is-common), then `inertialsense/is-gpx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)