### PR TITLE
SN-8471: add GET_DATA preserve-stream flag; fix flash-cfg-sync polling loops

### DIFF
--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1500,6 +1500,14 @@ int is_comm_get_data(port_handle_t port, uint32_t did, uint32_t size, uint32_t o
     return is_comm_write(port, PKT_TYPE_GET_DATA, 0, sizeof(p_data_get_t), 0, &get);
 }
 
+bool isbStream_shouldPreserve(uint64_t currentBits, uint64_t didBitMask, uint32_t currentPeriodMultiple, int requestedPeriod, bool preserveIfStreaming)
+{
+    return requestedPeriod == 0
+        && preserveIfStreaming
+        && (currentBits & didBitMask) != 0
+        && currentPeriodMultiple != 0;
+}
+
 void is_comm_encode_hdr(packet_t *pkt, uint8_t flags, uint16_t did, uint16_t data_size, uint16_t offset, const void* data)
 {
     // Header

--- a/src/ISComm.c
+++ b/src/ISComm.c
@@ -1482,6 +1482,7 @@ int is_comm_get_data_to_buf(uint8_t *buf, uint32_t buf_size, is_comm_instance_t*
     get.offset = offset;
     get.size = size;
     get.period = periodMultiple;
+    get.flags = 0;
 
     return is_comm_write_to_buf(buf, buf_size, comm, PKT_TYPE_GET_DATA, 0, sizeof(p_data_get_t), 0, &get);
 }
@@ -1494,6 +1495,7 @@ int is_comm_get_data(port_handle_t port, uint32_t did, uint32_t size, uint32_t o
     get.offset = offset;
     get.size = size;
     get.period = periodMultiple;
+    get.flags = 0;
 
     return is_comm_write(port, PKT_TYPE_GET_DATA, 0, sizeof(p_data_get_t), 0, &get);
 }

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -244,6 +244,22 @@ typedef enum
     ISB_FLAGS_MASK                          = 0xF0, //!< Bitmask for the packet flags field (upper nibble)
     ISB_FLAGS_EXTENDED_PAYLOAD              = 0x10, //!< Payload exceeds 2048 bytes and continues in the next packet
     ISB_FLAGS_PAYLOAD_W_OFFSET              = 0x20, //!< First two bytes of the payload contain the data-set byte offset
+
+    /**
+     * @brief Only meaningful on a PKT_TYPE_GET_DATA packet whose p_data_get_t::period is 0. A
+     *        plain period=0 GET_DATA is a genuine one-shot request (deliver the current value
+     *        once) -- but on a device that also honors this flag, it ALSO implicitly stops any
+     *        existing broadcast for that DID on the requesting port, since there was previously
+     *        no way to distinguish "just poll me a value" from "stop this stream" (SN-8471).
+     *        Setting this bit tells a device that supports it: if this DID's broadcast bit is
+     *        already set on this port, leave it alone (deliver the one-shot reply without
+     *        disturbing the existing stream). Unset (the default for every existing caller),
+     *        behavior is unchanged. Ignored on older firmware that doesn't recognize it -- an
+     *        unrecognized upper-nibble flag bit is never validated/rejected by the parser, so a
+     *        period=0 GET_DATA from a newer client talking to older firmware still stops any
+     *        existing stream exactly as it always has.
+     */
+    ISB_FLAGS_GET_DATA_PRESERVE_STREAM      = 0x40,
 } eISBPacketFlags;
 
 /** Represents size number of bytes in memory, up to a maximum of PKT_BUF_SIZE */

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -244,22 +244,6 @@ typedef enum
     ISB_FLAGS_MASK                          = 0xF0, //!< Bitmask for the packet flags field (upper nibble)
     ISB_FLAGS_EXTENDED_PAYLOAD              = 0x10, //!< Payload exceeds 2048 bytes and continues in the next packet
     ISB_FLAGS_PAYLOAD_W_OFFSET              = 0x20, //!< First two bytes of the payload contain the data-set byte offset
-
-    /**
-     * @brief Only meaningful on a PKT_TYPE_GET_DATA packet whose p_data_get_t::period is 0. A
-     *        plain period=0 GET_DATA is a genuine one-shot request (deliver the current value
-     *        once) -- but on a device that also honors this flag, it ALSO implicitly stops any
-     *        existing broadcast for that DID on the requesting port, since there was previously
-     *        no way to distinguish "just poll me a value" from "stop this stream" (SN-8471).
-     *        Setting this bit tells a device that supports it: if this DID's broadcast bit is
-     *        already set on this port, leave it alone (deliver the one-shot reply without
-     *        disturbing the existing stream). Unset (the default for every existing caller),
-     *        behavior is unchanged. Ignored on older firmware that doesn't recognize it -- an
-     *        unrecognized upper-nibble flag bit is never validated/rejected by the parser, so a
-     *        period=0 GET_DATA from a newer client talking to older firmware still stops any
-     *        existing stream exactly as it always has.
-     */
-    ISB_FLAGS_GET_DATA_PRESERVE_STREAM      = 0x40,
 } eISBPacketFlags;
 
 /** Represents size number of bytes in memory, up to a maximum of PKT_BUF_SIZE */
@@ -515,7 +499,20 @@ typedef struct
     uint8_t             buf[MAX_DATASET_SIZE];
 } p_data_buf_t;
 
-/** Represents the complete body of a PKT_TYPE_GET_DATA packet */
+/**
+ * @brief Represents the complete body of a PKT_TYPE_GET_DATA packet.
+ *
+ * `flags` was appended after `period` (SN-8471) -- older senders never included it, and the wire
+ * framing is self-describing (packet_hdr_t::payloadSize is explicit, not inferred from
+ * sizeof(p_data_get_t)), so this is a backward/forward-compatible growth: older firmware
+ * receiving a newer, larger request simply never reads past its own (smaller) compiled struct,
+ * and newer firmware receiving an older, shorter request must not trust `flags` unless it first
+ * confirms the actual received payload was large enough to include it -- see
+ * GET_DATA_FLAGS_PRESERVE_STREAM below and ISComManager::getDataRequest()'s receivedPayloadSize
+ * parameter. Any code constructing a p_data_get_t locally (not just decoding one off the wire)
+ * must explicitly initialize `flags` (e.g. `= {}` or an explicit assignment) -- it is easy to
+ * accidentally send uninitialized stack garbage in this field otherwise.
+ */
 typedef struct
 {
     /** Data ID being requested */
@@ -529,7 +526,25 @@ typedef struct
 
     /**    The broadcast source period multiple.  0 for a one-time broadcast.  */
     uint16_t            period;
+
+    /** Request flags -- see GET_DATA_FLAGS_PRESERVE_STREAM. Always 0 from any sender that predates SN-8471. */
+    uint16_t            flags;
 } p_data_get_t;
+
+enum eGetDataFlags
+{
+    /**
+     * @brief Only meaningful when `period` is 0. A plain period=0 GET_DATA is a genuine one-shot
+     *        request (deliver the current value once) -- but a device may also use it to
+     *        implicitly stop any existing broadcast for that DID on the requesting port, since
+     *        there was previously no way to distinguish "just poll me a value" from "stop this
+     *        stream" (SN-8471). Setting this bit tells a device that supports it: if this DID's
+     *        broadcast bit is already set on this port, leave it alone (deliver the one-shot
+     *        reply without disturbing the existing stream). Unset (the default for every
+     *        pre-SN-8471 caller and every older client), behavior is unchanged.
+     */
+    GET_DATA_FLAGS_PRESERVE_STREAM = 0x0001,
+};
 
 /** Represents the body header of an ACK or NACK packet */
 typedef struct

--- a/src/ISComm.h
+++ b/src/ISComm.h
@@ -53,6 +53,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include "data_sets.h"
 #include "stddef.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -545,6 +546,35 @@ enum eGetDataFlags
      */
     GET_DATA_FLAGS_PRESERVE_STREAM = 0x0001,
 };
+
+/**
+ * @brief True if a period=0 GET_DATA/RMC request should leave the DID's existing broadcast
+ *        state untouched rather than disabling it.
+ *
+ *        A plain period=0 GET_DATA is a genuine one-shot poll, but both GPX's isb_enable_stream()
+ *        and IMX's cmMsgHandlerRmc() historically also used it to implicitly stop any existing
+ *        broadcast for that DID on the requesting port -- there was no way for a caller to say
+ *        "just poll me a value, don't disturb whatever's already streaming." A caller that
+ *        recognizes this sets GET_DATA_FLAGS_PRESERVE_STREAM (above); this returns true only when
+ *        there's actually something to preserve: the requested period is 0, the flag is set, the
+ *        DID's broadcast-enable bit is currently set, AND its period multiple is nonzero (SN-8471).
+ *
+ *        The period-multiple check matters specifically for IMX: cmMsgHandlerRmc() sets the bit
+ *        immediately (via OR) but the actual clear happens one broadcast cycle later, in
+ *        sendRmcMessage(), once it observes periodMultiple==0 for that DID -- so there's a narrow
+ *        window where the bit reads as set even though a just-processed period=0 request already
+ *        queued it for clearing. Checking periodMultiple too avoids incorrectly treating that
+ *        transient state as "actively streaming." GPX's isb_enable_stream() keeps its bit and
+ *        periodMultiple in sync immediately, so the check is always consistent there, but passing
+ *        it costs nothing and keeps one shared, unambiguous contract for both callers.
+ *
+ * @param currentBits           the port's current broadcast-enable bits (grmci_t.rmc.bits or rmci_t.rmc.bits)
+ * @param didBitMask            the specific bit for the DID being requested/enabled (e.g. g_gpxDidToGrmcBit[did] or g_didToRmcBit[did])
+ * @param currentPeriodMultiple the DID's current period-multiple value on this port, before this request is applied
+ * @param requestedPeriod       the requested broadcast period; 0 means "one-shot / disable"
+ * @param preserveIfStreaming   true if the request explicitly asked not to disturb an existing stream
+ */
+bool isbStream_shouldPreserve(uint64_t currentBits, uint64_t didBitMask, uint32_t currentPeriodMultiple, int requestedPeriod, bool preserveIfStreaming);
 
 /** Represents the body header of an ACK or NACK packet */
 typedef struct

--- a/src/ISDevice.cpp
+++ b/src/ISDevice.cpp
@@ -1163,6 +1163,7 @@ bool ISDevice::WaitForImxFlashCfgSynced(bool forceSync, uint32_t timeoutMs)
 
     // If there are no upload pending, then just go ahead and check...
     unsigned int startMs = current_timeMs();
+    uint32_t lastSeenChecksum = sysParams.flashCfgChecksum;
     while(!ImxFlashConfigSynced())
     {   // Request and wait for IMX flash config
         step();
@@ -1174,9 +1175,18 @@ bool ISDevice::WaitForImxFlashCfgSynced(bool forceSync, uint32_t timeoutMs)
             log_warn(IS_LOG_ISDEVICE, "[%s] Timeout waiting for DID_FLASH_CONFIG to sync! (%d ms elapsed, 0x%08x (FlashCfg) != 0x%08x (SysParams)", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str(), elaspedMs, imxFlashCfg.checksum, sysParams.flashCfgChecksum);
             return false;
         }
+        else if (sysParams.flashCfgChecksum != lastSeenChecksum)
+        {   // SN-8471: DID_SYS_PARAMS arrived on its own since our last check -- something is
+            // already streaming it (this session or a persisted config), so don't poll here.
+            // A plain period=0 poll would otherwise silently stop that existing stream.
+            lastSeenChecksum = sysParams.flashCfgChecksum;
+            log_bombastic(IS_LOG_ISDEVICE, "[%s] DID_SYS_PARAMS arrived passively, still waiting for a matching checksum...", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        }
         else
-        {   // Query DID_SYS_PARAMS
-            GetData(DID_SYS_PARAMS);
+        {   // Nothing arrived passively -- explicitly request one value. Set the preserve-stream
+            // flag so a device that supports it won't stop some OTHER stream for this DID that we
+            // simply haven't observed yet (e.g. a persisted config, or another client's stream).
+            GetDataPreserveStream(DID_SYS_PARAMS);
             log_bombastic(IS_LOG_ISDEVICE, "[%s] Waiting for IMX flash sync...", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
         }
     }
@@ -1199,6 +1209,7 @@ bool ISDevice::WaitForGpxFlashCfgSynced(bool forceSync, uint32_t timeout)
 
     // If there are no upload pending, then just go ahead and check...
     unsigned int startMs = current_timeMs();
+    uint32_t lastSeenChecksum = gpxStatus.flashCfgChecksum;
     while(!GpxFlashConfigSynced())
     {   // Request and wait for GPX flash config
         step();
@@ -1209,9 +1220,18 @@ bool ISDevice::WaitForGpxFlashCfgSynced(bool forceSync, uint32_t timeout)
             log_info(IS_LOG_ISDEVICE, "[%s] Timeout waiting for DID_GPX_FLASH_CONFIG to sync!", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
             return false;
         }
+        else if (gpxStatus.flashCfgChecksum != lastSeenChecksum)
+        {   // SN-8471: DID_GPX_STATUS arrived on its own since our last check -- something is
+            // already streaming it (this session or a persisted GRMC config), so don't poll here.
+            // A plain period=0 poll would otherwise silently stop that existing stream.
+            lastSeenChecksum = gpxStatus.flashCfgChecksum;
+            log_bombastic(IS_LOG_ISDEVICE, "[%s] DID_GPX_STATUS arrived passively, still waiting for a matching checksum...", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
+        }
         else
-        {   // Query DID_GPX_STATUS
-            GetData(DID_GPX_STATUS);
+        {   // Nothing arrived passively -- explicitly request one value. Set the preserve-stream
+            // flag so a device that supports it won't stop some OTHER stream for this DID that we
+            // simply haven't observed yet (e.g. a persisted GRMC config, or another client's stream).
+            GetDataPreserveStream(DID_GPX_STATUS);
             log_bombastic(IS_LOG_ISDEVICE, "[%s] Waiting for GPX flash sync...", getDescription(ESSENTIAL_FIRMWARE_INFO|COMPACT_SERIALNO).c_str());
         }
     }

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -416,15 +416,15 @@ public:
     int SendData(eDataIDs dataId, const void* data, uint32_t length, uint32_t offset = 0) { std::lock_guard<std::recursive_mutex> lock(portMutex); return (isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER) ? comManagerSendData(port, data, dataId, length, offset) : -1; }
     /**
      * @brief Requests the device broadcast (or fetch once, if period is 0) the given DID. No-op if not connected or the device is in the bootloader.
-     * @param flags ISB packet flags to OR into the request (see eISBPacketFlags). Most callers
-     *              want the default of 0; pass ISB_FLAGS_GET_DATA_PRESERVE_STREAM when polling
-     *              with period=0 to ask a device that supports it not to stop an existing
-     *              broadcast for this DID on this port (SN-8471) -- see GetDataPreserveStream().
+     * @param flags p_data_get_t request flags (see eGetDataFlags in ISComm.h). Most callers want
+     *              the default of 0; pass GET_DATA_FLAGS_PRESERVE_STREAM when polling with
+     *              period=0 to ask a device that supports it not to stop an existing broadcast
+     *              for this DID on this port (SN-8471) -- see GetDataPreserveStream().
      */
-    void GetData(eDataIDs dataId, uint16_t length=0, uint16_t offset=0, uint16_t period=0, uint8_t flags=0) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetDataFlags(port, dataId, length, offset, period, flags); }
+    void GetData(eDataIDs dataId, uint16_t length=0, uint16_t offset=0, uint16_t period=0, uint16_t flags=0) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetDataFlags(port, dataId, length, offset, period, flags); }
 
-    /** @brief Convenience for GetData(dataId, 0, 0, 0, ISB_FLAGS_GET_DATA_PRESERVE_STREAM) -- a one-shot poll that won't stop an existing broadcast for this DID on this port, on a device that supports the flag (SN-8471). */
-    void GetDataPreserveStream(eDataIDs dataId) { GetData(dataId, 0, 0, 0, ISB_FLAGS_GET_DATA_PRESERVE_STREAM); }
+    /** @brief Convenience for GetData(dataId, 0, 0, 0, GET_DATA_FLAGS_PRESERVE_STREAM) -- a one-shot poll that won't stop an existing broadcast for this DID on this port, on a device that supports the flag (SN-8471). */
+    void GetDataPreserveStream(eDataIDs dataId) { GetData(dataId, 0, 0, 0, GET_DATA_FLAGS_PRESERVE_STREAM); }
 
     /** @brief Requests the device broadcast a preset RMC (real-time message controller) bundle of messages. No-op if not connected or the device is in the bootloader. */
     void BroadcastBinaryDataRmcPreset(uint64_t rmcPreset, uint32_t rmcOptions) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetDataRmc(port, rmcPreset, rmcOptions); }

--- a/src/ISDevice.h
+++ b/src/ISDevice.h
@@ -414,8 +414,17 @@ public:
     int SendRaw(const void* data, uint32_t length) { std::lock_guard<std::recursive_mutex> lock(portMutex); return (isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER) ? comManagerSendRaw(port, data, length) : -1; }
     /** @brief Sends a DID_* data set to the device (a "set data" request). @return bytes sent, or -1 if not connected or the device is in the bootloader. */
     int SendData(eDataIDs dataId, const void* data, uint32_t length, uint32_t offset = 0) { std::lock_guard<std::recursive_mutex> lock(portMutex); return (isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER) ? comManagerSendData(port, data, dataId, length, offset) : -1; }
-    /** @brief Requests the device broadcast (or fetch once, if period is 0) the given DID. No-op if not connected or the device is in the bootloader. */
-    void GetData(eDataIDs dataId, uint16_t length=0, uint16_t offset=0, uint16_t period=0) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetData(port, dataId, length, offset, period); }
+    /**
+     * @brief Requests the device broadcast (or fetch once, if period is 0) the given DID. No-op if not connected or the device is in the bootloader.
+     * @param flags ISB packet flags to OR into the request (see eISBPacketFlags). Most callers
+     *              want the default of 0; pass ISB_FLAGS_GET_DATA_PRESERVE_STREAM when polling
+     *              with period=0 to ask a device that supports it not to stop an existing
+     *              broadcast for this DID on this port (SN-8471) -- see GetDataPreserveStream().
+     */
+    void GetData(eDataIDs dataId, uint16_t length=0, uint16_t offset=0, uint16_t period=0, uint8_t flags=0) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetDataFlags(port, dataId, length, offset, period, flags); }
+
+    /** @brief Convenience for GetData(dataId, 0, 0, 0, ISB_FLAGS_GET_DATA_PRESERVE_STREAM) -- a one-shot poll that won't stop an existing broadcast for this DID on this port, on a device that supports the flag (SN-8471). */
+    void GetDataPreserveStream(eDataIDs dataId) { GetData(dataId, 0, 0, 0, ISB_FLAGS_GET_DATA_PRESERVE_STREAM); }
 
     /** @brief Requests the device broadcast a preset RMC (real-time message controller) bundle of messages. No-op if not connected or the device is in the bootloader. */
     void BroadcastBinaryDataRmcPreset(uint64_t rmcPreset, uint32_t rmcOptions) { std::lock_guard<std::recursive_mutex> lock(portMutex); if ((isConnected() && devInfo.hdwRunState != HDW_STATE_BOOTLOADER)) comManagerGetDataRmc(port, rmcPreset, rmcOptions); }

--- a/src/com_manager.cpp
+++ b/src/com_manager.cpp
@@ -335,7 +335,12 @@ void comManagerGetData(port_handle_t port, uint16_t did, uint16_t size, uint16_t
     s_cm.getData(port, did, size, offset, period);
 }
 
-void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period)
+void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags)
+{
+    s_cm.getData(port, did, size, offset, period, flags);
+}
+
+void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags)
 {
     // Create and Send request packet
     p_data_get_t get;
@@ -344,7 +349,7 @@ void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint
     get.size = size;
     get.period = period;
 
-    if (port && send(port, PKT_TYPE_GET_DATA, &get, 0, sizeof(get), 0)) {
+    if (port && send(port, PKT_TYPE_GET_DATA | flags, &get, 0, sizeof(get), 0)) {
         // if send() is true, then an error occurred...
         // depending on the nature of the error, we may want to close the port.
         // FIXME: we really should be more selective with which errors we actually close the port for.

--- a/src/com_manager.cpp
+++ b/src/com_manager.cpp
@@ -335,12 +335,12 @@ void comManagerGetData(port_handle_t port, uint16_t did, uint16_t size, uint16_t
     s_cm.getData(port, did, size, offset, period);
 }
 
-void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags)
+void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint16_t flags)
 {
     s_cm.getData(port, did, size, offset, period, flags);
 }
 
-void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags)
+void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint16_t flags)
 {
     // Create and Send request packet
     p_data_get_t get;
@@ -348,8 +348,9 @@ void ISComManager::getData(port_handle_t port, uint16_t did, uint16_t size, uint
     get.offset = offset;
     get.size = size;
     get.period = period;
+    get.flags = flags;
 
-    if (port && send(port, PKT_TYPE_GET_DATA | flags, &get, 0, sizeof(get), 0)) {
+    if (port && send(port, PKT_TYPE_GET_DATA, &get, 0, sizeof(get), 0)) {
         // if send() is true, then an error occurred...
         // depending on the nature of the error, we may want to close the port.
         // FIXME: we really should be more selective with which errors we actually close the port for.
@@ -561,7 +562,7 @@ int ISComManager::processBinaryRxPacket(protocol_type_t ptype, packet_t *pkt, po
             }
         }
 #endif
-        if (getDataRequest(port, (p_data_get_t*)(pkt->data.ptr)))
+        if (getDataRequest(port, (p_data_get_t*)(pkt->data.ptr), pkt->data.size))
         {
             sendAck(port, pkt, PKT_TYPE_NACK);
         }
@@ -636,12 +637,12 @@ bufTxRxPtr_t* ISComManager::getRegisteredDataInfo(uint16_t did)
 }
 
 // 0 on success. -1 on failure.
-int comManagerGetDataRequest(port_handle_t port, p_data_get_t* req)
+int comManagerGetDataRequest(port_handle_t port, p_data_get_t* req, uint32_t receivedPayloadSize)
 {
-    return s_cm.getDataRequest(port, req);
+    return s_cm.getDataRequest(port, req, receivedPayloadSize);
 }
 
-int ISComManager::getDataRequest(port_handle_t port, p_data_get_t* req)
+int ISComManager::getDataRequest(port_handle_t port, p_data_get_t* req, uint32_t receivedPayloadSize)
 {
     broadcast_msg_t* msg = NULL;
 
@@ -651,10 +652,21 @@ int ISComManager::getDataRequest(port_handle_t port, p_data_get_t* req)
         // invalid data id
         return -1;
     }
+
+    // SN-8471: req->flags was appended after the legacy 8-byte layout. An older sender's packet
+    // never included it -- the wire framing is self-describing (packet_hdr_t::payloadSize is
+    // explicit, not inferred from sizeof(p_data_get_t)), so an older sender's request arrives here
+    // with receivedPayloadSize < sizeof(p_data_get_t). The receive buffer is only zeroed once, at
+    // is_comm_init() -- not between subsequent packets -- so bytes past what was actually sent
+    // could still hold a previous packet's leftovers at this offset. Sanitize explicitly here,
+    // once, rather than have every consumer of req (cmMsgHandlerRmc, etc.) re-check this.
+    if (receivedPayloadSize < sizeof(p_data_get_t))
+        req->flags = 0;
+
     // Call RealtimeMessageController (RMC) handler
-    else if (cmMsgHandlerRmc && (cmMsgHandlerRmc(this, req, port) == 0))
+    if (cmMsgHandlerRmc && (cmMsgHandlerRmc(this, req, port) == 0))
     {
-        // Don't allow comManager broadcasts for messages handled by RealtimeMessageController. 
+        // Don't allow comManager broadcasts for messages handled by RealtimeMessageController.
         return 0;
     }
     // if size is 0 and offset is 0, set size to full data struct size
@@ -837,6 +849,9 @@ void ISComManager::disableDidBroadcast(port_handle_t port, uint16_t did)
         req.size = 0;
         req.offset = 0;
         req.period = 0;
+
+        // This is an explicit stop request, not a received GET_DATA -- never preserve (SN-8471).
+        req.flags = 0;
         cmMsgHandlerRmc(this, &req, port);
     }
 }

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -283,6 +283,15 @@ void stepSendMessages(void);
 void comManagerGetData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period);
 
 /**
+ * @brief Same as comManagerGetData(), with an additional ISB packet flags parameter (see
+ *        eISBPacketFlags) OR'd into the request -- e.g. ISB_FLAGS_GET_DATA_PRESERVE_STREAM,
+ *        which asks a device that supports it not to stop an existing broadcast for this DID on
+ *        this port when period is 0 (SN-8471). comManagerGetData() is equivalent to calling this
+ *        with flags=0.
+ */
+void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags);
+
+/**
  * @brief Request a device to broadcast a preset collection of messages via RMC bits.
  *
  * @param port       Port handle to send the request to.
@@ -544,7 +553,7 @@ public:
      * @param offset Byte offset into the data structure; 0 = start.
      * @param period Broadcast period in step multiples; 0 = one-shot request.
      */
-    void getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period);
+    void getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags = 0);
 
     /**
      * @brief Request broadcast of a preset collection of messages via RMC bits.

--- a/src/com_manager.h
+++ b/src/com_manager.h
@@ -283,13 +283,13 @@ void stepSendMessages(void);
 void comManagerGetData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period);
 
 /**
- * @brief Same as comManagerGetData(), with an additional ISB packet flags parameter (see
- *        eISBPacketFlags) OR'd into the request -- e.g. ISB_FLAGS_GET_DATA_PRESERVE_STREAM,
- *        which asks a device that supports it not to stop an existing broadcast for this DID on
- *        this port when period is 0 (SN-8471). comManagerGetData() is equivalent to calling this
- *        with flags=0.
+ * @brief Same as comManagerGetData(), with an additional request-flags parameter (see
+ *        eGetDataFlags in ISComm.h) written into p_data_get_t::flags -- e.g.
+ *        GET_DATA_FLAGS_PRESERVE_STREAM, which asks a device that supports it not to stop an
+ *        existing broadcast for this DID on this port when period is 0 (SN-8471).
+ *        comManagerGetData() is equivalent to calling this with flags=0.
  */
-void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags);
+void comManagerGetDataFlags(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint16_t flags);
 
 /**
  * @brief Request a device to broadcast a preset collection of messages via RMC bits.
@@ -403,11 +403,20 @@ bufTxRxPtr_t* comManagerGetRegisteredDataInfo(uint16_t did);
 
 /**
  * @brief Process a GET_DATA request and schedule the requested broadcast.
- * @param port Port handle that sent the request.
- * @param req  Parsed GET_DATA request specifying the DID, offset, size, and period.
+ * @param port                Port handle that sent the request.
+ * @param req                 Parsed GET_DATA request specifying the DID, offset, size, period,
+ *                            and flags (see GET_DATA_FLAGS_PRESERVE_STREAM in ISComm.h).
+ * @param receivedPayloadSize Actual number of payload bytes received for this request (e.g.
+ *                            packet_t::data.size). If less than sizeof(p_data_get_t) -- i.e. the
+ *                            sender predates SN-8471's `flags` field -- req->flags is zeroed
+ *                            before any handler sees it, rather than trusting whatever bytes
+ *                            happen to sit in the (not-zeroed-between-packets) receive buffer at
+ *                            that offset. Defaults to sizeof(p_data_get_t) (trust flags as-is) for
+ *                            any caller constructing req itself rather than decoding one off the
+ *                            wire.
  * @return 0 on success, non-zero on failure.
  */
-int comManagerGetDataRequest(port_handle_t port, p_data_get_t* req);
+int comManagerGetDataRequest(port_handle_t port, p_data_get_t* req, uint32_t receivedPayloadSize = sizeof(p_data_get_t));
 
 /**
  * @brief Register a callback invoked whenever a packet parse error is detected.
@@ -553,7 +562,7 @@ public:
      * @param offset Byte offset into the data structure; 0 = start.
      * @param period Broadcast period in step multiples; 0 = one-shot request.
      */
-    void getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint8_t flags = 0);
+    void getData(port_handle_t port, uint16_t did, uint16_t size, uint16_t offset, uint16_t period, uint16_t flags = 0);
 
     /**
      * @brief Request broadcast of a preset collection of messages via RMC bits.
@@ -639,11 +648,12 @@ public:
 
 
     /**
-    * Internal use mostly, process a get data request for a message that needs to be broadcasted
+    * Internal use mostly, process a get data request for a message that needs to be broadcasted.
+    * See comManagerGetDataRequest() for receivedPayloadSize's role (SN-8471).
     *
     * @return 0 on success, anything else is failure
     */
-    int getDataRequest(port_handle_t port, p_data_get_t* req);
+    int getDataRequest(port_handle_t port, p_data_get_t* req, uint32_t receivedPayloadSize = sizeof(p_data_get_t));
 
 
     /**

--- a/tests/test_ISComm.cpp
+++ b/tests/test_ISComm.cpp
@@ -1192,10 +1192,10 @@ TEST(ISComm, IsCommGetDataTest)
 }
 #endif
 
-// SN-8471: ISB_FLAGS_GET_DATA_PRESERVE_STREAM is a new upper-nibble packet flag telling a device
-// that supports it not to stop an existing broadcast when a period=0 GET_DATA is otherwise a
-// plain one-shot poll. These tests confirm it round-trips correctly over the wire and that an
-// older/unaware decoder path (i.e. code that only masks with PKT_TYPE_MASK) is unaffected.
+// SN-8471: GET_DATA_FLAGS_PRESERVE_STREAM is a new bit in p_data_get_t::flags (appended after
+// the legacy 4-field layout) telling a device that supports it not to stop an existing broadcast
+// when a period=0 GET_DATA is otherwise a plain one-shot poll. These tests confirm the new field
+// round-trips correctly over the wire.
 TEST(ISComm, GetDataPreserveStreamFlagRoundTrips)
 {
     uint8_t txBuf[256];
@@ -1204,48 +1204,7 @@ TEST(ISComm, GetDataPreserveStreamFlagRoundTrips)
     get.size   = 0;
     get.offset = 0;
     get.period = 0;
-
-    is_comm_instance_t txComm{};
-    uint8_t txCommBuf[256];
-    is_comm_init(&txComm, txCommBuf, sizeof(txCommBuf), nullptr);
-    int n = is_comm_write_to_buf(txBuf, sizeof(txBuf), &txComm, PKT_TYPE_GET_DATA | ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0, sizeof(get), 0, &get);
-    ASSERT_GT(n, 0);
-
-    is_comm_instance_t rxComm{};
-    uint8_t rxCommBuf[256];
-    is_comm_init(&rxComm, rxCommBuf, sizeof(rxCommBuf), nullptr);
-
-    bool parsed = false;
-    for (int i = 0; i < n; ++i)
-    {
-        protocol_type_t pt = is_comm_parse_byte(&rxComm, txBuf[i]);
-        if (pt == _PTYPE_INERTIAL_SENSE_CMD)
-        {
-            parsed = true;
-            break;
-        }
-    }
-    ASSERT_TRUE(parsed);
-
-    // The flag survives decode, and the packet is still correctly identified as GET_DATA (the
-    // lower nibble -- the actual type -- is unaffected by the new upper-nibble bit).
-    EXPECT_EQ(rxComm.rxPkt.hdr.flags & PKT_TYPE_MASK, (uint8_t)PKT_TYPE_GET_DATA);
-    EXPECT_NE(rxComm.rxPkt.hdr.flags & ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0);
-
-    ASSERT_NE(rxComm.rxPkt.data.ptr, nullptr);
-    const p_data_get_t *request = (const p_data_get_t*)rxComm.rxPkt.data.ptr;
-    EXPECT_EQ(request->id, (uint16_t)DID_GPX_STATUS);
-    EXPECT_EQ(request->period, 0);
-}
-
-TEST(ISComm, GetDataWithoutPreserveStreamFlagDoesNotSetIt)
-{
-    // Control case: a plain GET_DATA (today's default, e.g. from an older client or any existing
-    // caller that hasn't opted in) must not have the new flag set.
-    uint8_t txBuf[256];
-    p_data_get_t get = {};
-    get.id     = DID_SYS_PARAMS;
-    get.period = 0;
+    get.flags  = GET_DATA_FLAGS_PRESERVE_STREAM;
 
     is_comm_instance_t txComm{};
     uint8_t txCommBuf[256];
@@ -1268,7 +1227,85 @@ TEST(ISComm, GetDataWithoutPreserveStreamFlagDoesNotSetIt)
         }
     }
     ASSERT_TRUE(parsed);
-    EXPECT_EQ(rxComm.rxPkt.hdr.flags & ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0);
+
+    ASSERT_NE(rxComm.rxPkt.data.ptr, nullptr);
+    ASSERT_GE(rxComm.rxPkt.data.size, sizeof(p_data_get_t));
+    const p_data_get_t *request = (const p_data_get_t*)rxComm.rxPkt.data.ptr;
+    EXPECT_EQ(request->id, (uint16_t)DID_GPX_STATUS);
+    EXPECT_EQ(request->period, 0);
+    EXPECT_EQ(request->flags & GET_DATA_FLAGS_PRESERVE_STREAM, GET_DATA_FLAGS_PRESERVE_STREAM);
+}
+
+TEST(ISComm, GetDataWithoutPreserveStreamFlagDoesNotSetIt)
+{
+    // Control case: a plain GET_DATA (today's default, e.g. from an older client or any existing
+    // caller that hasn't opted in) must not have the new flag set.
+    uint8_t txBuf[256];
+    p_data_get_t get = {};
+    get.id     = DID_SYS_PARAMS;
+    get.period = 0;
+    get.flags  = 0;
+
+    is_comm_instance_t txComm{};
+    uint8_t txCommBuf[256];
+    is_comm_init(&txComm, txCommBuf, sizeof(txCommBuf), nullptr);
+    int n = is_comm_write_to_buf(txBuf, sizeof(txBuf), &txComm, PKT_TYPE_GET_DATA, 0, sizeof(get), 0, &get);
+    ASSERT_GT(n, 0);
+
+    is_comm_instance_t rxComm{};
+    uint8_t rxCommBuf[256];
+    is_comm_init(&rxComm, rxCommBuf, sizeof(rxCommBuf), nullptr);
+
+    bool parsed = false;
+    for (int i = 0; i < n; ++i)
+    {
+        protocol_type_t pt = is_comm_parse_byte(&rxComm, txBuf[i]);
+        if (pt == _PTYPE_INERTIAL_SENSE_CMD)
+        {
+            parsed = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(parsed);
+
+    ASSERT_NE(rxComm.rxPkt.data.ptr, nullptr);
+    ASSERT_GE(rxComm.rxPkt.data.size, sizeof(p_data_get_t));
+    const p_data_get_t *request = (const p_data_get_t*)rxComm.rxPkt.data.ptr;
+    EXPECT_EQ(request->flags & GET_DATA_FLAGS_PRESERVE_STREAM, 0);
+}
+
+// SN-8471: is_comm_get_data()/is_comm_get_data_to_buf() build a p_data_get_t on the stack without
+// zero-initializing it (`p_data_get_t get;`, not `= {}`) -- confirm they explicitly set .flags=0
+// rather than sending whatever garbage happened to be on the stack in that field.
+TEST(ISComm, LegacyGetDataHelpersSendZeroFlags)
+{
+    uint8_t txBuf[256];
+    is_comm_instance_t txComm{};
+    uint8_t txCommBuf[256];
+    is_comm_init(&txComm, txCommBuf, sizeof(txCommBuf), nullptr);
+
+    int n = is_comm_get_data_to_buf(txBuf, sizeof(txBuf), &txComm, DID_DEV_INFO, 0, 0, 0);
+    ASSERT_GT(n, 0);
+
+    is_comm_instance_t rxComm{};
+    uint8_t rxCommBuf[256];
+    is_comm_init(&rxComm, rxCommBuf, sizeof(rxCommBuf), nullptr);
+
+    bool parsed = false;
+    for (int i = 0; i < n; ++i)
+    {
+        protocol_type_t pt = is_comm_parse_byte(&rxComm, txBuf[i]);
+        if (pt == _PTYPE_INERTIAL_SENSE_CMD)
+        {
+            parsed = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(parsed);
+    ASSERT_NE(rxComm.rxPkt.data.ptr, nullptr);
+    ASSERT_GE(rxComm.rxPkt.data.size, sizeof(p_data_get_t));
+    const p_data_get_t *request = (const p_data_get_t*)rxComm.rxPkt.data.ptr;
+    EXPECT_EQ(request->flags, 0);
 }
 
 

--- a/tests/test_ISComm.cpp
+++ b/tests/test_ISComm.cpp
@@ -1308,6 +1308,63 @@ TEST(ISComm, LegacyGetDataHelpersSendZeroFlags)
     EXPECT_EQ(request->flags, 0);
 }
 
+// isbStream_shouldPreserve() -- the SN-8471 decision logic shared by GPX's isb_enable_stream()
+// and IMX's cmMsgHandlerRmc() that lets a period=0 poll leave an already-streaming DID's bit
+// alone instead of clearing it (see GET_DATA_FLAGS_PRESERVE_STREAM above).
+namespace {
+constexpr uint64_t kIsbStreamDidBit = 1ull << 5;
+constexpr uint64_t kIsbStreamOtherBit = 1ull << 9;
+constexpr uint32_t kIsbStreamNonZeroPeriod = 250;
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_PreservesWhenStreamingAndFlagSetAndPeriodZero)
+{
+    EXPECT_TRUE(isbStream_shouldPreserve(kIsbStreamDidBit | kIsbStreamOtherBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, true));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_DoesNotPreserveWhenFlagNotSet)
+{
+    // This is today's exact pre-SN-8471 behavior: default (flag unset) always clears.
+    EXPECT_FALSE(isbStream_shouldPreserve(kIsbStreamDidBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, false));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_DoesNotPreserveWhenBitNotCurrentlySet)
+{
+    // Nothing to preserve -- not streaming yet, so a plain period=0 poll behaves as a normal
+    // one-shot with no side effect either way.
+    EXPECT_FALSE(isbStream_shouldPreserve(kIsbStreamOtherBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, true));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_DoesNotPreserveWhenPeriodIsNonZero)
+{
+    // A nonzero requested period is an explicit enable/refresh request, not a poll -- the flag
+    // is irrelevant here; the caller proceeds with its normal set-the-bit behavior.
+    EXPECT_FALSE(isbStream_shouldPreserve(kIsbStreamDidBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 100, true));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_DoesNotPreserveWhenBitZeroAndCurrentBitsZero)
+{
+    EXPECT_FALSE(isbStream_shouldPreserve(0, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, true));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_IsIndependentOfOtherBits)
+{
+    // Only the specific DID's own bit matters -- other unrelated bits being set/clear doesn't
+    // change the verdict for this DID.
+    EXPECT_TRUE(isbStream_shouldPreserve(kIsbStreamDidBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, true));
+    EXPECT_FALSE(isbStream_shouldPreserve(kIsbStreamOtherBit, kIsbStreamDidBit, kIsbStreamNonZeroPeriod, 0, true));
+}
+
+TEST(ISComm, IsbStreamShouldPreserve_DoesNotPreserveWhenCurrentPeriodMultipleIsZero)
+{
+    // IMX-specific scenario: cmMsgHandlerRmc() sets the bit immediately (via OR) but the actual
+    // clear happens one broadcast cycle later, in sendRmcMessage(), once it observes
+    // periodMultiple==0 -- so there's a narrow window where the bit reads as set even though a
+    // just-processed period=0 request already queued it for clearing. periodMultiple==0 here
+    // means "already queued for removal, nothing genuinely active to preserve."
+    EXPECT_FALSE(isbStream_shouldPreserve(kIsbStreamDidBit, kIsbStreamDidBit, 0, 0, true));
+}
+
 
 #if TEST_ALTERNATING_ISB_NMEA_PARSE_ERRORS
 uint8_t rxBuf[8192] = {0};

--- a/tests/test_ISComm.cpp
+++ b/tests/test_ISComm.cpp
@@ -1192,6 +1192,85 @@ TEST(ISComm, IsCommGetDataTest)
 }
 #endif
 
+// SN-8471: ISB_FLAGS_GET_DATA_PRESERVE_STREAM is a new upper-nibble packet flag telling a device
+// that supports it not to stop an existing broadcast when a period=0 GET_DATA is otherwise a
+// plain one-shot poll. These tests confirm it round-trips correctly over the wire and that an
+// older/unaware decoder path (i.e. code that only masks with PKT_TYPE_MASK) is unaffected.
+TEST(ISComm, GetDataPreserveStreamFlagRoundTrips)
+{
+    uint8_t txBuf[256];
+    p_data_get_t get = {};
+    get.id     = DID_GPX_STATUS;
+    get.size   = 0;
+    get.offset = 0;
+    get.period = 0;
+
+    is_comm_instance_t txComm{};
+    uint8_t txCommBuf[256];
+    is_comm_init(&txComm, txCommBuf, sizeof(txCommBuf), nullptr);
+    int n = is_comm_write_to_buf(txBuf, sizeof(txBuf), &txComm, PKT_TYPE_GET_DATA | ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0, sizeof(get), 0, &get);
+    ASSERT_GT(n, 0);
+
+    is_comm_instance_t rxComm{};
+    uint8_t rxCommBuf[256];
+    is_comm_init(&rxComm, rxCommBuf, sizeof(rxCommBuf), nullptr);
+
+    bool parsed = false;
+    for (int i = 0; i < n; ++i)
+    {
+        protocol_type_t pt = is_comm_parse_byte(&rxComm, txBuf[i]);
+        if (pt == _PTYPE_INERTIAL_SENSE_CMD)
+        {
+            parsed = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(parsed);
+
+    // The flag survives decode, and the packet is still correctly identified as GET_DATA (the
+    // lower nibble -- the actual type -- is unaffected by the new upper-nibble bit).
+    EXPECT_EQ(rxComm.rxPkt.hdr.flags & PKT_TYPE_MASK, (uint8_t)PKT_TYPE_GET_DATA);
+    EXPECT_NE(rxComm.rxPkt.hdr.flags & ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0);
+
+    ASSERT_NE(rxComm.rxPkt.data.ptr, nullptr);
+    const p_data_get_t *request = (const p_data_get_t*)rxComm.rxPkt.data.ptr;
+    EXPECT_EQ(request->id, (uint16_t)DID_GPX_STATUS);
+    EXPECT_EQ(request->period, 0);
+}
+
+TEST(ISComm, GetDataWithoutPreserveStreamFlagDoesNotSetIt)
+{
+    // Control case: a plain GET_DATA (today's default, e.g. from an older client or any existing
+    // caller that hasn't opted in) must not have the new flag set.
+    uint8_t txBuf[256];
+    p_data_get_t get = {};
+    get.id     = DID_SYS_PARAMS;
+    get.period = 0;
+
+    is_comm_instance_t txComm{};
+    uint8_t txCommBuf[256];
+    is_comm_init(&txComm, txCommBuf, sizeof(txCommBuf), nullptr);
+    int n = is_comm_write_to_buf(txBuf, sizeof(txBuf), &txComm, PKT_TYPE_GET_DATA, 0, sizeof(get), 0, &get);
+    ASSERT_GT(n, 0);
+
+    is_comm_instance_t rxComm{};
+    uint8_t rxCommBuf[256];
+    is_comm_init(&rxComm, rxCommBuf, sizeof(rxCommBuf), nullptr);
+
+    bool parsed = false;
+    for (int i = 0; i < n; ++i)
+    {
+        protocol_type_t pt = is_comm_parse_byte(&rxComm, txBuf[i]);
+        if (pt == _PTYPE_INERTIAL_SENSE_CMD)
+        {
+            parsed = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(rxComm.rxPkt.hdr.flags & ISB_FLAGS_GET_DATA_PRESERVE_STREAM, 0);
+}
+
 
 #if TEST_ALTERNATING_ISB_NMEA_PARSE_ERRORS
 uint8_t rxBuf[8192] = {0};

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -1088,10 +1088,19 @@ TEST(ComManager, Evb2DataForwardTest)
 // received payload didn't include it, rather than trust whatever memory happens to be there.
 // Uses a fresh, local ISComManager (mirroring tcm.cm elsewhere in this file) rather than the
 // global s_cm/free-function API, so this doesn't depend on any other test's registration state.
+// init() must be called before getDataRequest() -- broadcastMessages is a raw pointer with no
+// default member initializer, so an un-init'd ISComManager dereferences garbage and segfaults.
+
+static ISComManager makeInitializedComManager()
+{
+    ISComManager cm;
+    cm.init(NULL, TASK_PERIOD_MS, 0, 0, 0, 0, &g_cmBufBcastMsg);
+    return cm;
+}
 
 TEST(ComManager, GetDataRequest_SanitizesFlagsFromShortLegacyPacket)
 {
-    ISComManager cm;
+    ISComManager cm = makeInitializedComManager();
     p_data_get_t req = {};
     req.id = DID_DEV_INFO;
     req.period = 0;
@@ -1105,7 +1114,7 @@ TEST(ComManager, GetDataRequest_SanitizesFlagsFromShortLegacyPacket)
 
 TEST(ComManager, GetDataRequest_TrustsFlagsFromFullSizePacket)
 {
-    ISComManager cm;
+    ISComManager cm = makeInitializedComManager();
     p_data_get_t req = {};
     req.id = DID_DEV_INFO;
     req.period = 0;
@@ -1122,7 +1131,7 @@ TEST(ComManager, GetDataRequest_DefaultReceivedSizeTrustsFlags)
     // comManagerGetDataRequest()'s receivedPayloadSize defaults to sizeof(p_data_get_t) -- for
     // any caller constructing req itself (not decoding one off the wire), flags should be
     // trusted as-is with no explicit size argument needed.
-    ISComManager cm;
+    ISComManager cm = makeInitializedComManager();
     p_data_get_t req = {};
     req.id = DID_DEV_INFO;
     req.period = 0;

--- a/tests/test_com_manager.cpp
+++ b/tests/test_com_manager.cpp
@@ -1080,3 +1080,56 @@ TEST(ComManager, Evb2DataForwardTest)
 }
 #endif
 
+// SN-8471: p_data_get_t::flags was appended after the legacy 4-field layout so older
+// senders (who never included it) stay wire-compatible -- but the receive buffer is only
+// zeroed once, at is_comm_init(), not between subsequent packets, so a shorter/older
+// request's unset trailing bytes could still hold a previous packet's leftovers at that
+// offset. ISComManager::getDataRequest() must sanitize req->flags whenever the actual
+// received payload didn't include it, rather than trust whatever memory happens to be there.
+// Uses a fresh, local ISComManager (mirroring tcm.cm elsewhere in this file) rather than the
+// global s_cm/free-function API, so this doesn't depend on any other test's registration state.
+
+TEST(ComManager, GetDataRequest_SanitizesFlagsFromShortLegacyPacket)
+{
+    ISComManager cm;
+    p_data_get_t req = {};
+    req.id = DID_DEV_INFO;
+    req.period = 0;
+    req.flags = GET_DATA_FLAGS_PRESERVE_STREAM;  // simulate stale bytes left at this offset
+
+    // Simulate an older sender's packet that never included the flags field.
+    cm.getDataRequest(nullptr, &req, sizeof(p_data_get_t) - sizeof(req.flags));
+
+    EXPECT_EQ(req.flags, 0);
+}
+
+TEST(ComManager, GetDataRequest_TrustsFlagsFromFullSizePacket)
+{
+    ISComManager cm;
+    p_data_get_t req = {};
+    req.id = DID_DEV_INFO;
+    req.period = 0;
+    req.flags = GET_DATA_FLAGS_PRESERVE_STREAM;
+
+    // A full-size received payload genuinely included the flags field -- trust it.
+    cm.getDataRequest(nullptr, &req, sizeof(p_data_get_t));
+
+    EXPECT_EQ(req.flags, (uint16_t)GET_DATA_FLAGS_PRESERVE_STREAM);
+}
+
+TEST(ComManager, GetDataRequest_DefaultReceivedSizeTrustsFlags)
+{
+    // comManagerGetDataRequest()'s receivedPayloadSize defaults to sizeof(p_data_get_t) -- for
+    // any caller constructing req itself (not decoding one off the wire), flags should be
+    // trusted as-is with no explicit size argument needed.
+    ISComManager cm;
+    p_data_get_t req = {};
+    req.id = DID_DEV_INFO;
+    req.period = 0;
+    req.flags = GET_DATA_FLAGS_PRESERVE_STREAM;
+
+    cm.getDataRequest(nullptr, &req);
+
+    EXPECT_EQ(req.flags, (uint16_t)GET_DATA_FLAGS_PRESERVE_STREAM);
+}
+


### PR DESCRIPTION
## Summary

Root cause (SN-8471, Observation 2): a plain `period=0` `GET_DATA` is a genuine one-shot request, but both IMX (RMC) and GPX (GRMC) broadcast-enable handlers also use it to implicitly stop any existing broadcast for that DID on the requesting port — there was previously no way to ask for "just today's value" without that side effect. Since repeated `period=0` polling is a legitimate, common client pattern (confirmed with Kyle — not a mistake isolated to one call site), any client polling a DID that's also configured as a persisted or independently-started stream will silently kill it over time. This is exactly the "grmcBits* only ever loses bits, never gains them" behavior from the original bug report — and the same defect exists on the IMX/RMC side too (`cmMsgHandlerRmc()`/`sendRmcMessage()`), just via a slightly different (delayed-by-one-cycle) mechanism.

**Design revision (superseding the first commit on this branch):** the preserve-stream signal now lives in a new `p_data_get_t::flags` field (appended after the legacy 4-field layout), not a packet-header flag. Reasoning from review discussion:
- The packet header's upper flags nibble is shared across all 9 packet types and only had 2 of 4 bits free — a scarce, non-renewable resource for something meaningful only to `GET_DATA`.
- Existing precedent (`rmc_t.options`) already puts message-specific modifier flags inside the message's own struct, not the generic packet header.
- Growing `p_data_get_t` is safe: packet framing is self-describing (`packet_hdr_t::payloadSize` is explicit, never inferred from `sizeof(p_data_get_t)`), so older firmware receiving a newer/larger request simply never reads past its own compiled 8-byte struct — confirmed the receive buffer is a generic 2048-byte buffer shared across all packet types, not sized per payload struct, so there's no overflow risk there either.
- The one real subtlety: newer firmware receiving an *older*, shorter request must not trust `req->flags` blindly — the receive buffer is only zeroed once, at `is_comm_init()`, not between subsequent packets, so bytes past what was actually sent could still hold a previous packet's leftovers at that offset. `ISComManager::getDataRequest()` now takes the actual received payload size and zeroes `req->flags` whenever it's smaller than `sizeof(p_data_get_t)`, once, at the single shared choke point every `GET_DATA` request passes through — so every downstream consumer (`cmMsgHandlerRmc`, `isb_get_data`, etc.) can just read `req->flags` directly and trust it. This also removes the need for the `lastGetDataFlags`/`comManagerGetLastGetDataFlags()` side-channel the packet-header approach required.

**Also fixed:** every local `p_data_get_t` construction site (`ISComm.c`'s legacy `is_comm_get_data()`/`is_comm_get_data_to_buf()`, `com_manager.cpp`'s `getData()` and `disableDidBroadcast()`) explicitly zeroes `.flags` now — none of them zero-initialize the struct, so the new field would otherwise transmit whatever garbage was on the stack.

**Fixed the two known repeat-offenders directly:** `WaitForGpxFlashCfgSynced()`/`WaitForImxFlashCfgSynced()` now track whether a fresh value already arrived passively (checksum changed since the last check) before deciding to poll at all — if something is already streaming, they never issue the `GetData` call in the first place. When they do poll, they set the new flag as defense in depth.

The firmware side that actually **honors** the flag (`isb_enable_stream()` for GPX, `cmMsgHandlerRmc()` for IMX) lands as a separate PR in `imx`/`is-common`, reviewable independently — see linked PR below.

**CI fix (`c6863695`):** the three new `getDataRequest()` tests constructed a bare `ISComManager` without calling `init()` first — `broadcastMessages` is a raw pointer with no default member initializer, so `getDataRequest()` dereferenced garbage and segfaulted on Linux CI / threw SEH on Windows CI. Fixed by properly initializing the local `ISComManager` before use, mirroring the existing `initComManager()` pattern used elsewhere in this test file. No functional/production code changed.

**Also added (`b22adbc9`):** `isbStream_shouldPreserve()` -- the shared decision logic used by GPX's `isb_enable_stream()` and IMX's `cmMsgHandlerRmc()` to honor this flag -- now lives here in `ISComm.h`/`.c`, colocated with `p_data_get_t`/`GET_DATA_FLAGS_PRESERVE_STREAM`, rather than in a standalone header+source pair in the firmware repo. Per review feedback, a whole new file for one 1-line function was overkill, and `ISComm.c` is already compiled into both GPX-1's (Zephyr) and IMX-5's (Makefile) firmware builds, so this needs zero build-file changes on the firmware side. Bonus: the previous standalone-file version had only been added to `IMX-5/CMakeLists.txt`, which isn't what IMX-5's real firmware build actually uses (that's a plain Makefile) -- so it would have failed to link with an undefined reference on a real IMX-5 build. Tests moved into `test_ISComm.cpp` alongside the other SN-8471 flag tests.

## Test plan

- [x] `test_ISComm.cpp`: flag round-trips correctly in `p_data_get_t.flags` (`GetDataPreserveStreamFlagRoundTrips`), a plain `GET_DATA` doesn't set it (`GetDataWithoutPreserveStreamFlagDoesNotSetIt`), and the legacy encoder helpers don't leak stack garbage into the new field (`LegacyGetDataHelpersSendZeroFlags`)
- [x] `test_com_manager.cpp` (new): `ISComManager::getDataRequest()`'s sanitize-on-short-packet guard, exercised directly via a properly-initialized local `ISComManager` instance — confirms flags are zeroed for a short/legacy-sized packet and trusted for a full-sized one, including the default-argument path
- [x] `test_ISComm.cpp` (moved from firmware-side `test_isb_stream_policy.cpp`): 7 cases covering each condition of `isbStream_shouldPreserve()`'s decision independently, including the IMX-specific `currentPeriodMultiple==0` window
- [x] Full suite: 468 passed (11 new total), 4 pre-existing skipped, 0 failures

Jira: https://inertialsense.atlassian.net/browse/SN-8471
Related: https://github.com/inertialsense/imx/pull/1659 (firmware side — honors the flag for both GPX/GRMC and IMX/RMC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

