### PR TITLE
SN-8445: rank DID_DEV_INFO above peripheral dev_info (fixes imx#1648 build failures)

### DIFF
--- a/src/ISLogReader.cpp
+++ b/src/ISLogReader.cpp
@@ -663,17 +663,41 @@ std::pair<const uint8_t*, std::size_t> ISLogReader::rawBytes() const noexcept {
     return { rawSource_->data(), rawSource_->size() };
 }
 
+void ISLogReader::adoptDevInfo(const dev_info_t& info) noexcept {
+    deviceId_ = info.serialNumber;
+    hdwId_    = static_cast<uint16_t>(ENCODE_DEV_INFO_TO_HDW_ID(info));
+    // Retain the whole struct, not just the two fields we distill from it (SN-8463). Firmware version, build info
+    // and the rest were being parsed and thrown away, leaving consumers unable to report a device beyond serial
+    // plus hardware id.
+    devInfo_    = info;
+    hasDevInfo_ = true;
+}
+
 void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
     deviceId_   = 0;
     hdwId_      = 0;
     devInfo_    = dev_info_t{};
     hasDevInfo_ = false;
 
-    // 1) Walk the raw bytes via `is_comm_parse_byte` looking for the first DID_DEV_INFO packet. We can't shortcut to
+    // 1) Walk the raw bytes via `is_comm_parse_byte` looking for a `dev_info_t`-bearing packet. We can't shortcut to
     //    the record's `.offset` because that is the ISB packet *start* (framing + header + payload + checksum), not
     //    the payload offset — we need the parser to hand us `comm.rxPkt.data.ptr`, which points into the dev_info_t
-    //    payload proper. Bounded: terminate at the first DEV_INFO packet so this is at most a single early-exit
-    //    linear pass.
+    //    payload proper.
+    //
+    //    Three DIDs carry an identical `dev_info_t`: DID_DEV_INFO is the *logging* device's own record, while
+    //    DID_GPX_DEV_INFO (120) and DID_EVB_DEV_INFO (93) describe an attached PERIPHERAL. They are not
+    //    interchangeable as an identity source, so DID_DEV_INFO always wins and a peripheral record is only adopted
+    //    when the segment carries no primary record at all. A GPX-only capture has just the GPX record, which is the
+    //    case SN-8445 exists to serve — without it such logs recover a serial from the filename but no hardware id,
+    //    and render as "???-0.0::SN<serial>".
+    //
+    //    Ranking rather than first-match matters because a MIXED capture contains both, in an order that varies
+    //    between rollover segments. First-match made two segments of one log derive two different device ids, and
+    //    `ISDeviceLog::fromSegments` then rejected the whole log as Corrupted (SN-8445 regression, caught by the
+    //    goldenlogs suite on imx#1648 against an IMX+GPX capture).
+    //
+    //    Cost: a segment holding a primary record still early-exits on it. Only a segment with no primary record is
+    //    scanned to the end — the same single linear pass the no-dev_info case has always cost.
     if (rawSource_ && rawSource_->size() > 0) {
         is_comm_instance_t comm{};
         uint8_t commBuf[PKT_BUF_SIZE];
@@ -682,40 +706,43 @@ void ISLogReader::deriveDeviceId(const fs::path& rawPath) {
 
         const uint8_t* base = rawSource_->data();
         const std::size_t total = rawSource_->size();
+
+        dev_info_t peripheral{};              // first peripheral record seen, held in reserve
+        bool       havePeripheral = false;
+
         for (std::size_t i = 0; i < total; ++i) {
             protocol_type_t p = is_comm_parse_byte(&comm, base[i]);
             if (p != _PTYPE_INERTIAL_SENSE_DATA && p != _PTYPE_INERTIAL_SENSE_CMD) {
                 continue;
             }
-            // Accept EVERY DID whose payload is a `dev_info_t`, not just DID_DEV_INFO.
-            // A GPX-only capture files its device info under DID_GPX_DEV_INFO (120) and an
-            // EVB under DID_EVB_DEV_INFO — identical struct, so ENCODE_DEV_INFO_TO_HDW_ID
-            // works on all three unchanged. Matching only DID_DEV_INFO meant a GPX-only log
-            // fell through to the filename fallback, which recovers the serial but cannot
-            // recover a hardware id, so every device rendered as "???-0.0::SN<serial>"
-            // (reported by Kyle 2026-08-06 against a 14-device GPX capture).
             const auto didId = comm.rxPkt.dataHdr.id;
-            if (didId != DID_DEV_INFO &&
-                didId != DID_GPX_DEV_INFO &&
-                didId != DID_EVB_DEV_INFO) continue;
+            const bool isPrimary    = (didId == DID_DEV_INFO);
+            const bool isPeripheral = (didId == DID_GPX_DEV_INFO || didId == DID_EVB_DEV_INFO);
+            if (!isPrimary && !isPeripheral) continue;
             if (comm.rxPkt.dataHdr.size != sizeof(dev_info_t)) continue;
 
             dev_info_t info{};
             std::memcpy(&info, comm.rxPkt.data.ptr, sizeof(info));
-            if (info.serialNumber != 0) {
-                deviceId_ = info.serialNumber;
-                hdwId_    = static_cast<uint16_t>(ENCODE_DEV_INFO_TO_HDW_ID(info));
-                // Retain the whole struct, not just the two fields we distill from
-                // it (SN-8463). Firmware version, build info and the rest were being
-                // parsed and thrown away, leaving consumers unable to report a device
-                // beyond serial + hardware id.
-                devInfo_    = info;
-                hasDevInfo_ = true;
+
+            // A zero serial is a partial-update record, an unprovisioned unit, or a fixture stub. Keep scanning: a
+            // later record in the same segment may be complete. (This used to abort the scan, which meant one stub
+            // early in a segment hid every valid record behind it.)
+            if (info.serialNumber == 0) continue;
+
+            if (isPrimary) {
+                adoptDevInfo(info);
                 return;
             }
-            // First DEV_INFO had a zero serial — partial-update record or test fixture stub. Stop scanning; let the
-            // filename fallback handle it.
-            break;
+            if (!havePeripheral) {
+                peripheral     = info;
+                havePeripheral = true;
+            }
+            // Keep scanning — a primary record later in this segment outranks the peripheral one.
+        }
+
+        if (havePeripheral) {
+            adoptDevInfo(peripheral);
+            return;
         }
     }
 

--- a/src/ISLogReader.h
+++ b/src/ISLogReader.h
@@ -606,14 +606,28 @@ private:
     void buildIndexFromScan();
 
     /**
-     * Resolves the device id by inspecting the first
-     * `DID_DEV_INFO` record's serial number, falling back to
-     * filename parsing.
+     * @brief Resolves the device id from the segment's `dev_info_t` records, falling back to filename parsing.
      *
-     * @param rawPath  Path the segment was opened from. Used only
-     *                 for the filename-fallback path.
+     * Prefers `DID_DEV_INFO` (the logging device's own record). `DID_GPX_DEV_INFO` / `DID_EVB_DEV_INFO` describe an
+     * attached peripheral and are adopted only when the segment carries no primary record — which is the GPX-only
+     * capture case. Records with a zero serial are skipped rather than treated as terminal.
+     *
+     * @param rawPath  Path the segment was opened from. Used only for the filename-fallback path.
+     * @note SN-8445 / SN-8463. The ranking (rather than first-match) is what keeps the segments of one mixed
+     *       IMX+GPX log agreeing on a device id, which `ISDeviceLog::fromSegments` requires.
      */
     void deriveDeviceId(const std::filesystem::path& rawPath);
+
+    /**
+     * @brief Adopts a `dev_info_t` as this segment's identity.
+     *
+     * Sets the device id, the packed hardware id, and retains the whole struct so consumers can report firmware and
+     * build info rather than just serial plus hardware id.
+     *
+     * @param info  A `dev_info_t` with a non-zero serial number.
+     * @note SN-8463 — the retained struct is what `devInfo()` / `hasDevInfo()` expose.
+     */
+    void adoptDevInfo(const dev_info_t& info) noexcept;
 
     /**
      * Computes the end-of-bytes offset for the record at the given

--- a/tests/test_log_reader_devinfo.cpp
+++ b/tests/test_log_reader_devinfo.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file test_log_reader_devinfo.cpp
+ * @brief Coverage for how `ISLogReader` derives a segment's identity from `dev_info_t` records.
+ *
+ * Three DIDs carry an identical `dev_info_t`: `DID_DEV_INFO` is the logging device's own record, while
+ * `DID_GPX_DEV_INFO` and `DID_EVB_DEV_INFO` describe an attached peripheral. They are NOT interchangeable as an
+ * identity source, and these tests pin that ranking.
+ *
+ * @note SN-8445 / SN-8463. Written after a regression that shipped with no coverage here at all: broadening the
+ *       accepted DID set to fix GPX-only logs made identity first-match-wins, so two rollover segments of one mixed
+ *       IMX+GPX capture derived two different device ids and `ISDeviceLog::fromSegments` rejected the log as
+ *       Corrupted. It surfaced two repositories downstream, in imx#1648's goldenlogs suite, rather than here.
+ *
+ * Deliberately portable (no `::getpid()`, no hard-coded `/tmp`) so it runs on Windows too — the regression failed on
+ * both platforms, so the guard has to exist on both.
+ */
+
+#include <gtest/gtest.h>
+
+#include "ISLogReader.h"
+#include "ISDeviceLog.h"
+#include "ISComm.h"
+#include "data_sets.h"
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace inertial_sense;
+namespace fs = std::filesystem;
+
+namespace {
+
+constexpr uint32_t kImxSerial = 509040u;    //!< The logging IMX in the goldenlogs capture that regressed.
+constexpr uint32_t kGpxSerial = 808527428u; //!< The attached GPX's record from that same capture.
+
+/**
+ * @brief Builds a `dev_info_t` with the fields `ENCODE_DEV_INFO_TO_HDW_ID` reads.
+ *
+ * @param serial    Serial number to report.
+ * @param hwType    `eIsHardwareType` value (3=IMX, 4=GPX).
+ * @param major     Hardware version major.
+ * @param minor     Hardware version minor.
+ * @return A populated `dev_info_t`.
+ */
+dev_info_t makeDevInfo(uint32_t serial, uint8_t hwType, uint8_t major, uint8_t minor) {
+    dev_info_t d{};
+    d.serialNumber  = serial;
+    d.hardwareType  = hwType;
+    d.hardwareVer[0] = major;
+    d.hardwareVer[1] = minor;
+    d.firmwareVer[0] = 2;
+    d.firmwareVer[1] = 4;
+    return d;
+}
+
+/**
+ * @brief Serialises one record as a real ISB packet (framing + header + payload + checksum).
+ *
+ * @param did   DID to stamp on the packet.
+ * @param info  Payload.
+ * @return The framed bytes, or empty on failure.
+ * @note `deriveDeviceId` walks the raw byte stream with `is_comm_parse_byte`, so a payload-only fixture would be
+ *       invisible to it. The packet must be genuinely framed.
+ */
+std::vector<uint8_t> framedPacket(uint16_t did, const dev_info_t& info) {
+    is_comm_instance_t comm{};
+    uint8_t commBuf[PKT_BUF_SIZE];
+    is_comm_init(&comm, commBuf, sizeof(commBuf), nullptr);
+
+    uint8_t pkt[PKT_BUF_SIZE];
+    dev_info_t payload = info;
+    const int n = is_comm_data_to_buf(pkt, sizeof(pkt), &comm, did,
+                                      static_cast<uint16_t>(sizeof(payload)), 0, &payload);
+    if (n <= 0) return {};
+    return std::vector<uint8_t>(pkt, pkt + n);
+}
+
+/**
+ * @brief Writes a `.raw` segment containing the given (DID, dev_info) records in order.
+ *
+ * @param path  Destination file.
+ * @param recs  Records to emit, in stream order.
+ * @note Filenames here deliberately contain no "SN<digits>", so `deriveDeviceId`'s filename fallback yields nothing
+ *       and cannot mask a failure in the byte-scan path these tests are about.
+ */
+void writeRawSegment(const fs::path& path, const std::vector<std::pair<uint16_t, dev_info_t>>& recs) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.good()) << "could not open " << path.string();
+    for (const auto& [did, info] : recs) {
+        const auto bytes = framedPacket(did, info);
+        ASSERT_FALSE(bytes.empty()) << "failed to frame DID " << did;
+        out.write(reinterpret_cast<const char*>(bytes.data()),
+                  static_cast<std::streamsize>(bytes.size()));
+    }
+    out.close();
+}
+
+/**
+ * @brief Per-test scratch directory, cleaned up on teardown.
+ */
+class LogReaderDevInfoTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dir_ = fs::temp_directory_path() /
+               ("is_devinfo_" + std::string(::testing::UnitTest::GetInstance()
+                                                ->current_test_info()->name()));
+        std::error_code ec;
+        fs::remove_all(dir_, ec);
+        ASSERT_TRUE(fs::create_directories(dir_, ec)) << ec.message();
+    }
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(dir_, ec);
+    }
+    fs::path dir_;
+};
+
+}  // namespace
+
+/**
+ * The regression's direct cause: a peripheral record physically earlier in the stream must not outrank the logging
+ * device's own record.
+ */
+TEST_F(LogReaderDevInfoTest, PrimaryDevInfoWinsOverPeripheralThatAppearsFirst) {
+    const fs::path seg = dir_ / "seg_0001.raw";
+    writeRawSegment(seg, {
+        { DID_GPX_DEV_INFO, makeDevInfo(kGpxSerial, IS_HARDWARE_TYPE_GPX, 1, 0) },
+        { DID_DEV_INFO,     makeDevInfo(kImxSerial, IS_HARDWARE_TYPE_IMX, 5, 0) },
+    });
+
+    auto r = ISLogReader::openSegment(seg);
+    ASSERT_TRUE(r.has_value()) << "openSegment failed";
+    EXPECT_EQ(r->deviceId(), kImxSerial);
+    EXPECT_EQ(r->hdwId(), static_cast<uint16_t>(ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0)));
+    ASSERT_TRUE(r->hasDevInfo());
+    EXPECT_EQ(r->devInfo().serialNumber, kImxSerial);
+}
+
+/**
+ * SN-8445's actual target: a GPX-only capture has no `DID_DEV_INFO`, so the peripheral record is the only identity
+ * available and must still yield a hardware id — otherwise such devices render as "???-0.0::SN<serial>".
+ */
+TEST_F(LogReaderDevInfoTest, PeripheralDevInfoUsedWhenNoPrimaryPresent) {
+    const fs::path seg = dir_ / "seg_0001.raw";
+    writeRawSegment(seg, {
+        { DID_GPX_DEV_INFO, makeDevInfo(500123u, IS_HARDWARE_TYPE_GPX, 1, 0) },
+    });
+
+    auto r = ISLogReader::openSegment(seg);
+    ASSERT_TRUE(r.has_value()) << "openSegment failed";
+    EXPECT_EQ(r->deviceId(), 500123u);
+    EXPECT_EQ(r->hdwId(), static_cast<uint16_t>(ENCODE_HDW_ID(IS_HARDWARE_TYPE_GPX, 1, 0)))
+        << "a GPX-only log must still recover a hardware id (SN-8445)";
+    EXPECT_TRUE(r->hasDevInfo());
+}
+
+/**
+ * An unprovisioned unit or a partial-update record reports serial 0. That must not terminate the scan, or one stub
+ * early in a segment hides every valid record behind it.
+ */
+TEST_F(LogReaderDevInfoTest, ZeroSerialRecordDoesNotHideALaterValidRecord) {
+    const fs::path seg = dir_ / "seg_0001.raw";
+    writeRawSegment(seg, {
+        { DID_DEV_INFO, makeDevInfo(0u,         IS_HARDWARE_TYPE_IMX, 5, 0) },
+        { DID_DEV_INFO, makeDevInfo(kImxSerial, IS_HARDWARE_TYPE_IMX, 5, 0) },
+    });
+
+    auto r = ISLogReader::openSegment(seg);
+    ASSERT_TRUE(r.has_value()) << "openSegment failed";
+    EXPECT_EQ(r->deviceId(), kImxSerial);
+    EXPECT_EQ(r->hdwId(), static_cast<uint16_t>(ENCODE_HDW_ID(IS_HARDWARE_TYPE_IMX, 5, 0)));
+}
+
+/**
+ * The regression at the level it actually broke. A mixed capture writes both records per segment, in an order that
+ * varies between rollover files. Every segment must still agree on the device id, or `fromSegments` rejects the whole
+ * log as Corrupted — which is exactly what happened to
+ * `gpx/gpx1/intellian_ut/.../20250313_054706` in imx#1648.
+ */
+TEST_F(LogReaderDevInfoTest, MixedSegmentsInEitherOrderAgreeOnDeviceId) {
+    const dev_info_t imx = makeDevInfo(kImxSerial, IS_HARDWARE_TYPE_IMX, 5, 0);
+    const dev_info_t gpx = makeDevInfo(kGpxSerial, IS_HARDWARE_TYPE_GPX, 1, 0);
+
+    const fs::path segA = dir_ / "seg_0001.raw";   // primary first
+    const fs::path segB = dir_ / "seg_0002.raw";   // peripheral first — the ordering that regressed
+    writeRawSegment(segA, { { DID_DEV_INFO, imx }, { DID_GPX_DEV_INFO, gpx } });
+    writeRawSegment(segB, { { DID_GPX_DEV_INFO, gpx }, { DID_DEV_INFO, imx } });
+
+    auto a = ISLogReader::openSegment(segA);
+    auto b = ISLogReader::openSegment(segB);
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(b.has_value());
+    ASSERT_EQ(a->deviceId(), b->deviceId())
+        << "segments of one log disagreed on device id; fromSegments will reject the log";
+
+    auto log = ISDeviceLog::fromSegments({ segA, segB });
+    ASSERT_TRUE(log.has_value())
+        << "fromSegments rejected a mixed IMX+GPX log — the SN-8445 regression";
+    EXPECT_EQ(log->deviceId(), kImxSerial);
+}


### PR DESCRIPTION
Fixes a regression that #1265 introduced into `3.1.0-rc`, which is currently failing **both** the Windows and Linux builds on `inertialsense/imx#1648` (4 tests in the goldenlogs suite).

## What broke

#1265 broadened `ISLogReader::deriveDeviceId` to accept any `dev_info_t`-bearing DID, so a GPX-only capture could recover a hardware id instead of rendering as `???-0.0::SN<serial>`. That part was right. The mistake was making it **first-match-wins**.

Three DIDs carry an identical `dev_info_t`, but they are not interchangeable as an identity source:

- `DID_DEV_INFO` — the **logging device's own** record.
- `DID_GPX_DEV_INFO` (120) / `DID_EVB_DEV_INFO` (93) — an attached **peripheral**.

In a mixed IMX+GPX capture both are present, and which one appears first *varies between rollover segments*. So segments of one log started deriving different device ids. `ISDeviceLog::fromSegments` validates that every segment agrees and returns `Corrupted` when they don't — so the whole log stopped opening.

Measured on the goldenlogs log that fails in imx#1648, `gpx/gpx1/intellian_ut/2axis_motion_table/20250313_P10HV24110007_UT-Unprovisioned.ppd/20250313_054706`:

| segment | before #1265 | with #1265 | with this fix |
|---|---|---|---|
| `..._0001.raw` | SN509040 (DID 1) | SN509040 (DID 1) | SN509040 (DID 1) |
| `..._0002.raw` | SN509040 (DID 1) | **SN808527428 (DID 120)** | SN509040 (DID 1) |
| `..._0003.raw` | SN509040 (DID 1) | SN509040 (DID 1) | SN509040 (DID 1) |
| `..._0004.raw` | SN509040 (DID 1) | SN509040 (DID 1) | SN509040 (DID 1) |
| `..._0005.raw` | SN509040 (DID 1) | **SN808527428 (DID 120)** | SN509040 (DID 1) |
| `..._0006.raw` | SN509040 (DID 1) | **SN808527428 (DID 120)** | SN509040 (DID 1) |

## The fix

- **Rank instead of first-match.** `DID_DEV_INFO` always wins; a peripheral record is held in reserve and adopted only if the segment carries no primary record. The GPX-only case #1265 targeted still works — that is the only situation where a peripheral record is the sole identity available.
- **A zero serial no longer aborts the scan.** It previously `break`'d, so one partial-update or unprovisioned stub early in a segment hid every valid record behind it. Now skipped, and scanning continues.
- Extracted `adoptDevInfo()` as the single writer of `deviceId_` / `hdwId_` / `devInfo_`.

Cost is unchanged in the common case: a segment holding a primary record still early-exits on it. Only a segment with no primary record is scanned to the end — the same single linear pass the no-`dev_info` case has always cost.

## Verification

`tests/test_log_reader_devinfo.cpp`, 4 new cases. There was **no coverage of `deriveDeviceId` at all** before this, which is why #1265 shipped and broke two repos downstream.

- `PrimaryDevInfoWinsOverPeripheralThatAppearsFirst`
- `PeripheralDevInfoUsedWhenNoPrimaryPresent` — guards #1265's actual fix against regression
- `ZeroSerialRecordDoesNotHideALaterValidRecord`
- `MixedSegmentsInEitherOrderAgreeOnDeviceId` — the regression at the level it broke, via `fromSegments`

Checked for non-vacuity by reverting the source and re-running: **3 of the 4 fail without the fix**, including the `fromSegments` one, which reports exactly the two serials from the real log (509040 vs 808527428). `PeripheralDevInfoUsedWhenNoPrimaryPresent` passes either way by design — it exists to prove this change doesn't undo #1265.

Written portable (no `getpid()`, no hard-coded `/tmp`) so they are not excluded on Windows — the regression failed on both platforms, so the guard has to exist on both.

- Full SDK suite: **465 passed, 0 failed**, 4 skipped (env-gated live fixtures).
- End-to-end against the real failing log through the built library: `fromSegments` now returns `OPENED ok deviceId=509040 segments=6`.

## Note for a follow-up, not addressed here

That GPX record's serial reads `808527428` = `0x30312644` = ASCII `"D&10"` — not a plausible serial next to the 6-digit ones in the same corpus. The unit is flagged `UT-Unprovisioned`, so its GPX `dev_info_t` appears to carry non-numeric data in `serialNumber`. It no longer affects identity for mixed captures, but a **GPX-only** log from an unprovisioned unit would still adopt it. Worth deciding separately whether `deriveDeviceId` should sanity-check a serial before trusting it; I did not add a plausibility heuristic here because that is policy, not a regression fix.
