### PR TITLE
Extend external aiding with speed, heading, attitude, and IMU inputs (SN-8318)

### DIFF
--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1240,16 +1240,6 @@ static void PopulateMapExtAidingAttitude(data_set_t data_set[DID_COUNT], uint32_
     mapper.AddArray("var", &ext_aiding_attitude_t::var, DATA_TYPE_F32, 9, {"rad^2"}, {"3x3 row-major attitude-error covariance, in the roll/pitch/yaw tangent space.  Must have a non-zero diagonal or the observation is discarded"}, DATA_FLAGS_FIXED_DECIMAL_4);
 }
 
-static void PopulateMapExtAidingImu(data_set_t data_set[DID_COUNT], uint32_t did)
-{
-    DataMapper<ext_aiding_imu_t> mapper(data_set, did);
-    mapper.AddMember("timeOfWeekMs", &ext_aiding_imu_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
-    mapper.AddMember("status", &ext_aiding_imu_t::status, DATA_TYPE_UINT32, "", "reserved", DATA_FLAGS_DISPLAY_HEX);
-    mapper.AddArray("pqr", &ext_aiding_imu_t::pqr, DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Angular rate, IMU (body) frame {p,q,r}"}, DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
-    mapper.AddArray("acc", &ext_aiding_imu_t::acc, DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration, IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
-    mapper.AddArray("pqrVar", &ext_aiding_imu_t::pqrVar, DATA_TYPE_F32, 3, {"(rad/s)^2"}, {"Gyro noise variance per axis"}, DATA_FLAGS_FIXED_DECIMAL_4);
-    mapper.AddArray("accVar", &ext_aiding_imu_t::accVar, DATA_TYPE_F32, 3, {"(m/s^2)^2"}, {"Accelerometer noise variance per axis"}, DATA_FLAGS_FIXED_DECIMAL_4);
-}
 
 static void PopulateMapSystemCommand(data_set_t data_set[DID_COUNT], uint32_t did)
 {
@@ -2331,10 +2321,10 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_EXT_AIDING_POS",               // 106
     "DID_EXT_AIDING_VEL",               // 107
     "DID_EXT_AIDING_SPEED",             // 108
-    "DID_EXT_AIDING_IMU",               // 109
-    "DID_EXT_AIDING_DIR_SPEED",         // 110
-    "DID_EXT_AIDING_HEADING",           // 111
-    "DID_EXT_AIDING_ATTITUDE",          // 112
+    "DID_EXT_AIDING_DIR_SPEED",         // 109
+    "DID_EXT_AIDING_HEADING",           // 110
+    "DID_EXT_AIDING_ATTITUDE",          // 111
+    "DID_EXT_IMU",                      // 112
     "UNUSED_113",                       // 113
     "UNUSED_114",                       // 114
     "UNUSED_115",                       // 115
@@ -2409,7 +2399,7 @@ cISDataMappings::cISDataMappings()
     PopulateMapExtAidingDirSpeed(m_data_set, DID_EXT_AIDING_DIR_SPEED);
     PopulateMapExtAidingHeading(m_data_set, DID_EXT_AIDING_HEADING);
     PopulateMapExtAidingAttitude(m_data_set, DID_EXT_AIDING_ATTITUDE);
-    PopulateMapExtAidingImu(m_data_set, DID_EXT_AIDING_IMU);
+    PopulateMapImu(m_data_set, DID_EXT_IMU, "External IMU.");
 
     PopulateMapGnssPos(m_data_set, DID_GNSS1_RTK_POS);
     PopulateMapGnssRtkRel(m_data_set, DID_GNSS1_RTK_POS_REL);

--- a/src/ISDataMappings.cpp
+++ b/src/ISDataMappings.cpp
@@ -1201,6 +1201,56 @@ static void PopulateMapExtAidingVel(data_set_t data_set[DID_COUNT], uint32_t did
     mapper.AddArray("var", &ext_aiding_vel_t::var, DATA_TYPE_F32, 3, {"m^2/s^2"}, {"Observation variance per axis, in NED.  Must be non-zero or the observation is discarded"}, DATA_FLAGS_FIXED_DECIMAL_4);
 }
 
+static void PopulateMapExtAidingSpeed(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_speed_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_speed_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_speed_t::status, DATA_TYPE_UINT32, "", "Speed type: 1=3D magnitude, 2=horizontal magnitude (see eExtAidingSpeedType)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("speed", &ext_aiding_speed_t::speed, DATA_TYPE_F32, SYM_M_PER_S, "Speed magnitude", DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddMember("var", &ext_aiding_speed_t::var, DATA_TYPE_F32, "m^2/s^2", "Observation variance.  Must be non-zero or the observation is discarded", DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("offset", &ext_aiding_speed_t::offset, DATA_TYPE_F32, 3, {"m"}, {"Point of measurement relative to IMU origin, in IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
+}
+
+static void PopulateMapExtAidingDirSpeed(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_dir_speed_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_dir_speed_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_dir_speed_t::status, DATA_TYPE_UINT32, "", "reserved", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("speed", &ext_aiding_dir_speed_t::speed, DATA_TYPE_F32, SYM_M_PER_S, "Speed along `direction`", DATA_FLAGS_FIXED_DECIMAL_2);
+    mapper.AddMember("var", &ext_aiding_dir_speed_t::var, DATA_TYPE_F32, "m^2/s^2", "Observation variance.  Must be non-zero or the observation is discarded", DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("offset", &ext_aiding_dir_speed_t::offset, DATA_TYPE_F32, 3, {"m"}, {"Point of measurement relative to IMU origin, in IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("direction", &ext_aiding_dir_speed_t::direction, DATA_TYPE_F32, 3, {""}, {"Unit vector, in IMU (body) frame, along which `speed` is measured"}, DATA_FLAGS_FIXED_DECIMAL_3);
+}
+
+static void PopulateMapExtAidingHeading(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_heading_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_heading_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_heading_t::status, DATA_TYPE_UINT32, "", "Heading type: 1=true, 2=magnetic, 3=course over ground (see eExtAidingHeadingType)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddMember("heading", &ext_aiding_heading_t::heading, DATA_TYPE_F32, SYM_DEG, "Heading, 0=north, positive clockwise", DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddMember("var", &ext_aiding_heading_t::var, DATA_TYPE_F32, "rad^2", "Observation variance.  Must be non-zero or the observation is discarded", DATA_FLAGS_FIXED_DECIMAL_4);
+}
+
+static void PopulateMapExtAidingAttitude(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_attitude_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_attitude_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_attitude_t::status, DATA_TYPE_UINT32, "", "Attitude representation: 1=euler, 2=quaternion (see eExtAidingAttitudeType)", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddArray("att", &ext_aiding_attitude_t::att, DATA_TYPE_F32, 4, {""}, {"Attitude, interpreted per `status`: euler {roll,pitch,yaw,-} or quaternion {w,x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("var", &ext_aiding_attitude_t::var, DATA_TYPE_F32, 9, {"rad^2"}, {"3x3 row-major attitude-error covariance, in the roll/pitch/yaw tangent space.  Must have a non-zero diagonal or the observation is discarded"}, DATA_FLAGS_FIXED_DECIMAL_4);
+}
+
+static void PopulateMapExtAidingImu(data_set_t data_set[DID_COUNT], uint32_t did)
+{
+    DataMapper<ext_aiding_imu_t> mapper(data_set, did);
+    mapper.AddMember("timeOfWeekMs", &ext_aiding_imu_t::timeOfWeekMs, DATA_TYPE_UINT32, "ms", "Time of week since Sunday morning, GMT");
+    mapper.AddMember("status", &ext_aiding_imu_t::status, DATA_TYPE_UINT32, "", "reserved", DATA_FLAGS_DISPLAY_HEX);
+    mapper.AddArray("pqr", &ext_aiding_imu_t::pqr, DATA_TYPE_F32, 3, {SYM_DEG_PER_S}, {"Angular rate, IMU (body) frame {p,q,r}"}, DATA_FLAGS_FIXED_DECIMAL_2, C_RAD2DEG);
+    mapper.AddArray("acc", &ext_aiding_imu_t::acc, DATA_TYPE_F32, 3, {SYM_M_PER_S_2}, {"Linear acceleration, IMU (body) frame {x,y,z}"}, DATA_FLAGS_FIXED_DECIMAL_3);
+    mapper.AddArray("pqrVar", &ext_aiding_imu_t::pqrVar, DATA_TYPE_F32, 3, {"(rad/s)^2"}, {"Gyro noise variance per axis"}, DATA_FLAGS_FIXED_DECIMAL_4);
+    mapper.AddArray("accVar", &ext_aiding_imu_t::accVar, DATA_TYPE_F32, 3, {"(m/s^2)^2"}, {"Accelerometer noise variance per axis"}, DATA_FLAGS_FIXED_DECIMAL_4);
+}
+
 static void PopulateMapSystemCommand(data_set_t data_set[DID_COUNT], uint32_t did)
 {
     DataMapper<system_command_t> mapper(data_set, did);
@@ -2280,11 +2330,11 @@ const char* const cISDataMappings::m_dataIdNames[] =
     "DID_CAL_MOTION_MAG",               // 105
     "DID_EXT_AIDING_POS",               // 106
     "DID_EXT_AIDING_VEL",               // 107
-    "UNUSED_108",                       // 108
-    "UNUSED_109",                       // 109
-    "UNUSED_110",                       // 110
-    "UNUSED_111",                       // 111
-    "UNUSED_112",                       // 112
+    "DID_EXT_AIDING_SPEED",             // 108
+    "DID_EXT_AIDING_IMU",               // 109
+    "DID_EXT_AIDING_DIR_SPEED",         // 110
+    "DID_EXT_AIDING_HEADING",           // 111
+    "DID_EXT_AIDING_ATTITUDE",          // 112
     "UNUSED_113",                       // 113
     "UNUSED_114",                       // 114
     "UNUSED_115",                       // 115
@@ -2355,6 +2405,11 @@ cISDataMappings::cISDataMappings()
     PopulateMapWheelEncoder(m_data_set, DID_WHEEL_ENCODER);
     PopulateMapExtAidingPos(m_data_set, DID_EXT_AIDING_POS);
     PopulateMapExtAidingVel(m_data_set, DID_EXT_AIDING_VEL);
+    PopulateMapExtAidingSpeed(m_data_set, DID_EXT_AIDING_SPEED);
+    PopulateMapExtAidingDirSpeed(m_data_set, DID_EXT_AIDING_DIR_SPEED);
+    PopulateMapExtAidingHeading(m_data_set, DID_EXT_AIDING_HEADING);
+    PopulateMapExtAidingAttitude(m_data_set, DID_EXT_AIDING_ATTITUDE);
+    PopulateMapExtAidingImu(m_data_set, DID_EXT_AIDING_IMU);
 
     PopulateMapGnssPos(m_data_set, DID_GNSS1_RTK_POS);
     PopulateMapGnssRtkRel(m_data_set, DID_GNSS1_RTK_POS_REL);

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -381,11 +381,11 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 105: DID_CAL_MOTION_MAG
         offsetsExtAidingPos,    // 106: DID_EXT_AIDING_POS
         0,                      // 107: DID_EXT_AIDING_VEL
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
+        0,                      // 108: DID_EXT_AIDING_SPEED
+        0,                      // 109: DID_EXT_AIDING_IMU
+        0,                      // 110: DID_EXT_AIDING_DIR_SPEED
+        0,                      // 111: DID_EXT_AIDING_HEADING
+        0,                      // 112: DID_EXT_AIDING_ATTITUDE
         0,                      // 113:
         0,                      // 114:
         0,                      // 115:
@@ -571,11 +571,11 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 105: DID_CAL_MOTION_MAG
         0,                      // 106: DID_EXT_AIDING_POS
         0,                      // 107: DID_EXT_AIDING_VEL
-        0,                      // 108:
-        0,                      // 109:
-        0,                      // 110:
-        0,                      // 111:
-        0,                      // 112:
+        0,                      // 108: DID_EXT_AIDING_SPEED
+        0,                      // 109: DID_EXT_AIDING_IMU
+        0,                      // 110: DID_EXT_AIDING_DIR_SPEED
+        0,                      // 111: DID_EXT_AIDING_HEADING
+        0,                      // 112: DID_EXT_AIDING_ATTITUDE
         0,                      // 113:
         0,                      // 114:
         0,                      // 115:
@@ -686,6 +686,11 @@ const uint64_t g_didToRmcBit[DID_COUNT] =
     [DID_GROUND_VEHICLE]        = RMC_BITS_GROUND_VEHICLE,
     [DID_EXT_AIDING_POS]        = RMC_BITS_EXT_AIDING_POS,
     [DID_EXT_AIDING_VEL]        = RMC_BITS_EXT_AIDING_VEL,
+    [DID_EXT_AIDING_SPEED]      = RMC_BITS_EXT_AIDING_SPEED,
+    [DID_EXT_AIDING_DIR_SPEED]  = RMC_BITS_EXT_AIDING_DIR_SPEED,
+    [DID_EXT_AIDING_HEADING]    = RMC_BITS_EXT_AIDING_HEADING,
+    [DID_EXT_AIDING_ATTITUDE]   = RMC_BITS_EXT_AIDING_ATTITUDE,
+    // NOTE: DID_EXT_AIDING_IMU intentionally has no RMC bit; see data_sets.h.
     [DID_IMU_MAG]               = RMC_BITS_IMU_MAG,
     [DID_PIMU_MAG]              = RMC_BITS_PIMU_MAG,
     [DID_EVENT]                 = RMC_BITS_EVENT,

--- a/src/data_sets.c
+++ b/src/data_sets.c
@@ -382,10 +382,10 @@ uint16_t* getDoubleOffsets(eDataIDs dataId, uint16_t* offsetsLength)
         offsetsExtAidingPos,    // 106: DID_EXT_AIDING_POS
         0,                      // 107: DID_EXT_AIDING_VEL
         0,                      // 108: DID_EXT_AIDING_SPEED
-        0,                      // 109: DID_EXT_AIDING_IMU
-        0,                      // 110: DID_EXT_AIDING_DIR_SPEED
-        0,                      // 111: DID_EXT_AIDING_HEADING
-        0,                      // 112: DID_EXT_AIDING_ATTITUDE
+        0,                      // 109: DID_EXT_AIDING_DIR_SPEED
+        0,                      // 110: DID_EXT_AIDING_HEADING
+        0,                      // 111: DID_EXT_AIDING_ATTITUDE
+        0,                      // 112: DID_EXT_IMU
         0,                      // 113:
         0,                      // 114:
         0,                      // 115:
@@ -572,10 +572,10 @@ uint16_t* getStringOffsetsLengths(eDataIDs dataId, uint16_t* offsetsLength)
         0,                      // 106: DID_EXT_AIDING_POS
         0,                      // 107: DID_EXT_AIDING_VEL
         0,                      // 108: DID_EXT_AIDING_SPEED
-        0,                      // 109: DID_EXT_AIDING_IMU
-        0,                      // 110: DID_EXT_AIDING_DIR_SPEED
-        0,                      // 111: DID_EXT_AIDING_HEADING
-        0,                      // 112: DID_EXT_AIDING_ATTITUDE
+        0,                      // 109: DID_EXT_AIDING_DIR_SPEED
+        0,                      // 110: DID_EXT_AIDING_HEADING
+        0,                      // 111: DID_EXT_AIDING_ATTITUDE
+        0,                      // 112: DID_EXT_IMU
         0,                      // 113:
         0,                      // 114:
         0,                      // 115:
@@ -690,7 +690,7 @@ const uint64_t g_didToRmcBit[DID_COUNT] =
     [DID_EXT_AIDING_DIR_SPEED]  = RMC_BITS_EXT_AIDING_DIR_SPEED,
     [DID_EXT_AIDING_HEADING]    = RMC_BITS_EXT_AIDING_HEADING,
     [DID_EXT_AIDING_ATTITUDE]   = RMC_BITS_EXT_AIDING_ATTITUDE,
-    // NOTE: DID_EXT_AIDING_IMU intentionally has no RMC bit; see data_sets.h.
+    // NOTE: DID_EXT_IMU intentionally has no RMC bit; see data_sets.h.
     [DID_IMU_MAG]               = RMC_BITS_IMU_MAG,
     [DID_PIMU_MAG]              = RMC_BITS_PIMU_MAG,
     [DID_EVENT]                 = RMC_BITS_EVENT,

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -174,6 +174,7 @@ typedef uint32_t eDataIDs;
 #define DID_CAL_MOTION_MAG              (eDataIDs)105   /**< INTERNAL USE ONLY (sensor_mcal_group_t) */
 #define DID_EXT_AIDING_POS              (eDataIDs)106   /**< (ext_aiding_pos_t) External aiding position observation, input to the INS/EKF */
 #define DID_EXT_AIDING_VEL              (eDataIDs)107   /**< (ext_aiding_vel_t) External aiding velocity observation, input to the INS/EKF */
+// The following External aiding DIDs are under development.  Contact Inertial Sense for more information on their use and availability.
 #define DID_EXT_AIDING_SPEED            (eDataIDs)108   /**< (ext_aiding_speed_t) External aiding speed (scalar) observation, input to the INS/EKF */
 #define DID_EXT_AIDING_DIR_SPEED        (eDataIDs)109   /**< (ext_aiding_dir_speed_t) External aiding directional speed (e.g. airspeed) observation, input to the INS/EKF */
 #define DID_EXT_AIDING_HEADING          (eDataIDs)110   /**< (ext_aiding_heading_t) External aiding heading observation, input to the INS/EKF */

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -179,7 +179,7 @@ typedef uint32_t eDataIDs;
 #define DID_EXT_AIDING_DIR_SPEED        (eDataIDs)109   /**< (ext_aiding_dir_speed_t) External aiding directional speed (e.g. airspeed) observation, input to the INS/EKF */
 #define DID_EXT_AIDING_HEADING          (eDataIDs)110   /**< (ext_aiding_heading_t) External aiding heading observation, input to the INS/EKF */
 #define DID_EXT_AIDING_ATTITUDE         (eDataIDs)111   /**< (ext_aiding_attitude_t) External aiding attitude observation, input to the INS/EKF */
-#define DID_EXT_AIDING_IMU              (eDataIDs)112   /**< (ext_aiding_imu_t) External IMU (gyro/accel) input. Not currently fused by the INS/EKF; reserved for a future consistency-check or blended time-update path. */
+#define DID_EXT_IMU                     (eDataIDs)112   /**< (imu_t) External IMU (gyro/accel) input. Not currently fused by the INS/EKF; reserved for a future consistency-check or blended time-update path. */
 // RESERVED: a future consolidated external-aiding message (DID + sub-ID + SID-dependent payload,
 // covering position/velocity/speed/heading/attitude/IMU/config with full covariance) was proposed
 // under SN-7740. The flat DIDs above are the initial subset; see SN-7740 before adding more.
@@ -1874,7 +1874,7 @@ typedef struct PACKED
 #define RMC_BITS_EXT_AIDING_DIR_SPEED   0x0100000000000000
 #define RMC_BITS_EXT_AIDING_HEADING     0x0200000000000000
 #define RMC_BITS_EXT_AIDING_ATTITUDE    0x0400000000000000
-// NOTE: DID_EXT_AIDING_IMU has no RMC bit - out of free bits below RMC_BITS_EVENT (RMC_BITS_MASK
+// NOTE: DID_EXT_IMU has no RMC bit - out of free bits below RMC_BITS_EVENT (RMC_BITS_MASK
 // excludes the top nibble, so bits 60+ aren't usable here). It is writable/pollable but not
 // relayed for logging the way the other external aiding DIDs are. Free a bit here if that's needed.
 
@@ -3464,17 +3464,6 @@ typedef struct PACKED
     float      att[4];       //!< attitude, interpreted per `status`: euler {roll,pitch,yaw,-} or quaternion {w,x,y,z}
     float      var[9];       //!< 3x3 row-major attitude-error covariance (rad^2), in the roll/pitch/yaw tangent space. Must have a non-zero diagonal or the observation is discarded.
 } ext_aiding_attitude_t;
-
-/** @brief (DID_EXT_AIDING_IMU) External IMU (gyro/accel) input, supplied by a host or external sensor. Not currently fused by the INS/EKF; the DID exists for streaming/logging an external IMU alongside the primary one. */
-typedef struct PACKED
-{
-    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
-    uint32_t   status;       //!< reserved, set to 0
-    float      pqr[3];       //!< angular rate, IMU/body frame {p,q,r} (rad/s)
-    float      acc[3];       //!< linear acceleration, IMU/body frame {x,y,z} (m/s^2)
-    float      pqrVar[3];    //!< gyro noise variance, per axis ((rad/s)^2)
-    float      accVar[3];    //!< accelerometer noise variance, per axis ((m/s^2)^2)
-} ext_aiding_imu_t;
 
 /** @brief INS dynamic platform model selection, used with nvm_flash_cfg_t.dynamicModel (DID_FLASH_CONFIG). Selects a motion-profile model (expected acceleration/jerk limits) that the EKF and the GNSS receiver's own navigation filter use to balance measurement noise rejection against tracking responsiveness; the model chosen must be at least as dynamic as the actual platform motion or navigation accuracy will suffer. Also passed through to the GNSS receiver's dynamic model setting where supported. */
 enum eDynamicModel
@@ -5369,7 +5358,7 @@ typedef union PACKED
     ext_aiding_dir_speed_t          extAidingDirSpeed; //!< DID_EXT_AIDING_DIR_SPEED
     ext_aiding_heading_t            extAidingHeading;  //!< DID_EXT_AIDING_HEADING
     ext_aiding_attitude_t           extAidingAttitude; //!< DID_EXT_AIDING_ATTITUDE
-    ext_aiding_imu_t                extAidingImu;      //!< DID_EXT_AIDING_IMU
+    imu_t                           extAidingImu;      //!< DID_EXT_IMU
     pos_measurement_t               posMeasurement; //!< DID_POSITION_MEASUREMENT
     pimu_t                          pImu;           //!< DID_PIMU / DID_REFERENCE_PIMU
     gnss_pos_t                      gnssPos;        //!< DID_GNSS1_POS / DID_GNSS2_POS / DID_GNSS1_RTK_POS / DID_GNSS1_RCVR_POS

--- a/src/data_sets.h
+++ b/src/data_sets.h
@@ -174,9 +174,14 @@ typedef uint32_t eDataIDs;
 #define DID_CAL_MOTION_MAG              (eDataIDs)105   /**< INTERNAL USE ONLY (sensor_mcal_group_t) */
 #define DID_EXT_AIDING_POS              (eDataIDs)106   /**< (ext_aiding_pos_t) External aiding position observation, input to the INS/EKF */
 #define DID_EXT_AIDING_VEL              (eDataIDs)107   /**< (ext_aiding_vel_t) External aiding velocity observation, input to the INS/EKF */
+#define DID_EXT_AIDING_SPEED            (eDataIDs)108   /**< (ext_aiding_speed_t) External aiding speed (scalar) observation, input to the INS/EKF */
+#define DID_EXT_AIDING_DIR_SPEED        (eDataIDs)109   /**< (ext_aiding_dir_speed_t) External aiding directional speed (e.g. airspeed) observation, input to the INS/EKF */
+#define DID_EXT_AIDING_HEADING          (eDataIDs)110   /**< (ext_aiding_heading_t) External aiding heading observation, input to the INS/EKF */
+#define DID_EXT_AIDING_ATTITUDE         (eDataIDs)111   /**< (ext_aiding_attitude_t) External aiding attitude observation, input to the INS/EKF */
+#define DID_EXT_AIDING_IMU              (eDataIDs)112   /**< (ext_aiding_imu_t) External IMU (gyro/accel) input. Not currently fused by the INS/EKF; reserved for a future consistency-check or blended time-update path. */
 // RESERVED: a future consolidated external-aiding message (DID + sub-ID + SID-dependent payload,
 // covering position/velocity/speed/heading/attitude/IMU/config with full covariance) was proposed
-// under SN-7740. The two flat DIDs above are the initial subset; see SN-7740 before adding more.
+// under SN-7740. The flat DIDs above are the initial subset; see SN-7740 before adding more.
 
 #define DID_EVENT                       (eDataIDs)119   /**< INTERNAL USE ONLY (did_event_t)*/
 
@@ -1864,6 +1869,13 @@ typedef struct PACKED
 // source produces rather than a period multiple.
 #define RMC_BITS_EXT_AIDING_POS         0x0020000000000000
 #define RMC_BITS_EXT_AIDING_VEL         0x0040000000000000
+#define RMC_BITS_EXT_AIDING_SPEED       0x0080000000000000
+#define RMC_BITS_EXT_AIDING_DIR_SPEED   0x0100000000000000
+#define RMC_BITS_EXT_AIDING_HEADING     0x0200000000000000
+#define RMC_BITS_EXT_AIDING_ATTITUDE    0x0400000000000000
+// NOTE: DID_EXT_AIDING_IMU has no RMC bit - out of free bits below RMC_BITS_EVENT (RMC_BITS_MASK
+// excludes the top nibble, so bits 60+ aren't usable here). It is writable/pollable but not
+// relayed for logging the way the other external aiding DIDs are. Free a bit here if that's needed.
 
 #define RMC_BITS_EVENT                  0x0800000000000000
 
@@ -1894,6 +1906,10 @@ typedef struct PACKED
                                             | RMC_BITS_DIAGNOSTIC_MESSAGE\
                                             | RMC_BITS_EXT_AIDING_POS \
                                             | RMC_BITS_EXT_AIDING_VEL \
+                                            | RMC_BITS_EXT_AIDING_SPEED \
+                                            | RMC_BITS_EXT_AIDING_DIR_SPEED \
+                                            | RMC_BITS_EXT_AIDING_HEADING \
+                                            | RMC_BITS_EXT_AIDING_ATTITUDE \
                                             | RMC_BITS_GPX_SYS_FAULT)
 #define RMC_PRESET_IMX_PPD                  (RMC_PRESET_IMX_PPD_NO_IMU \
                                             | RMC_BITS_PIMU \
@@ -3383,6 +3399,81 @@ typedef struct PACKED
     float      offset[3];    //!< point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
     float      var[3];       //!< observation variance, per axis, in NED (m^2/s^2).  Must be non-zero or the observation is discarded.
 } ext_aiding_vel_t;
+
+/** @brief Type of scalar speed carried by ext_aiding_speed_t.status (DID_EXT_AIDING_SPEED), held in the low nibble. Note 0 is not a valid type. */
+enum eExtAidingSpeedType
+{
+    EXT_AIDING_SPEED_TYPE_MASK          = 0x0000000F,  //!< Mask for the speed type
+    EXT_AIDING_SPEED_TYPE_3D            = 1,           //!< speed is the full 3D velocity magnitude, |v|
+    EXT_AIDING_SPEED_TYPE_HORIZONTAL    = 2            //!< speed is the horizontal (ground) velocity magnitude only, |v_NE|
+};
+
+/** @brief (DID_EXT_AIDING_SPEED) External aiding scalar speed observation (e.g. a wheel-speed sensor or GNSS-derived ground speed with no direction), supplied by a host or external sensor as an input to the INS/EKF. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       //!< Speed type, 1=3D magnitude, 2=horizontal magnitude (see eExtAidingSpeedType)
+    float      speed;        //!< speed (m/s)
+    float      var;          //!< observation variance (m^2/s^2).  Must be non-zero or the observation is discarded.
+    float      offset[3];    //!< point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
+} ext_aiding_speed_t;
+
+/** @brief (DID_EXT_AIDING_DIR_SPEED) External aiding directional speed observation (e.g. airspeed from a pitot tube), supplied by a host or external sensor as an input to the INS/EKF. `direction` is a unit vector in the IMU/body frame (e.g. [1,0,0] for a sensor measuring speed along the body X axis); `speed` is the velocity component along that direction at the point of measurement. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       //!< reserved, set to 0
+    float      speed;        //!< speed along `direction` (m/s)
+    float      var;          //!< observation variance (m^2/s^2).  Must be non-zero or the observation is discarded.
+    float      offset[3];    //!< point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
+    float      direction[3]; //!< unit vector, in IMU/body frame, along which `speed` is measured (e.g. [1,0,0] for forward-pointing airspeed)
+} ext_aiding_dir_speed_t;
+
+/** @brief Type of heading carried by ext_aiding_heading_t.status (DID_EXT_AIDING_HEADING), held in the low nibble. Note 0 is not a valid type. */
+enum eExtAidingHeadingType
+{
+    EXT_AIDING_HEADING_TYPE_MASK        = 0x0000000F,  //!< Mask for the heading type
+    EXT_AIDING_HEADING_TYPE_TRUE        = 1,           //!< true heading (body X axis bearing relative to true north)
+    EXT_AIDING_HEADING_TYPE_MAGNETIC    = 2,           //!< magnetic heading (body X axis bearing relative to magnetic north); converted to true heading using the EKF's declination estimate
+    EXT_AIDING_HEADING_TYPE_COURSE      = 3            //!< course over ground (direction of travel, i.e. velocity bearing - not necessarily the same as body heading)
+};
+
+/** @brief (DID_EXT_AIDING_HEADING) External aiding heading observation, supplied by a host or external sensor as an input to the INS/EKF. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       //!< Heading type, 1=true, 2=magnetic, 3=course over ground (see eExtAidingHeadingType)
+    float      heading;      //!< heading (rad), 0 = north, positive clockwise, range [-pi, pi]
+    float      var;          //!< observation variance (rad^2).  Must be non-zero or the observation is discarded.
+} ext_aiding_heading_t;
+
+/** @brief Representation of ext_aiding_attitude_t.att, carried in ext_aiding_attitude_t.status (DID_EXT_AIDING_ATTITUDE), held in the low nibble. Note 0 is not a valid type. */
+enum eExtAidingAttitudeType
+{
+    EXT_AIDING_ATTITUDE_TYPE_MASK       = 0x0000000F,  //!< Mask for the attitude representation
+    EXT_AIDING_ATTITUDE_TYPE_EULER      = 1,           //!< att = {roll, pitch, yaw} (rad); att[3] unused
+    EXT_AIDING_ATTITUDE_TYPE_QUATERNION = 2            //!< att = {w, x, y, z}
+};
+
+/** @brief (DID_EXT_AIDING_ATTITUDE) External aiding attitude observation, supplied by a host or external sensor (e.g. a second INS) as an input to the INS/EKF. `var` is the 3x3 attitude-error covariance (row-major), expressed as a small-angle roll/pitch/yaw rotation vector regardless of whether `att` is euler or quaternion. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       //!< Attitude representation, 1=euler, 2=quaternion (see eExtAidingAttitudeType)
+    float      att[4];       //!< attitude, interpreted per `status`: euler {roll,pitch,yaw,-} or quaternion {w,x,y,z}
+    float      var[9];       //!< 3x3 row-major attitude-error covariance (rad^2), in the roll/pitch/yaw tangent space. Must have a non-zero diagonal or the observation is discarded.
+} ext_aiding_attitude_t;
+
+/** @brief (DID_EXT_AIDING_IMU) External IMU (gyro/accel) input, supplied by a host or external sensor. Not currently fused by the INS/EKF; the DID exists for streaming/logging an external IMU alongside the primary one. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; //!< GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       //!< reserved, set to 0
+    float      pqr[3];       //!< angular rate, IMU/body frame {p,q,r} (rad/s)
+    float      acc[3];       //!< linear acceleration, IMU/body frame {x,y,z} (m/s^2)
+    float      pqrVar[3];    //!< gyro noise variance, per axis ((rad/s)^2)
+    float      accVar[3];    //!< accelerometer noise variance, per axis ((m/s^2)^2)
+} ext_aiding_imu_t;
 
 /** @brief INS dynamic platform model selection, used with nvm_flash_cfg_t.dynamicModel (DID_FLASH_CONFIG). Selects a motion-profile model (expected acceleration/jerk limits) that the EKF and the GNSS receiver's own navigation filter use to balance measurement noise rejection against tracking responsiveness; the model chosen must be at least as dynamic as the actual platform motion or navigation accuracy will suffer. Also passed through to the GNSS receiver's dynamic model setting where supported. */
 enum eDynamicModel
@@ -5273,6 +5364,11 @@ typedef union PACKED
     ground_vehicle_t                groundVehicle;  //!< DID_GROUND_VEHICLE
     ext_aiding_pos_t                extAidingPos;   //!< DID_EXT_AIDING_POS
     ext_aiding_vel_t                extAidingVel;   //!< DID_EXT_AIDING_VEL
+    ext_aiding_speed_t              extAidingSpeed;   //!< DID_EXT_AIDING_SPEED
+    ext_aiding_dir_speed_t          extAidingDirSpeed; //!< DID_EXT_AIDING_DIR_SPEED
+    ext_aiding_heading_t            extAidingHeading;  //!< DID_EXT_AIDING_HEADING
+    ext_aiding_attitude_t           extAidingAttitude; //!< DID_EXT_AIDING_ATTITUDE
+    ext_aiding_imu_t                extAidingImu;      //!< DID_EXT_AIDING_IMU
     pos_measurement_t               posMeasurement; //!< DID_POSITION_MEASUREMENT
     pimu_t                          pImu;           //!< DID_PIMU / DID_REFERENCE_PIMU
     gnss_pos_t                      gnssPos;        //!< DID_GNSS1_POS / DID_GNSS2_POS / DID_GNSS1_RTK_POS / DID_GNSS1_RCVR_POS


### PR DESCRIPTION
## Extend external aiding with speed, heading, attitude, and IMU inputs (SN-8318)

### Summary

Builds on the existing `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL` external aiding feature (SN-8317/SN-8318) by adding five more writable observation types, so a host or external sensor can feed the IMX EKF from a wider range of source hardware — wheel-speed sensors, airspeed/pitot tubes, compasses, GPS course, a second INS, or a redundant IMU.

| DID | Observation | Fused by EKF |
|---|---|:---:|
| `DID_EXT_AIDING_SPEED` | Scalar speed (3D or horizontal magnitude) | Yes |
| `DID_EXT_AIDING_DIR_SPEED` | Directional speed, e.g. airspeed (body-frame direction) | Yes |
| `DID_EXT_AIDING_HEADING` | Heading — true, magnetic, or course-over-ground | Yes |
| `DID_EXT_AIDING_ATTITUDE` | Full attitude, euler or quaternion, 3x3 covariance | Yes |
| `DID_EXT_AIDING_IMU` | Gyro/accel | No — plumbed through and loggable only |

### Design notes

- Each new EKF measurement update (`ExtSpeedUpdate`, `ExtDirSpeedUpdate`, `ExtHeadingUpdate`, `ExtAttitudeUpdate` in `external_ref.cpp`) is built by reusing the exact Jacobian construction already proven in the shipped `ExtPosUpdate`/`ExtVelUpdate`/`MagUpdate`/`GnssCompassUpdate`, rather than a new derivation from scratch — speed/directional-speed project the existing velocity/attitude Jacobian blocks onto a unit direction; heading (true/magnetic) reuses the `-Rb2t·cross_mat(bodyVector)` recipe through an atan2 gradient; attitude uses a direct identity Jacobian on the error states via a quaternion residual.
- **Course-over-ground is deliberately modeled as a velocity-direction observation, not an attitude observation** — it has no attitude-state coupling, since course and heading can differ under sideslip/crab.
- `DID_EXT_AIDING_IMU` has no RMC relay bit — the four bits below `RMC_BITS_EVENT` were the last ones free before the reserved top nibble; flagged in `data_sets.h` for whoever revisits fusion for it.
- Adds a `NavINL_base`/`NavINL2` virtual dispatch layer for the 4 new `Set*Data` calls (mirroring the existing `SetExtPosData`/`SetExtVelData` pattern) — required since `g_nav` is accessed through the abstract base class.

### Scope / what's NOT here

- `DID_EXT_AIDING_IMU` fusion (consistency-check or blended time-update) is out of scope for this PR — plumbing only.
- GPX-1 does not produce any of the 5 new types (unlike POS/VEL) — no GRMC-side changes.

### Test plan

- [x] `NavPostProcess` (`navpp`) builds clean against the shared `nav-common` EKF code (same files used by IMX firmware)
- [ ] IMX-5 / GPX-1 embedded builds (no ARM toolchain available in this environment — needs a real build)
- [ ] Bench test each new DID via `cltool -set` against a live IMX, confirm EKF innovation/NIS behaves sanely (recommend SIL/HIL review of the new Jacobians before flight — novel code, not literal copies)
- [ ] Confirm EvalTool Data Sets/Logger tabs show the 5 new DIDs
- [ ] Confirm relay (`RMC_BITS_EXT_AIDING_*`) logs correctly on a second port

### Related

- SDK: `607ef2e96`, `8b85fefe9` (this branch)
- Docs: `docs/user-manual/imx/external-aiding.md` updated with structs, usage, and `cltool` examples for all 5 new types
- Builds on SN-8317/PR-1266, PR-1653
